### PR TITLE
Use TextComponent instead of Component in LegacyComponentSerializer

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/ScopedComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScopedComponent.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.text.format.Style;
@@ -147,5 +149,23 @@ public interface ScopedComponent<C extends Component> extends Component {
   @SuppressWarnings("unchecked")
   default @NonNull C insertion(final @Nullable String insertion) {
     return (C) Component.super.insertion(insertion);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  default @NonNull C replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement) {
+    return (C) Component.super.replaceText(pattern, replacement);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  default @NonNull Component replaceFirstText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement) {
+    return (C) Component.super.replaceFirstText(pattern, replacement);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  default @NonNull C replaceText(final @NonNull Pattern pattern, final @NonNull UnaryOperator<TextComponent.Builder> replacement, final int numberOfReplacements) {
+    return (C) Component.super.replaceText(pattern, replacement, numberOfReplacements);
   }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.serializer.legacy;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
@@ -38,7 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>Legacy does <b>not</b> support more complex features such as, but not limited
  * to, {@link ClickEvent} and {@link HoverEvent}.</p>
  */
-public interface LegacyComponentSerializer extends ComponentSerializer<Component, Component, String>, Buildable<LegacyComponentSerializer, LegacyComponentSerializer.Builder> {
+public interface LegacyComponentSerializer extends ComponentSerializer<Component, TextComponent, String>, Buildable<LegacyComponentSerializer, LegacyComponentSerializer.Builder> {
   /**
    * Gets a component serializer for legacy-based serialization and deserialization. Note that this
    * serializer works exactly like vanilla Minecraft and does not detect any links. If you want to
@@ -123,7 +124,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return the component
    */
   @Override
-  @NonNull Component deserialize(final @NonNull String input);
+  @NonNull TextComponent deserialize(final @NonNull String input);
 
   /**
    * Serializes a component into a legacy {@link String}.

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -162,13 +162,13 @@ class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     return Character.toString(LEGACY_CHARS.charAt(index));
   }
 
-  private Component extractUrl(final TextComponent component) {
+  private TextComponent extractUrl(final TextComponent component) {
     if(!this.urlLink) return component;
     return component.replaceText(URL_PATTERN, url -> (this.urlStyle == null ? url : url.style(this.urlStyle)).clickEvent(ClickEvent.openUrl(url.content())));
   }
 
   @Override
-  public @NonNull Component deserialize(final @NonNull String input) {
+  public @NonNull TextComponent deserialize(final @NonNull String input) {
     int next = input.lastIndexOf(this.character, input.length() - 2);
     if(next == -1) {
       return this.extractUrl(TextComponent.of(input));


### PR DESCRIPTION
e120cd9f4e4f675b8880a8cabb996ce67b7de96e changed the output component type of `LegacyComponentSerializer` from `TextComponent` to `Component` because of restrictions caused by the addition of the replace methods in Component.

However, as the `LegacyComponentSerializer` exclusively deals with components that are definitely text, it makes sense to use `TextComponent` instead of `Component` (as it used to be).

This PR adds the recently edited replace methods (in `Component`) to `ScopedComponent` to alleviate the restriction and allow `LegacyComponentSerializer` to deal with TextComponents instead of Components again.