### PR TITLE
Make Listenable thread-safe

### DIFF
--- a/api/src/main/java/net/kyori/adventure/util/Listenable.java
+++ b/api/src/main/java/net/kyori/adventure/util/Listenable.java
@@ -23,11 +23,10 @@
  */
 package net.kyori.adventure.util;
 
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Something that has listeners.
@@ -35,7 +34,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <L> the listener type
  */
 public abstract class Listenable<L> {
-  private @Nullable Queue<L> listeners = null;
+  private final List<L> listeners = new CopyOnWriteArrayList<>();
 
   /**
    * Process an action for each listener.
@@ -43,11 +42,8 @@ public abstract class Listenable<L> {
    * @param consumer the consumer
    */
   protected final void forEachListener(final @NonNull Consumer<L> consumer) {
-    final Queue<L> listeners = this.listeners;
-    if(listeners != null) {
-      for(final L listener : listeners) {
-        consumer.accept(listener);
-      }
+    for(final L listener : listeners) {
+      consumer.accept(listener);
     }
   }
 
@@ -57,9 +53,6 @@ public abstract class Listenable<L> {
    * @param listener the listener
    */
   protected final void addListener0(final @NonNull L listener) {
-    if(this.listeners == null) {
-      this.listeners = new ConcurrentLinkedQueue<>();
-    }
     this.listeners.add(listener);
   }
 
@@ -69,11 +62,6 @@ public abstract class Listenable<L> {
    * @param listener the listener
    */
   protected final void removeListener0(final @NonNull L listener) {
-    if(this.listeners != null) {
-      this.listeners.remove(listener);
-      if(this.listeners.isEmpty()) {
-        this.listeners = null;
-      }
-    }
+    this.listeners.remove(listener);
   }
 }


### PR DESCRIPTION
This class has thread-safety issues: the `listeners` field is not updated in an atomic matter, which may cause a `NullPointerException` or listeners to not be successfully added or removed when any class that extends `Listenable` is used from multiple threads. This is a problem especially for Velocity and BungeeCord as both are multi-threaded.

I decided to go with the "obvious, safe" route to solve this problem. This PR resolves the issue by:

* Switching to `CopyOnWriteArrayList` as a more appropriate data structure.
* Always initializing the `listeners` field. This appears to be an attempt at reducing memory usage, but I really don't think anyone will lose sleep over wasting 48 bytes in the worst case if there are no listeners ever registered.

We can explore other approaches if that is desired, but I think the "safe" approach is the best way to solve the problem without introducing risky hand-rolled concurrency code into a library not well-equipped to solve the problem.