### PR TITLE
Add default string to TextComponent#make()

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/TextComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponent.java
@@ -533,7 +533,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @return the text component
    */
   static @NonNull TextComponent make(final @NonNull Consumer<? super Builder> consumer) {
-    final Builder builder = builder();
+    final Builder builder = builder("");
     return Buildable.configureAndBuild(builder, consumer);
   }
 


### PR DESCRIPTION
Allows use of this method by only appending other components without having to remember to give it a string