### PR TITLE
Add a check for null nbt data on item hovers

### DIFF
--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.text.serializer.gson;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
@@ -59,7 +60,7 @@ final class ShowItemSerializer implements JsonDeserializer<HoverEvent.ShowItem>,
     }
 
     BinaryTagHolder nbt = null;
-    if(object.has(TAG)) {
+    if(object.has(TAG) && !(object.get(TAG) instanceof JsonNull)) {
       nbt = BinaryTagHolder.of(object.get(TAG).getAsString());
     }
 

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
@@ -26,9 +26,9 @@ package net.kyori.adventure.text.serializer.gson;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
@@ -60,7 +60,7 @@ final class ShowItemSerializer implements JsonDeserializer<HoverEvent.ShowItem>,
     }
 
     BinaryTagHolder nbt = null;
-    if(object.has(TAG) && !(object.get(TAG) instanceof JsonNull)) {
+    if(object.has(TAG) && object.get(TAG) instanceof JsonPrimitive) {
       nbt = BinaryTagHolder.of(object.get(TAG).getAsString());
     }
 


### PR DESCRIPTION
This fixes an error being thrown when trying to deserialise (from json) an item hover with a null nbt tag as seen in the example below.
```json
{"translate":"commands.give.success.single","with":["1",{"translate":"chat.square_brackets","with":[{"text":"","extra":[{"translate":"block.minecraft.stone"}]}],"color":"white","hoverEvent":{"action":"show_item","contents":{"id":"minecraft:stone","count":0,"tag":null}}},{"text":"rtm516","clickEvent":{"action":"suggest_command","value":"/tell rtm516 "},"hoverEvent":{"action":"show_entity","contents":{"type":"minecraft:player","id":"cb7a4c0c-a7cd-4846-8b6f-477de8f5f3ee","name":"rtm516"}},"insertion":"rtm516"}]}
```
with `{"id":"minecraft:stone","count":0,"tag":null}` being the main issue