### PR TITLE
serializer-legacy: Add option to downsample text colors when using legacy format

### DIFF
--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -150,6 +150,14 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
     @NonNull Builder extractUrls(final @Nullable Style style);
 
     /**
+     * Set that the builder should downsample any colors to their closest
+     * {@link net.kyori.adventure.text.format.NamedTextColor named color}.
+     *
+     * @return this builder
+     */
+    @NonNull Builder downsampleColors();
+
+    /**
      * Builds the serializer.
      *
      * @return the built serializer

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -148,6 +148,12 @@ class LegacyComponentSerializerTest {
   }
 
   @Test
+  void testToLegacyWithHexColorDownsampling() {
+    final TextComponent comp = TextComponent.of("purr", TextColor.of(0xff0000));
+    assertEquals("§4purr", LegacyComponentSerializer.builder().downsampleColors().build().serialize(comp));
+  }
+
+  @Test
   void testFromLegacyWithHexColor() {
     final TextComponent component = TextComponent.builder("")
       .append(TextComponent.of("pretty").color(TextColor.fromHexString("#ffb6c1")))


### PR DESCRIPTION
otherwise we start trying to send RGB color codes to old versions, and that looks pretty awkward :)