### PR TITLE
Fix empty compound parsing

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.nbt;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.nbt;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -38,6 +39,11 @@ final class TagStringReader {
 
   public CompoundBinaryTag compound() throws StringTagParseException {
     this.buffer.expect(Tokens.COMPOUND_BEGIN);
+    if(this.buffer.peek() == Tokens.COMPOUND_END) {
+      this.buffer.take();
+      return new CompoundBinaryTagImpl(new HashMap<>());
+    }
+
     final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder();
     while(this.buffer.hasMore()) {
       builder.put(this.key(), this.tag());

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -41,7 +41,7 @@ final class TagStringReader {
     this.buffer.expect(Tokens.COMPOUND_BEGIN);
     if(this.buffer.peek() == Tokens.COMPOUND_END) {
       this.buffer.take();
-      return new CompoundBinaryTagImpl(new HashMap<>());
+      return CompoundBinaryTag.empty();
     }
 
     final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder();

--- a/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
@@ -242,6 +242,12 @@ class StringIOTest {
     assertEquals(LongArrayBinaryTag.of(2, 4, 6, -8, 10, 12), this.stringToTag("[L; 2l, 4l, 6l, -8l, 10l, 12l]"));
   }
 
+  @Test
+  public void testEmptyCompoundTag() throws StringTagParseException {
+    final TagStringReader read = new TagStringReader(new CharBuffer("{}"));
+    assert read.compound().keySet().isEmpty();
+  }
+
   private String tagToString(final BinaryTag tag) throws IOException {
     final StringWriter writer = new StringWriter();
     try(final TagStringWriter emitter = new TagStringWriter(writer, "")) {

--- a/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StringIOTest {
   @Test
@@ -245,7 +246,7 @@ class StringIOTest {
   @Test
   public void testEmptyCompoundTag() throws StringTagParseException {
     final TagStringReader read = new TagStringReader(new CharBuffer("{}"));
-    assert read.compound().keySet().isEmpty();
+    assertTrue(read.compound().keySet().isEmpty());
   }
 
   private String tagToString(final BinaryTag tag) throws IOException {


### PR DESCRIPTION
Previously, parsing would fail for compounds like `{}` or `{a: \"hello\", empty: {}}`