### PR TITLE
add checkstyle validation, fix errors

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -6,7 +6,7 @@
   <property name="charset" value="UTF-8"/>
   <property name="severity" value="error"/>
   <property name="fileExtensions" value="java, properties, xml"/>
-  <!-- Excludes all 'module-info.java' files              -->
+  <!-- Excludes all 'module-info.java' files -->
   <!-- See https://checkstyle.org/config_filefilters.html -->
   <module name="BeforeExecutionExclusionFileFilter">
     <property name="fileNamePattern" value="module\-info\.java$"/>
@@ -21,7 +21,7 @@
   <!-- allow // CHECKSTYLE:OFF and // CHECKSTYLE:ON comments -->
   <module name="SuppressWithPlainTextCommentFilter"/>
 
-  <!-- Checks for whitespace                               -->
+  <!-- Checks for whitespace -->
   <!-- See http://checkstyle.org/config_whitespace.html -->
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
@@ -33,8 +33,8 @@
     <module name="EmptyForInitializerPad"/>
     <module name="EmptyForIteratorPad"/>
 
-    <module name="ca.stellardrift.stylecheck.StatementNoWhitespaceAfter">
-      <property name="tokens" value="LITERAL_IF, LITERAL_FOR, LITERAL_WHILE, LITERAL_CATCH"/>
+    <module name="StatementNoWhitespaceAfter">
+      <property name="tokens" value="LITERAL_IF, LITERAL_FOR, LITERAL_WHILE, LITERAL_CATCH, LITERAL_TRY"/>
     </module>
 
     <!-- one empty line between each class element -->
@@ -80,10 +80,13 @@
     <module name="HideUtilityClassConstructor"/>
     <module name="FinalClass"/>
     <!-- explicit visibility modifier, as first modifier -->
-    <module name="ca.stellardrift.stylecheck.RequireExplicitVisibilityModifier">
+    <module name="RequireExplicitVisibilityModifier">
       <property name="anchoredToBeginning" value="true"/>
       <property name="checkedElementTypes" value="CLASS, METHOD"/>
     </module>
+
+    <!-- no local variable type annotations -->
+    <module name="NoLvTypeAnnotations"/>
 
     <!-- braces and parentheses on block statements on same line -->
     <module name="LeftCurly"/>

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -33,10 +33,9 @@
     <module name="EmptyForInitializerPad"/>
     <module name="EmptyForIteratorPad"/>
 
-    <!-- waiting on https://github.com/checkstyle/checkstyle/issues/8312
-    <module name="NoWhitespaceAfter">
-      <property name="tokens" value="LITERAL_IF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
-    </module> -->
+    <module name="ca.stellardrift.stylecheck.StatementNoWhitespaceAfter">
+      <property name="tokens" value="LITERAL_IF, LITERAL_FOR, LITERAL_WHILE, LITERAL_CATCH"/>
+    </module>
 
     <!-- one empty line between each class element -->
     <module name="EmptyLineSeparator">
@@ -80,6 +79,11 @@
     <module name="UnusedImports"/>
     <module name="HideUtilityClassConstructor"/>
     <module name="FinalClass"/>
+    <!-- explicit visibility modifier, as first modifier -->
+    <module name="ca.stellardrift.stylecheck.RequireExplicitVisibilityModifier">
+      <property name="anchoredToBeginning" value="true"/>
+      <property name="checkedElementTypes" value="CLASS, METHOD"/>
+    </module>
 
     <!-- braces and parentheses on block statements on same line -->
     <module name="LeftCurly"/>

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -120,6 +120,11 @@
       <property name="illegalPkgs" value="sun, jdk, com.sun"/>
     </module>
 
+    <!-- no get* or set* method names -->
+    <module name="MethodName">
+      <property name="format" value="^(?:(?:.{1,3})|(?:[gs]et[^A-Z].*)|(?:(?:[^gsA-Z]..|.[^e].|..[^t]).+))$"/>
+    </module>
+
     <!-- misc formatting based on Google style -->
     <!-- match filenames, don't use unicode escapes, no star imports -->
     <module name="OuterTypeFilename"/>

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -13,8 +13,8 @@
   </module>
   <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
   <module name="SuppressionFilter">
-    <property name="file" value="${basedir}/checkstyle/checkstyle-suppressions.xml"
-              default="checkstyle-suppressions.xml" />
+    <property name="file" value="${basedir}/suppressions.xml"
+              default=".checkstyle/suppressions.xm" />
     <property name="optional" value="true"/>
   </module>
 
@@ -106,6 +106,7 @@
       <property name="lineWrappingIndentation" value="0"/>
       <property name="arrayInitIndent" value="2"/>
     </module>
+    <module name="CommentsIndentation"/>
 
     <!-- misc formatting based on Google style -->
     <!-- match filenames, don't use unicode escapes, no star imports -->
@@ -127,7 +128,6 @@
     <module name="MultipleVariableDeclarations"/>
     <module name="ArrayTypeStyle"/>
     <module name="FallThrough"/>
-    <module name="ModifierOrder"/>
     <module name="NoFinalizer"/>
     <module name="MethodParamPad">
       <property name="tokens"

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -115,6 +115,11 @@
     </module>
     <module name="CommentsIndentation"/>
 
+    <!-- some generally unwanted imports -->
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="sun, jdk, com.sun"/>
+    </module>
+
     <!-- misc formatting based on Google style -->
     <!-- match filenames, don't use unicode escapes, no star imports -->
     <module name="OuterTypeFilename"/>

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -4,4 +4,5 @@
   "http://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
   <!-- add any necessary suppressions here -->
+  <suppress files="src/test/java/.*" checks="RequireExplicitVisibilityModifier"/>
 </suppressions>

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "http://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+  <!-- add any necessary suppressions here -->
+</suppressions>

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -5,4 +5,5 @@
 <suppressions>
   <!-- add any necessary suppressions here -->
   <suppress files="src/test/java/.*" checks="RequireExplicitVisibilityModifier"/>
+  <suppress files=".*/nbt/(List|Compound)BinaryTag.java" checks="MethodName"/>
 </suppressions>

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ ${TRAVIS_BRANCH} = 'master' ]; then
-  ./gradlew -PsonatypeUsername="${SONATYPE_USERNAME}" -PsonatypePassword="${SONATYPE_PASSWORD}" build uploadArchives
+  ./gradlew -PsonatypeUsername="${SONATYPE_USERNAME}" -PsonatypePassword="${SONATYPE_PASSWORD}" build uploadArchives --stacktrace
 else
