### PR TITLE
Improve performance of BinaryTagIO by buffering and clarify stream closing

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/IOStreamUtil.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IOStreamUtil.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.nbt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/* package */ final class IOStreamUtil {
+  private IOStreamUtil() {
+    throw new AssertionError();
+  }
+
+  /* package */ static InputStream closeShield(final InputStream stream) {
+    return new InputStream() {
+      @Override
+      public int read() throws IOException {
+        return stream.read();
+      }
+
+      @Override
+      public int read(final byte[] b) throws IOException {
+        return stream.read(b);
+      }
+
+      @Override
+      public int read(final byte[] b, final int off, final int len) throws IOException {
+        return stream.read(b, off, len);
+      }
+    };
+  }
+
+  /* package */ static OutputStream closeShield(final OutputStream stream) {
+    return new OutputStream() {
+      @Override
+      public void write(final int b) throws IOException {
+        stream.write(b);
+      }
+
+      @Override
+      public void write(final byte[] b) throws IOException {
+        stream.write(b);
+      }
+
+      @Override
+      public void write(final byte[] b, final int off, final int len) throws IOException {
+        stream.write(b, off, len);
+      }
+    };
+  }
+}

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IOStreamUtil.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IOStreamUtil.java
@@ -29,7 +29,6 @@ import java.io.OutputStream;
 
 /* package */ final class IOStreamUtil {
   private IOStreamUtil() {
-    throw new AssertionError();
   }
 
   /* package */ static InputStream closeShield(final InputStream stream) {


### PR DESCRIPTION
While looking at `adventure-nbt` I spotted two issues:

* Lack of stream buffering. This can hurt performance, especially for compressed NBT and slow disks.
* `BinaryTagIO` will indiscriminately close streams given to it. For single-shot cases or reading from a in-memory buffer this isn't an issue, but if (say) you were parsing a set of NBT streams this could be an issue.

To fix this:

* `Path`-taking methods and `*Compressed*` methods now buffer the relevant streams (I assume if you're passing in an `InputStream` or a `DataInput` directly that you know what you're doing)
* Added code so that `BinaryTagIO` won't close streams it is given

Still a bit of a WIP (need to write tests), but wanted to get this up here.