### PR TITLE
Fix regression in #82 with a single chat component from the main logic loop

### DIFF
--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -206,12 +206,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
     if(current != null) {
       parts.add(current.build());
     }
+    if(pos > 0) {
+      parts.add(TextComponent.of(input.substring(0, pos)));
+    }
 
     if(parts.size() == 1) {
       return this.extractUrl(parts.get(0));
     } else {
       Collections.reverse(parts);
-      return this.extractUrl(TextComponent.builder(pos > 0 ? input.substring(0, pos) : "").append(parts).build());
+      return this.extractUrl(parts.get(0).children(parts.subList(1, parts.size())));
     }
   }
 

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -207,7 +207,7 @@ class LegacyComponentSerializerTest {
   }
 
   @Test
-  void testFromLegacyWithNewline() {
+  void testFromLegacyWithNewline() { // https://github.com/KyoriPowered/adventure/issues/108
     final TextComponent comp = TextComponent.builder("One: Test ")
       .append(TextComponent.of("String\nTwo: ", NamedTextColor.GREEN))
       .append(TextComponent.of("Test ", NamedTextColor.AQUA))
@@ -218,7 +218,7 @@ class LegacyComponentSerializerTest {
   }
 
   @Test
-  void testBeginningTextUnformatted() {
+  void testBeginningTextUnformatted() { // https://github.com/KyoriPowered/adventure/issues/108
     final String input = "Test &cString";
     final TextComponent expected = TextComponent.builder("Test ")
       .append(TextComponent.of("String", NamedTextColor.RED))

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -205,4 +205,25 @@ class LegacyComponentSerializerTest {
     final TextComponent expected = TextComponent.of("Kittens!", NamedTextColor.YELLOW);
     assertEquals(expected, LegacyComponentSerializer.builder().hexColors().build().deserialize("§x§eKittens!"));
   }
+
+  @Test
+  void testFromLegacyWithNewline() {
+    final TextComponent comp = TextComponent.builder("One: Test ")
+      .append(TextComponent.of("String\nTwo: ", NamedTextColor.GREEN))
+      .append(TextComponent.of("Test ", NamedTextColor.AQUA))
+      .append(TextComponent.of("String", NamedTextColor.GREEN))
+      .build();
+    final String in = "One: Test &aString\nTwo: &bTest &aString";
+    assertEquals(comp, LegacyComponentSerializer.legacy('&').deserialize(in));
+  }
+
+  @Test
+  void testBeginningTextUnformatted() {
+    final String input = "Test &cString";
+    final TextComponent expected = TextComponent.builder("Test ")
+      .append(TextComponent.of("String", NamedTextColor.RED))
+      .build();
+
+    assertEquals(expected, LegacyComponentSerializer.legacy(LegacyComponentSerializer.AMPERSAND_CHAR).deserialize(input));
+  }
 }

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -41,8 +41,8 @@ class LegacyComponentSerializerTest {
 
   @Test
   void testFromColor() {
-    final TextComponent component = TextComponent.builder("")
-      .append(TextComponent.of("foo").color(NamedTextColor.GREEN).decoration(TextDecoration.BOLD, TextDecoration.State.TRUE))
+    final TextComponent component = TextComponent.builder("foo")
+      .color(NamedTextColor.GREEN).decoration(TextDecoration.BOLD, TextDecoration.State.TRUE)
       .append(TextComponent.of("bar").color(NamedTextColor.BLUE))
       .build();
 
@@ -58,8 +58,7 @@ class LegacyComponentSerializerTest {
 
   @Test
   void testResetOverride() {
-    final TextComponent component = TextComponent.builder("")
-      .append(TextComponent.of("foo").color(NamedTextColor.GREEN).decoration(TextDecoration.BOLD, TextDecoration.State.TRUE))
+    final TextComponent component = TextComponent.builder("foo").color(NamedTextColor.GREEN).decoration(TextDecoration.BOLD, TextDecoration.State.TRUE)
       .append(TextComponent.of("bar").color(NamedTextColor.DARK_GRAY))
       .build();
 
@@ -153,8 +152,7 @@ class LegacyComponentSerializerTest {
 
   @Test
   void testFromLegacyWithHexColor() {
-    final TextComponent component = TextComponent.builder("")
-      .append(TextComponent.of("pretty").color(TextColor.fromHexString("#ffb6c1")))
+    final TextComponent component = TextComponent.builder("pretty").color(TextColor.fromHexString("#ffb6c1"))
       .append(TextComponent.of("in").color(TextColor.fromHexString("#ff69b4")).decoration(TextDecoration.BOLD, TextDecoration.State.TRUE))
       .append(TextComponent.of("pink").color(TextColor.fromHexString("#ffc0cb")))
       .build();
@@ -175,8 +173,7 @@ class LegacyComponentSerializerTest {
 
   @Test
   void testFromLegacyWithHexColorTerribleFormatMixed() {
-    final TextComponent expected = TextComponent.builder("")
-      .append(TextComponent.of("Hugs and ", NamedTextColor.RED))
+    final TextComponent expected = TextComponent.builder("Hugs and ", NamedTextColor.RED)
       .append(TextComponent.of("Kittens!", TextColor.of(0xffefd5)))
       .build();
     assertEquals(expected, LegacyComponentSerializer.builder().hexColors().build().deserialize("§cHugs and §x§f§f§e§f§d§5Kittens!"));
@@ -184,8 +181,7 @@ class LegacyComponentSerializerTest {
 
   @Test
   void testFromLegacyWithHexColorTerribleFormatEnsureProperLookahead() {
-    final TextComponent expected = TextComponent.builder("")
-      .append(TextComponent.of("Hugs and ", NamedTextColor.RED))
+    final TextComponent expected = TextComponent.builder("Hugs and ", NamedTextColor.RED)
       .append(TextComponent.of("Kittens!", NamedTextColor.DARK_PURPLE))
       .build();
     assertEquals(expected, LegacyComponentSerializer.builder().hexColors().build().deserialize("§cHugs and §f§f§e§f§d§5Kittens!"));
@@ -202,7 +198,9 @@ class LegacyComponentSerializerTest {
 
   @Test
   void testFromLegacyWithHexColorTerribleFormatHangingCharacter() {
-    final TextComponent expected = TextComponent.of("Kittens!", NamedTextColor.YELLOW);
+    final TextComponent expected = TextComponent.builder("§x")
+      .append("Kittens!", NamedTextColor.YELLOW)
+      .build();
     assertEquals(expected, LegacyComponentSerializer.builder().hexColors().build().deserialize("§x§eKittens!"));
   }
 

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
@@ -74,8 +74,7 @@ class LinkingLegacyComponentSerializerTest {
   void testPrefixSuffixUrlAndColors() {
     final String bareUrl = "https://www.example.com";
     final String hasPrefixSuffixColors = "&adid you hear about &chttps://www.example.com? &9they're really cool";
-    final TextComponent expectedHasPrefixSuffixColors = TextComponent.builder("")
-      .append(TextComponent.of("did you hear about ", NamedTextColor.GREEN))
+    final TextComponent expectedHasPrefixSuffixColors = TextComponent.builder("did you hear about ", NamedTextColor.GREEN)
       .append(TextComponent.of("https://www.example.com", NamedTextColor.RED).clickEvent(ClickEvent.openUrl(bareUrl)))
       .append(TextComponent.of("? ", NamedTextColor.RED))
       .append(TextComponent.of("they're really cool", NamedTextColor.BLUE))


### PR DESCRIPTION
Fixes #108.

This does introduce a behavioral change: we now revert to the historical text 3.x behavior of using the very first component found and append everything else as children. This change was made in #82 but it was botched and I didn't notice until now.