### PR TITLE
api: Allow TranslatableComponent builder to use empty keys

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
@@ -171,7 +171,6 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
     @Override
     public @NonNull TranslatableComponentImpl build() {
       if(this.key == null) throw new IllegalStateException("key must be set");
-      if(this.key.isEmpty()) throw new IllegalStateException("key must not be empty");
       return new TranslatableComponentImpl(this.children, this.buildStyle(), this.key, this.args);
     }
   }


### PR DESCRIPTION
This is accepted by vanilla for some reason, although it's not particularly logical. See https://gist.github.com/astei/7a5ed3afedf6e4b23dcb99e0d72ea315