### PR TITLE
Revise text component replacement

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -85,7 +85,7 @@ public abstract class AbstractComponent implements Component, Examinable {
 
   @Override
   public @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {
-    return TextReplacementRenderer.INSTANCE.render(this, new TextReplacementRenderer.State(pattern, (result, build) -> replacement.apply(build), fn));
+    return TextReplacementRenderer.INSTANCE.render(this, new TextReplacementRenderer.State(pattern, (result, builder) -> replacement.apply(builder), fn));
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -27,8 +27,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
@@ -78,6 +81,11 @@ public abstract class AbstractComponent implements Component, Examinable {
   @Override
   public final @NonNull Style style() {
     return this.style;
+  }
+
+  @Override
+  public @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {
+    return TextReplacementRenderer.INSTANCE.render(this, new TextReplacementRenderer.State(pattern, (result, build) -> replacement.apply(build), fn));
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -28,12 +28,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.util.IntFunction2;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -382,6 +384,52 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ho
   default boolean hasStyling() {
     return !this.style().isEmpty();
   }
+
+  /**
+   * Finds and replaces text within any {@link TextComponent}s using a regex pattern.
+   *
+   * @param pattern a regex pattern
+   * @param replacement a function to replace each match
+   * @return a modified copy of this component
+   */
+  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement) {
+    return this.replaceText(pattern, replacement, (index, replaced) -> PatternReplacementResult.REPLACE);
+  }
+
+  /**
+   * Finds and replaces the first occurrence of text within any {@link TextComponent}s using a regex pattern.
+   *
+   * @param pattern a regex pattern
+   * @param replacement a function to replace the first match
+   * @return a modified copy of this component
+   */
+  default @NonNull Component replaceFirstText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement) {
+    return this.replaceText(pattern, replacement, 1);
+  }
+
+  /**
+   * Finds and replaces {@code n} instances of text within any {@link TextComponent}s using a regex pattern.
+   *
+   * @param pattern a regex pattern
+   * @param replacement a function to replace each match
+   * @param numberOfReplacements the amount of matches that should be replaced
+   * @return a modified copy of this component
+   */
+  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement, final int numberOfReplacements) {
+    return this.replaceText(pattern, replacement, (index, replaced) -> replaced < numberOfReplacements ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
+  }
+
+  /**
+   * Finds and replaces text using a regex pattern.
+   *
+   * <p>Utilises an {@link IntFunction2} to determine if each instance should be replaced.</p>
+   *
+   * @param pattern a regex pattern
+   * @param replacement a function to replace the first match
+   * @param fn a function of (index, replaced) used to determine if matches should be replaced, where "replaced" is the number of successful replacements
+   * @return a modified copy of this component
+   */
+  @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn);
 
   @Override
   default void componentBuilderApply(final @NonNull ComponentBuilder<?, ?> component) {

--- a/api/src/main/java/net/kyori/adventure/text/PatternReplacementResult.java
+++ b/api/src/main/java/net/kyori/adventure/text/PatternReplacementResult.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+import net.kyori.adventure.util.IntFunction2;
+
+/**
+ * A result for {@link Component#replaceText(Pattern, UnaryOperator, IntFunction2) pattern-based replacements}.
+ */
+public enum PatternReplacementResult {
+  /**
+   * Replace the current match.
+   */
+  REPLACE,
+  /**
+   * Skip the current match, but continue searching for others.
+   */
+  CONTINUE,
+  /**
+   * Stop matching.
+   */
+  STOP;
+}

--- a/api/src/main/java/net/kyori/adventure/text/TextComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponent.java
@@ -583,7 +583,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @param replacement a function to replace each match
    * @return a modified copy of this component
    */
-  default @NonNull TextComponent replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
+  default @NonNull Component replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
     return this.replace(pattern, replacement, (index, replaced) -> PatternReplacementResult.REPLACE);
   }
 
@@ -594,7 +594,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @param replacement a function to replace the first match
    * @return a modified copy of this component
    */
-  default @NonNull TextComponent replaceFirst(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
+  default @NonNull Component replaceFirst(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
     return this.replace(pattern, replacement, 1);
   }
 
@@ -606,7 +606,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @param numberOfReplacements the amount of matches that should be replaced
    * @return a modified copy of this component
    */
-  default @NonNull TextComponent replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final int numberOfReplacements) {
+  default @NonNull Component replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final int numberOfReplacements) {
     return this.replace(pattern, replacement, (index, replaced) -> replaced < numberOfReplacements ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
   }
 
@@ -620,7 +620,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @param fn a function of (index, replaced) used to determine if matches should be replaced, where "replaced" is the number of successful replacements
    * @return a modified copy of this component
    */
-  @NonNull TextComponent replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn);
+  @NonNull Component replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn);
 
   /**
    * A result for {@link #replace(Pattern, UnaryOperator, IntFunction2) pattern-based replacements}.

--- a/api/src/main/java/net/kyori/adventure/text/TextComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponent.java
@@ -583,8 +583,8 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @param replacement a function to replace each match
    * @return a modified copy of this component
    */