-  ./gradlew build
+  ./gradlew build --stacktrace
 fi

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -48,7 +48,7 @@ public abstract class AbstractComponent implements Component, Examinable {
    * We do not need to create a new list if the one we are copying is empty - we can
    * simply just return our known-empty list instead.
    */
-  static List<Component> unmodifiableCopy(final List<? extends Component> list) {
+  /* package */ static List<Component> unmodifiableCopy(final List<? extends Component> list) {
     return list.isEmpty()
       ? EMPTY_COMPONENT_LIST
       : Collections.unmodifiableList(new ArrayList<>(list));

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -43,7 +43,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <C> the component type
  * @param <B> the builder type
  */
-abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B extends ComponentBuilder<C, B>> implements ComponentBuilder<C, B> {
+/* package */ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B extends ComponentBuilder<C, B>> implements ComponentBuilder<C, B> {
   /**
    * The list of children.
    *

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -148,7 +148,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B mapChildren(final @NonNull Function<BuildableComponent<? ,?>, ? extends BuildableComponent<? ,?>> function) {
+  public @NonNull B mapChildren(final @NonNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function) {
     if(this.children == AbstractComponent.EMPTY_COMPONENT_LIST) {
       return (B) this;
     }
@@ -169,7 +169,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B mapChildrenDeep(final @NonNull Function<BuildableComponent<? ,?>, ? extends BuildableComponent<? ,?>> function) {
+  public @NonNull B mapChildrenDeep(final @NonNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function) {
     if(this.children == AbstractComponent.EMPTY_COMPONENT_LIST) {
       return (B) this;
     }

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
@@ -34,7 +34,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, BlockNBTComponent.Builder> implements BlockNBTComponent {
+/* package */ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, BlockNBTComponent.Builder> implements BlockNBTComponent {
   private final Pos pos;
 
   BlockNBTComponentImpl(final @NonNull List<Component> children, final @NonNull Style style, final String nbtPath, final boolean interpret, final @NonNull Pos pos) {
@@ -106,7 +106,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
     return new BuilderImpl(this);
   }
 
-  static final class BuilderImpl extends NBTComponentImpl.BuilderImpl<BlockNBTComponent, Builder> implements Builder {
+  /* package */ static final class BuilderImpl extends NBTComponentImpl.BuilderImpl<BlockNBTComponent, Builder> implements Builder {
     private @Nullable Pos pos;
 
     BuilderImpl() {
@@ -131,7 +131,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
     }
   }
 
-  static final class LocalPosImpl implements LocalPos {
+  /* package */ static final class LocalPosImpl implements LocalPos {
     private final double left;
     private final double up;
     private final double forwards;
@@ -181,7 +181,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
     }
   }
 
-  static final class WorldPosImpl implements WorldPos {
+  /* package */ static final class WorldPosImpl implements WorldPos {
     private final Coordinate x;
     private final Coordinate y;
     private final Coordinate z;
@@ -230,7 +230,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
       return this.x.toString() + ' ' + this.y.toString() + ' ' + this.z.toString();
     }
 
-    static final class CoordinateImpl implements Coordinate {
+    /* package */ static final class CoordinateImpl implements Coordinate {
       private final int value;
       private final Type type;
 

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -213,7 +213,7 @@ public interface Component {
    * @param color the color
    * @return this builder
    */
-  default  @NonNull Component colorIfAbsent(final @Nullable TextColor color) {
+  default @NonNull Component colorIfAbsent(final @Nullable TextColor color) {
     if(this.color() == null) return this.color(color);
     return this;
   }

--- a/api/src/main/java/net/kyori/adventure/text/EntityNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/EntityNBTComponentImpl.java
@@ -31,7 +31,7 @@ import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class EntityNBTComponentImpl extends NBTComponentImpl<EntityNBTComponent, EntityNBTComponent.Builder> implements EntityNBTComponent {
+/* package */ final class EntityNBTComponentImpl extends NBTComponentImpl<EntityNBTComponent, EntityNBTComponent.Builder> implements EntityNBTComponent {
   private final String selector;
 
   EntityNBTComponentImpl(final @NonNull List<Component> children, final @NonNull Style style, final String nbtPath, final boolean interpret, final String selector) {
@@ -104,7 +104,7 @@ final class EntityNBTComponentImpl extends NBTComponentImpl<EntityNBTComponent, 
     return new BuilderImpl(this);
   }
 
-  static final class BuilderImpl extends NBTComponentImpl.BuilderImpl<EntityNBTComponent, Builder> implements Builder {
+  /* package */ static final class BuilderImpl extends NBTComponentImpl.BuilderImpl<EntityNBTComponent, Builder> implements Builder {
     private @Nullable String selector;
 
     BuilderImpl() {

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponentImpl.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-final class KeybindComponentImpl extends AbstractComponent implements KeybindComponent {
+/* package */ final class KeybindComponentImpl extends AbstractComponent implements KeybindComponent {
   private final String keybind;
 
   KeybindComponentImpl(final @NonNull List<Component> children, final @NonNull Style style, final @NonNull String keybind) {
@@ -94,7 +94,7 @@ final class KeybindComponentImpl extends AbstractComponent implements KeybindCom
     return new BuilderImpl(this);
   }
 
-  static final class BuilderImpl extends AbstractComponentBuilder<KeybindComponent, Builder> implements KeybindComponent.Builder {
+  /* package */ static final class BuilderImpl extends AbstractComponentBuilder<KeybindComponent, Builder> implements KeybindComponent.Builder {
     private @Nullable String keybind;
 
     BuilderImpl() {

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
@@ -79,7 +79,7 @@ abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTCompo
     );
   }
 
-  abstract static class BuilderImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponentBuilder<C, B> implements NBTComponentBuilder<C, B> {
+  static abstract class BuilderImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponentBuilder<C, B> implements NBTComponentBuilder<C, B> {
     @Nullable String nbtPath;
     boolean interpret;
 

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
@@ -31,7 +31,7 @@ import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponent implements NBTComponent<C, B> {
+/* package */ abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponent implements NBTComponent<C, B> {
   final String nbtPath;
   final boolean interpret;
 
@@ -79,9 +79,9 @@ abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTCompo
     );
   }
 
-  static abstract class BuilderImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponentBuilder<C, B> implements NBTComponentBuilder<C, B> {
-    @Nullable String nbtPath;
-    boolean interpret;
+  /* package */ static abstract class BuilderImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponentBuilder<C, B> implements NBTComponentBuilder<C, B> {
+    protected @Nullable String nbtPath;
+    protected boolean interpret;
 
     BuilderImpl() {
     }

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
@@ -79,7 +79,7 @@ abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTCompo
     );
   }
 
-  static abstract class BuilderImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponentBuilder<C, B> implements NBTComponentBuilder<C, B> {
+  abstract static class BuilderImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponentBuilder<C, B> implements NBTComponentBuilder<C, B> {
     @Nullable String nbtPath;
     boolean interpret;
 

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-final class ScoreComponentImpl extends AbstractComponent implements ScoreComponent {
+/* package */ final class ScoreComponentImpl extends AbstractComponent implements ScoreComponent {
   private final String name;
   private final String objective;
   private final @Nullable String value;
@@ -126,7 +126,7 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
     return new BuilderImpl(this);
   }
 
-  static final class BuilderImpl extends AbstractComponentBuilder<ScoreComponent, Builder> implements ScoreComponent.Builder {
+  /* package */ static final class BuilderImpl extends AbstractComponentBuilder<ScoreComponent, Builder> implements ScoreComponent.Builder {
     private @Nullable String name;
     private @Nullable String objective;
     private @Nullable String value;

--- a/api/src/main/java/net/kyori/adventure/text/SelectorComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/SelectorComponentImpl.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-final class SelectorComponentImpl extends AbstractComponent implements SelectorComponent {
+/* package */ final class SelectorComponentImpl extends AbstractComponent implements SelectorComponent {
   private final String pattern;
 
   SelectorComponentImpl(final @NonNull List<Component> children, final @NonNull Style style, final @NonNull String pattern) {
@@ -94,7 +94,7 @@ final class SelectorComponentImpl extends AbstractComponent implements SelectorC
     return new BuilderImpl(this);
   }
 
-  static final class BuilderImpl extends AbstractComponentBuilder<SelectorComponent, Builder> implements SelectorComponent.Builder {
+  /* package */ static final class BuilderImpl extends AbstractComponentBuilder<SelectorComponent, Builder> implements SelectorComponent.Builder {
     private @Nullable String pattern;
 
     BuilderImpl() {

--- a/api/src/main/java/net/kyori/adventure/text/StorageNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/StorageNBTComponentImpl.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class StorageNBTComponentImpl extends NBTComponentImpl<StorageNBTComponent, StorageNBTComponent.Builder> implements StorageNBTComponent {
+/* package */ final class StorageNBTComponentImpl extends NBTComponentImpl<StorageNBTComponent, StorageNBTComponent.Builder> implements StorageNBTComponent {
   private final Key storage;
 
   protected StorageNBTComponentImpl(final @NonNull List<Component> children, final @NonNull Style style, final String nbtPath, final boolean interpret, final Key storage) {
@@ -106,7 +106,7 @@ final class StorageNBTComponentImpl extends NBTComponentImpl<StorageNBTComponent
     return new BuilderImpl(this);
   }
 
-  static class BuilderImpl extends NBTComponentImpl.BuilderImpl<StorageNBTComponent, Builder> implements Builder {
+  /* package */ static class BuilderImpl extends NBTComponentImpl.BuilderImpl<StorageNBTComponent, Builder> implements Builder {
     private @MonotonicNonNull Key storage;
 
     BuilderImpl() {

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -186,7 +186,7 @@ class TextComponentImpl extends AbstractComponent implements TextComponent {
 
     @Override
     public @NonNull String content() {
-      return content;
+      return this.content;
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -40,10 +40,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-class TextComponentImpl extends AbstractComponent implements TextComponent {
-  static final TextComponent EMPTY = createDirect("");
-  static final TextComponent NEWLINE = createDirect("\n");
-  static final TextComponent SPACE = createDirect(" ");
+/* package */ class TextComponentImpl extends AbstractComponent implements TextComponent {
+  /* package */ static final TextComponent EMPTY = createDirect("");
+  /* package */ static final TextComponent NEWLINE = createDirect("\n");
+  /* package */ static final TextComponent SPACE = createDirect(" ");
 
   private static @NonNull TextComponent createDirect(final @NonNull String content) {
     return new TextComponentImpl(EMPTY_COMPONENT_LIST, Style.empty(), content);
@@ -162,7 +162,7 @@ class TextComponentImpl extends AbstractComponent implements TextComponent {
     return new BuilderImpl(this);
   }
 
-  static final class BuilderImpl extends AbstractComponentBuilder<TextComponent, Builder> implements TextComponent.Builder {
+  /* package */ static final class BuilderImpl extends AbstractComponentBuilder<TextComponent, Builder> implements TextComponent.Builder {
     /*
      * We default to an empty string to avoid needing to manually set the
      * content of a newly-created builder when we only want to append other

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
@@ -36,7 +36,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-final class TranslatableComponentImpl extends AbstractComponent implements TranslatableComponent {
+/* package */ final class TranslatableComponentImpl extends AbstractComponent implements TranslatableComponent {
   private final String key;
   private final List<Component> args;
 
@@ -120,7 +120,7 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
     return new BuilderImpl(this);
   }
 
-  static final class BuilderImpl extends AbstractComponentBuilder<TranslatableComponent, Builder> implements TranslatableComponent.Builder {
+  /* package */ static final class BuilderImpl extends AbstractComponentBuilder<TranslatableComponent, Builder> implements TranslatableComponent.Builder {
     private @Nullable String key;
     private List<? extends Component> args = EMPTY_COMPONENT_LIST;
 

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -383,7 +383,7 @@ public final class HoverEvent<V> implements Examinable {
     }
 
     @FunctionalInterface
-    interface Renderer<V> {
+    /* package */ interface Renderer<V> {
       <C> @NonNull V render(final @NonNull ComponentRenderer<C> renderer, final @NonNull C context, final @NonNull V value);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -638,6 +638,7 @@ public final class Style implements Buildable<Style, Style.Builder>, Examinable 
      * A merge strategy.
      */
     public enum Strategy {
+      // CHECKSTYLE:OFF
       /**
        * Always merge onto target.
        */
@@ -660,6 +661,7 @@ public final class Style implements Buildable<Style, Style.Builder>, Examinable 
         @Override boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion) { return false; }
         @Override boolean mergeFont(final @NonNull Builder target, final @Nullable Key font) { return false; }
       },
+      // CHECKSTYLE:ON
       /**
        * Merge onto target when not already set on target.
        */
@@ -706,12 +708,14 @@ public final class Style implements Buildable<Style, Style.Builder>, Examinable 
         }
       };
 
+      // CHECKSTYLE:OFF
       abstract boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color);
       abstract boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration);
       abstract boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event);
       abstract boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event);
       abstract boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion);
       abstract boolean mergeFont(final @NonNull Builder target, final @Nullable Key font);
+      // CHECKSTYLE:ON
     }
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -599,8 +599,8 @@ public final class Style implements Buildable<Style, Style.Builder>, Examinable 
     INSERTION,
     FONT;
 
-    static final Set<Merge> ALL = of(values());
-    static final Set<Merge> COLOR_AND_DECORATIONS = of(COLOR, DECORATIONS);
+    /* package */ static final Set<Merge> ALL = of(values());
+    /* package */ static final Set<Merge> COLOR_AND_DECORATIONS = of(COLOR, DECORATIONS);
 
     /**
      * Gets a merge set of all merge types.
@@ -630,7 +630,7 @@ public final class Style implements Buildable<Style, Style.Builder>, Examinable 
       return ShadyPines.enumSet(Merge.class, merges);
     }
 
-    static boolean hasAll(final @NonNull Set<Merge> merges) {
+    /* package */ static boolean hasAll(final @NonNull Set<Merge> merges) {
       return merges.size() == ALL.size();
     }
 
@@ -643,23 +643,23 @@ public final class Style implements Buildable<Style, Style.Builder>, Examinable 
        * Always merge onto target.
        */
       ALWAYS {
-        @Override boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color) { return true; }
-        @Override boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration) { return true; }
-        @Override boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event) { return true; }
-        @Override boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event) { return true; }
-        @Override boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion) { return true; }
-        @Override boolean mergeFont(final @NonNull Builder target, final @Nullable Key font) { return true; }
+        @Override /* package */ boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color) { return true; }
+        @Override /* package */ boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration) { return true; }
+        @Override /* package */ boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event) { return true; }
+        @Override /* package */ boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event) { return true; }
+        @Override /* package */ boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion) { return true; }
+        @Override /* package */ boolean mergeFont(final @NonNull Builder target, final @Nullable Key font) { return true; }
       },
       /**
        * Never merges onto target.
        */
       NEVER {
-        @Override boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color) { return false; }
-        @Override boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration) { return false; }
-        @Override boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event) { return false; }
-        @Override boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event) { return false; }
-        @Override boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion) { return false; }
-        @Override boolean mergeFont(final @NonNull Builder target, final @Nullable Key font) { return false; }
+        @Override /* package */ boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color) { return false; }
+        @Override /* package */ boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration) { return false; }
+        @Override /* package */ boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event) { return false; }
+        @Override /* package */ boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event) { return false; }
+        @Override /* package */ boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion) { return false; }
+        @Override /* package */ boolean mergeFont(final @NonNull Builder target, final @Nullable Key font) { return false; }
       },
       // CHECKSTYLE:ON
       /**
@@ -667,12 +667,12 @@ public final class Style implements Buildable<Style, Style.Builder>, Examinable 
        */
       IF_ABSENT_ON_TARGET {
         @Override
-        boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color) {
+        /* package */ boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color) {
           return target.color == null;
         }
 
         @Override
-        boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration) {
+        /* package */ boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration) {
           if(decoration == TextDecoration.OBFUSCATED) {
             return target.obfuscated == TextDecoration.State.NOT_SET;
           } else if(decoration == TextDecoration.BOLD) {
@@ -688,33 +688,33 @@ public final class Style implements Buildable<Style, Style.Builder>, Examinable 
         }
 
         @Override
-        boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event) {
+        /* package */ boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event) {
           return target.clickEvent == null;
         }
 
         @Override
-        boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event) {
+        /* package */ boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event) {
           return target.hoverEvent == null;
         }
 
         @Override
-        boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion) {
+        /* package */ boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion) {
           return target.insertion == null;
         }
 
         @Override
-        boolean mergeFont(final @NonNull Builder target, final @Nullable Key font) {
+        /* package */ boolean mergeFont(final @NonNull Builder target, final @Nullable Key font) {
           return target.font == null;
         }
       };
 
       // CHECKSTYLE:OFF
-      abstract boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color);
-      abstract boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration);
-      abstract boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event);
-      abstract boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event);
-      abstract boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion);
-      abstract boolean mergeFont(final @NonNull Builder target, final @Nullable Key font);
+      /* package */ abstract boolean mergeColor(final @NonNull Builder target, final @Nullable TextColor color);
+      /* package */ abstract boolean mergeDecoration(final @NonNull Builder target, final @NonNull TextDecoration decoration);
+      /* package */ abstract boolean mergeClickEvent(final @NonNull Builder target, final @Nullable ClickEvent event);
+      /* package */ abstract boolean mergeHoverEvent(final @NonNull Builder target, final @Nullable HoverEvent<?> event);
+      /* package */ abstract boolean mergeInsertion(final @NonNull Builder target, final @Nullable String insertion);
+      /* package */ abstract boolean mergeFont(final @NonNull Builder target, final @Nullable Key font);
       // CHECKSTYLE:ON
     }
   }

--- a/api/src/main/java/net/kyori/adventure/util/Listenable.java
+++ b/api/src/main/java/net/kyori/adventure/util/Listenable.java
@@ -42,7 +42,7 @@ public abstract class Listenable<L> {
    * @param consumer the consumer
    */
   protected final void forEachListener(final @NonNull Consumer<L> consumer) {
-    for(final L listener : listeners) {
+    for(final L listener : this.listeners) {
       consumer.accept(listener);
     }
   }

--- a/api/src/test/java/net/kyori/adventure/text/TextAssertions.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextAssertions.java
@@ -31,8 +31,11 @@ import net.kyori.adventure.text.format.TextDecoration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TextAssertions {
+public final class TextAssertions {
   private static final Set<TextDecoration> DECORATIONS = ImmutableSet.copyOf(TextDecoration.values());
+
+  private TextAssertions() {
+  }
 
   public static void assertDecorations(final Component component, final Set<TextDecoration> trues, final Set<TextDecoration> falses) {
     assertDecorations(component.style(), trues, falses);

--- a/api/src/test/java/net/kyori/test/WeirdAssertions.java
+++ b/api/src/test/java/net/kyori/test/WeirdAssertions.java
@@ -30,7 +30,11 @@ import java.util.function.Function;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class WeirdAssertions {
+public final class WeirdAssertions {
+  
+  private WeirdAssertions() {
+  }
+  
   public static <T> void doWith(final T value, final Consumer<T> consumer) {
     consumer.accept(value);
   }

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ subprojects {
   }
 
   dependencies {
+    checkstyle 'ca.stellardrift:stylecheck:0.1-SNAPSHOT'
     testImplementation 'com.google.guava:guava-testlib:28.2-jre'
     testImplementation 'com.google.truth:truth:1.0.1'
     testImplementation 'com.google.truth.extensions:truth-java8-extension:1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,10 @@ subprojects {
   }
 
   checkstyle {
+    def configRoot = new File(rootProject.projectDir, ".checkstyle")
     toolVersion = "8.34"
-    configDirectory = new File(rootProject.projectDir, "/etc/checkstyle")
-    configProperties= [basedir: rootProject.projectDir]
+    configDirectory = configRoot
+    configProperties= [basedir: configRoot.getAbsolutePath()]
   }
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ subprojects {
   apply plugin: 'maven'
   apply plugin: 'signing'
   apply plugin: 'net.minecrell.licenser'
+  apply plugin: 'checkstyle'
 
   group 'net.kyori'
   version '4.0.0-SNAPSHOT'
@@ -32,6 +33,12 @@ subprojects {
     header rootProject.file('header.txt')
     include '**/*.java'
     newLine false
+  }
+
+  checkstyle {
+    toolVersion = "8.34"
+    configDirectory = new File(rootProject.projectDir, "/etc/checkstyle")
+    configProperties= [basedir: rootProject.projectDir]
   }
 
   repositories {

--- a/etc/checkstyle/checkstyle.xml
+++ b/etc/checkstyle/checkstyle.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE module PUBLIC
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <property name="charset" value="UTF-8"/>
+  <property name="severity" value="error"/>
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+  <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${basedir}/checkstyle/checkstyle-suppressions.xml"
+              default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- allow // CHECKSTYLE:OFF and // CHECKSTYLE:ON comments -->
+  <module name="SuppressWithPlainTextCommentFilter"/>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/config_whitespace.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+  <module name="NewlineAtEndOfFile"/>
+
+  <module name="TreeWalker">
+    <!-- no space between parameters and parenthesis -->
+    <module name="EmptyForInitializerPad"/>
+    <module name="EmptyForIteratorPad"/>
+
+    <!-- waiting on https://github.com/checkstyle/checkstyle/issues/8312
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="LITERAL_IF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+    </module> -->
+
+    <!-- one empty line between each class element -->
+    <module name="EmptyLineSeparator">
+      <!-- No new line after the license header -->
+      <property name="tokens"
+                value="IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+      <property name="allowMultipleEmptyLines" value="false"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+    </module>
+    <module name="GenericWhitespace"/>
+    <!-- packages and imports must be on one line each -->
+    <module name="NoLineWrap"/>
+    <module name="NoWhitespaceAfter">
+      <property name="allowLineBreaks" value="false"/>
+    </module>
+    <module name="SingleSpaceSeparator">
+      <property name="validateComments" value="true"/>
+    </module>
+    <module name="TypecastParenPad"/>
+    <module name="UnnecessaryParentheses"/>
+
+    <!-- field and method access qualified with `this` -->
+
+    <module name="FinalLocalVariable">
+      <property name="validateEnhancedForLoopVariable" value="true"/>
+      <property name="tokens" value="VARIABLE_DEF, PARAMETER_DEF"/>
+    </module>
+    <module name="RequireThis">
+      <property name="validateOnlyOverlapping" value="false"/>
+    </module>
+
+    <!-- coding practices -->
+    <module name="RedundantImport"/>
+    <module name="RedundantModifier">
+      <!-- Take out METHOD_DEF and RESOURCE so we can have finals -->
+      <property name="tokens"
+                value="VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CTOR_DEF, CLASS_DEF, ENUM_DEF"/>
+    </module>
+    <module name="UnusedImports"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="FinalClass"/>
+
+    <!-- braces and parentheses on block statements on same line -->
+    <module name="LeftCurly"/>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlySame"/>
+      <property name="tokens"
+            value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                LITERAL_DO"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="option" value="alone"/>
+      <property name="tokens"
+            value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF"/>
+    </module>
+
+    <!-- 2 space indentation -->
+    <module name="Indentation">
+      <property name="basicOffset" value="2"/>
+      <property name="braceAdjustment" value="0"/>
+      <property name="caseIndent" value="2"/>
+      <property name="throwsIndent" value="2"/>
+      <property name="lineWrappingIndentation" value="0"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+
+    <!-- misc formatting based on Google style -->
+    <!-- match filenames, don't use unicode escapes, no star imports -->
+    <module name="OuterTypeFilename"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+      <property name="format"
+                value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+      <property name="message"
+                value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="FallThrough"/>
+    <module name="ModifierOrder"/>
+    <module name="NoFinalizer"/>
+    <module name="MethodParamPad">
+      <property name="tokens"
+                value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+                value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+  </module>
+</module>

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CharBuffer.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CharBuffer.java
@@ -86,7 +86,7 @@ package net.kyori.adventure.nbt;
       throw this.makeError("No occurrence of " + until + " was found");
     }
 
-    final CharSequence result =  this.sequence.subSequence(this.index, endIdx);
+    final CharSequence result = this.sequence.subSequence(this.index, endIdx);
     this.index = endIdx + 1;
     return result;
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTag.java
@@ -52,7 +52,7 @@ public interface FloatBinaryTag extends NumberBinaryTag {
    *
    * @return the value
    */
-   float value();
+  float value();
 }
 
 /* package */ final class FloatBinaryTagImpl implements FloatBinaryTag {

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -37,7 +37,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /* package */ final class ListBinaryTagImpl implements ListBinaryTag {
-  static final ListBinaryTag EMPTY = new ListBinaryTagImpl(BinaryTagTypes.END, Collections.emptyList());
+  /* package */ static final ListBinaryTag EMPTY = new ListBinaryTagImpl(BinaryTagTypes.END, Collections.emptyList());
   private final List<? extends BinaryTag> tags;
   private final BinaryTagType<? extends BinaryTag> type;
   private final int hashCode;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -130,7 +130,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
       @Override
       public BinaryTag next() {
-        return  iterator.next();
+        return iterator.next();
       }
 
       @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /* package */ final class LongArrayBinaryTagImpl implements LongArrayBinaryTag {
-  final long[] value;
+  /* package */ final long[] value;
 
   /* package */ LongArrayBinaryTagImpl(final long[] value) {
     this.value = Arrays.copyOf(value, value.length);

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ShadyPines.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ShadyPines.java
@@ -28,12 +28,12 @@ package net.kyori.adventure.nbt;
   private ShadyPines() {
   }
   
-  static int floor(final double dv) {
+  /* package */ static int floor(final double dv) {
     final int iv = (int) dv;
     return dv < (double) iv ? iv - 1 : iv;
   }
 
-  static int floor(final float fv) {
+  /* package */ static int floor(final float fv) {
     final int iv = (int) fv;
     return fv < (float) iv ? iv - 1 : iv;
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ShadyPines.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ShadyPines.java
@@ -24,6 +24,10 @@
 package net.kyori.adventure.nbt;
 
 /* package */ final class ShadyPines {
+  
+  private ShadyPines() {
+  }
+  
   static int floor(final double dv) {
     final int iv = (int) dv;
     return dv < (double) iv ? iv - 1 : iv;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/StringTagParseException.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/StringTagParseException.java
@@ -33,7 +33,7 @@ import java.io.IOException;
   private final CharSequence buffer;
   private final int position;
 
-  public StringTagParseException(final String message, final CharSequence buffer, final int position) {
+  StringTagParseException(final String message, final CharSequence buffer, final int position) {
     super(message);
     this.buffer = buffer;
     this.position = position;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -30,7 +30,7 @@ import java.util.stream.IntStream;
 /* package */ final class TagStringReader {
   private final CharBuffer buffer;
 
-  public TagStringReader(final CharBuffer buffer) {
+  TagStringReader(final CharBuffer buffer) {
     this.buffer = buffer;
   }
 
@@ -254,7 +254,6 @@ import java.util.stream.IntStream;
     this.buffer.expect(Tokens.VALUE_SEPARATOR);
     return false;
   }
-
 
   /**
    * Remove simple escape sequences from a string

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -50,7 +50,7 @@ import java.util.stream.IntStream;
     final ListBinaryTag.Builder<BinaryTag> builder = ListBinaryTag.builder();
     this.buffer.expect(Tokens.ARRAY_BEGIN);
     final boolean prefixedIndex = this.buffer.peek() == '0' && this.buffer.peek(1) == ':';
-    while (this.buffer.hasMore()) {
+    while(this.buffer.hasMore()) {
       if(prefixedIndex) {
         this.buffer.takeUntil(':');
       }
@@ -98,7 +98,7 @@ import java.util.stream.IntStream;
 
       if(this.separatorOrCompleteWith(Tokens.ARRAY_END)) {
         final byte[] result = new byte[bytes.size()];
-        for (int i = 0; i < bytes.size(); ++i) { // todo yikes, let's do less boxing
+        for(int i = 0; i < bytes.size(); ++i) { // todo yikes, let's do less boxing
           result[i] = bytes.get(i);
         }
         return result;
@@ -134,7 +134,7 @@ import java.util.stream.IntStream;
 
       if(this.separatorOrCompleteWith(Tokens.ARRAY_END)) {
         final long[] result = new long[longs.size()];
-        for (int i = 0; i < longs.size(); ++i) { // todo yikes
+        for(int i = 0; i < longs.size(); ++i) { // todo yikes
           result[i] = longs.get(i);
         }
         return result;
@@ -227,7 +227,7 @@ import java.util.stream.IntStream;
       if(current == '\\') { // escape -- we are significantly more lenient than original format at the moment
         this.buffer.advance();
         builder.append(this.buffer.take());
-      } else if (Tokens.id(current)) {
+      } else if(Tokens.id(current)) {
         builder.append(this.buffer.take());
       } else { // end of value
         break;
@@ -263,7 +263,7 @@ import java.util.stream.IntStream;
    */
   private static String unescape(final String withEscapes) {
     int escapeIdx = withEscapes.indexOf(Tokens.ESCAPE_MARKER);
-    if (escapeIdx == -1) { // nothing to unescape
+    if(escapeIdx == -1) { // nothing to unescape
       return withEscapes;
     }
     int lastEscape = 0;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringWriter.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringWriter.java
@@ -41,7 +41,7 @@ import java.util.Map;
    */
   private boolean needsSeparator;
 
-  public TagStringWriter(final Appendable out) {
+  TagStringWriter(final Appendable out) {
     this.out = out;
   }
 
@@ -232,7 +232,6 @@ import java.util.Map;
       this.needsSeparator = false;
     }
   }
-
 
   @Override
   public void close() throws IOException {

--- a/nbt/src/main/java/net/kyori/adventure/nbt/Tokens.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/Tokens.java
@@ -60,7 +60,7 @@ package net.kyori.adventure.nbt;
    * @param c the character
    * @return identifier
    */
-  static boolean id(final char c) {
+  /* package */ static boolean id(final char c) {
     return (c >= 'a' && c <= 'z')
       || (c >= 'A' && c <= 'Z')
       || (c >= '0' && c <= '9')
@@ -76,7 +76,7 @@ package net.kyori.adventure.nbt;
    * @param c character to check
    * @return if possibly part of a number
    */
-  static boolean numeric(final char c) {
+  /* package */ static boolean numeric(final char c) {
     return (c >= '0' && c <= '9') // digit
       || c == '+' || c == '-' // positive or negative
       || c == 'e' || c == 'E' // exponent

--- a/nbt/src/main/java/net/kyori/adventure/nbt/Tokens.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/Tokens.java
@@ -53,29 +53,6 @@ package net.kyori.adventure.nbt;
   }
 
   /**
-   * Get the type signature character based on the scalar provided tag type
-   *
-   * @param type tag type
-   * @return a type signature, or {@code 0} if an unknown tag type was provided
-   */
-  static char tagType(final BinaryTagType<?> type) {
-   if(type == BinaryTagTypes.BYTE) {
-     return TYPE_BYTE;
-   } else if(type == BinaryTagTypes.SHORT) {
-     return TYPE_SHORT;
-   } else if(type == BinaryTagTypes.INT) {
-     return TYPE_INT;
-   } else if(type == BinaryTagTypes.LONG) {
-     return TYPE_LONG;
-   } else if(type == BinaryTagTypes.FLOAT) {
-     return TYPE_FLOAT;
-   } else if(type == BinaryTagTypes.DOUBLE) {
-     return TYPE_DOUBLE;
-   }
-   return '\0';
- }
-
-  /**
    * Return if a character is a valid component in an identifier
    *
    * <p>An identifier character must match the expression {@code [a-zA-Z0-9_+.-]}</p>

--- a/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
@@ -92,7 +92,6 @@ class StringIOTest {
     assertEquals(bigTest, parsedSnbt);
   }
 
-
   @Test
   public void testStringTag() throws IOException {
     final StringBinaryTag basic = StringBinaryTag.of("hello");
@@ -104,7 +103,6 @@ class StringIOTest {
     final String withEscapesStr = this.tagToString(withEscapes);
     assertEquals("\"hello \\\\world\"", withEscapesStr);
     assertEquals(withEscapes, this.stringToTag(withEscapesStr));
-
 
     // single quotes
     assertEquals(StringBinaryTag.of("something single-quoted"), this.stringToTag("'something single-quoted'"));
@@ -187,8 +185,8 @@ class StringIOTest {
 
   @Test
   public void testLegacyListTag() throws IOException {
-    final BinaryTag tag = stringToTag("[0:\"Tag #1\",1:\"Tag #2\"]");
-    assertEquals("[\"Tag #1\",\"Tag #2\"]", tagToString(tag));
+    final BinaryTag tag = this.stringToTag("[0:\"Tag #1\",1:\"Tag #2\"]");
+    assertEquals("[\"Tag #1\",\"Tag #2\"]", this.tagToString(tag));
 
     final ListTagBuilder<BinaryTag> builder = new ListTagBuilder<>();
     builder.add(StringBinaryTag.of("Tag #1"));

--- a/text-feature-pagination/src/main/java/net/kyori/adventure/text/feature/pagination/PaginationBuilder.java
+++ b/text-feature-pagination/src/main/java/net/kyori/adventure/text/feature/pagination/PaginationBuilder.java
@@ -29,7 +29,7 @@ import net.kyori.adventure.text.format.Style;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-final class PaginationBuilder implements Pagination.Builder {
+/* package */ final class PaginationBuilder implements Pagination.Builder {
   private int width = Pagination.WIDTH;
   private int resultsPerPage = Pagination.RESULTS_PER_PAGE;
 

--- a/text-feature-pagination/src/main/java/net/kyori/adventure/text/feature/pagination/PaginationImpl.java
+++ b/text-feature-pagination/src/main/java/net/kyori/adventure/text/feature/pagination/PaginationImpl.java
@@ -37,7 +37,7 @@ import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-final class PaginationImpl<T> implements Examinable, Pagination<T> {
+/* package */ final class PaginationImpl<T> implements Examinable, Pagination<T> {
   private static final int LINE_CHARACTER_LENGTH = 1;
 
   private final int width;
@@ -147,7 +147,7 @@ final class PaginationImpl<T> implements Examinable, Pagination<T> {
     return TextComponent.of(repeat(String.valueOf(this.lineCharacter), characters), this.lineStyle);
   }
 
-  static int length(final @NonNull Component component) {
+  /* package */ static int length(final @NonNull Component component) {
     int length = 0;
     if(component instanceof TextComponent) {
       length += ((TextComponent) component).content().length();
@@ -158,11 +158,11 @@ final class PaginationImpl<T> implements Examinable, Pagination<T> {
     return length;
   }
 
-  static @NonNull String repeat(final @NonNull String character, final int count) {
+  /* package */ static @NonNull String repeat(final @NonNull String character, final int count) {
     return String.join("", Collections.nCopies(count, character));
   }
 
-  static int pages(final int pageSize, final int count) {
+  /* package */ static int pages(final int pageSize, final int count) {
     final int pages = count / pageSize + 1;
     if(count % pageSize == 0) {
       return pages - 1;
@@ -170,7 +170,7 @@ final class PaginationImpl<T> implements Examinable, Pagination<T> {
     return pages;
   }
 
-  static boolean pageInRange(final int page, final int pages) {
+  /* package */ static boolean pageInRange(final int page, final int pages) {
     return page > 0 && page <= pages;
   }
 

--- a/text-feature-pagination/src/main/java/net/kyori/adventure/text/feature/pagination/Paginator.java
+++ b/text-feature-pagination/src/main/java/net/kyori/adventure/text/feature/pagination/Paginator.java
@@ -30,7 +30,7 @@ import java.util.RandomAccess;
 import java.util.function.ObjIntConsumer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-interface Paginator {
+/* package */ interface Paginator {
   @SuppressWarnings("unchecked")
   static <T> void forEachPageEntry(final @NonNull Collection<? extends T> content, final int pageSize, final int page, final @NonNull ObjIntConsumer<? super T> consumer) {
     final int size = content.size();

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -89,7 +89,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     return new BuilderImpl(this);
   }
 
-  static final class BuilderImpl implements Builder {
+  /* package */ static final class BuilderImpl implements Builder {
     private boolean downsampleColor = false;
 
     BuilderImpl() {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/IndexedSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/IndexedSerializer.java
@@ -28,7 +28,6 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.util.Optional;
 import net.kyori.adventure.util.Index;
 
 /* package */ final class IndexedSerializer<E> extends TypeAdapter<E> {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/KeySerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/KeySerializer.java
@@ -37,7 +37,7 @@ import net.kyori.adventure.key.Key;
   
   @Override
   public void write(final JsonWriter out, final Key value) throws IOException {
-      out.value(value.asString());
+    out.value(value.asString());
   }
 
   @Override

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -116,8 +116,8 @@ import net.kyori.adventure.text.format.TextDecoration;
             final /* @Nullable */ JsonElement rawValue = hoverEvent.get(HOVER_EVENT_CONTENTS);
             value = context.deserialize(rawValue, action.type());
           } else if(hoverEvent.has(HOVER_EVENT_VALUE)) {
-//            final /* @Nullable */ JsonElement rawValue = hoverEvent.get(HOVER_EVENT_VALUE);
-//            value = rawValue == null ? null : context.deserialize(rawValue, Component.class);
+            // final /* @Nullable */ JsonElement rawValue = hoverEvent.get(HOVER_EVENT_VALUE);
+            // value = rawValue == null ? null : context.deserialize(rawValue, Component.class);
             throw new UnsupportedOperationException(); // TODO: legacy support
           } else {
             value = null;

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorWrapper.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorWrapper.java
@@ -36,18 +36,18 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /*
  * This is a hack.
  */
-final class TextColorWrapper {
+/* package */ final class TextColorWrapper {
   final @Nullable TextColor color;
   final @Nullable TextDecoration decoration;
   final boolean reset;
 
-  TextColorWrapper(final @Nullable TextColor color, final @Nullable TextDecoration decoration, final boolean reset) {
+  /* package */ TextColorWrapper(final @Nullable TextColor color, final @Nullable TextDecoration decoration, final boolean reset) {
     this.color = color;
     this.decoration = decoration;
     this.reset = reset;
   }
 
-  static class Serializer extends TypeAdapter<TextColorWrapper> {
+  /* package */ static class Serializer extends TypeAdapter<TextColorWrapper> {
     @Override
     public void write(final JsonWriter out, final TextColorWrapper value) {
       throw new JsonSyntaxException("Cannot write TextColorWrapper instances");

--- a/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerTest.java
+++ b/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerTest.java
@@ -73,7 +73,7 @@ class GsonComponentSerializerTest {
     assertEquals("{\"text\":\"hey\",\"extra\":[{\"text\":\"there\",\"color\":\"" + name(downsampled) + "\"}]}", AbstractComponentTest.GSON_DOWNSAMPLING.toJson(test));
   }
 
-  private static String name(NamedTextColor color) {
+  private static String name(final NamedTextColor color) {
     return NamedTextColor.NAMES.key(color);
   }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -82,7 +82,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
   /**
    * The legacy character used by Minecraft. ('§')
    */
-  char SECTION_CHAR = '\u00A7';
+  char SECTION_CHAR = '§';
 
   /**
    * The legacy character frequently used by configurations and commands. ('&amp;')

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -47,6 +47,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   private static final String LEGACY_CHARS = "0123456789abcdefklmnor";
   private static final char LEGACY_BUNGEE_HEX_CHAR = 'x';
   private static final List<TextFormat> FORMATS;
+
   static {
     final List<TextFormat> formats = new ArrayList<>();
     formats.addAll(NamedTextColor.values());
@@ -101,7 +102,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         if(this.useTerriblyStupidHexFormat) {
           // ah yes, wonderful. A 14 digit long completely unreadable string.
           final StringBuilder legacy = new StringBuilder(String.valueOf(LEGACY_BUNGEE_HEX_CHAR));
-          for(char c : hex.toCharArray()) {
+          for(final char c : hex.toCharArray()) {
             legacy.append(this.character).append(c);
           }
           return legacy.toString();
@@ -124,7 +125,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   public @NonNull TextComponent deserialize(final @NonNull String input) {
     int next = input.lastIndexOf(this.character, input.length() - 2);
     if(next == -1) {
-      return extractUrl(TextComponent.of(input));
+      return this.extractUrl(TextComponent.of(input));
     }
 
     final List<TextComponent> parts = new ArrayList<>();
@@ -134,7 +135,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
 
     int pos = input.length();
     do {
-      final TextFormat format = fromLegacyCode(input.charAt(next + 1), input, next + 2);
+      final TextFormat format = this.fromLegacyCode(input.charAt(next + 1), input, next + 2);
       if(format != null) {
         final int from = next + (isHexTextColor(format) ? 8 : 2);
         if(from != pos) {
@@ -167,7 +168,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     Collections.reverse(parts);
-    return extractUrl(TextComponent.builder(pos > 0 ? input.substring(0, pos) : "").append(parts).build());
+    return this.extractUrl(TextComponent.builder(pos > 0 ? input.substring(0, pos) : "").append(parts).build());
   }
 
   @Override
@@ -240,7 +241,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     void append(final @NonNull TextFormat format) {
-      this.sb.append(this.character).append(toLegacyCode(format));
+      this.sb.append(this.character).append(LegacyComponentSerializerImpl.this.toLegacyCode(format));
     }
 
     @Override

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -41,7 +41,7 @@ import net.kyori.adventure.text.format.TextFormat;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
+/* package */ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   private static final Pattern URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
   private static final String LEGACY_CHARS = "0123456789abcdefklmnor";
@@ -215,7 +215,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
       this.character = character;
     }
 
-    void append(final @NonNull Component component) {
+    /* package */ void append(final @NonNull Component component) {
       this.append(component, new Style());
     }
 
@@ -240,7 +240,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
       }
     }
 
-    void append(final @NonNull TextFormat format) {
+    /* package */ void append(final @NonNull TextFormat format) {
       this.sb.append(this.character).append(LegacyComponentSerializerImpl.this.toLegacyCode(format));
     }
 
@@ -262,13 +262,13 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         this.decorations = EnumSet.copyOf(that.decorations);
       }
 
-      void set(final @NonNull Style that) {
+      /* package */ void set(final @NonNull Style that) {
         this.color = that.color;
         this.decorations.clear();
         this.decorations.addAll(that.decorations);
       }
 
-      void apply(final @NonNull Component component) {
+      /* package */ void apply(final @NonNull Component component) {
         final TextColor color = component.color();
         if(color != null) {
           this.color = color;
@@ -287,7 +287,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         }
       }
 
-      void applyFormat() {
+      /* package */ void applyFormat() {
         // If color changes, we need to do a full reset
         if(this.color != Cereal.this.style.color) {
           this.applyFullFormat();
@@ -327,7 +327,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
   }
 
-  static final class BuilderImpl implements Builder {
+  /* package */ static final class BuilderImpl implements Builder {
     private char character = LegacyComponentSerializer.SECTION_CHAR;
     private char hexCharacter = LegacyComponentSerializer.HEX_CHAR;
     private Style urlStyle = null;

--- a/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainComponentSerializer.java
+++ b/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainComponentSerializer.java
@@ -82,7 +82,7 @@ public class PlainComponentSerializer implements ComponentSerializer<Component, 
     } else if(component instanceof TextComponent) {
       sb.append(((TextComponent) component).content());
     } else if(component instanceof TranslatableComponent) {
-      if (this.translatable != null) sb.append(this.translatable.apply((TranslatableComponent) component));
+      if(this.translatable != null) sb.append(this.translatable.apply((TranslatableComponent) component));
     } else {
       throw new UnsupportedOperationException("Don't know how to turn " + component.getClass().getSimpleName() + " into a string");
     }


### PR DESCRIPTION
Starting out a checkstyle file for some basic formatting things.

There are several custom checks used -- see https://gitlab.com/stellardrift/stylecheck for their source. For now, i've put in a check that will prohibit TYPE_USE nullability annotations, but not perform any further validation.

~~This also doesn't verify usage of nullability annotations or prohibiting TYPE_USE annotations on local variables. I'm going to explore writing an annotation processor to do that.~~