### PR TITLE
Separate BossBar update logic from the API

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.audience;
 
 import java.util.Arrays;
-import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.bossbar.BossBarContainer;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
@@ -134,14 +134,14 @@ public interface Audience {
    *
    * @param bar the bossbar
    */
-  void showBossBar(final @NonNull BossBar bar);
+  void showBossBar(final @NonNull BossBarContainer bar);
 
   /**
    * Hides a bossbar.
    *
    * @param bar the bossbar
    */
-  void hideBossBar(final @NonNull BossBar bar);
+  void hideBossBar(final @NonNull BossBarContainer bar);
 
   // ----------------
   // ---- Sounds ----

--- a/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.audience;
 
-import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.bossbar.BossBarContainer;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
@@ -55,11 +55,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
   }
 
   @Override
-  public void showBossBar(final @NonNull BossBar bar) {
+  public void showBossBar(final @NonNull BossBarContainer bar) {
   }
 
   @Override
-  public void hideBossBar(final @NonNull BossBar bar) {
+  public void hideBossBar(final @NonNull BossBarContainer bar) {
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.audience;
 
-import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.bossbar.BossBarContainer;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
@@ -75,13 +75,13 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void showBossBar(final @NonNull BossBar bar) {
+  default void showBossBar(final @NonNull BossBarContainer bar) {
     final Audience audience = this.audience();
     if(audience != null) audience.showBossBar(bar);
   }
 
   @Override
-  default void hideBossBar(final @NonNull BossBar bar) {
+  default void hideBossBar(final @NonNull BossBarContainer bar) {
     final Audience audience = this.audience();
     if(audience != null) audience.hideBossBar(bar);
   }

--- a/api/src/main/java/net/kyori/adventure/audience/MultiAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/MultiAudience.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.audience;
 
-import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.bossbar.BossBarContainer;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
@@ -69,12 +69,12 @@ public interface MultiAudience extends Audience {
   }
 
   @Override
-  default void showBossBar(final @NonNull BossBar bar) {
+  default void showBossBar(final @NonNull BossBarContainer bar) {
     for(final Audience audience : this.audiences()) audience.showBossBar(bar);
   }
 
   @Override
-  default void hideBossBar(final @NonNull BossBar bar) {
+  default void hideBossBar(final @NonNull BossBarContainer bar) {
     for(final Audience audience : this.audiences()) audience.hideBossBar(bar);
   }
 

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
@@ -83,7 +83,7 @@ public interface BossBar {
    * Sets the name.
    *
    * @param name the name
-   * @return the bossbar
+   * @return a new bossbar
    */
   @NonNull BossBar name(final @NonNull Component name);
 
@@ -102,7 +102,7 @@ public interface BossBar {
    * <p>The percent is a value between 0 and 1.</p>
    *
    * @param percent the percent
-   * @return the bossbar
+   * @return a new bossbar
    * @throws IllegalArgumentException if percent is less than 0 or greater than 1
    */
   @NonNull BossBar percent(final float percent);
@@ -118,7 +118,7 @@ public interface BossBar {
    * Sets the color.
    *
    * @param color the color
-   * @return the bossbar
+   * @return a new bossbar
    */
   @NonNull BossBar color(final @NonNull Color color);
 
@@ -133,7 +133,7 @@ public interface BossBar {
    * Sets the overlay.
    *
    * @param overlay the overlay
-   * @return the bossbar
+   * @return a new bossbar
    */
   @NonNull BossBar overlay(final @NonNull Overlay overlay);
 
@@ -148,7 +148,7 @@ public interface BossBar {
    * Sets the flags.
    *
    * @param flags the flags
-   * @return the bossbar
+   * @return a new bossbar
    */
   @NonNull BossBar flags(final @NonNull Set<Flag> flags);
 
@@ -156,7 +156,7 @@ public interface BossBar {
    * Sets the flags.
    *
    * @param flags the flags
-   * @return the bossbar
+   * @return a new bossbar
    */
   @NonNull BossBar addFlags(final @NonNull Flag@NonNull... flags);
 
@@ -164,80 +164,9 @@ public interface BossBar {
    * Sets the flags.
    *
    * @param flags the flags
-   * @return the bossbar
+   * @return a new bossbar
    */
   @NonNull BossBar removeFlags(final @NonNull Flag@NonNull... flags);
-
-  /**
-   * Adds a listener.
-   *
-   * @param listener a listener
-   * @return the bossbar
-   */
-  @NonNull BossBar addListener(final @NonNull Listener listener);
-
-  /**
-   * Removes a listener.
-   *
-   * @param listener a listener
-   * @return the bossbar
-   */
-  @NonNull BossBar removeListener(final @NonNull Listener listener);
-
-  /**
-   * A listener.
-   */
-  interface Listener {
-    /**
-     * Bossbar name changed.
-     *
-     * @param bar the bossbar
-     * @param oldName the old name
-     * @param newName the new name
-     */
-    default void bossBarNameChanged(final @NonNull BossBar bar, final @NonNull Component oldName, final @NonNull Component newName) {
-    }
-
-    /**
-     * Bossbar percent changed.
-     *
-     * @param bar the bossbar
-     * @param oldPercent the old percent
-     * @param newPercent the new percent
-     */
-    default void bossBarPercentChanged(final @NonNull BossBar bar, final float oldPercent, final float newPercent) {
-    }
-
-    /**
-     * Bossbar color changed.
-     *
-     * @param bar the bossbar
-     * @param oldColor the old color
-     * @param newColor the new color
-     */
-    default void bossBarColorChanged(final @NonNull BossBar bar, final @NonNull Color oldColor, final @NonNull Color newColor) {
-    }
-
-    /**
-     * Bossbar overlay changed.
-     *
-     * @param bar the bossbar
-     * @param oldOverlay the old overlay
-     * @param newOverlay the new overlay
-     */
-    default void bossBarOverlayChanged(final @NonNull BossBar bar, final @NonNull Overlay oldOverlay, final @NonNull Overlay newOverlay) {
-    }
-
-    /**
-     * Bossbar flags changed.
-     *
-     * @param bar the bossbar
-     * @param oldFlags the old flags
-     * @param newFlags the new flags
-     */
-    default void bossBarFlagsChanged(final @NonNull BossBar bar, final @NonNull Set<Flag> oldFlags, final @NonNull Set<Flag> newFlags) {
-    }
-  }
 
   enum Color {
     PINK("pink"),

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarContainer.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarContainer.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.bossbar;
+
+import net.kyori.adventure.audience.Audience;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * A container for a {@link BossBar}. This is used as a platform-independent
+ * way of updating boss bars to {@link Audience}s.
+ */
+public interface BossBarContainer {
+  /**
+   * Returns the boss bar currently contained in this container.
+   *
+   * @return the boss bar
+   */
+  @NonNull BossBar bar();
+
+  /**
+   * Sets the boss bar within this container, updating any clients
+   * as needed.
+   *
+   * @param bar the new boss bar to set
+   */
+  void bar(@NonNull BossBar bar);
+}

--- a/api/src/test/java/net/kyori/adventure/bossbar/BossBarTest.java
+++ b/api/src/test/java/net/kyori/adventure/bossbar/BossBarTest.java
@@ -36,37 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BossBarTest {
-  private final AtomicInteger name = new AtomicInteger();
-  private final AtomicInteger percent = new AtomicInteger();
-  private final AtomicInteger color = new AtomicInteger();
-  private final AtomicInteger overlay = new AtomicInteger();
-  private final AtomicInteger flags = new AtomicInteger();
-  private final BossBar.Listener listener = new BossBar.Listener() {
-    @Override
-    public void bossBarNameChanged(final @NonNull BossBar bar, final @NonNull Component oldName, final @NonNull Component newName) {
-      BossBarTest.this.name.incrementAndGet();
-    }
-
-    @Override
-    public void bossBarPercentChanged(final @NonNull BossBar bar, final float oldPercent, final float newPercent) {
-      BossBarTest.this.percent.incrementAndGet();
-    }
-
-    @Override
-    public void bossBarColorChanged(final @NonNull BossBar bar, final BossBar.@NonNull Color oldColor, final BossBar.@NonNull Color newColor) {
-      BossBarTest.this.color.incrementAndGet();
-    }
-
-    @Override
-    public void bossBarOverlayChanged(final @NonNull BossBar bar, final BossBar.@NonNull Overlay oldOverlay, final BossBar.@NonNull Overlay newOverlay) {
-      BossBarTest.this.overlay.incrementAndGet();
-    }
-
-    @Override
-    public void bossBarFlagsChanged(final @NonNull BossBar bar, final @NonNull Set<BossBar.Flag> oldFlags, final @NonNull Set<BossBar.Flag> newFlags) {
-      BossBarTest.this.flags.incrementAndGet();
-    }
-  };
   private final BossBar bar = BossBar.of(TextComponent.empty(), 1f, BossBar.Color.PURPLE, BossBar.Overlay.PROGRESS);
 
   @Test
@@ -80,27 +49,15 @@ public class BossBarTest {
   @Test
   void testName() {
     assertEquals(TextComponent.of("A"), this.bar.name(TextComponent.of("A")).name());
-    assertEquals(0, this.name.get());
-
-    this.bar.addListener(this.listener);
     assertEquals(TextComponent.of("B"), this.bar.name(TextComponent.of("B")).name());
-    assertEquals(1, this.name.get());
-
     assertEquals(TextComponent.of("B"), this.bar.name(TextComponent.of("B")).name());
-    assertEquals(1, this.name.get()); // value has not changed, should not have incremented
   }
 
   @Test
   void testPercent() {
     assertEquals(0f, this.bar.percent(0f).percent());
-    assertEquals(0, this.percent.get());
-
-    this.bar.addListener(this.listener);
     assertEquals(0.1f, this.bar.percent(0.1f).percent());
-    assertEquals(1, this.percent.get());
-
     assertEquals(0.1f, this.bar.percent(0.1f).percent());
-    assertEquals(1, this.percent.get()); // value has not changed, should not have incremented
   }
 
   @Test
@@ -112,45 +69,20 @@ public class BossBarTest {
   @Test
   void testColor() {
     assertEquals(BossBar.Color.PINK, this.bar.color(BossBar.Color.PINK).color());
-    assertEquals(0, this.color.get());
-
-    this.bar.addListener(this.listener);
     assertEquals(BossBar.Color.PURPLE, this.bar.color(BossBar.Color.PURPLE).color());
-    assertEquals(1, this.color.get());
-
-    assertEquals(BossBar.Color.PURPLE, this.bar.color(BossBar.Color.PURPLE).color());
-    assertEquals(1, this.color.get()); // value has not changed, should not have incremented
   }
 
   @Test
   void testOverlay() {
     assertEquals(BossBar.Overlay.NOTCHED_6, this.bar.overlay(BossBar.Overlay.NOTCHED_6).overlay());
-    assertEquals(0, this.overlay.get());
-
-    this.bar.addListener(this.listener);
     assertEquals(BossBar.Overlay.PROGRESS, this.bar.overlay(BossBar.Overlay.PROGRESS).overlay());
-    assertEquals(1, this.overlay.get());
-
-    assertEquals(BossBar.Overlay.PROGRESS, this.bar.overlay(BossBar.Overlay.PROGRESS).overlay());
-    assertEquals(1, this.overlay.get()); // value has not changed, should not have incremented
   }
 
   @Test
   void testFlags() {
     assertEquals(ImmutableSet.of(), this.bar.flags(ImmutableSet.of()).flags());
-    assertEquals(0, this.flags.get());
-
-    this.bar.addListener(this.listener);
     assertEquals(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN), this.bar.flags(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN)).flags());
-    assertEquals(1, this.flags.get());
-
-    assertEquals(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN), this.bar.flags(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN)).flags());
-    assertEquals(1, this.flags.get()); // value has not changed, should not have incremented
-
-    assertEquals(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN, BossBar.Flag.CREATE_WORLD_FOG), this.bar.addFlags(BossBar.Flag.CREATE_WORLD_FOG).flags());
-    assertEquals(2, this.flags.get());
-
-    assertEquals(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN), this.bar.removeFlags(BossBar.Flag.CREATE_WORLD_FOG).flags());
-    assertEquals(3, this.flags.get());
+    assertEquals(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN, BossBar.Flag.CREATE_WORLD_FOG), this.bar.flags(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN)).addFlags(BossBar.Flag.CREATE_WORLD_FOG).flags());
+    assertEquals(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN), this.bar.flags(ImmutableSet.of(BossBar.Flag.DARKEN_SCREEN)).addFlags(BossBar.Flag.CREATE_WORLD_FOG).removeFlags(BossBar.Flag.CREATE_WORLD_FOG).flags());
   }
 }


### PR DESCRIPTION
This PR is more meant as a way to spark a discussion about how to best handle boss bars in platforms without resorting to coarse locks to ensure operations are safe in a multithreaded environment. In addition, this abstraction provides a more "natural" abstraction over the underlying boss bar objects in each platform whilst still hiding platform-specific details. I am happy to implement this solution in Velocity.

Specifically, this PR:

* Turns `BossBar` into an immutable class, consistent with the rest of the API. All "mutating" methods now return new `BossBar`s and the `flags()` method now returns an unmodifiable view of the flags
* Adds a new `BossBarContainer` class that `adventure-platform` and other platform implementations are expected to implement, which wraps a `BossBar` and trusts the container to have its own logic for handling boss bars on the client
* `Audience` boss bar methods now expect an `BossBarContainer`

I want to tag @zml2008 as he discussed this topic with me and doesn't like the current solution in `adventure-platform` - deferring the logic of updating and showing boss bars to the platform (without any listeners) might be a better solution than what we have now. (As a nice consequence, if managed correctly, this could used to conveniently control the order in which boss bars appear on the client and allow reordering very easily.)