-  default @NonNull Component replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
-    return this.replace(pattern, replacement, (index, replaced) -> PatternReplacementResult.REPLACE);
+  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
+    return this.replaceText(pattern, replacement, (index, replaced) -> PatternReplacementResult.REPLACE);
   }
 
   /**
@@ -594,8 +594,8 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @param replacement a function to replace the first match
    * @return a modified copy of this component
    */
-  default @NonNull Component replaceFirst(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
-    return this.replace(pattern, replacement, 1);
+  default @NonNull Component replaceFirstText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
+    return this.replaceText(pattern, replacement, 1);
   }
 
   /**
@@ -606,8 +606,8 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @param numberOfReplacements the amount of matches that should be replaced
    * @return a modified copy of this component
    */
-  default @NonNull Component replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final int numberOfReplacements) {
-    return this.replace(pattern, replacement, (index, replaced) -> replaced < numberOfReplacements ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
+  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final int numberOfReplacements) {
+    return this.replaceText(pattern, replacement, (index, replaced) -> replaced < numberOfReplacements ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
   }
 
   /**
@@ -620,10 +620,10 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @param fn a function of (index, replaced) used to determine if matches should be replaced, where "replaced" is the number of successful replacements
    * @return a modified copy of this component
    */
-  @NonNull Component replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn);
+  @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn);
 
   /**
-   * A result for {@link #replace(Pattern, UnaryOperator, IntFunction2) pattern-based replacements}.
+   * A result for {@link #replaceText(Pattern, UnaryOperator, IntFunction2) pattern-based replacements}.
    */
   enum PatternReplacementResult {
     /**

--- a/api/src/main/java/net/kyori/adventure/text/TextComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponent.java
@@ -28,13 +28,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
-import java.util.regex.Pattern;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.Buildable;
-import net.kyori.adventure.util.IntFunction2;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -575,70 +572,6 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @return a copy of this component
    */
   @NonNull TextComponent content(final @NonNull String content);
-
-  /**
-   * Finds and replaces text using a regex pattern.
-   *
-   * @param pattern a regex pattern
-   * @param replacement a function to replace each match
-   * @return a modified copy of this component
-   */
-  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
-    return this.replaceText(pattern, replacement, (index, replaced) -> PatternReplacementResult.REPLACE);
-  }
-
-  /**
-   * Finds and replaces the first occurrence of text using a regex pattern.
-   *
-   * @param pattern a regex pattern
-   * @param replacement a function to replace the first match
-   * @return a modified copy of this component
-   */
-  default @NonNull Component replaceFirstText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement) {
-    return this.replaceText(pattern, replacement, 1);
-  }
-
-  /**
-   * Finds and replaces n instances of text using a regex pattern.
-   *
-   * @param pattern a regex pattern
-   * @param replacement a function to replace each match
-   * @param numberOfReplacements the amount of matches that should be replaced
-   * @return a modified copy of this component
-   */
-  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final int numberOfReplacements) {
-    return this.replaceText(pattern, replacement, (index, replaced) -> replaced < numberOfReplacements ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
-  }
-
-  /**
-   * Finds and replaces text using a regex pattern.
-   *
-   * <p>Utilises an {@link IntFunction2} to determine if each instance should be replaced.</p>
-   *
-   * @param pattern a regex pattern
-   * @param replacement a function to replace the first match
-   * @param fn a function of (index, replaced) used to determine if matches should be replaced, where "replaced" is the number of successful replacements
-   * @return a modified copy of this component
-   */
-  @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn);
-
-  /**
-   * A result for {@link #replaceText(Pattern, UnaryOperator, IntFunction2) pattern-based replacements}.
-   */
-  enum PatternReplacementResult {
-    /**
-     * Replace the current match.
-     */
-    REPLACE,
-    /**
-     * Skip the current match, but continue searching for others.
-     */
-    CONTINUE,
-    /**
-     * Stop matching.
-     */
-    STOP;
-  }
 
   /**
    * A text component builder.

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -80,8 +80,8 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   }
 
   @Override
-  public @NonNull Component replace(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement,
-          final @NonNull IntFunction2<PatternReplacementResult> fn) {
+  public @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement,
+                                        final @NonNull IntFunction2<PatternReplacementResult> fn) {
     return new Replacer(pattern, (result, build) -> replacement.apply(build), fn).replace(this);
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -23,20 +23,11 @@
  */
 package net.kyori.adventure.text;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.UnaryOperator;
