### PR TITLE
Add support for serializing to bungeecord-chat's legacy hex format

### DIFF
--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -159,13 +159,21 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
     @NonNull Builder hexColors();
 
     /**
-     * Sets that the serializer should use the '&amp;x' repeated code format when serializing hex colors.
+     * Sets that the serializer should use the '&amp;x' repeated code format when serializing hex
+     * colors.
      *
      * <p>This is the format adopted by the BungeeCord (and by usage, Spigot) text API.</p>
      *
+     * <p>The format is hard to manipulate and read, and really, is horrible in every way. Support
+     * is provided for it, only to allow plugin developers to use this library alongside parts of
+     * the Spigot API which expect legacy strings in this format.</p>
+     *
+     * <p>It is recommended to use only when absolutely necessary, and when no better alternatives
+     * are available.</p>
+     *
      * @return this builder
      */
-    @NonNull Builder useXRepeatedCodeHexFormat();
+    @NonNull Builder useUnusualXRepeatedCharacterHexFormat();
 
     /**
      * Builds the serializer.

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -159,6 +159,15 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
     @NonNull Builder hexColors();
 
     /**
+     * Sets that the serializer should use the '&amp;x' repeated code format when serializing hex colors.
+     *
+     * <p>This is the format adopted by the BungeeCord (and by usage, Spigot) text API.</p>
+     *
+     * @return this builder
+     */
+    @NonNull Builder useXRepeatedCodeHexFormat();
+
+    /**
      * Builds the serializer.
      *
      * @return the built serializer

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -68,15 +68,15 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   private final Style urlStyle;
   private final boolean urlLink;
   private final boolean colorDownsample;
-  private final boolean terribleHexFormat;
+  private final boolean useTerriblyStupidHexFormat; // (╯°□°)╯︵ ┻━┻
 
-  LegacyComponentSerializerImpl(final char character, final char hexCharacter, final @Nullable Style urlStyle, final boolean urlLink, final boolean colorDownsample, final boolean terribleHexFormat) {
+  LegacyComponentSerializerImpl(final char character, final char hexCharacter, final @Nullable Style urlStyle, final boolean urlLink, final boolean colorDownsample, final boolean useTerriblyStupidHexFormat) {
     this.character = character;
     this.hexCharacter = hexCharacter;
     this.urlStyle = urlStyle;
     this.urlLink = urlLink;
     this.colorDownsample = colorDownsample;
-    this.terribleHexFormat = terribleHexFormat;
+    this.useTerriblyStupidHexFormat = useTerriblyStupidHexFormat;
   }
 
   private @Nullable TextFormat fromLegacyCode(final char legacy, final String input, final int pos) {
@@ -98,13 +98,15 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         format = NamedTextColor.nearestTo(color);
       } else {
         final String hex = String.format("%06x", color.value());
-        if(this.terribleHexFormat) {
+        if(this.useTerriblyStupidHexFormat) {
+          // ah yes, wonderful. A 14 digit long completely unreadable string.
           final StringBuilder legacy = new StringBuilder(String.valueOf(LEGACY_BUNGEE_HEX_CHAR));
           for(char c : hex.toCharArray()) {
             legacy.append(this.character).append(c);
           }
           return legacy.toString();
         } else {
+          // this is a bit nicer, hey?
           return this.hexCharacter + hex;
         }
       }
@@ -330,7 +332,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     private Style urlStyle = null;
     private boolean urlLink = false;
     private boolean colorDownsample = true;
-    private boolean terribleHexFormat = false;
+    private boolean useTerriblyStupidHexFormat = false;
 
     BuilderImpl() {
 
@@ -375,14 +377,14 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public @NonNull Builder useXRepeatedCodeHexFormat() {
-      this.terribleHexFormat = true;
+    public @NonNull Builder useUnusualXRepeatedCharacterHexFormat() {
+      this.useTerriblyStupidHexFormat = true; // :(
       return this;
     }
 
     @Override
     public @NonNull LegacyComponentSerializer build() {
-      return new LegacyComponentSerializerImpl(this.character, this.hexCharacter, this.urlStyle, this.urlLink, this.colorDownsample, this.terribleHexFormat);
+      return new LegacyComponentSerializerImpl(this.character, this.hexCharacter, this.urlStyle, this.urlLink, this.colorDownsample, this.useTerriblyStupidHexFormat);
     }
   }
 }

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -162,4 +162,10 @@ class LegacyComponentSerializerTest {
       .build();
     assertEquals(component, LegacyComponentSerializer.builder().character('&').hexColors().build().deserialize("&#ffb6c1pretty&#ff69b4&lin&#ffc0cbpink"));
   }
+
+  @Test
+  void testToLegacyWithHexColorTerribleFormat() {
+    final TextComponent c0 = TextComponent.of("Kittens!", TextColor.of(0xffefd5));
+    assertEquals("§x§f§f§e§f§d§5Kittens!", LegacyComponentSerializer.builder().hexColors().useXRepeatedCodeHexFormat().build().serialize(c0));
+  }
 }

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -166,6 +166,6 @@ class LegacyComponentSerializerTest {
   @Test
   void testToLegacyWithHexColorTerribleFormat() {
     final TextComponent c0 = TextComponent.of("Kittens!", TextColor.of(0xffefd5));
-    assertEquals("§x§f§f§e§f§d§5Kittens!", LegacyComponentSerializer.builder().hexColors().useXRepeatedCodeHexFormat().build().serialize(c0));
+    assertEquals("§x§f§f§e§f§d§5Kittens!", LegacyComponentSerializer.builder().hexColors().useUnusualXRepeatedCharacterHexFormat().build().serialize(c0));
   }
 }


### PR DESCRIPTION
Pretty gross but it works I suppose.

Is needed in order to support setting things like entity / itemstack custom names to `Component`s on Bukkit.