### PR TITLE
build: Update for gradle 6.7

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   api("net.kyori:examination-api:1.0.0")
   api("net.kyori:examination-string:1.0.0")
-  api("org.checkerframework:checker-qual:3.7.1")
+  compileOnlyApi("org.checkerframework:checker-qual:3.7.1")
   testImplementation("com.google.guava:guava:23.0")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,7 @@ subprojects {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven {
-      url "https://oss.sonatype.org/content/groups/public/"
-    }
+    sonatypeSnapshots()
   }
 
   dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/nbt/build.gradle
+++ b/nbt/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   api("net.kyori:examination-api:1.0.0")
   api("net.kyori:examination-string:1.0.0")
-  api("org.checkerframework:checker-qual:3.7.1")
+  compileOnlyApi("org.checkerframework:checker-qual:3.7.1")
 }
 
 jar {

--- a/serializer-configurate4/build.gradle
+++ b/serializer-configurate4/build.gradle
@@ -4,10 +4,6 @@ dependencies {
   testImplementation(project(":adventure-text-serializer-gson"))
 }
 
-repositories {
-  sonatypeSnapshots()
-}
-
 jar {
   manifest.attributes(
     "Automatic-Module-Name": "net.kyori.adventure.serializer.configurate4"


### PR DESCRIPTION
Uses the new `compileOnlyApi` configuration.

I've not set things up to use toolchains yet -- adding version-specific test tasks is a bit annoying, will probably wait to finish the pull multirelease jar plugin for that.