-import java.util.regex.MatchResult;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
-import net.kyori.adventure.text.renderer.ComponentRenderer;
-import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -78,162 +69,6 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   @Override
   public @NonNull TextComponent style(final @NonNull Style style) {
     return new TextComponentImpl(this.children, style, this.content);
-  }
-
-  @Override
-  public @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<Builder> replacement,
-                                        final @NonNull IntFunction2<PatternReplacementResult> fn) {
-    return Replacer.INSTANCE.render(this, new ReplaceState(pattern, (result, build) -> replacement.apply(build), fn));
-  }
-
-  static final class ReplaceState {
-    final Pattern pattern;
-    final BiFunction<MatchResult, Builder, @Nullable Builder> replacement;
-    final IntFunction2<PatternReplacementResult> continuer;
-    boolean running = true;
-    int matchCount = 0;
-    int replaceCount = 0;
-
-    ReplaceState(final @NonNull Pattern pattern, final @NonNull BiFunction<MatchResult, Builder, @Nullable Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> continuer) {
-      this.pattern = pattern;
-      this.replacement = replacement;
-      this.continuer = continuer;
-    }
-  }
-
-  static final class Replacer implements ComponentRenderer<ReplaceState> {
-    static Replacer INSTANCE = new Replacer();
-
-    private Replacer() {
-    }
-
-    @Override
-    public @NonNull Component render(final @NonNull Component component, final @NonNull ReplaceState state) {
-      if(!state.running) return component;
-
-      List<Component> children = null;
-      Component modified = component;
-      // replace the component itself
-      if(component instanceof TextComponent) {
-        final String content = ((TextComponent) component).content();
-        final Matcher matcher = state.pattern.matcher(content);
-        int replacedUntil = 0; // last index handled
-        while(matcher.find()) {
-          final PatternReplacementResult result = state.continuer.apply(++state.matchCount, state.replaceCount);
-          if(result == PatternReplacementResult.CONTINUE) {
-            // ignore this replacement
-            continue;
-          } else if(result == PatternReplacementResult.STOP) {
-            // end replacement
-            state.running = false;
-            break;
-          }
-
-          if(matcher.start() == 0) {
-            // if we're a full match, modify the component directly
-            if(matcher.end() == content.length()) {
-              final TextComponent.Builder replacement = state.replacement.apply(matcher, TextComponent.builder(matcher.group())
-                .style(component.style()));
-
-              modified = replacement == null ? TextComponent.empty() : replacement.build();
-            } else {
-              // otherwise, work on a child of the root node
-              modified = TextComponent.of("", component.style());
-              final TextComponent.Builder child = state.replacement.apply(matcher, TextComponent.builder(matcher.group()));
-              if(child != null) {
-                children = this.listOrNew(children, component.children().size() + 1);
-                children.add(child.build());
-              }
-            }
-          } else {
-            children = this.listOrNew(children, component.children().size() + 2);
-            if(state.replaceCount == 0) {
-              // truncate parent to content before match
-              modified = ((TextComponent) component).content(content.substring(0, matcher.start()));
-            } else if(replacedUntil < matcher.start()) {
-              children.add(TextComponent.of(content.substring(replacedUntil, matcher.start())));
-            }
-            final TextComponent.Builder builder = state.replacement.apply(matcher, TextComponent.builder(matcher.group()));
-            if(builder != null) {
-              children.add(builder.build());
-            }
-          }
-          state.replaceCount++;
-          replacedUntil = matcher.end();
-        }
-        if(replacedUntil < content.length()) {
-          // append trailing content
-          if(replacedUntil > 0) {
-            children = this.listOrNew(children, component.children().size());
-            children.add(TextComponent.of(content.substring(replacedUntil)));
-          }
-          // otherwise, we haven't modified the component, so nothing to change
-        }
-      } else if(modified instanceof TranslatableComponent) { // get TranslatableComponent with() args
-        final List<Component> args = ((TranslatableComponent) modified).args();
-        List<Component> newArgs = null;
-        for(int i = 0; i < args.size(); i++) {
-          final Component original = args.get(i);
-          final Component replaced = this.render(original, state);
-          if(replaced != component) {
-            if(newArgs == null) {
-              newArgs = new ArrayList<>(args.size());
-              if(i > 0) {
-                newArgs.addAll(args.subList(0, i));
-              }
-            }
-          }
-          if(newArgs != null) {
-            newArgs.add(replaced);
-          }
-        }
-        if(newArgs != null) {
-          modified = ((TranslatableComponent) modified).args(newArgs);
-        }
-      }
-      // Only visit children if we're running
-      if(state.running) {
-        // hover event
-        final HoverEvent<?> event = modified.style().hoverEvent();
-        if(event != null) {
-          final HoverEvent<?> rendered = event.withRenderedValue(this, state);
-          if(event != rendered) {
-            modified = modified.style(s -> s.hoverEvent(rendered));
-          }
-        }
-        // Children
-        boolean first = true;
-        for(int i = 0; i < component.children().size(); ++i) {
-          final Component child = component.children().get(i);
-          final Component replaced = this.render(child, state);
-          if(replaced != child) {
-            children = this.listOrNew(children, component.children().size());
-            if(first) {
-              children.addAll(component.children().subList(0, i));
-            }
-            first = false;
-          }
-          if(children != null) {
-            children.add(replaced);
-          }
-        }
-      } else {
-        // we're not visiting children, re-add original children if necessary
-        if(children != null) {
-          children.addAll(component.children());
-        }
-      }
-
-      // Update the modified component with new children
-      if(children != null) {
-        return modified.children(children);
-      }
-      return modified;
-    }
-
-    private <T> @NonNull List<T> listOrNew(final @Nullable List<T> init, final int size) {
-      return init == null ? new ArrayList<>(size) : init;
-    }
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
@@ -1,0 +1,189 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.renderer.ComponentRenderer;
+import net.kyori.adventure.util.IntFunction2;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A renderer performing a replacement on every {@link TextComponent} element of a component tree.
+ */
+final class TextReplacementRenderer implements ComponentRenderer<TextReplacementRenderer.State> {
+  static final TextReplacementRenderer INSTANCE = new TextReplacementRenderer();
+
+  private TextReplacementRenderer() {
+  }
+
+  @Override
+  public @NonNull Component render(final @NonNull Component component, final @NonNull State state) {
+    if(!state.running) return component;
+
+    List<Component> children = null;
+    Component modified = component;
+    // replace the component itself
+    if(component instanceof TextComponent) {
+      final String content = ((TextComponent) component).content();
+      final Matcher matcher = state.pattern.matcher(content);
+      int replacedUntil = 0; // last index handled
+      while(matcher.find()) {
+        final PatternReplacementResult result = state.continuer.apply(++state.matchCount, state.replaceCount);
+        if(result == PatternReplacementResult.CONTINUE) {
+          // ignore this replacement
+          continue;
+        } else if(result == PatternReplacementResult.STOP) {
+          // end replacement
+          state.running = false;
+          break;
+        }
+
+        if(matcher.start() == 0) {
+          // if we're a full match, modify the component directly
+          if(matcher.end() == content.length()) {
+            final TextComponent.Builder replacement = state.replacement.apply(matcher, TextComponent.builder(matcher.group())
+              .style(component.style()));
+
+            modified = replacement == null ? TextComponent.empty() : replacement.build();
+          } else {
+            // otherwise, work on a child of the root node
+            modified = TextComponent.of("", component.style());
+            final TextComponent.Builder child = state.replacement.apply(matcher, TextComponent.builder(matcher.group()));
+            if(child != null) {
+              children = this.listOrNew(children, component.children().size() + 1);
+              children.add(child.build());
+            }
+          }
+        } else {
+          children = this.listOrNew(children, component.children().size() + 2);
+          if(state.replaceCount == 0) {
+            // truncate parent to content before match
+            modified = ((TextComponent) component).content(content.substring(0, matcher.start()));
+          } else if(replacedUntil < matcher.start()) {
+            children.add(TextComponent.of(content.substring(replacedUntil, matcher.start())));
+          }
+          final TextComponent.Builder builder = state.replacement.apply(matcher, TextComponent.builder(matcher.group()));
+          if(builder != null) {
+            children.add(builder.build());
+          }
+        }
+        state.replaceCount++;
+        replacedUntil = matcher.end();
+      }
+      if(replacedUntil < content.length()) {
+        // append trailing content
+        if(replacedUntil > 0) {
+          children = this.listOrNew(children, component.children().size());
+          children.add(TextComponent.of(content.substring(replacedUntil)));
+        }
+        // otherwise, we haven't modified the component, so nothing to change
+      }
+    } else if(modified instanceof TranslatableComponent) { // get TranslatableComponent with() args
+      final List<Component> args = ((TranslatableComponent) modified).args();
+      List<Component> newArgs = null;
+      for(int i = 0; i < args.size(); i++) {
+        final Component original = args.get(i);
+        final Component replaced = this.render(original, state);
+        if(replaced != component) {
+          if(newArgs == null) {
+            newArgs = new ArrayList<>(args.size());
+            if(i > 0) {
+              newArgs.addAll(args.subList(0, i));
+            }
+          }
+        }
+        if(newArgs != null) {
+          newArgs.add(replaced);
+        }
+      }
+      if(newArgs != null) {
+        modified = ((TranslatableComponent) modified).args(newArgs);
+      }
+    }
+    // Only visit children if we're running
+    if(state.running) {
+      // hover event
+      final HoverEvent<?> event = modified.style().hoverEvent();
+      if(event != null) {
+        final HoverEvent<?> rendered = event.withRenderedValue(this, state);
+        if(event != rendered) {
+          modified = modified.style(s -> s.hoverEvent(rendered));
+        }
+      }
+      // Children
+      boolean first = true;
+      for(int i = 0; i < component.children().size(); ++i) {
+        final Component child = component.children().get(i);
+        final Component replaced = this.render(child, state);
+        if(replaced != child) {
+          children = this.listOrNew(children, component.children().size());
+          if(first) {
+            children.addAll(component.children().subList(0, i));
+          }
+          first = false;
+        }
+        if(children != null) {
+          children.add(replaced);
+        }
+      }
+    } else {
+      // we're not visiting children, re-add original children if necessary
+      if(children != null) {
+        children.addAll(component.children());
+      }
+    }
+
+    // Update the modified component with new children
+    if(children != null) {
+      return modified.children(children);
+    }
+    return modified;
+  }
+
+  private <T> @NonNull List<T> listOrNew(final @Nullable List<T> init, final int size) {
+    return init == null ? new ArrayList<>(size) : init;
+  }
+
+  static final class State {
+    final Pattern pattern;
+    final BiFunction<MatchResult, TextComponent.Builder, TextComponent.@Nullable Builder> replacement;
+    final IntFunction2<PatternReplacementResult> continuer;
+    boolean running = true;
+    int matchCount = 0;
+    int replaceCount = 0;
+
+    State(final @NonNull Pattern pattern, final @NonNull BiFunction<MatchResult, TextComponent.Builder, TextComponent.@Nullable Builder> replacement, final @NonNull IntFunction2<PatternReplacementResult> continuer) {
+      this.pattern = pattern;
+      this.replacement = replacement;
+      this.continuer = continuer;
+    }
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -225,6 +225,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      */
     public @NonNull ShowItem item(final @NonNull Key item) {
+      if(requireNonNull(item, "time").equals(this.item)) return this;
       return new ShowItem(item, this.count, this.nbt);
     }
 
@@ -244,6 +245,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      */
     public @NonNull ShowItem count(final @NonNegative int count) {
+      if(count == this.count) return this;
       return new ShowItem(this.item, count, this.nbt);
     }
 
@@ -263,6 +265,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      */
     public @NonNull ShowItem count(final @Nullable BinaryTagHolder nbt) {
+      if(Objects.equals(nbt, this.nbt)) return this;
       return new ShowItem(this.item, this.count, nbt);
     }
 
@@ -323,6 +326,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      */
     public @NonNull ShowEntity type(final @NonNull Key type) {
+      if(requireNonNull(type, "type").equals(this.type)) return this;
       return new ShowEntity(type, this.id, this.name);
     }
 
@@ -342,6 +346,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      */
     public @NonNull ShowEntity id(final @NonNull UUID id) {
+      if(requireNonNull(id).equals(this.id)) return this;
       return new ShowEntity(this.type, id, this.name);
     }
 
@@ -361,6 +366,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      */
     public @NonNull ShowEntity name(final @Nullable Component name) {
+      if(Objects.equals(name, this.name)) return this;
       return new ShowEntity(this.type, this.id, name);
     }
 
@@ -419,7 +425,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
       @Override
       public <C> @NonNull ShowEntity render(final @NonNull ComponentRenderer<C> renderer, final @NonNull C context, final @NonNull ShowEntity value) {
         if(value.name == null) return value;
-        return new ShowEntity(value.type, value.id, renderer.render(value.name, context));
+        return value.name(renderer.render(value.name, context));
       }
     });
 

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -225,7 +225,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      */
     public @NonNull ShowItem item(final @NonNull Key item) {
-      if(requireNonNull(item, "time").equals(this.item)) return this;
+      if(requireNonNull(item, "item").equals(this.item)) return this;
       return new ShowItem(item, this.count, this.nbt);
     }
 

--- a/api/src/main/java/net/kyori/adventure/text/renderer/ComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/ComponentRenderer.java
@@ -43,7 +43,7 @@ public interface ComponentRenderer<C> {
   @NonNull Component render(final @NonNull Component component, final @NonNull C context);
 
   /**
-   * Return a {@link ComponentRenderer} that takes a different context type
+   * Return a {@link ComponentRenderer} that takes a different context type.
    *
    * @param transformer context type transformer
    * @param <T> transformation function

--- a/api/src/main/java/net/kyori/adventure/text/renderer/ComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/ComponentRenderer.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.renderer;
 
+import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -40,4 +41,15 @@ public interface ComponentRenderer<C> {
    * @return the rendered component
    */
   @NonNull Component render(final @NonNull Component component, final @NonNull C context);
+
+  /**
+   * Return a {@link ComponentRenderer} that takes a different context type
+   *
+   * @param transformer context type transformer
+   * @param <T> transformation function
+   * @return mapping renderer
+   */
+  default <T> ComponentRenderer<T> mapContext(final Function<T, C> transformer) {
+    return (component, ctx) -> this.render(component, transformer.apply(ctx));
+  }
 }

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -189,7 +189,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .build();
 
     final Component replaced = component.replaceText(Pattern.compile("purple"), match -> match.color(NamedTextColor.DARK_PURPLE),
-      (index, replace) -> index % 2 == 0 ? TextComponent.PatternReplacementResult.REPLACE : TextComponent.PatternReplacementResult.CONTINUE);
+      (index, replace) -> index % 2 == 0 ? PatternReplacementResult.REPLACE : PatternReplacementResult.CONTINUE);
 
     assertEquals(TextComponent.builder()
       .content("purple ")

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -140,7 +140,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .content("cat says ")
       .append(TranslatableComponent.of("cat.meow")) // or any non-text component
       .build();
-    final Component replaced = component.replace(Pattern.compile("says"), match -> match.color(NamedTextColor.DARK_PURPLE));
+    final Component replaced = component.replaceText(Pattern.compile("says"), match -> match.color(NamedTextColor.DARK_PURPLE));
     assertEquals(TextComponent.builder()
       .content("cat ")
       .append("says", NamedTextColor.DARK_PURPLE)
@@ -155,7 +155,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .content("Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo ")
       .append(TranslatableComponent.of("buffalo.buffalo")) // or any non-text component
       .build();
-    final Component replaced = component.replaceFirst(Pattern.compile("buffalo"), match -> match.color(NamedTextColor.DARK_PURPLE));
+    final Component replaced = component.replaceFirstText(Pattern.compile("buffalo"), match -> match.color(NamedTextColor.DARK_PURPLE));
     assertEquals(TextComponent.builder()
       .content("Buffalo ")
       .append("buffalo", NamedTextColor.DARK_PURPLE)
@@ -170,7 +170,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .content("Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo ")
       .append(TranslatableComponent.of("buffalo.buffalo")) // or any non-text component
       .build();
-    final Component replaced = component.replace(Pattern.compile("buffalo"), match -> match.color(NamedTextColor.DARK_PURPLE), 2);
+    final Component replaced = component.replaceText(Pattern.compile("buffalo"), match -> match.color(NamedTextColor.DARK_PURPLE), 2);
     assertEquals(TextComponent.builder()
       .content("Buffalo ")
       .append("buffalo", NamedTextColor.DARK_PURPLE)
@@ -188,7 +188,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .append(TranslatableComponent.of("purple.purple")) // or any non-text component
       .build();
 
-    final Component replaced = component.replace(Pattern.compile("purple"), match -> match.color(NamedTextColor.DARK_PURPLE),
+    final Component replaced = component.replaceText(Pattern.compile("purple"), match -> match.color(NamedTextColor.DARK_PURPLE),
       (index, replace) -> index % 2 == 0 ? TextComponent.PatternReplacementResult.REPLACE : TextComponent.PatternReplacementResult.CONTINUE);
 
     assertEquals(TextComponent.builder()
@@ -214,7 +214,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .append(TextComponent.builder().append("Parent").append(" 1"), KeybindComponent.of("key.adventure.purr"), TextComponent.builder().append("Parent").append(" 3"))
       .build();
 
-    assertEquals(expectedReplacement, original.replace(Pattern.compile("Child"), match -> match.content("Parent")));
+    assertEquals(expectedReplacement, original.replaceText(Pattern.compile("Child"), match -> match.content("Parent")));
   }
 
   // https://github.com/KyoriPowered/adventure/issues/129
@@ -235,7 +235,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .append(TextComponent.of(" under ").color(NamedTextColor.DARK_AQUA).append(TextComponent.of("me")))
       .build();
 
-    assertEquals(expectedReplacement, component.replace(Pattern.compile("test"), match -> match.content("me")));
+    assertEquals(expectedReplacement, component.replaceText(Pattern.compile("test"), match -> match.content("me")));
   }
 
   @Test
@@ -247,7 +247,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .hoverEvent(HoverEvent.showText(TextComponent.of("meow", NamedTextColor.DARK_RED)))
       .build();
 
-    assertEquals(expectedReplacement, component.replace(Pattern.compile("meep"), builder -> builder.content("meow").color(NamedTextColor.DARK_RED)));
+    assertEquals(expectedReplacement, component.replaceText(Pattern.compile("meep"), builder -> builder.content("meow").color(NamedTextColor.DARK_RED)));
   }
 
   @Test
@@ -259,7 +259,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .append(TranslatableComponent.of("my.translation", TextComponent.builder("cats ").append(TextComponent.of("good"))))
       .build();
 
-    assertEquals(expectedReplacement, component.replace(Pattern.compile("bad"), builder -> builder.content("good")));
+    assertEquals(expectedReplacement, component.replaceText(Pattern.compile("bad"), builder -> builder.content("good")));
   }
 
   @Test
@@ -271,7 +271,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
         .append(" world");
     });
 
