### PR TITLE
nbt: Add array access and stream methods for tags

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/ArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ArrayBinaryTag.java
@@ -26,52 +26,11 @@ package net.kyori.adventure.nbt;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * A binary tag holding a {@code byte}-array value.
+ * An array binary tag.
  *
- * @since 4.0.0
+ * @since 4.2.0
  */
-public interface ByteArrayBinaryTag extends ArrayBinaryTag, Iterable<Byte> {
-  /**
-   * Creates a binary tag holding a {@code byte}-array value.
-   *
-   * @param value the value
-   * @return a binary tag
-   * @since 4.0.0
-   */
-  static @NonNull ByteArrayBinaryTag of(final byte@NonNull... value) {
-    return new ByteArrayBinaryTagImpl(value);
-  }
-
+public interface ArrayBinaryTag extends BinaryTag {
   @Override
-  default @NonNull BinaryTagType<ByteArrayBinaryTag> type() {
-    return BinaryTagTypes.BYTE_ARRAY;
-  }
-
-  /**
-   * Gets the value.
-   *
-   * <p>The returned array is a copy.</p>
-   *
-   * @return the value
-   * @since 4.0.0
-   */
-  byte@NonNull[] value();
-
-  /**
-   * Get the size of the array.
-   *
-   * @return array size
-   * @since 4.2.0
-   */
-  int size();
-
-  /**
-   * Gets the value at {@code index} in this tag.
-   *
-   * @param index the index in the array
-   * @return the byte at the index in the array
-   * @throws IndexOutOfBoundsException if index is &lt; 0 or &ge; {@link #size()}
-   * @since 4.2.0
-   */
-  byte get(final int index);
+  @NonNull BinaryTagType<? extends ArrayBinaryTag> type();
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ArrayBinaryTagImpl.java
@@ -23,55 +23,10 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
-/**
- * A binary tag holding a {@code byte}-array value.
- *
- * @since 4.0.0
- */
-public interface ByteArrayBinaryTag extends ArrayBinaryTag, Iterable<Byte> {
-  /**
-   * Creates a binary tag holding a {@code byte}-array value.
-   *
-   * @param value the value
-   * @return a binary tag
-   * @since 4.0.0
-   */
-  static @NonNull ByteArrayBinaryTag of(final byte@NonNull... value) {
-    return new ByteArrayBinaryTagImpl(value);
+abstract class ArrayBinaryTagImpl implements ArrayBinaryTag {
+  static void checkIndex(final int index, final int length) {
+    if(index < 0 || index >= length) {
+      throw new IndexOutOfBoundsException("Index out of bounds: " + index);
+    }
   }
-
-  @Override
-  default @NonNull BinaryTagType<ByteArrayBinaryTag> type() {
-    return BinaryTagTypes.BYTE_ARRAY;
-  }
-
-  /**
-   * Gets the value.
-   *
-   * <p>The returned array is a copy.</p>
-   *
-   * @return the value
-   * @since 4.0.0
-   */
-  byte@NonNull[] value();
-
-  /**
-   * Get the size of the array.
-   *
-   * @return array size
-   * @since 4.2.0
-   */
-  int size();
-
-  /**
-   * Gets the value at {@code index} in this tag.
-   *
-   * @param index the index in the array
-   * @return the byte at the index in the array
-   * @throws IndexOutOfBoundsException if index is &lt; 0 or &ge; {@link #size()}
-   * @since 4.2.0
-   */
-  byte get(final int index);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
@@ -24,12 +24,13 @@
 package net.kyori.adventure.nbt;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class ByteArrayBinaryTagImpl implements ByteArrayBinaryTag {
+final class ByteArrayBinaryTagImpl extends ArrayBinaryTagImpl implements ByteArrayBinaryTag {
   final byte[] value;
 
   ByteArrayBinaryTagImpl(final byte[] value) {
@@ -39,6 +40,17 @@ final class ByteArrayBinaryTagImpl implements ByteArrayBinaryTag {
   @Override
   public byte@NonNull[] value() {
     return Arrays.copyOf(this.value, this.value.length);
+  }
+
+  @Override
+  public int size() {
+    return this.value.length;
+  }
+
+  @Override
+  public byte get(final int index) {
+    checkIndex(index, this.value.length);
+    return this.value[index];
   }
 
   // to avoid copying array internally
@@ -62,5 +74,22 @@ final class ByteArrayBinaryTagImpl implements ByteArrayBinaryTag {
   @Override
   public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
+  }
+
+  @Override
+  public Iterator<Byte> iterator() {
+    return new Iterator<Byte>() {
+      private int index;
+
+      @Override
+      public boolean hasNext() {
+        return this.index < ByteArrayBinaryTagImpl.this.value.length - 1;
+      }
+
+      @Override
+      public Byte next() {
+        return ByteArrayBinaryTagImpl.this.value[this.index++];
+      }
+    };
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTag.java
@@ -23,6 +23,10 @@
  */
 package net.kyori.adventure.nbt;
 
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -30,7 +34,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  *
  * @since 4.0.0
  */
-public interface IntArrayBinaryTag extends BinaryTag {
+public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
   /**
    * Creates a binary tag holding an {@code int}-array value.
    *
@@ -56,4 +60,51 @@ public interface IntArrayBinaryTag extends BinaryTag {
    * @since 4.0.0
    */
   int@NonNull[] value();
+
+  /**
+   * Get the length of the array.
+   *
+   * @return value size
+   * @since 4.2.0
+   */
+  int size();
+
+  /**
+   * Gets the value at {@code index} in this tag.
+   *
+   * @param index the index in the array
+   * @return the int at the index in the array
+   * @throws IndexOutOfBoundsException if idx &lt; 0 or &ge; {@link #size()}
+   * @since 4.2.0
+   */
+  int get(final int index);
+
+  /**
+   * {@inheritDoc}
+   * 
+   * <p>The returned iterator is immutable.</p>
+   *
+   * @since 4.2.0
+   */
+  @Override
+  PrimitiveIterator.@NonNull OfInt iterator();
+
+  @Override
+  Spliterator.@NonNull OfInt spliterator();
+
+  /**
+   * Create a stream whose elements are the elements of this array tag.
+   *
+   * @return a new stream
+   * @since 4.2.0
+   */
+  @NonNull IntStream stream();
+
+  /**
+   * Perform an action for every int in the backing array.
+   *
+   * @param action the action to perform
+   * @since 4.2.0
+   */
+  void forEachInt(final @NonNull IntConsumer action);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
@@ -24,12 +24,17 @@
 package net.kyori.adventure.nbt;
 
 import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class IntArrayBinaryTagImpl implements IntArrayBinaryTag {
+final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArrayBinaryTag {
   final int[] value;
 
   IntArrayBinaryTagImpl(final int... value) {
@@ -39,6 +44,54 @@ final class IntArrayBinaryTagImpl implements IntArrayBinaryTag {
   @Override
   public int@NonNull[] value() {
     return Arrays.copyOf(this.value, this.value.length);
+  }
+
+  @Override
+  public int size() {
+    return this.value.length;
+  }
+
+  @Override
+  public int get(final int index) {
+    checkIndex(index, this.value.length);
+    return this.value[index];
+  }
+
+  @Override
+  public PrimitiveIterator.@NonNull OfInt iterator() {
+    return new PrimitiveIterator.OfInt() {
+      private int index;
+
+      @Override
+      public boolean hasNext() {
+        return this.index < (IntArrayBinaryTagImpl.this.value.length - 1);
+      }
+
+      @Override
+      public int nextInt() {
+        if(!this.hasNext()) {
+          throw new NoSuchElementException();
+        }
+        return IntArrayBinaryTagImpl.this.value[this.index++];
+      }
+    };
+  }
+
+  @Override
+  public Spliterator.@NonNull OfInt spliterator() {
+    return Arrays.spliterator(this.value);
+  }
+
+  @Override
+  public @NonNull IntStream stream() {
+    return Arrays.stream(this.value);
+  }
+
+  @Override
+  public void forEachInt(final @NonNull IntConsumer action) {
+    for(int i = 0, length = this.value.length; i < length; i++) {
+      action.accept(this.value[i]);
+    }
   }
 
   // to avoid copying array internally

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.nbt;
 
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -441,6 +442,14 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
     }
     return defaultValue;
   }
+
+  /**
+   * Creates a stream of the tags contained within this list.
+   *
+   * @return a new stream
+   * @since 4.2.0
+   */
+  @NonNull Stream<BinaryTag> stream();
 
   /**
    * A list tag builder.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -38,11 +38,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ListBinaryTagImpl implements ListBinaryTag {
   static final ListBinaryTag EMPTY = new ListBinaryTagImpl(BinaryTagTypes.END, Collections.emptyList());
-  private final List<? extends BinaryTag> tags;
+  private final List<BinaryTag> tags;
   private final BinaryTagType<? extends BinaryTag> type;
   private final int hashCode;
 
-  ListBinaryTagImpl(final BinaryTagType<? extends BinaryTag> type, final List<? extends BinaryTag> tags) {
+  ListBinaryTagImpl(final BinaryTagType<? extends BinaryTag> type, final List<BinaryTag> tags) {
     this.tags = tags;
     this.type = type;
     this.hashCode = tags.hashCode();
@@ -120,8 +120,13 @@ final class ListBinaryTagImpl implements ListBinaryTag {
   }
 
   @Override
+  public @NonNull Stream<BinaryTag> stream() {
+    return this.tags.stream();
+  }
+
+  @Override
   public Iterator<BinaryTag> iterator() {
-    final Iterator<? extends BinaryTag> iterator = this.tags.iterator();
+    final Iterator<BinaryTag> iterator = this.tags.iterator();
     return new Iterator<BinaryTag>() {
       @Override
       public boolean hasNext() {

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTag.java
@@ -23,6 +23,10 @@
  */
 package net.kyori.adventure.nbt;
 
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.function.LongConsumer;
+import java.util.stream.LongStream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -30,7 +34,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  *
  * @since 4.0.0
  */
-public interface LongArrayBinaryTag extends BinaryTag {
+public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
   /**
    * Creates a binary tag holding a {@code long}-array value.
    *
@@ -56,4 +60,51 @@ public interface LongArrayBinaryTag extends BinaryTag {
    * @since 4.0.0
    */
   long@NonNull[] value();
+
+  /**
+   * Gets the length of the array.
+   *
+   * @return value size
+   * @since 4.2.0
+   */
+  int size();
+
+  /**
+   * Gets the value at {@code index} in this tag.
+   *
+   * @param index the index in the array
+   * @return the long at the index in the array
+   * @throws IndexOutOfBoundsException if index is &lt; 0 or &ge; {@link #size()}
+   * @since 4.2.0
+   */
+  long get(final int index);
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned iterator is immutable.</p>
+   *
+   * @since 4.2.0
+   */
+  @Override
+  PrimitiveIterator.@NonNull OfLong iterator();
+
+  @Override
+  Spliterator.@NonNull OfLong spliterator();
+
+  /**
+   * Create a stream whose elements are the elements of this array tag.
+   *
+   * @return a new stream
+   * @since 4.2.0
+   */
+  @NonNull LongStream stream();
+
+  /**
+   * Perform an action for every long in the backing array.
+   *
+   * @param action the action to perform
+   * @since 4.2.0
+   */
+  void forEachLong(final @NonNull LongConsumer action);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
@@ -24,12 +24,17 @@
 package net.kyori.adventure.nbt;
 
 import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.function.LongConsumer;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class LongArrayBinaryTagImpl implements LongArrayBinaryTag {
+final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArrayBinaryTag {
   final long[] value;
 
   LongArrayBinaryTagImpl(final long[] value) {
@@ -39,6 +44,54 @@ final class LongArrayBinaryTagImpl implements LongArrayBinaryTag {
   @Override
   public long@NonNull[] value() {
     return Arrays.copyOf(this.value, this.value.length);
+  }
+  
+  @Override
+  public int size() {
+    return this.value.length;
+  }
+
+  @Override
+  public long get(final int index) {
+    checkIndex(index, this.value.length);
+    return this.value[index];
+  }
+
+  @Override
+  public PrimitiveIterator.@NonNull OfLong iterator() {
+    return new PrimitiveIterator.OfLong() {
+      private int index;
+
+      @Override
+      public boolean hasNext() {
+        return this.index < (LongArrayBinaryTagImpl.this.value.length - 1);
+      }
+
+      @Override
+      public long nextLong() {
+        if(!this.hasNext()) {
+          throw new NoSuchElementException();
+        }
+        return LongArrayBinaryTagImpl.this.value[this.index++];
+      }
+    };
+  }
+
+  @Override
+  public Spliterator.@NonNull OfLong spliterator() {
+    return Arrays.spliterator(this.value);
+  }
+
+  @Override
+  public @NonNull LongStream stream() {
+    return Arrays.stream(this.value);
+  }
+
+  @Override
+  public void forEachLong(final @NonNull LongConsumer action) {
+    for(int i = 0, length = this.value.length; i < length; i++) {
+      action.accept(this.value[i]);
+    }
   }
 
   // to avoid copying array internally


### PR DESCRIPTION
This allows interacting with array tags without creating a copy of the
backing array.

Not sure how to handle the primitive consumer `forEach` methods -- they're currently ambiguous with the boxed variants from the `Iterable` interface.