### PR TITLE
Update build tool configurations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,10 @@ There are various artifacts:
 
 * Maven
 ```xml
+<repository>
+  <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+</repository>
+
 <dependency>
   <groupId>net.kyori</groupId>
   <artifactId>adventure-api</artifactId>
@@ -24,11 +28,13 @@ There are various artifacts:
 * Gradle
 ```gradle
 repositories {
-  mavenCentral()
+  maven {
+    url = 'https://oss.sonatype.org/content/repositories/snapshots'
+  }
 }
 
 dependencies {
-  compile 'net.kyori:adventure-api:4.0.0-SNAPSHOT'
+  implementation 'net.kyori:adventure-api:4.0.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
adventure isn't hosted on central, it's hosted on sonatype. the compile keyword is also deprecated in gradle, for this specific use case, implementation should be used instead. Not sure if maven repository declarations require an id or name; I don't use maven.