-    assertEquals(expectedReplacement, component.replace(Pattern.compile("Hello"), builder -> builder.content("Goodbye").color(NamedTextColor.LIGHT_PURPLE)));
+    assertEquals(expectedReplacement, component.replaceText(Pattern.compile("Hello"), builder -> builder.content("Goodbye").color(NamedTextColor.LIGHT_PURPLE)));
 
   }
 

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.serializer.legacy;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
@@ -39,7 +38,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>Legacy does <b>not</b> support more complex features such as, but not limited
  * to, {@link ClickEvent} and {@link HoverEvent}.</p>
  */
-public interface LegacyComponentSerializer extends ComponentSerializer<Component, TextComponent, String>, Buildable<LegacyComponentSerializer, LegacyComponentSerializer.Builder> {
+public interface LegacyComponentSerializer extends ComponentSerializer<Component, Component, String>, Buildable<LegacyComponentSerializer, LegacyComponentSerializer.Builder> {
   /**
    * Gets a component serializer for legacy-based serialization and deserialization. Note that this
    * serializer works exactly like vanilla Minecraft and does not detect any links. If you want to
@@ -124,7 +123,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return the component
    */
   @Override
-  @NonNull TextComponent deserialize(final @NonNull String input);
+  @NonNull Component deserialize(final @NonNull String input);
 
   /**
    * Serializes a component into a legacy {@link String}.

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -162,13 +162,13 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     return Character.toString(LEGACY_CHARS.charAt(index));
   }
 
-  private TextComponent extractUrl(final TextComponent component) {
+  private Component extractUrl(final TextComponent component) {
     if(!this.urlLink) return component;
     return component.replace(URL_PATTERN, url -> (this.urlStyle == null ? url : url.style(this.urlStyle)).clickEvent(ClickEvent.openUrl(url.content())));
   }
 
   @Override
-  public @NonNull TextComponent deserialize(final @NonNull String input) {
+  public @NonNull Component deserialize(final @NonNull String input) {
     int next = input.lastIndexOf(this.character, input.length() - 2);
     if(next == -1) {
       return this.extractUrl(TextComponent.of(input));

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -164,7 +164,7 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
 
   private Component extractUrl(final TextComponent component) {
     if(!this.urlLink) return component;
-    return component.replace(URL_PATTERN, url -> (this.urlStyle == null ? url : url.style(this.urlStyle)).clickEvent(ClickEvent.openUrl(url.content())));
+    return component.replaceText(URL_PATTERN, url -> (this.urlStyle == null ? url : url.style(this.urlStyle)).clickEvent(ClickEvent.openUrl(url.content())));
   }
 
   @Override

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
@@ -76,8 +76,9 @@ class LinkingLegacyComponentSerializerTest {
     final String hasPrefixSuffixColors = "&adid you hear about &chttps://www.example.com? &9they're really cool";
     final TextComponent expectedHasPrefixSuffixColors = TextComponent.builder("")
       .append(TextComponent.of("did you hear about ", NamedTextColor.GREEN))
-      .append(TextComponent.of("https://www.example.com", NamedTextColor.RED).clickEvent(ClickEvent.openUrl(bareUrl)))
-      .append(TextComponent.of("? ", NamedTextColor.RED))
+      .append(TextComponent.make(b -> b.append(TextComponent.of("https://www.example.com").clickEvent(ClickEvent.openUrl(bareUrl)))
+        .append(TextComponent.of("? "))
+        .color(NamedTextColor.RED)))
       .append(TextComponent.of("they're really cool", NamedTextColor.BLUE))
       .build();
     assertEquals(expectedHasPrefixSuffixColors, LegacyComponentSerializer.builder().character('&').extractUrls().build().deserialize(hasPrefixSuffixColors));


### PR DESCRIPTION
This now properly handles non-`TextComponent` children, plus traverses `TranslatableComponent`s and hover events.

At some point the logic in this and in `TranslatableComponentRenderer` should be abstracted out into a common component visitor. There's also potential to expand the exposed replacement api -- this PR doesn't expose any new functionality.