### PR TITLE
Fix nbt array reading with prefixed indexes

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/impl/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/impl/TagStringReader.java
@@ -49,7 +49,12 @@ import java.util.stream.IntStream;
   public ListBinaryTag list() throws StringTagParseException {
     final ListBinaryTag.Builder<BinaryTag> builder = ListBinaryTag.builder();
     this.buffer.expect(Tokens.ARRAY_BEGIN);
+    final boolean prefixedIndex = this.buffer.peek() == '0' && this.buffer.peek(1) == ':';
     while (this.buffer.hasMore()) {
+      if(prefixedIndex) {
+        this.buffer.takeUntil(':');
+      }
+
       final BinaryTag next = this.tag();
       // TODO: validate type
       builder.add(next);

--- a/nbt/src/test/java/net/kyori/adventure/nbt/impl/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/impl/StringIOTest.java
@@ -186,6 +186,17 @@ class StringIOTest {
   }
 
   @Test
+  public void testLegacyListTag() throws IOException {
+    final BinaryTag tag = stringToTag("[0:\"Tag #1\",1:\"Tag #2\"]");
+    assertEquals("[\"Tag #1\",\"Tag #2\"]", tagToString(tag));
+
+    final ListTagBuilder<BinaryTag> builder = new ListTagBuilder<>();
+    builder.add(StringBinaryTag.of("Tag #1"));
+    builder.add(StringBinaryTag.of("Tag #2"));
+    assertEquals(builder.build(), tag);
+  }
+
+  @Test
   public void testIntArrayTag() throws IOException {
     assertEquals("[I;1,2,3]", this.tagToString(IntArrayBinaryTag.of(1, 2, 3)));
     assertEquals(IntArrayBinaryTag.of(2, 4, 6, 8, 10, 12), this.stringToTag("[I; 2, 4, 6, 8, 10, 12]"));


### PR DESCRIPTION
This makes the old `[0:"hello",1:"hello2"]` list format readable. Since it's always written from 0 upwards (and any other sane legacy lib should do the same, and and it would require changes to the builder otherwise), I simply ignored the actual index.