### PR TITLE
text-serializer-gson: Ensure GsonComponentSerializer#toBuilder() carries over legacy hover event serializer configuration

### DIFF
--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -30,6 +30,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A gson component serializer.
@@ -94,15 +95,17 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
     @NonNull Builder downsampleColors();
 
     /**
-     * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads
+     * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
+     * If the serializer is {@code null}, then only {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}
+     * legacy hover events can be deserialized.
+     *
      * @param serializer serializer
      * @return this builder
      */
-    @NonNull Builder legacyHoverEventSerializer(final @NonNull LegacyHoverEventSerializer serializer);
+    @NonNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
 
     /**
-     * Output a legacy hover event {@code value} in addition to the modern {@code contents}
-     *
+     * Output a legacy hover event {@code value} in addition to the modern {@code contents}.
      *
      * <p>A {@link #legacyHoverEventSerializer(LegacyHoverEventSerializer) legacy hover serializer} must also be set
      * to serialize any hover events beyond those with action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}</p>

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -37,8 +37,6 @@ import net.kyori.adventure.text.format.TextDecoration;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import static java.util.Objects.requireNonNull;
-
 final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   static final GsonComponentSerializer INSTANCE = new GsonComponentSerializerImpl(false, null, false);
   static final GsonComponentSerializer LEGACY_INSTANCE = new GsonComponentSerializerImpl(true, null, true);
@@ -46,13 +44,17 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   private final Gson serializer;
   private final UnaryOperator<GsonBuilder> populator;
   private final boolean downsampleColor;
+  private final @Nullable LegacyHoverEventSerializer legacyHoverSerializer;
+  private final boolean emitLegacyHover;
 
-  GsonComponentSerializerImpl(final boolean downsampleColor, final @Nullable LegacyHoverEventSerializer legacy, final boolean emitLegacy) {
+  GsonComponentSerializerImpl(final boolean downsampleColor, final @Nullable LegacyHoverEventSerializer legacyHoverSerializer, final boolean emitLegacyHover) {
     this.downsampleColor = downsampleColor;
+    this.legacyHoverSerializer = legacyHoverSerializer;
+    this.emitLegacyHover = emitLegacyHover;
     this.populator = builder -> {
       builder.registerTypeHierarchyAdapter(Key.class, KeySerializer.INSTANCE);
       builder.registerTypeHierarchyAdapter(Component.class, new ComponentSerializerImpl());
-      builder.registerTypeAdapter(Style.class, new StyleSerializer(legacy, emitLegacy));
+      builder.registerTypeAdapter(Style.class, new StyleSerializer(legacyHoverSerializer, emitLegacyHover));
       builder.registerTypeAdapter(ClickEvent.Action.class, IndexedSerializer.of("click action", ClickEvent.Action.NAMES));
       builder.registerTypeAdapter(HoverEvent.Action.class, IndexedSerializer.of("hover action", HoverEvent.Action.NAMES));
       builder.registerTypeAdapter(HoverEvent.ShowItem.class, new ShowItemSerializer());
@@ -102,6 +104,8 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
 
     BuilderImpl(final GsonComponentSerializerImpl serializer) {
       this.downsampleColor = serializer.downsampleColor;
+      this.emitLegacyHover = serializer.emitLegacyHover;
+      this.legacyHoverSerializer = serializer.legacyHoverSerializer;
     }
 
     @Override
@@ -111,8 +115,8 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
     }
 
     @Override
-    public @NonNull Builder legacyHoverEventSerializer(final @NonNull LegacyHoverEventSerializer serializer) {
-      this.legacyHoverSerializer = requireNonNull(serializer, "serializer");
+    public @NonNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer) {
+      this.legacyHoverSerializer = serializer;
       return this;
     }
 


### PR DESCRIPTION
Just a bug I noticed while working on something unrelated.