### PR TITLE
api: Add Audience.toAudience()

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.audience;
 
 import java.util.Arrays;
+import java.util.stream.Collector;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.sound.Sound;
@@ -116,6 +117,18 @@ public interface Audience {
    */
   static @NonNull ForwardingAudience audience(final @NonNull Iterable<? extends Audience> audiences) {
     return () -> audiences;
+  }
+
+  /**
+   * Provides a collector to create a forwarding audience from a stream of audiences.
+   *
+   * <p>The audience produced is immutable and can be reused as desired.</p>
+   *
+   * @return a collector to create a forwarding audience
+   * @since 4.0.0
+   */
+  static @NonNull Collector<? super Audience, ?, ForwardingAudience> toAudience() {
+    return Audiences.COLLECTOR;
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/Audiences.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audiences.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.audience;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+final class Audiences {
+  private Audiences() {
+  }
+
+  static final Collector<? super Audience, ?, ForwardingAudience> COLLECTOR = Collectors.collectingAndThen(
+    Collectors.toCollection(ArrayList::new),
+    audiences -> Audience.audience(Collections.unmodifiableCollection(audiences))
+  );
+}

--- a/api/src/test/java/net/kyori/adventure/audience/AudienceTest.java
+++ b/api/src/test/java/net/kyori/adventure/audience/AudienceTest.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.audience;
 
 import com.google.common.testing.EqualsTester;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -59,5 +60,15 @@ class AudienceTest {
         Audience.audience() // of() with no args returns empty
       )
       .testEquals();
+  }
+
+  @Test
+  void testCollectorEmpty() {
+    assertThat(Stream.<Audience>empty().collect(Audience.toAudience()).audiences()).isEmpty();
+  }
+
+  @Test
+  void testCollectorSingleItem() {
+    assertThat(Stream.of(Audience.empty()).collect(Audience.toAudience()).audiences()).containsExactly(Audience.empty());
   }
 }


### PR DESCRIPTION
This arose out of somewhat related discussion that led to #155 being filed, but it's not related.

This API adds a collector for `Audience`s. It is a convenient and idiomatic shorthand for `Audience.of(stream.collect(Collectors.toList()))` and is more concise: `stream.collect(Audience.toAudience())`