### PR TITLE
Custom line rendering support

### DIFF
--- a/feature-pagination/src/main/java/net/kyori/text/feature/pagination/Pagination.java
+++ b/feature-pagination/src/main/java/net/kyori/text/feature/pagination/Pagination.java
@@ -23,6 +23,10 @@
  */
 package net.kyori.text.feature.pagination;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.event.ClickEvent;
@@ -32,11 +36,6 @@ import net.kyori.text.format.TextColor;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * Pagination.

--- a/feature-pagination/src/main/java/net/kyori/text/feature/pagination/Pagination.java
+++ b/feature-pagination/src/main/java/net/kyori/text/feature/pagination/Pagination.java
@@ -23,9 +23,6 @@
  */
 package net.kyori.text.feature.pagination;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Consumer;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.event.ClickEvent;
@@ -35,6 +32,11 @@ import net.kyori.text.format.TextColor;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Pagination.
@@ -200,6 +202,14 @@ public interface Pagination<T> {
         .append(GRAY_RIGHT_SQUARE_BRACKET)
         .append(TextComponent.space())
         .build();
+    }
+
+    default @NonNull Component renderLine(final char character, final @NonNull Style style, final int length) {
+      return TextComponent.of(repeat(String.valueOf(character), length), style);
+    }
+
+    static @NonNull String repeat(final @NonNull String character, final int count) {
+      return String.join("", Collections.nCopies(count, character));
     }
 
     /**

--- a/feature-pagination/src/main/java/net/kyori/text/feature/pagination/Pagination.java
+++ b/feature-pagination/src/main/java/net/kyori/text/feature/pagination/Pagination.java
@@ -208,7 +208,11 @@ public interface Pagination<T> {
     }
 
     static @NonNull String repeat(final @NonNull String character, final int count) {
-      return String.join("", Collections.nCopies(count, character));
+      StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < count; i++) {
+        builder.append(character);
+      }
+      return builder.toString();
     }
 
     /**

--- a/feature-pagination/src/main/java/net/kyori/text/feature/pagination/PaginationImpl.java
+++ b/feature-pagination/src/main/java/net/kyori/text/feature/pagination/PaginationImpl.java
@@ -23,14 +23,18 @@
  */
 package net.kyori.text.feature.pagination;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.format.Style;
 import net.kyori.text.util.ToStringer;
 import org.checkerframework.checker.nullness.qual.NonNull;
-
-import java.util.*;
 
 final class PaginationImpl<T> implements Pagination<T> {
   private static final int LINE_CHARACTER_LENGTH = 1;

--- a/feature-pagination/src/test/java/net/kyori/text/feature/pagination/PaginationImplTest.java
+++ b/feature-pagination/src/test/java/net/kyori/text/feature/pagination/PaginationImplTest.java
@@ -26,7 +26,9 @@ package net.kyori.text.feature.pagination;
 import net.kyori.text.TextComponent;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PaginationImplTest {
   @Test

--- a/feature-pagination/src/test/java/net/kyori/text/feature/pagination/PaginationImplTest.java
+++ b/feature-pagination/src/test/java/net/kyori/text/feature/pagination/PaginationImplTest.java
@@ -26,9 +26,7 @@ package net.kyori.text.feature.pagination;
 import net.kyori.text.TextComponent;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class PaginationImplTest {
   @Test
@@ -41,12 +39,6 @@ class PaginationImplTest {
         .append(TextComponent.of("def"))
       .build()
     ));
-  }
-
-  @Test
-  void testRepeat() {
-    assertEquals("aaa", PaginationImpl.repeat("a", 3));
-    assertEquals("abcabcabc", PaginationImpl.repeat("abc", 3));
   }
 
   @Test

--- a/feature-pagination/src/test/java/net/kyori/text/feature/pagination/PaginationTest.java
+++ b/feature-pagination/src/test/java/net/kyori/text/feature/pagination/PaginationTest.java
@@ -23,16 +23,17 @@
  */
 package net.kyori.text.feature.pagination;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.format.TextColor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,6 +64,12 @@ class PaginationTest {
     final List<? extends Component> rendered = PAGINATION.render(CONTENT_0, 1);
     assertEquals(1, rendered.size());
     assertEquals(EMPTY, rendered.get(0));
+  }
+
+  @Test
+  void testRepeat() {
+    assertEquals("aaa", Pagination.Renderer.repeat("a", 3));
+    assertEquals("abcabcabc", Pagination.Renderer.repeat("abc", 3));
   }
 
   @Test

--- a/feature-pagination/src/test/java/net/kyori/text/feature/pagination/PaginationTest.java
+++ b/feature-pagination/src/test/java/net/kyori/text/feature/pagination/PaginationTest.java
@@ -23,17 +23,16 @@
  */
 package net.kyori.text.feature.pagination;
 
-import net.kyori.text.Component;
-import net.kyori.text.TextComponent;
-import net.kyori.text.format.TextColor;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.junit.jupiter.api.Test;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.kyori.text.Component;
+import net.kyori.text.TextComponent;
+import net.kyori.text.format.TextColor;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
A follow up from #39 for Pagination

I've run into an issue that the maintainers here likely have already grappled with from @lucko 's input, where the variable width Minecraft font characters leave the header and footers unaligned. This is likely a headache to solve, but the thing that I felt was that at the very least there should be more customization as to how the lines are rendered to give customization to those who implement to handle it individually.

This PR migrates line rendering logic into a new method on `Pagination.Renderer`. It's a very basic implementation because I feel that this is something that probably will have some discussion around it and I'd rather not go overboard without seeing what the maintainers here would prefer.

There aren't any contribution guidelines that I've seen so this is mostly just a shot in the dark based on the current code base.

Side note, the `repeat` method is kind of an odd floating method, uncertain really where to put it after this migration.