### PR TITLE
Configurate serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /nbt/build/
 /nbt/out/
 /run/
+/serializer-configurate3/build/
+/serializer-configurate3/out/
 /text-serializer-gson/build/
 /text-serializer-gson/out/
 /text-serializer-legacy/build/

--- a/serializer-configurate3/build.gradle
+++ b/serializer-configurate3/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+  api project(":adventure-api")
+  api 'org.spongepowered:configurate-core:3.7.1'
+  testImplementation project(":adventure-text-serializer-gson")
+}
+
+jar {
+  manifest.attributes(
+    'Automatic-Module-Name': 'net.kyori.adventure.serializer.configurate3'
+  )
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/BlockNBTPosSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/BlockNBTPosSerializer.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.function.Predicate;
+import net.kyori.adventure.text.BlockNBTComponent;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class BlockNBTPosSerializer extends ScalarSerializer<BlockNBTComponent.Pos> {
+  static final BlockNBTPosSerializer INSTANCE = new BlockNBTPosSerializer();
+
+  private BlockNBTPosSerializer() {
+    super(BlockNBTComponent.Pos.class);
+  }
+
+  @Override
+  public BlockNBTComponent.Pos deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+    try {
+      return BlockNBTComponent.Pos.fromString(obj.toString());
+    } catch(final IllegalArgumentException ex) {
+      throw new ObjectMappingException(ex);
+    }
+  }
+
+  @Override
+  public Object serialize(final BlockNBTComponent.@NonNull Pos item, final @NonNull Predicate<Class<?>> typeSupported) {
+    return item.asString();
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/BookTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/BookTypeSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.List;
+import net.kyori.adventure.inventory.Book;
+import net.kyori.adventure.text.Component;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class BookTypeSerializer implements TypeSerializer<Book> {
+  static TypeToken<Book> TYPE = TypeToken.of(Book.class);
+  static BookTypeSerializer INSTANCE = new BookTypeSerializer();
+  static String TITLE = "title";
+  static String AUTHOR = "author";
+  static String PAGES = "pages";
+
+  private BookTypeSerializer() {
+  }
+
+  @Override
+  public Book deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    final Component title = value.getNode(TITLE).getValue(ComponentTypeSerializer.TYPE);
+    final Component author = value.getNode(AUTHOR).getValue(ComponentTypeSerializer.TYPE);
+    final List<Component> pages = value.getNode(PAGES).getValue(ComponentTypeSerializer.LIST_TYPE);
+    if(title == null || author == null || pages == null) {
+      throw new ObjectMappingException("title, author, and pages fields are all required to deserialize a Book");
+    }
+    return Book.book(title, author, pages);
+  }
+
+  @Override
+  public void serialize(final @NonNull TypeToken<?> type, final @Nullable Book obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(obj == null) {
+      value.setValue(null);
+      return;
+    }
+    value.getNode(TITLE).setValue(ComponentTypeSerializer.TYPE, obj.title());
+    value.getNode(AUTHOR).setValue(ComponentTypeSerializer.TYPE, obj.author());
+    value.getNode(PAGES).setValue(ComponentTypeSerializer.LIST_TYPE, obj.pages());
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
@@ -1,0 +1,261 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.List;
+import java.util.Map;
+import net.kyori.adventure.text.BlockNBTComponent;
+import net.kyori.adventure.text.BuildableComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentBuilder;
+import net.kyori.adventure.text.EntityNBTComponent;
+import net.kyori.adventure.text.KeybindComponent;
+import net.kyori.adventure.text.NBTComponent;
+import net.kyori.adventure.text.NBTComponentBuilder;
+import net.kyori.adventure.text.ScoreComponent;
+import net.kyori.adventure.text.SelectorComponent;
+import net.kyori.adventure.text.StorageNBTComponent;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.serializer.ComponentSerializer;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class ComponentTypeSerializer implements TypeSerializer<Component> {
+  static final TypeToken<Component> TYPE = TypeToken.of(Component.class);
+  static final TypeToken<List<Component>> LIST_TYPE = new TypeToken<List<Component>>() {};
+  static final String TEXT = "text";
+  static final String TRANSLATE = "translate";
+  static final String TRANSLATE_WITH = "with";
+  static final String SCORE = "score";
+  static final String SCORE_NAME = "name";
+  static final String SCORE_OBJECTIVE = "objective";
+  static final String SCORE_VALUE = "value";
+  static final String SELECTOR = "selector";
+  static final String KEYBIND = "keybind";
+  static final String EXTRA = "extra";
+  static final String NBT = "nbt";
+  static final String NBT_INTERPRET = "interpret";
+  static final String NBT_BLOCK = "block";
+  static final String NBT_ENTITY = "entity";
+  static final String NBT_STORAGE = "storage";
+
+  private final @Nullable ComponentSerializer<Component, ? extends Component, String> stringSerial;
+  private final boolean preferString;
+
+  ComponentTypeSerializer(final @Nullable ComponentSerializer<Component, ? extends Component, String> stringSerial, final boolean preferString) {
+    this.stringSerial = stringSerial;
+    this.preferString = preferString;
+  }
+
+  @Override
+  public @NonNull Component deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    return this.deserialize0(type, value);
+  }
+
+  public @NonNull BuildableComponent<?, ?> deserialize0(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    // Try to read as a string
+    if(!value.isList() && !value.isMap()) {
+      final String str = value.getString();
+      if(str != null) {
+        if(this.stringSerial != null) {
+          final Component ret = this.stringSerial.deserialize(str);
+          if(!(ret instanceof BuildableComponent<?, ?>)) {
+            throw new ObjectMappingException("Result " + ret + " is not builable");
+          }
+          return (BuildableComponent<?, ?>) ret;
+        } else {
+          return Component.text(str);
+        }
+      }
+    } else if(value.isList()) {
+      ComponentBuilder<?, ?> parent = null;
+      for(final ConfigurationNode childElement : value.getChildrenList()) {
+        final BuildableComponent<?, ?> child = this.deserialize0(TYPE, childElement);
+        if(parent == null) {
+          parent = child.toBuilder();
+        } else {
+          parent.append(child);
+        }
+      }
+      if(parent == null) {
+        throw notSureHowToDeserialize(value);
+      }
+      return parent.build();
+    } else if(!value.isMap()) {
+      throw notSureHowToDeserialize(value);
+    }
+
+    final ComponentBuilder<?, ?> component;
+    final Map<Object, ? extends ConfigurationNode> children = value.getChildrenMap();
+    if(children.containsKey(TEXT)) {
+      component = Component.text().content(children.get(TEXT).getString());
+    } else if(children.containsKey(TRANSLATE)) {
+      final String key = children.get(TRANSLATE).getString();
+      if(!children.containsKey(TRANSLATE_WITH)) {
+        component = Component.translatable().key(key);
+      } else {
+        final ConfigurationNode with = children.get(TRANSLATE_WITH);
+        if(!with.isList()) {
+          throw new ObjectMappingException("Expected "+ TRANSLATE_WITH + " to be a list");
+        }
+        final List<Component> args = with.getValue(LIST_TYPE);
+        component = Component.translatable().key(key).args(args);
+      }
+    } else if(children.containsKey(SCORE)) {
+      final ConfigurationNode score = children.get(SCORE);
+      final ConfigurationNode name = score.getNode(SCORE_NAME);
+      final ConfigurationNode objective = score.getNode(SCORE_OBJECTIVE);
+      if(name.isVirtual() || objective.isVirtual()) {
+        throw new ObjectMappingException("A score component requires a " + SCORE_NAME + " and " + SCORE_OBJECTIVE);
+      }
+      final ScoreComponent.Builder builder = Component.score()
+        .name(name.getString())
+        .objective(objective.getString());
+      // score components can have a value sometimes, let's grab it
+      final ConfigurationNode scoreValue = score.getNode(SCORE_VALUE);
+      if(!scoreValue.isVirtual()) {
+        component = builder.value(scoreValue.getString());
+      } else {
+        component = builder;
+      }
+    } else if(children.containsKey(SELECTOR)) {
+      component = Component.selector().pattern(children.get(SELECTOR).getString());
+    } else if(children.containsKey(KEYBIND)) {
+      component = Component.keybind().keybind(children.get(KEYBIND).getString());
+    } else if(children.containsKey(NBT)) {
+      final String nbt = children.get(NBT).getString();
+      final boolean interpret = children.containsKey(NBT_INTERPRET) && children.get(NBT_INTERPRET).getBoolean();
+      if(children.containsKey(NBT_BLOCK)) {
+        final BlockNBTComponent.Pos pos = children.get(NBT_BLOCK).getValue(BlockNBTPosSerializer.INSTANCE.type());
+        component = nbt(Component.blockNBT(), nbt, interpret).pos(pos);
+      } else if(children.containsKey(NBT_ENTITY)) {
+        component = nbt(Component.entityNBT(), nbt, interpret).selector(children.get(NBT_ENTITY).getString());
+      } else if(children.containsKey(NBT_STORAGE)) {
+        component = nbt(Component.storageNBT(), nbt, interpret).storage(children.get(NBT_STORAGE).getValue(KeySerializer.INSTANCE.type()));
+      } else {
+        throw notSureHowToDeserialize(value);
+      }
+    } else {
+      throw notSureHowToDeserialize(value);
+    }
+
+    if(children.containsKey(EXTRA)) {
+      final ConfigurationNode extra = children.get(EXTRA);
+      for(final ConfigurationNode child : extra.getChildrenList()) {
+        component.append(this.deserialize0(TYPE, child));
+      }
+    }
+
+    final Style style = value.getValue(StyleSerializer.TYPE, Style.empty());
+    if(!style.isEmpty()) {
+      component.style(style);
+    }
+
+    return component.build();
+  }
+
+  @Override
+  public void serialize(@NonNull final TypeToken<?> type, @Nullable final Component src, @NonNull final ConfigurationNode value) throws ObjectMappingException {
+    value.setValue(null);
+    if(src == null) {
+      return;
+    } else if(this.stringSerial != null && this.preferString) {
+      try {
+        value.setValue(this.stringSerial.serialize(src));
+      } catch(final Exception ex) {
+        throw new ObjectMappingException(ex);
+      }
+    }
+    if(src instanceof TextComponent) {
+      value.getNode(TEXT).setValue(((TextComponent) src).content());
+    } else if(src instanceof TranslatableComponent) {
+      final TranslatableComponent tc = (TranslatableComponent) src;
+      value.getNode(TRANSLATE).setValue(tc.key());
+      if(!tc.args().isEmpty()) {
+        final ConfigurationNode with = value.getNode(TRANSLATE_WITH);
+        for(final Component arg : tc.args()) {
+          with.appendListNode().setValue(TYPE, arg);
+        }
+      }
+    } else if(src instanceof ScoreComponent) {
+      final ScoreComponent sc = (ScoreComponent) src;
+      final ConfigurationNode score = value.getNode(SCORE);
+      score.getNode(SCORE_NAME).setValue(sc.name());
+      score.getNode(SCORE_OBJECTIVE).setValue(sc.objective());
+      // score component value is optional
+      final /* @Nullable */ String scoreValue = sc.value();
+      if(scoreValue != null) score.getNode(SCORE_VALUE).setValue(scoreValue);
+    } else if(src instanceof SelectorComponent) {
+      value.getNode(SELECTOR).setValue(((SelectorComponent) src).pattern());
+    } else if(src instanceof KeybindComponent) {
+      value.getNode(KEYBIND).setValue(((KeybindComponent) src).keybind());
+    } else if(src instanceof NBTComponent) {
+      final NBTComponent<?, ?> nc = (NBTComponent<?, ?>) src;
+      value.getNode(NBT).setValue(nc.nbtPath());
+      value.getNode(NBT_INTERPRET).setValue(nc.interpret());
+      if(src instanceof BlockNBTComponent) {
+        value.getNode(NBT_BLOCK).setValue(BlockNBTPosSerializer.INSTANCE.type(), ((BlockNBTComponent) nc).pos());
+      } else if(src instanceof EntityNBTComponent) {
+        value.getNode(NBT_ENTITY).setValue(((EntityNBTComponent) nc).selector());
+      } else if(src instanceof StorageNBTComponent) {
+        value.getNode(NBT_STORAGE).setValue(KeySerializer.INSTANCE.type(), ((StorageNBTComponent) nc).storage());
+      } else {
+        throw notSureHowToSerialize(src);
+      }
+    } else {
+      throw notSureHowToSerialize(src);
+    }
+
+    final List<Component> children = src.children();
+    if(!children.isEmpty()) {
+      value.getNode(EXTRA).setValue(LIST_TYPE, children);
+    }
+
+    if(src.hasStyling()) {
+      // merge
+      value.setValue(StyleSerializer.TYPE, src.style());
+    }
+  }
+
+  private static <C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> B nbt(final B builder, final String nbt, final boolean interpret) {
+    return builder
+      .nbtPath(nbt)
+      .interpret(interpret);
+  }
+
+  private static ObjectMappingException notSureHowToDeserialize(final ConfigurationNode element) {
+    return new ObjectMappingException("Don't know how to turn " + element + " into a Component");
+  }
+
+  private static ObjectMappingException notSureHowToSerialize(final Component component) {
+    return new ObjectMappingException("Don't know how to serialize " + component + " as a Component");
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializer.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.ComponentSerializer;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * A serializer that will output to Configurate {@link ConfigurationNode}s.
+ *
+ * <p>This serializer only modifies its own serializer collection. To add to another collection, 
+ * use an existing serializer instance to {@linkplain #addSerializersTo(TypeSerializerCollection) populate}
+ * that collection. Serializers are added for every Adventure data type.</p>
+ *
+ * <p>The preferred way to use Configurate integration is by registering this serializer's
+ * {@linkplain TypeSerializer type serializers} with a separate </p>
+ *
+ * @since 4.0.0
+ */
+public interface ConfigurateComponentSerializer extends ComponentSerializer<Component, Component, ConfigurationNode> {
+  /**
+   * Get an instance with default settings.
+   *
+   * @return the shared default instance
+   * @since 4.0.0
+   */
+  static @NonNull ConfigurateComponentSerializer configurate() {
+    return ConfigurateComponentSerializerImpl.INSTANCE;
+  }
+
+  /**
+   * Create a new builder for a customized Configurate serializer
+   *
+   * @return a new builder
+   * @since 4.0.0
+   */
+  static @NonNull Builder builder() {
+    return new ConfigurateComponentSerializerImpl.Builder();
+  }
+
+  // TODO @ Configurate 4: expose serializer collection for new child creation
+
+  /**
+   * Populate an existing serializer collection with Adventure serializers.
+   *
+   * @param collection collection to populate
+   * @return input collection
+   * @since 4.0.0
+   */
+  @NonNull TypeSerializerCollection addSerializersTo(final @NonNull TypeSerializerCollection collection);
+
+  /**
+   * A builder for a configurate serializer instance.
+   *
+   * @since 4.0.0
+   */
+  interface Builder {
+    /**
+     * Set the serializer to use when reading Components.
+     *
+     * <p>While the created serializer will always be able to read and write {@linkplain Component Components}
+     * in their object structure, for configuration purposes it is often easier to work with Components as Strings
+     * using one of a variety of available representations.</p>
+     *
+     * @param stringSerializer string serializer to use
+     * @return this builder
+     * @since 4.0.0
+     */
+    @NonNull Builder scalarSerializer(final @NonNull ComponentSerializer<Component, ?, String> stringSerializer);
+
+    /**
+     * If the {@link #scalarSerializer(ComponentSerializer)} is set, output components as serialized strings
+     * rather than following an object structure.
+     *
+     * <p>By default, Components are serialized in object form, and deserialized in either format
+     * based on the configured {@link #scalarSerializer(ComponentSerializer)}.</p>
+     *
+     * @param stringComponents Whether to output as strings
+     * @return this builder
+     * @since 4.0.0
+     */
+    @NonNull Builder outputStringComponents(final boolean stringComponents);
+
+    /**
+     * Create a new component serializer instance
+     *
+     * @return new serializer
+     * @since 4.0.0
+     */
+    @NonNull ConfigurateComponentSerializer build();
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializerImpl.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializerImpl.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.Arrays;
+import java.util.HashSet;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.ComponentSerializer;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSerializer {
+  private final ConfigurationOptions ownNodeOptions;
+  private final @Nullable ComponentSerializer<Component, ?, String> stringSerializer;
+  private final boolean serializeStringComponents;
+  static final ConfigurateComponentSerializer INSTANCE = new Builder().build();
+
+  private ConfigurateComponentSerializerImpl(final @NonNull Builder builder) {
+    this.stringSerializer = builder.stringSerializer;
+    this.serializeStringComponents = builder.outputStringComponents;
+    this.ownNodeOptions = ConfigurationOptions.defaults()
+      .withSerializers(this::addSerializersTo)
+      .withNativeTypes(new HashSet<>(Arrays.asList(String.class, Integer.class, Boolean.class, Double.class, Float.class)));
+  }
+
+  @Override
+  public @NonNull Component deserialize(final @NonNull ConfigurationNode input) {
+    try {
+      final /* @Nullable */ Component deserialized = input.getValue(ComponentTypeSerializer.TYPE);
+      if(deserialized != null) {
+        return deserialized;
+      }
+    } catch(final ObjectMappingException e) {
+      throw new IllegalArgumentException(e);
+    }
+    throw new IllegalArgumentException("No value present");
+  }
+
+  @Override
+  public @NonNull ConfigurationNode serialize(final @NonNull Component component) {
+    final ConfigurationNode base = ConfigurationNode.root(this.ownNodeOptions);
+    try {
+      base.setValue(ComponentTypeSerializer.TYPE, component);
+    } catch(final ObjectMappingException e) {
+      throw new IllegalStateException("Unable to serialize component " + component, e);
+    }
+    return base;
+  }
+
+  @Override
+  public @NonNull TypeSerializerCollection addSerializersTo(final @NonNull TypeSerializerCollection serializers) {
+    return serializers
+      .register(BookTypeSerializer.TYPE, BookTypeSerializer.INSTANCE)
+      .register(TitleSerializer.TYPE, TitleSerializer.INSTANCE)
+      .register(SoundSerializer.TYPE, SoundSerializer.INSTANCE)
+      .register(SoundStopSerializer.TYPE, SoundStopSerializer.INSTANCE)
+      .register(ComponentTypeSerializer.TYPE, new ComponentTypeSerializer(this.stringSerializer, this.serializeStringComponents))
+
+      // shared types
+      .register(KeySerializer.INSTANCE)
+      .register(DurationSerializer.INSTANCE)
+      .register(StyleSerializer.TYPE, StyleSerializer.INSTANCE)
+      .register(TextColorSerializer.INSTANCE)
+      .register(BlockNBTPosSerializer.INSTANCE)
+      .register(new IndexSerializer<>(TypeToken.of(ClickEvent.Action.class), ClickEvent.Action.NAMES))
+      .register(new IndexSerializer<>(new TypeToken<HoverEvent.Action<?>>() {}, HoverEvent.Action.NAMES))
+      .register(new IndexSerializer<>(TypeToken.of(Sound.Source.class), Sound.Source.NAMES))
+      .register(new IndexSerializer<>(TypeToken.of(TextDecoration.class), TextDecoration.NAMES))
+      .register(HoverEventShowEntitySerializer.TYPE, HoverEventShowEntitySerializer.INSTANCE)
+      .register(HoverEventShowItemSerializer.TYPE, HoverEventShowItemSerializer.INSTANCE);
+  }
+
+  static class Builder implements ConfigurateComponentSerializer.Builder {
+    private @Nullable ComponentSerializer<Component, ?, String> stringSerializer;
+    private boolean outputStringComponents = false;
+
+    Builder() {
+    }
+
+    @Override
+    public ConfigurateComponentSerializer.@NonNull Builder scalarSerializer(final @NonNull ComponentSerializer<Component, ?, String> stringSerializer) {
+      this.stringSerializer = requireNonNull(stringSerializer, "stringSerializer");
+      return this;
+    }
+
+    @Override
+    public ConfigurateComponentSerializer.@NonNull Builder outputStringComponents(final boolean stringComponents) {
+      this.outputStringComponents = stringComponents;
+      return this;
+    }
+
+    @Override
+    public @NonNull ConfigurateComponentSerializer build() {
+      return new ConfigurateComponentSerializerImpl(this);
+    }
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/DurationSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/DurationSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.function.Predicate;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * A serializer for the JDK {@link Duration} type.
+ *
+ * <p>This will eventually be incorporated into upstream Configurate</p>
+ */
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class DurationSerializer extends ScalarSerializer<Duration> {
+  static final DurationSerializer INSTANCE = new DurationSerializer();
+
+  private DurationSerializer() {
+    super(Duration.class);
+  }
+
+  @Override
+  public Duration deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+    if(obj instanceof CharSequence) {
+      String value = obj.toString();
+      if(!value.startsWith("P") && !value.startsWith("p")) {
+        value = "P" + value;
+      }
+
+      try {
+        return Duration.parse(value);
+      } catch(final DateTimeParseException ex) {
+        throw new ObjectMappingException(ex);
+      }
+    }
+    throw new ObjectMappingException("Value was not of appropriate type");
+  }
+
+  @Override
+  public Object serialize(final @NonNull Duration item, final @NonNull Predicate<Class<?>> typeSupported) {
+    return item.toString();
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowEntitySerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowEntitySerializer.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.UUID;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEvent.ShowEntity> {
+  static final HoverEventShowEntitySerializer INSTANCE = new HoverEventShowEntitySerializer();
+  static final TypeToken<HoverEvent.ShowEntity> TYPE = TypeToken.of(HoverEvent.ShowEntity.class);
+  private static final TypeToken<UUID> UUID_TYPE = TypeToken.of(UUID.class);
+
+  static final String ENTITY_TYPE = "type";
+  static final String ID = "id";
+  static final String NAME = "name";
+
+  private HoverEventShowEntitySerializer() {
+  }
+
+  @Override
+  public HoverEvent.ShowEntity deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    final Key typeId = value.getNode(ENTITY_TYPE).getValue(KeySerializer.INSTANCE.type());
+    final UUID id = value.getNode(ID).getValue(UUID_TYPE);
+    if(typeId == null || id == null) {
+      throw new ObjectMappingException("A show entity hover event needs type and id fields to be deserialized");
+    }
+    final /* @Nullable */ Component name = value.getNode(NAME).getValue(ComponentTypeSerializer.TYPE);
+
+    return HoverEvent.ShowEntity.of(typeId, id, name);
+  }
+
+  @Override
+  public void serialize(final @NonNull TypeToken<?> type, final HoverEvent.@Nullable ShowEntity obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(obj == null) {
+      value.setValue(null);
+      return;
+    }
+
+    value.getNode(ENTITY_TYPE).setValue(KeySerializer.INSTANCE.type(), obj.type());
+    value.getNode(ID).setValue(UUID_TYPE, obj.id());
+    value.getNode(NAME).setValue(ComponentTypeSerializer.TYPE, obj.name());
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowItemSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowItemSerializer.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.event.HoverEvent;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class HoverEventShowItemSerializer implements TypeSerializer<HoverEvent.ShowItem> {
+  static final HoverEventShowItemSerializer INSTANCE = new HoverEventShowItemSerializer();
+  static final TypeToken<HoverEvent.ShowItem> TYPE = TypeToken.of(HoverEvent.ShowItem.class);
+
+  static final String ID = "id";
+  static final String COUNT = "count";
+  static final String TAG = "tag";
+
+  private HoverEventShowItemSerializer() {
+  }
+
+  @Override
+  public HoverEvent.ShowItem deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    final Key id = value.getNode(ID).getValue(KeySerializer.INSTANCE.type());
+    if(id == null) {
+      throw new ObjectMappingException("An id is required to deserialize the show_item hover event");
+    }
+    final int count = value.getNode(COUNT).getInt(1);
+    final String tag = value.getNode(TAG).getString();
+
+    return HoverEvent.ShowItem.of(id, count, tag == null ? null : BinaryTagHolder.of(tag));
+  }
+
+  @Override
+  public void serialize(final @NonNull TypeToken<?> type, final HoverEvent.@Nullable ShowItem obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(obj == null) {
+      value.setValue(null);
+      return;
+    }
+
+    value.getNode(ID).setValue(KeySerializer.INSTANCE.type(), obj.item());
+    value.getNode(COUNT).setValue(obj.count());
+
+    if(obj.nbt() == null) {
+      value.getNode(TAG).setValue(null);
+    } else {
+      value.getNode(TAG).setValue(obj.nbt().string());
+    }
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/IndexSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/IndexSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.function.Predicate;
+import net.kyori.adventure.util.Index;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class IndexSerializer<T> extends ScalarSerializer<T> {
+  private final Index<String, T> idx;
+  
+  IndexSerializer(final @NonNull TypeToken<T> type, final @NonNull Index<String, T> idx) {
+    super(type);
+    this.idx = idx;
+  }
+  
+  @Override
+  public @NonNull T deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+    final T value = this.idx.value(obj.toString());
+    if(value == null) {
+      throw new ObjectMappingException("No value for key '" + obj + "' in index for type " + this.type());
+    }
+    return value;
+  }
+
+  @Override
+  public Object serialize(final @NonNull T item, final @NonNull Predicate<Class<?>> typeSupported) {
+    return this.idx.key(item);
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/KeySerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/KeySerializer.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.function.Predicate;
+import net.kyori.adventure.key.InvalidKeyException;
+import net.kyori.adventure.key.Key;
+import ninja.leaping.configurate.objectmapping.InvalidTypeException;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class KeySerializer extends ScalarSerializer<Key> {
+  static final KeySerializer INSTANCE = new KeySerializer();
+  
+  private KeySerializer() {
+    super(Key.class);
+  }
+
+  @Override
+  public @NonNull Key deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+    if(!(obj instanceof CharSequence)) {
+      throw new InvalidTypeException(type);
+    }
+    try {
+      return Key.key(obj.toString());
+    } catch(final InvalidKeyException ex) {
+      throw new ObjectMappingException(ex);
+    }
+  }
+
+  @Override
+  public @NonNull Object serialize(final @NonNull Key item, final @NonNull Predicate<Class<?>> typeSupported) {
+    return item.asString();
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/SoundSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/SoundSerializer.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class SoundSerializer implements TypeSerializer<Sound> {
+  static final TypeToken<Sound> TYPE = TypeToken.of(Sound.class);
+  static final TypeToken<Sound.Source> SOURCE_TYPE = TypeToken.of(Sound.Source.class);
+  static final SoundSerializer INSTANCE = new SoundSerializer();
+
+  static final String NAME = "name";
+  static final String SOURCE = "source";
+  static final String PITCH = "pitch";
+  static final String VOLUME = "volume";
+
+  private SoundSerializer() {
+  }
+
+  @Override
+  public @Nullable Sound deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(value.isEmpty()) {
+      return null;
+    }
+
+    final Key name = value.getNode(NAME).getValue(KeySerializer.INSTANCE.type());
+    final Sound.Source source = value.getNode(SOURCE).getValue(SOURCE_TYPE);
+    final float volume = value.getNode(VOLUME).getFloat(1.0f);
+    final float pitch = value.getNode(PITCH).getFloat(1.0f);
+
+    if(name == null || source == null) {
+      throw new ObjectMappingException("A name and source are required to deserialize a Sound");
+    }
+
+    return Sound.sound(name, source, volume, pitch);
+  }
+
+  @Override
+  public void serialize(final @NonNull TypeToken<?> type, final @Nullable Sound obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(obj == null) {
+      value.setValue(null);
+      return;
+    }
+    value.getNode(NAME).setValue(KeySerializer.INSTANCE.type(), obj.name());
+    value.getNode(SOURCE).setValue(SOURCE_TYPE, obj.source());
+    value.getNode(VOLUME).setValue(obj.volume());
+    value.getNode(PITCH).setValue(obj.pitch());
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/SoundStopSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/SoundStopSerializer.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.Collections;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.SoundStop;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class SoundStopSerializer implements TypeSerializer<SoundStop> {
+  static final TypeToken<SoundStop> TYPE = TypeToken.of(SoundStop.class);
+  static final SoundStopSerializer INSTANCE = new SoundStopSerializer();
+
+  static final String SOUND = "sound";
+  static final String SOURCE = "source";
+
+  private SoundStopSerializer() {
+  }
+
+  @Override
+  public SoundStop deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(value.isEmpty()) {
+      return SoundStop.all();
+    } else {
+      final Key sound = value.getNode(SOUND).getValue(KeySerializer.INSTANCE.type());
+      final Sound.Source source = value.getNode(SOURCE).getValue(SoundSerializer.SOURCE_TYPE);
+      if(sound == null) {
+        return source == null ? SoundStop.all() : SoundStop.source(source);
+      } else {
+        return source == null ? SoundStop.named(sound) : SoundStop.namedOnSource(sound, source);
+      }
+    }
+  }
+
+  @Override
+  public void serialize(final @NonNull TypeToken<?> type, final @Nullable SoundStop obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    value.getNode(SOUND).setValue(KeySerializer.INSTANCE.type(), obj == null ? null : obj.sound());
+    value.getNode(SOURCE).setValue(SoundSerializer.SOURCE_TYPE, obj == null ? null : obj.source());
+    if(value.isEmpty()) {
+      value.setValue(Collections.emptyMap());
+    }
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/StyleSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/StyleSerializer.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class StyleSerializer implements TypeSerializer<Style> {
+  static final TypeToken<Style> TYPE = TypeToken.of(Style.class);
+  static final StyleSerializer INSTANCE = new StyleSerializer();
+
+  private static final TextDecoration[] DECORATIONS = TextDecoration.values();
+  private static final TypeToken<TextDecoration.State> DECORATION_STATE = TypeToken.of(TextDecoration.State.class);
+
+  static final String FONT = "font";
+  static final String COLOR = "color";
+  static final String INSERTION = "insertion";
+  static final String CLICK_EVENT = "clickEvent";
+  static final String CLICK_EVENT_ACTION = "action";
+  static final TypeToken<ClickEvent.Action> CLICK_EVENT_ACTION_TYPE = TypeToken.of(ClickEvent.Action.class);
+  static final String CLICK_EVENT_VALUE = "value";
+  static final String HOVER_EVENT = "hoverEvent";
+  static final String HOVER_EVENT_ACTION = "action";
+  static final TypeToken<HoverEvent.Action<?>> HOVER_EVENT_ACTION_TYPE = new TypeToken<HoverEvent.Action<?>>() {};
+  static final String HOVER_EVENT_CONTENTS = "contents";
+  static final @Deprecated String HOVER_EVENT_VALUE = "value";
+
+  private StyleSerializer() {
+  }
+
+  @Override
+  public @NonNull Style deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(value.isVirtual()) {
+      return Style.empty();
+    }
+
+    final Style.Builder builder = Style.style();
+
+    final /* @Nullable */ Key font = value.getNode(FONT).getValue(KeySerializer.INSTANCE.type());
+    if(font != null) {
+      builder.font(font);
+    }
+    final /* @Nullable */ TextColor color = value.getNode(COLOR).getValue(TextColorSerializer.INSTANCE.type());
+    if(color != null) {
+      builder.color(color);
+    }
+
+    for(final TextDecoration decoration : DECORATIONS) {
+      final TextDecoration.State state = value.getNode(nonNull(TextDecoration.NAMES.key(decoration), "decoration")).getValue(DECORATION_STATE);
+      if(state != null) {
+        builder.decoration(decoration, state);
+      }
+    }
+
+    final /* @Nullable */ String insertion = value.getNode(INSERTION).getString();
+    if(insertion != null) {
+      builder.insertion(insertion);
+    }
+
+    final ConfigurationNode clickEvent = value.getNode(CLICK_EVENT);
+    if(!clickEvent.isVirtual()) {
+      final ClickEvent.Action action = nonNull(clickEvent.getNode(CLICK_EVENT_ACTION).getValue(CLICK_EVENT_ACTION_TYPE), "click event action");
+      builder.clickEvent(ClickEvent.clickEvent(action, nonNull(clickEvent.getNode(CLICK_EVENT_VALUE).getString(), "click event value")));
+    }
+
+    final ConfigurationNode hoverEvent = value.getNode(HOVER_EVENT);
+    if(!hoverEvent.isVirtual()) {
+      final HoverEvent.Action<?> action = hoverEvent.getNode(HOVER_EVENT_ACTION).getValue(HOVER_EVENT_ACTION_TYPE);
+      final ConfigurationNode contents = hoverEvent.getNode(HOVER_EVENT_CONTENTS);
+      if(contents.isVirtual()) {
+        final Component legacyValue = hoverEvent.getNode(HOVER_EVENT_VALUE).getValue(ComponentTypeSerializer.TYPE);
+        if(legacyValue == null) {
+          throw new ObjectMappingException("No modern contents or legacy value present for hover event");
+        }
+        if(action == HoverEvent.Action.SHOW_TEXT) {
+          builder.hoverEvent(HoverEvent.showText(legacyValue));
+        } else {
+          throw new ObjectMappingException("Unable to deserialize legacy hover event of type " + action);
+        }
+        // TODO: Legacy hover event
+      } else {
+        if(action == HoverEvent.Action.SHOW_TEXT) {
+          builder.hoverEvent(HoverEvent.showText(nonNull(contents.getValue(ComponentTypeSerializer.TYPE), "hover event text contents")));
+        } else if(action == HoverEvent.Action.SHOW_ENTITY) {
+          builder.hoverEvent(HoverEvent.showEntity(nonNull(contents.getValue(HoverEventShowEntitySerializer.TYPE), "hover event show entity contents")));
+        } else if(action == HoverEvent.Action.SHOW_ITEM) {
+          builder.hoverEvent(HoverEvent.showItem(nonNull(contents.getValue(HoverEventShowItemSerializer.TYPE), "hover event show item contents")));
+        } else {
+          throw new ObjectMappingException("Unsupported hover event action " + action);
+        }
+      }
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public void serialize(final @NonNull TypeToken<?> type, @Nullable Style obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(obj == null) {
+      obj = Style.empty();
+    }
+    value.getNode(FONT).setValue(KeySerializer.INSTANCE.type(), obj.font());
+    value.getNode(COLOR).setValue(TextColorSerializer.INSTANCE.type(), obj.color());
+    for(final TextDecoration decoration : DECORATIONS) {
+      final ConfigurationNode decorationNode = value.getNode(nonNull(TextDecoration.NAMES.key(decoration), "decoration"));
+      final TextDecoration.State state = obj.decoration(decoration);
+      if(state == TextDecoration.State.NOT_SET) {
+        decorationNode.setValue(null);
+      } else {
+        decorationNode.setValue(state == TextDecoration.State.TRUE);
+      }
+    }
+    value.getNode(INSERTION).setValue(obj.insertion());
+
+    final ConfigurationNode clickNode = value.getNode(CLICK_EVENT);
+    if(obj.clickEvent() == null) {
+      clickNode.setValue(null);
+    } else {
+      clickNode.getNode(CLICK_EVENT_ACTION).setValue(CLICK_EVENT_ACTION_TYPE, obj.clickEvent().action());
+      clickNode.getNode(CLICK_EVENT_VALUE).setValue(obj.clickEvent().value());
+    }
+
+    final ConfigurationNode hoverNode = value.getNode(HOVER_EVENT);
+    if(obj.hoverEvent() == null) {
+      hoverNode.setValue(null);
+    } else {
+      final HoverEvent<?> event = obj.hoverEvent();
+      hoverNode.getNode(HOVER_EVENT_ACTION).setValue(HOVER_EVENT_ACTION_TYPE, event.action());
+      final ConfigurationNode contentsNode = hoverNode.getNode(HOVER_EVENT_CONTENTS);
+      if(event.action() == HoverEvent.Action.SHOW_TEXT) {
+        contentsNode.setValue(ComponentTypeSerializer.TYPE, (Component) event.value());
+      } else if(event.action() == HoverEvent.Action.SHOW_ENTITY) {
+        contentsNode.setValue(HoverEventShowEntitySerializer.TYPE, (HoverEvent.ShowEntity) event.value());
+      } else if(event.action() == HoverEvent.Action.SHOW_ITEM) {
+        contentsNode.setValue(HoverEventShowItemSerializer.TYPE, (HoverEvent.ShowItem) event.value());
+      }
+    }
+  }
+
+  private static <T> @NonNull T nonNull(final @Nullable T value, final @NonNull String type) throws ObjectMappingException {
+    if(value == null) {
+      throw new ObjectMappingException(type + " was null in an unexpected location");
+    }
+    return value;
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TextColorSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TextColorSerializer.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.util.function.Predicate;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class TextColorSerializer extends ScalarSerializer<TextColor> {
+  static final TextColorSerializer INSTANCE = new TextColorSerializer();
+  private static final String HEX_PREFIX = "#";
+
+  private TextColorSerializer() {
+    super(TextColor.class);
+  }
+
+  @Override
+  public TextColor deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+    if(obj instanceof Number) { // numerical values
+      return TextColor.color(((Number) obj).intValue());
+    } else if(!(obj instanceof CharSequence)) {
+      throw new ObjectMappingException("Text colors must either be strings or integers");
+    }
+    final String value = obj.toString();
+    final TextColor result;
+    if(value.startsWith(HEX_PREFIX)) {
+      result = TextColor.fromHexString(value);
+    } else {
+      result = NamedTextColor.NAMES.value(value);
+    }
+    if(result == null) {
+      throw new ObjectMappingException("Could not convert '" + value + "' into a TextColor");
+    }
+    return result;
+  }
+
+  @Override
+  public Object serialize(final @NonNull TextColor item, final @NonNull Predicate<Class<?>> typeSupported) {
+    if(item instanceof NamedTextColor) { // TODO: Downsampling
+      return NamedTextColor.NAMES.key((NamedTextColor) item);
+    } else {
+      return item.asHexString();
+    }
+  }
+}

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TitleSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TitleSerializer.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.time.Duration;
+import java.util.Objects;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.title.Title;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+@SuppressWarnings("UnstableApiUsage") // TypeToken
+final class TitleSerializer implements TypeSerializer<Title> {
+  static final TypeToken<Title> TYPE = TypeToken.of(Title.class);
+  static final TitleSerializer INSTANCE = new TitleSerializer();
+
+  private TitleSerializer() {
+  }
+
+  static final Duration KEEP = Duration.ofSeconds(-1);
+  static final String TITLE = "title";
+  static final String SUBTITLE = "subtitle";
+  static final String TIMES = "times";
+  static final String FADE_IN = "fade-in";
+  static final String STAY = "stay";
+  static final String FADE_OUT = "fade-out";
+
+  @Override
+  public @Nullable Title deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(value.isEmpty()) {
+      return null;
+    }
+    final Component title = value.getNode(TITLE).getValue(ComponentTypeSerializer.TYPE, Component.empty());
+    final Component subtitle = value.getNode(SUBTITLE).getValue(ComponentTypeSerializer.TYPE, Component.empty());
+
+    final Duration fadeIn = value.getNode(TIMES, FADE_IN).getValue(DurationSerializer.INSTANCE.type(), KEEP);
+    final Duration stay = value.getNode(TIMES, STAY).getValue(DurationSerializer.INSTANCE.type(), KEEP);
+    final Duration fadeOut = value.getNode(TIMES, FADE_OUT).getValue(DurationSerializer.INSTANCE.type(), KEEP);
+
+    if(!Objects.equals(fadeIn, KEEP) || !Objects.equals(stay, KEEP) || !Objects.equals(fadeOut, KEEP)) {
+      return Title.title(title, subtitle, Title.Times.of(fadeIn, stay, fadeOut));
+    } else {
+      return Title.title(title, subtitle);
+    }
+  }
+
+  @Override
+  public void serialize(final @NonNull TypeToken<?> type, final @Nullable Title obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+    if(obj == null) {
+      value.setValue(null);
+      return;
+    }
+
+    value.getNode(TITLE).setValue(ComponentTypeSerializer.TYPE, obj.title());
+    value.getNode(SUBTITLE).setValue(ComponentTypeSerializer.TYPE, obj.subtitle());
+    final Title./* @Nullable */ Times times = obj.times();
+    value.getNode(TIMES, FADE_IN).setValue(DurationSerializer.INSTANCE.type(), times == null || times == Title.DEFAULT_TIMES ? null : times.fadeIn());
+    value.getNode(TIMES, STAY).setValue(DurationSerializer.INSTANCE.type(), times == null || times == Title.DEFAULT_TIMES ? null : times.stay());
+    value.getNode(TIMES, FADE_OUT).setValue(DurationSerializer.INSTANCE.type(), times == null || times == Title.DEFAULT_TIMES ? null : times.fadeOut());
+  }
+}

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/BookSerializerTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/BookSerializerTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import net.kyori.adventure.inventory.Book;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BookSerializerTest implements ConfigurateTestBase {
+  @Test
+  void testBook() throws ObjectMappingException {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(BookTypeSerializer.TITLE, ComponentTypeSerializer.TEXT).setValue("My book");
+      n.getNode(BookTypeSerializer.AUTHOR).act(author -> {
+        author.getNode(StyleSerializer.FONT).setValue("minecraft:uniform");
+        author.getNode(ComponentTypeSerializer.TEXT).setValue("myself");
+      });
+      n.getNode(BookTypeSerializer.PAGES).act(pages -> {
+        pages.appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("Page 1");
+        pages.appendListNode().act(page -> {
+          page.getNode(StyleSerializer.COLOR).setValue("dark_red");
+          page.getNode(ComponentTypeSerializer.TEXT).setValue("Page 2");
+        });
+        pages.appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("Page 3");
+      });
+    });
+    final Book deserialized = Book.builder().title(Component.text("My book"))
+      .author(Component.text("myself", Style.style().font(Key.key("uniform")).build()))
+      .addPage(Component.text("Page 1"))
+      .addPage(Component.text("Page 2", NamedTextColor.DARK_RED))
+      .addPage(Component.text("Page 3"))
+      .build();
+
+    this.assertRoundtrippable(BookTypeSerializer.TYPE, deserialized, node);
+  }
+
+  @Test
+  void testNoTitleFails() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(BookTypeSerializer.AUTHOR).act(author -> {
+        author.getNode(StyleSerializer.FONT).setValue("minecraft:uniform");
+        author.getNode(ComponentTypeSerializer.TEXT).setValue("myself");
+      });
+      n.getNode(BookTypeSerializer.PAGES).appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("Page 1");
+    });
+
+    assertThrows(ObjectMappingException.class, () -> node.getValue(BookTypeSerializer.TYPE));
+  }
+
+  @Test
+  void testNoAuthorFails() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(BookTypeSerializer.TITLE, ComponentTypeSerializer.TEXT).setValue("My book");
+      n.getNode(BookTypeSerializer.PAGES).appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("Page 1");
+    });
+
+    assertThrows(ObjectMappingException.class, () -> node.getValue(BookTypeSerializer.TYPE));
+  }
+}

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/ComponentSerializerTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/ComponentSerializerTest.java
@@ -1,0 +1,186 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextColor;
+import ninja.leaping.configurate.ConfigurationNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentSerializerTest implements ConfigurateTestBase {
+  @Test
+  void testTextComponent() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.TEXT).setValue("Hello world");
+    });
+    final Component component = Component.text("Hello world");
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testTranslatableComponent() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.TRANSLATE).setValue("translation.string");
+      n.getNode(ComponentTypeSerializer.TRANSLATE_WITH).act(w -> {
+        w.appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("test1");
+        w.appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("test2");
+      });
+    });
+    final Component component = Component.translatable("translation.string", Component.text("test1"), Component.text("test2"));
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testScoreComponent() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.SCORE).act(s -> {
+        s.getNode(ComponentTypeSerializer.SCORE_NAME).setValue("Holder");
+        s.getNode(ComponentTypeSerializer.SCORE_OBJECTIVE).setValue("some.objective");
+        s.getNode(ComponentTypeSerializer.SCORE_VALUE).setValue("Override");
+      });
+    });
+    final Component component = Component.score("Holder", "some.objective", "Override");
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testScoreComponentNoValue() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.SCORE).act(s -> {
+        s.getNode(ComponentTypeSerializer.SCORE_NAME).setValue("Holder");
+        s.getNode(ComponentTypeSerializer.SCORE_OBJECTIVE).setValue("some.objective");
+      });
+    });
+
+    final Component component = Component.score("Holder", "some.objective");
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testKeybindComponent() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.KEYBIND).setValue("key.worldeditcui.toggle");
+    });
+    final Component component = Component.keybind("key.worldeditcui.toggle");
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testSelectorComponent() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.SELECTOR).setValue("@e[limit=1]");
+    });
+    final Component component = Component.selector("@e[limit=1]");
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testBlockNBTComponent() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.NBT).setValue("Something[1].CustomName");
+      n.getNode(ComponentTypeSerializer.NBT_INTERPRET).setValue(true);
+      n.getNode(ComponentTypeSerializer.NBT_BLOCK).setValue("^0.0 ^0.0 ^0.0");
+    });
+    final Component component = Component.blockNBT()
+      .nbtPath("Something[1].CustomName")
+      .interpret(true)
+      .localPos(0, 0, 0)
+      .build();
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testEntityNBTComponent() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.NBT).setValue("Something[1].CustomName");
+      n.getNode(ComponentTypeSerializer.NBT_INTERPRET).setValue(false);
+      n.getNode(ComponentTypeSerializer.NBT_ENTITY).setValue("@e[limit=1]");
+    });
+    final Component component = Component.entityNBT()
+      .nbtPath("Something[1].CustomName")
+      .interpret(false)
+      .selector("@e[limit=1]")
+      .build();
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testStorageNBTComponent() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.NBT).setValue("Kittens.Toes[0]");
+      n.getNode(ComponentTypeSerializer.NBT_INTERPRET).setValue(false);
+      n.getNode(ComponentTypeSerializer.NBT_STORAGE).setValue("adventure:purr");
+    });
+    final Component component = Component.storageNBT()
+      .nbtPath("Kittens.Toes[0]")
+      .interpret(false)
+      .storage(Key.key("adventure", "purr"))
+      .build();
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testComponentWithChildren() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.getNode(ComponentTypeSerializer.TEXT).setValue("Hello");
+      n.getNode(ComponentTypeSerializer.EXTRA).act(extra -> {
+        extra.appendListNode().getNode(ComponentTypeSerializer.TRANSLATE).setValue("adventure.world");
+        extra.appendListNode().getNode(ComponentTypeSerializer.KEYBIND).setValue("minecraft.key.jump");
+      });
+    });
+    final Component component = Component.text().content("Hello")
+      .append(Component.translatable("adventure.world"))
+      .append(Component.keybind("minecraft.key.jump"))
+      .build();
+
+    this.assertRoundtrippable(component, serialized);
+  }
+
+  @Test
+  void testArrayChildren() {
+    final ConfigurationNode serialized = this.node(n -> {
+      n.appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("first");
+      n.appendListNode().act(child -> {
+        child.getNode(ComponentTypeSerializer.TRANSLATE).setValue("keys.second");
+        child.getNode(StyleSerializer.COLOR).setValue("#deadca");
+      });
+    });
+    final Component deserialized = Component.text("first")
+      .append(Component.translatable("keys.second", TextColor.color(0xdeadca)));
+
+    assertEquals(deserialized, this.deserialize(serialized));
+  }
+}

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/ConfigurateTestBase.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/ConfigurateTestBase.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
+import java.util.function.Consumer;
+import net.kyori.adventure.text.Component;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public interface ConfigurateTestBase {
+
+  ConfigurationOptions OPTIONS = ConfigurationOptions.defaults()
+    .withSerializers(s -> ConfigurateComponentSerializer.builder().build().addSerializersTo(s))
+    .withNativeTypes(ImmutableSet.of(String.class, Integer.class, Boolean.class, Double.class, Float.class));
+
+  default ConfigurationNode node() {
+    return ConfigurationNode.root(OPTIONS);
+  }
+
+  default ConfigurationNode node(final Object value) {
+    return ConfigurationNode.root(OPTIONS).setValue(value);
+  }
+
+  default ConfigurationNode node(final Consumer<ConfigurationNode> actor) {
+    return ConfigurationNode.root(OPTIONS, actor);
+  }
+
+  default ConfigurationNode serialize(final Component component) {
+    return ConfigurateComponentSerializer.configurate().serialize(component);
+  }
+
+  default Component deserialize(final ConfigurationNode node) {
+    return ConfigurateComponentSerializer.configurate().deserialize(node);
+  }
+
+  // make sure the value can be roundtripped
+  default <T> void assertRoundtrippable(final TypeToken<T> type, final T value, final ConfigurationNode holder) {
+    try {
+      assertEquals(holder, this.node().setValue(type, value));
+      assertEquals(value, holder.getValue(type));
+    } catch(ObjectMappingException ex) {
+      fail(ex);
+    }
+  }
+
+  default void assertRoundtrippable(final Component value, final ConfigurationNode holder) {
+    assertEquals(value, this.deserialize(holder));
+    assertEquals(holder, this.serialize(value));
+  }
+}

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/HoverEventSerializersTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/HoverEventSerializersTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import java.util.UUID;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import ninja.leaping.configurate.ConfigurationNode;
+import org.junit.jupiter.api.Test;
+
+public class HoverEventSerializersTest implements ConfigurateTestBase {
+  @Test
+  void testShowEntity() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(ComponentTypeSerializer.TEXT).setValue("kashike");
+      n.getNode(StyleSerializer.HOVER_EVENT).act(event -> {
+        event.getNode(StyleSerializer.HOVER_EVENT_ACTION).setValue("show_entity");
+        event.getNode(StyleSerializer.HOVER_EVENT_CONTENTS).act(entity -> {
+          entity.getNode(HoverEventShowEntitySerializer.ENTITY_TYPE).setValue("minecraft:cat");
+          entity.getNode(HoverEventShowEntitySerializer.ID).setValue("eb121687-8b1a-4944-bd4d-e0a818d9dfe2");
+        });
+      });
+    });
+    final Component component = Component.text().content("kashike")
+      .hoverEvent(HoverEvent.showEntity(HoverEvent.ShowEntity.of(Key.key("minecraft:cat"), UUID.fromString("eb121687-8b1a-4944-bd4d-e0a818d9dfe2"))))
+      .build();
+
+    this.assertRoundtrippable(component, node);
+  }
+
+  @Test
+  void testShowEntityCustomName() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(ComponentTypeSerializer.TEXT).setValue("kashike");
+      n.getNode(StyleSerializer.HOVER_EVENT).act(event -> {
+        event.getNode(StyleSerializer.HOVER_EVENT_ACTION).setValue("show_entity");
+        event.getNode(StyleSerializer.HOVER_EVENT_CONTENTS).act(entity -> {
+          entity.getNode(HoverEventShowEntitySerializer.ENTITY_TYPE).setValue("minecraft:cat");
+          entity.getNode(HoverEventShowEntitySerializer.ID).setValue("eb121687-8b1a-4944-bd4d-e0a818d9dfe2");
+          entity.getNode(HoverEventShowEntitySerializer.NAME, ComponentTypeSerializer.TEXT).setValue("meow");
+        });
+      });
+    });
+    final Component component = Component.text().content("kashike")
+      .hoverEvent(HoverEvent.showEntity(HoverEvent.ShowEntity.of(Key.key("minecraft:cat"), UUID.fromString("eb121687-8b1a-4944-bd4d-e0a818d9dfe2"), Component.text("meow"))))
+      .build();
+
+    this.assertRoundtrippable(component, node);
+  }
+
+  @Test
+  void testShowItem() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(ComponentTypeSerializer.TEXT).setValue("[");
+      n.getNode(StyleSerializer.COLOR).setValue("aqua");
+      n.getNode(ComponentTypeSerializer.EXTRA).act(extra -> {
+        extra.appendListNode().getNode(ComponentTypeSerializer.TRANSLATE).setValue("item.minecraft.purple_wool");
+        extra.appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("]");
+      });
+      n.getNode(StyleSerializer.HOVER_EVENT).act(hover -> {
+        hover.getNode(StyleSerializer.HOVER_EVENT_ACTION).setValue("show_item");
+        hover.getNode(StyleSerializer.HOVER_EVENT_CONTENTS).act(action -> {
+          action.getNode(HoverEventShowItemSerializer.ID).setValue("minecraft:purple_wool");
+          action.getNode(HoverEventShowItemSerializer.COUNT).setValue(2);
+          action.getNode(HoverEventShowItemSerializer.TAG).setValue("{Damage: 5b}");
+        });
+      });
+    });
+    final Component component = Component.text().content("[")
+      .color(NamedTextColor.AQUA)
+      .append(Component.translatable("item.minecraft.purple_wool"))
+      .append(Component.text("]"))
+      .hoverEvent(HoverEvent.showItem(HoverEvent.ShowItem.of(Key.key("minecraft:purple_wool"), 2, BinaryTagHolder.of("{Damage: 5b}"))))
+      .build();
+
+    this.assertRoundtrippable(component, node);
+  }
+
+  @Test
+  void testShowItemNoTag() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(ComponentTypeSerializer.TEXT).setValue("[");
+      n.getNode(StyleSerializer.COLOR).setValue("aqua");
+      n.getNode(ComponentTypeSerializer.EXTRA).act(extra -> {
+        extra.appendListNode().getNode(ComponentTypeSerializer.TRANSLATE).setValue("item.minecraft.purple_wool");
+        extra.appendListNode().getNode(ComponentTypeSerializer.TEXT).setValue("]");
+      });
+      n.getNode(StyleSerializer.HOVER_EVENT).act(hover -> {
+        hover.getNode(StyleSerializer.HOVER_EVENT_ACTION).setValue("show_item");
+        hover.getNode(StyleSerializer.HOVER_EVENT_CONTENTS).act(action -> {
+          action.getNode(HoverEventShowItemSerializer.ID).setValue("minecraft:purple_wool");
+          action.getNode(HoverEventShowItemSerializer.COUNT).setValue(1);
+        });
+      });
+    });
+    final Component component = Component.text().content("[")
+      .color(NamedTextColor.AQUA)
+      .append(Component.translatable("item.minecraft.purple_wool"))
+      .append(Component.text("]"))
+      .hoverEvent(HoverEvent.showItem(HoverEvent.ShowItem.of(Key.key("minecraft:purple_wool"), 1)))
+      .build();
+
+    this.assertRoundtrippable(component, node);
+  }
+
+  @Test
+  void testShowText() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(StyleSerializer.HOVER_EVENT).act(event -> {
+        event.getNode(StyleSerializer.HOVER_EVENT_ACTION).setValue("show_text");
+        event.getNode(StyleSerializer.HOVER_EVENT_CONTENTS, ComponentTypeSerializer.TEXT).setValue("i'm hovering");
+      });
+      n.getNode(ComponentTypeSerializer.TRANSLATE).setValue("look.at.me");
+    });
+    final Component component = Component.translatable("look.at.me", Style.style(HoverEvent.showText(Component.text("i'm hovering"))));
+
+    this.assertRoundtrippable(component, node);
+  }
+}

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/ScalarSerializersTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/ScalarSerializersTest.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.reflect.TypeToken;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ScalarSerializersTest implements ConfigurateTestBase {
+  @Test
+  void testSerializeNamedTextColor() throws ObjectMappingException {
+    final ConfigurationNode node = this.node();
+    node.setValue(TypeToken.of(TextColor.class), NamedTextColor.AQUA);
+    assertEquals("aqua", node.getValue());
+
+    node.setValue("dark_purple");
+    assertEquals(NamedTextColor.DARK_PURPLE, node.getValue(TextColorSerializer.INSTANCE.type()));
+  }
+
+  @Test
+  void testSerializeHexTextColor() throws ObjectMappingException {
+    // read as hex string
+    final ConfigurationNode node = this.node("#adface");
+    assertEquals(TextColor.color(0xadface), node.getValue(TypeToken.of(TextColor.class)));
+
+    // read as int
+    node.setValue(0x2468AC);
+    assertEquals(TextColor.color(0x2468AC), node.getValue(TypeToken.of(TextColor.class)));
+
+    node.setValue(TypeToken.of(TextColor.class), TextColor.color(0x123456));
+    assertEquals("#123456", node.getValue());
+  }
+
+  @Test
+  void testSerializerKey() throws ObjectMappingException {
+    final TypeToken<Key> keyType = TypeToken.of(Key.class);
+    assertThrows(ObjectMappingException.class, () -> {
+      this.node("MineCRaft:test/namespace-invalid.gif").getValue(keyType);
+    }, "namespace");
+    assertThrows(ObjectMappingException.class, () -> {
+      this.node("minecraft:test path invalid.gif").getValue(keyType);
+    }, "path");
+    assertEquals(Key.key("test/valid.wav"), this.node("minecraft:test/valid.wav").getValue(keyType));
+  }
+
+  @Test
+  void testSerializeKeyCustomNamespace() throws ObjectMappingException {
+    final TypeToken<Key> keyType = TypeToken.of(Key.class);
+    assertEquals(Key.key("adventure", "meow"), this.node("adventure:meow").getValue(keyType));
+  }
+
+  @Test
+  void testSerializeDuration() throws ObjectMappingException {
+    assertEquals("PT240H", this.durationTo(Duration.ofDays(10)));
+    assertEquals(Duration.ofDays(10), this.durationFrom("10d"));
+    assertEquals(Duration.ofSeconds(5).plus(50, ChronoUnit.MILLIS), this.durationFrom("PT5.05S"));
+  }
+
+  private Duration durationFrom(final String value) throws ObjectMappingException {
+    return this.node(value).getValue(DurationSerializer.INSTANCE.type());
+  }
+
+  private String durationTo(final Duration duration) throws ObjectMappingException {
+    return this.node().setValue(DurationSerializer.INSTANCE.type(), duration).getString();
+  }
+}

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/SoundSerializersTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/SoundSerializersTest.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import com.google.common.collect.ImmutableMap;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.SoundStop;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SoundSerializersTest implements ConfigurateTestBase {
+
+  @Test
+  void testSound() {
+    final ConfigurationNode sound = node(n -> {
+      n.getNode(SoundSerializer.NAME).setValue("minecraft:music_disc.cat");
+      n.getNode(SoundSerializer.SOURCE).setValue("ambient");
+      n.getNode(SoundSerializer.VOLUME).setValue(0.8f);
+      n.getNode(SoundSerializer.PITCH).setValue(2.0f);
+    });
+    final Sound deserialized = Sound.sound(Key.key("music_disc.cat"), Sound.Source.AMBIENT, 0.8f, 2.0f);
+    this.assertRoundtrippable(SoundSerializer.TYPE, deserialized, sound);
+  }
+
+  @Test
+  void testSoundNoVolume() throws ObjectMappingException {
+    final ConfigurationNode sound = node(n -> {
+      n.getNode(SoundSerializer.NAME).setValue("minecraft:music_disc.cat");
+      n.getNode(SoundSerializer.SOURCE).setValue("ambient");
+      n.getNode(SoundSerializer.PITCH).setValue(2.0f);
+    });
+    final Sound deserialized = Sound.sound(Key.key("music_disc.cat"), Sound.Source.AMBIENT, 1.0f, 2.0f);
+    assertEquals(deserialized, sound.getValue(SoundSerializer.TYPE));
+  }
+
+  @Test
+  void testSoundNoPitch() throws ObjectMappingException {
+    final ConfigurationNode sound = node(n -> {
+      n.getNode(SoundSerializer.NAME).setValue("minecraft:music_disc.cat");
+      n.getNode(SoundSerializer.SOURCE).setValue("ambient");
+      n.getNode(SoundSerializer.VOLUME).setValue(0.8f);
+    });
+    final Sound deserialized = Sound.sound(Key.key("music_disc.cat"), Sound.Source.AMBIENT, 0.8f, 1.0f);
+    assertEquals(deserialized, sound.getValue(SoundSerializer.TYPE));
+  }
+
+  @Test
+  void testNoNameThrows() {
+    assertThrows(ObjectMappingException.class, () -> node(n -> n.getNode(SoundSerializer.SOURCE).setValue("music")).getValue(SoundSerializer.TYPE));
+  }
+
+  @Test
+  void testNoSourceThrows() {
+    assertThrows(ObjectMappingException.class, () -> node(n -> n.getNode(SoundSerializer.NAME).setValue("music_disc.13")).getValue(SoundSerializer.TYPE));
+  }
+
+  @Test
+  void testSoundStopAll() {
+    final ConfigurationNode node = node(ImmutableMap.of());
+    final SoundStop stop = SoundStop.all();
+
+    this.assertRoundtrippable(SoundStopSerializer.TYPE, stop, node);
+  }
+
+  @Test
+  void testSoundStopName() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(SoundStopSerializer.SOUND).setValue("minecraft:music_disc.pigstep"); // jk who would want to stop pigstep
+    });
+    final SoundStop stop = SoundStop.named(Key.key("minecraft:music_disc.pigstep"));
+
+    this.assertRoundtrippable(SoundStopSerializer.TYPE, stop, node);
+  }
+
+  @Test
+  void testSoundStopSource() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(SoundStopSerializer.SOURCE).setValue("hostile");
+    });
+    final SoundStop stop = SoundStop.source(Sound.Source.HOSTILE);
+
+    this.assertRoundtrippable(SoundStopSerializer.TYPE, stop, node);
+  }
+
+  @Test
+  void testSoundStopNameAndSource() {
+    final ConfigurationNode node = node(n -> {
+      n.getNode(SoundStopSerializer.SOUND).setValue("minecraft:entity.cat.hiss");
+      n.getNode(SoundStopSerializer.SOURCE).setValue("ambient");
+    });
+    final SoundStop stop = SoundStop.namedOnSource(Key.key("minecraft", "entity.cat.hiss"), Sound.Source.AMBIENT);
+
+    this.assertRoundtrippable(SoundStopSerializer.TYPE, stop, node);
+  }
+}

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/StyleSerializerTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/StyleSerializerTest.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StyleSerializerTest implements ConfigurateTestBase {
+  @Test
+  void testSerializeFont() {
+    final ConfigurationNode node = this.node(n -> {
+      n.getNode(StyleSerializer.FONT).setValue("adventure:meow");
+    });
+    final Style style = Style.style()
+      .font(Key.key("adventure", "meow"))
+      .build();
+
+    this.assertRoundtrippable(StyleSerializer.TYPE, style, node);
+  }
+
+  @Test
+  void testSerializeHexColor() {
+    final ConfigurationNode node = this.node(n -> {
+      n.getNode(StyleSerializer.COLOR).setValue("#123456");
+    });
+    final Style style = Style.style()
+      .color(TextColor.color(0x123456))
+      .build();
+
+    this.assertRoundtrippable(StyleSerializer.TYPE, style, node);
+  }
+
+  @Test
+  void testSerializeNumericColor() throws ObjectMappingException {
+    final ConfigurationNode node = this.node(n -> {
+      n.getNode(StyleSerializer.COLOR).setValue(0x123456);
+    });
+    final Style style = Style.style()
+      .color(TextColor.color(0x123456))
+      .build();
+
+    // we won't roundtrip to this format
+    assertEquals(style, node.getValue(StyleSerializer.TYPE));
+  }
+
+  @Test
+  void testSerializeNamedColor() {
+    final ConfigurationNode node = this.node(n -> {
+      n.getNode(StyleSerializer.COLOR).setValue("dark_red");
+    });
+    final Style style = Style.style()
+      .color(NamedTextColor.DARK_RED)
+      .build();
+
+    this.assertRoundtrippable(StyleSerializer.TYPE, style, node);
+  }
+
+  @Test
+  void testSerializeInsertion() {
+    final ConfigurationNode node = this.node(n -> {
+      n.getNode(StyleSerializer.INSERTION).setValue("i'd like to get a cat!");
+    });
+    final Style style = Style.style()
+      .insertion("i'd like to get a cat!")
+      .build();
+
+    this.assertRoundtrippable(StyleSerializer.TYPE, style, node);
+  }
+
+  @Test
+  void testSerializeClickEvent() {
+    final ConfigurationNode node = this.node(n -> {
+      n.getNode(StyleSerializer.CLICK_EVENT).act(event -> {
+        event.getNode(StyleSerializer.CLICK_EVENT_ACTION).setValue("open_url");
+        event.getNode(StyleSerializer.CLICK_EVENT_VALUE).setValue("https://kyori.net");
+      });
+    });
+    final Style style = Style.style()
+      .clickEvent(ClickEvent.openUrl("https://kyori.net"))
+      .build();
+
+    this.assertRoundtrippable(StyleSerializer.TYPE, style, node);
+  }
+
+  // Hover event tested in HoverEventSerializersTest
+}

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/TitleSerializerTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/TitleSerializerTest.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate3;
+
+import java.time.Duration;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.title.Title;
+import ninja.leaping.configurate.ConfigurationNode;
+import org.junit.jupiter.api.Test;
+
+public class TitleSerializerTest implements ConfigurateTestBase {
+
+  @Test
+  void testTitleNoTimes() {
+    final ConfigurationNode node = this.node(n -> {
+      n.getNode(TitleSerializer.TITLE, ComponentTypeSerializer.TEXT).setValue("Title");
+      n.getNode(TitleSerializer.SUBTITLE).act(sub -> {
+        sub.getNode(ComponentTypeSerializer.TEXT).setValue("Subtitle");
+        sub.getNode(StyleSerializer.COLOR).setValue("dark_purple");
+      });
+    });
+
+    final Title title = Title.title(Component.text("Title"), Component.text("Subtitle", NamedTextColor.DARK_PURPLE));
+
+    this.assertRoundtrippable(TitleSerializer.TYPE, title, node);
+  }
+
+  @Test
+  void testTitleWithTimes() {
+    final ConfigurationNode node = this.node(n -> {
+      n.getNode(TitleSerializer.TITLE, ComponentTypeSerializer.TEXT).setValue("Title");
+      n.getNode(TitleSerializer.SUBTITLE).act(sub -> {
+        sub.getNode(ComponentTypeSerializer.TEXT).setValue("Subtitle");
+        sub.getNode(StyleSerializer.COLOR).setValue("dark_purple");
+      });
+      n.getNode(TitleSerializer.TIMES).act(times -> {
+        times.getNode(TitleSerializer.FADE_IN).setValue("PT50S");
+        times.getNode(TitleSerializer.STAY).setValue("PT20S");
+        times.getNode(TitleSerializer.FADE_OUT).setValue("PT50S");
+      });
+    });
+
+    final Title title = Title.title(Component.text("Title"), Component.text("Subtitle", NamedTextColor.DARK_PURPLE),
+      Title.Times.of(Duration.ofSeconds(50), Duration.ofSeconds(20), Duration.ofSeconds(50)));
+
+    this.assertRoundtrippable(TitleSerializer.TYPE, title, node);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ rootProject.name = 'adventure-parent'
 
 include 'api'
 include 'nbt'
+include 'serializer-configurate3'
 include 'text-serializer-gson'
 include 'text-serializer-legacy'
 include 'text-serializer-plain'
@@ -11,6 +12,7 @@ include 'text-serializer-plain'
 [
   'api',
   'nbt',
+  'serializer-configurate3',
   'text-serializer-gson',
   'text-serializer-legacy',
   'text-serializer-plain'


### PR DESCRIPTION
This allows for better integration with configurate-using projects (at least those with Configurate 3.7).

Unlike the other serializers, the main purpose of this serializer is for working with configuration files, so it supports serializing more types than just `Component`s.