### PR TITLE
api: Add a builder for replacement config

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -27,15 +27,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.regex.Pattern;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
-import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * An abstract implementation of a text component.
@@ -93,8 +93,20 @@ public abstract class AbstractComponent implements Component {
   }
 
   @Override
-  public @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {
-    return TextReplacementRenderer.INSTANCE.render(this, new TextReplacementRenderer.State(pattern, (result, builder) -> replacement.apply(builder), fn));
+  public @NonNull Component replaceText(final @NonNull Consumer<TextReplacementConfig.Builder> configurer) {
+    requireNonNull(configurer, "configurer");
+    final TextReplacementConfigImpl.Builder builder = new TextReplacementConfigImpl.Builder();
+    configurer.accept(builder);
+    return TextReplacementRenderer.INSTANCE.render(this, builder.toState());
+  }
+
+  @Override
+  public @NonNull Component replaceText(final @NonNull TextReplacementConfig config) {
+    requireNonNull(config, "replacement");
+    if(!(config instanceof TextReplacementConfigImpl)) {
+      throw new IllegalArgumentException("Provided replacement was a custom TextReplacementConfig implementation, which is not supported.");
+    }
+    return TextReplacementRenderer.INSTANCE.render(this, ((TextReplacementConfigImpl) config).toState());
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.util.Buildable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -95,9 +96,7 @@ public abstract class AbstractComponent implements Component {
   @Override
   public @NonNull Component replaceText(final @NonNull Consumer<TextReplacementConfig.Builder> configurer) {
     requireNonNull(configurer, "configurer");
-    final TextReplacementConfigImpl.Builder builder = new TextReplacementConfigImpl.Builder();
-    configurer.accept(builder);
-    return TextReplacementRenderer.INSTANCE.render(this, builder.toState());
+    return this.replaceText(Buildable.configureAndBuild(TextReplacementConfig.builder(), configurer));
   }
 
   @Override
@@ -106,7 +105,7 @@ public abstract class AbstractComponent implements Component {
     if(!(config instanceof TextReplacementConfigImpl)) {
       throw new IllegalArgumentException("Provided replacement was a custom TextReplacementConfig implementation, which is not supported.");
     }
-    return TextReplacementRenderer.INSTANCE.render(this, ((TextReplacementConfigImpl) config).toState());
+    return TextReplacementRenderer.INSTANCE.render(this, ((TextReplacementConfigImpl) config).createState());
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1470,15 +1470,35 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Finds and replaces any text with this or child {@link Component}s using the configured options.
+   *
+   * @param configurer the configurer
+   * @return a modified copy of this component
+   * @since 4.2.0
+   */
+  @NonNull Component replaceText(final @NonNull Consumer<TextReplacementConfig.Builder> configurer);
+
+  /**
+   * Finds and replaces any text with this or child {@link Component}s using the provided options.
+   *
+   * @param config the replacement config
+   * @return a modified copy of this component
+   * @since 4.2.0
+   */
+  @NonNull Component replaceText(final @NonNull TextReplacementConfig config);
+
+  /**
    * Finds and replaces text within any {@link Component}s using a string literal.
    *
    * @param search a string literal
    * @param replacement a {@link ComponentLike} to replace each match
    * @return a modified copy of this component
    * @since 4.0.0
+   * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @Deprecated
   default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement) {
-    return this.replaceText(Pattern.compile(search, Pattern.LITERAL), old -> replacement);
+    return this.replaceText(b -> b.matchLiteral(search).replacement(replacement));
   }
 
   /**
@@ -1488,9 +1508,11 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param replacement a function to replace each match
    * @return a modified copy of this component
    * @since 4.0.0
+   * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @Deprecated
   default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
-    return this.replaceText(pattern, replacement, (index, replaced) -> PatternReplacementResult.REPLACE);
+    return this.replaceText(b -> b.match(pattern).replacement(replacement));
   }
 
   /**
@@ -1500,9 +1522,11 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param replacement a {@link ComponentLike} to replace the first match
    * @return a modified copy of this component
    * @since 4.0.0
+   * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @Deprecated
   default @NonNull Component replaceFirstText(final @NonNull String search, final @Nullable ComponentLike replacement) {
-    return this.replaceText(search, replacement, 1);
+    return this.replaceText(b -> b.matchLiteral(search).once().replacement(replacement));
   }
 
   /**
@@ -1512,9 +1536,11 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param replacement a function to replace the first match
    * @return a modified copy of this component
    * @since 4.0.0
+   * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @Deprecated
   default @NonNull Component replaceFirstText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
-    return this.replaceText(pattern, replacement, 1);
+    return this.replaceText(b -> b.match(pattern).once().replacement(replacement));
   }
 
   /**
@@ -1525,9 +1551,11 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param numberOfReplacements the amount of matches that should be replaced
    * @return a modified copy of this component
    * @since 4.0.0
+   * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @Deprecated
   default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement, final int numberOfReplacements) {
-    return this.replaceText(search, replacement, (index, replaced) -> replaced < numberOfReplacements ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
+    return this.replaceText(b -> b.matchLiteral(search).times(numberOfReplacements).replacement(replacement));
   }
 
   /**
@@ -1538,9 +1566,11 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param numberOfReplacements the amount of matches that should be replaced
    * @return a modified copy of this component
    * @since 4.0.0
+   * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @Deprecated
   default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final int numberOfReplacements) {
-    return this.replaceText(pattern, replacement, (index, replaced) -> replaced < numberOfReplacements ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
+    return this.replaceText(b -> b.match(pattern).times(numberOfReplacements).replacement(replacement));
   }
 
   /**
@@ -1553,9 +1583,11 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param fn a function of (index, replaced) used to determine if matches should be replaced, where "replaced" is the number of successful replacements
    * @return a modified copy of this component
    * @since 4.0.0
+   * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @Deprecated
   default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {
-    return this.replaceText(Pattern.compile(search, Pattern.LITERAL), old -> replacement, fn);
+    return this.replaceText(b -> b.matchLiteral(search).replacement(replacement).condition(fn));
   }
 
   /**
@@ -1568,8 +1600,12 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param fn a function of (index, replaced) used to determine if matches should be replaced, where "replaced" is the number of successful replacements
    * @return a modified copy of this component
    * @since 4.0.0
+   * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
-  @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn);
+  @Deprecated
+  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {
+    return this.replaceText(b -> b.match(pattern).replacement(replacement).condition(fn));
+  }
 
   @Override
   default void componentBuilderApply(final @NonNull ComponentBuilder<?, ?> component) {

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
@@ -131,7 +131,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @return this builder
      * @since 4.2.0
      */
-    default @NonNull Builder times(int times) {
+    default @NonNull Builder times(final int times) {
       return this.condition((index, replaced) -> replaced < times ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
     }
 

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
@@ -1,0 +1,200 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import net.kyori.adventure.util.Buildable;
+import net.kyori.adventure.util.IntFunction2;
+import net.kyori.examination.Examinable;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.regex.qual.Regex;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A configuration for how text can be replaced in a component.
+ *
+ * <p>The exact structure for a replacement specification is an implementation detail and therefore not exposed.
+ * Custom implementations of {@code TextReplacementConfig} are not supported.</p>
+ *
+ * @since 4.2.0
+ */
+public interface TextReplacementConfig extends Buildable<TextReplacementConfig, TextReplacementConfig.Builder>, Examinable {
+  /**
+   * Create a new builder.
+   *
+   * @return a new builder
+   * @since 4.2.0
+   */
+  static @NonNull Builder builder() {
+    return new TextReplacementConfigImpl.Builder();
+  }
+
+  /**
+   * Get the pattern that will be searched for.
+   *
+   * @return the match pattern
+   * @since 4.2.0
+   */
+  @NonNull Pattern matchPattern();
+
+  /**
+   * A builder for replacement configurations.
+   *
+   * @since 4.2.0
+   */
+  interface Builder extends Buildable.Builder<TextReplacementConfig> {
+    /*
+     * -------------------
+     * ---- Patterns -----
+     * -------------------
+     */
+
+    /**
+     * Match against the literal string provided.
+     *
+     * <p>This will <b>NOT</b> be parsed as a regular expression.</p>
+     *
+     * @param literal the literal string to match
+     * @return this builder
+     * @since 4.2.0
+     */
+    default Builder matchLiteral(final String literal) {
+      return this.match(Pattern.compile(literal, Pattern.LITERAL));
+    }
+
+    /**
+     * Compile the provided input as a {@link Pattern} and match against it.
+     *
+     * @param pattern the regex pattern to match
+     * @return this builder
+     * @since 4.2.0
+     */
+    default @NonNull Builder match(final @NonNull @Regex String pattern) {
+      return this.match(Pattern.compile(pattern));
+    }
+
+    /**
+     * Match the provided {@link Pattern}.
+     *
+     * @param pattern pattern to find in any searched components
+     * @return this builder
+     * @since 4.2.0
+     */
+    @NonNull Builder match(final @NonNull Pattern pattern);
+
+    /*
+     * ---------------------------
+     * ---- Number of matches ----
+     * ---------------------------
+     */
+
+    /**
+     * Only replace the first occurrence of the matched pattern.
+     *
+     * @return this builder
+     * @since 4.2.0
+     */
+    default @NonNull Builder once() {
+      return this.times(1);
+    }
+
+    /**
+     * Only replace the first {@code times} matches of the pattern.
+     *
+     * @param times maximum amount of matches to process
+     * @return this builder
+     * @since 4.2.0
+     */
+    default @NonNull Builder times(int times) {
+      return this.condition((index, replaced) -> replaced < times ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
+    }
+
+    /**
+     * Set the function to determine how an individual match should be processed.
+     *
+     * @param condition a function of {@code (index, replaced)} used to determine if matches should be replaced, where "replaced" is the number of successful replacements.
+     * @return this builder
+     * @since 4.2.0
+     */
+    @NonNull Builder condition(final @NonNull IntFunction2<PatternReplacementResult> condition);
+
+    /*
+     * -------------------------
+     * ---- Action on match ----
+     * -------------------------
+     */
+
+    /**
+     * Supply a literal replacement for the matched pattern.
+     *
+     * @param replacement the replacement
+     * @return this builder
+     * @since 4.2.0
+     */
+    default @NonNull Builder replacement(final @NonNull String replacement) {
+      requireNonNull(replacement, "replacement");
+      return this.replacement(builder -> builder.content(replacement));
+    }
+
+    /**
+     * Supply a literal replacement for the matched pattern.
+     *
+     * @param replacement the replacement
+     * @return this builder
+     * @since 4.2.0
+     */
+    default @NonNull Builder replacement(final @NonNull ComponentLike replacement) {
+      requireNonNull(replacement, "replacement");
+      final Component baked = replacement.asComponent();
+      return this.replacement((result, input) -> baked);
+    }
+
+    /**
+     * Supply a function that provides replacements for each match.
+     *
+     * @param replacement the replacement function
+     * @return this builder
+     * @since 4.2.0
+     */
+    default @NonNull Builder replacement(final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
+      requireNonNull(replacement, "replacement");
+      return this.replacement((result, input) -> replacement.apply(input));
+
+    }
+
+    /**
+     * Supply a function that provides replacements for each match, with access to group information.
+     *
+     * @param replacement the replacement function, taking a match result and a text component pre-populated with
+     * @return this builder
+     * @since 4.2.0
+     */
+    @NonNull Builder replacement(final @NonNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement);
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
@@ -52,7 +52,7 @@ final class TextReplacementConfigImpl implements TextReplacementConfig {
     return this.matchPattern;
   }
 
-  TextReplacementRenderer.State toState() {
+  TextReplacementRenderer.State createState() {
     return new TextReplacementRenderer.State(this.matchPattern, this.replacement, this.continuer);
   }
 
@@ -77,7 +77,7 @@ final class TextReplacementConfigImpl implements TextReplacementConfig {
 
   static final class Builder implements TextReplacementConfig.Builder {
     @MonotonicNonNull Pattern matchPattern;
-    BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement;
+    @MonotonicNonNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement;
     IntFunction2<PatternReplacementResult> continuer = (index, replacement) -> PatternReplacementResult.REPLACE;
 
     Builder() {
@@ -107,24 +107,10 @@ final class TextReplacementConfigImpl implements TextReplacementConfig {
       return this;
     }
 
-    private void validate() {
-      if(this.matchPattern == null) {
-        throw new IllegalStateException("A pattern must be provided to match against");
-      }
-      if(this.replacement == null) {
-        throw new IllegalStateException("A replacement action must be provided");
-      }
-    }
-
-    TextReplacementRenderer.State toState() {
-      this.validate();
-      return new TextReplacementRenderer.State(this.matchPattern, this.replacement, this.continuer);
-    }
-
     @Override
     public TextReplacementConfig build() {
-      this.validate();
-
+      if(this.matchPattern == null) throw new IllegalStateException("A pattern must be provided to match against");
+      if(this.replacement == null) throw new IllegalStateException("A replacement action must be provided");
       return new TextReplacementConfigImpl(this);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.function.BiFunction;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import net.kyori.adventure.util.IntFunction2;
+import net.kyori.examination.ExaminableProperty;
+import net.kyori.examination.string.StringExaminer;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+final class TextReplacementConfigImpl implements TextReplacementConfig {
+  private final Pattern matchPattern;
+  private final BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement;
+  private final IntFunction2<PatternReplacementResult> continuer;
+
+  TextReplacementConfigImpl(final Builder builder) {
+    this.matchPattern = builder.matchPattern;
+    this.replacement = builder.replacement;
+    this.continuer = builder.continuer;
+  }
+
+  @Override
+  public @NonNull Pattern matchPattern() {
+    return this.matchPattern;
+  }
+
+  TextReplacementRenderer.State toState() {
+    return new TextReplacementRenderer.State(this.matchPattern, this.replacement, this.continuer);
+  }
+
+  @Override
+  public TextReplacementConfig.@NonNull Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("matchPattern", this.matchPattern),
+      ExaminableProperty.of("replacement", this.replacement),
+      ExaminableProperty.of("continuer", this.continuer)
+    );
+  }
+
+  @Override
+  public String toString() {
+    return this.examine(StringExaminer.simpleEscaping());
+  }
+
+  static final class Builder implements TextReplacementConfig.Builder {
+    @MonotonicNonNull Pattern matchPattern;
+    BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement;
+    IntFunction2<PatternReplacementResult> continuer = (index, replacement) -> PatternReplacementResult.REPLACE;
+
+    Builder() {
+    }
+
+    Builder(final TextReplacementConfigImpl instance) {
+      this.matchPattern = instance.matchPattern;
+      this.replacement = instance.replacement;
+      this.continuer = instance.continuer;
+    }
+
+    @Override
+    public @NonNull Builder match(final @NonNull Pattern pattern) {
+      this.matchPattern = requireNonNull(pattern, "pattern");
+      return this;
+    }
+
+    @Override
+    public @NonNull Builder condition(final @NonNull IntFunction2<PatternReplacementResult> condition) {
+      this.continuer = requireNonNull(condition, "continuation");
+      return this;
+    }
+
+    @Override
+    public @NonNull Builder replacement(final @NonNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement) {
+      this.replacement = requireNonNull(replacement, "replacement");
+      return this;
+    }
+
+    private void validate() {
+      if(this.matchPattern == null) {
+        throw new IllegalStateException("A pattern must be provided to match against");
+      }
+      if(this.replacement == null) {
+        throw new IllegalStateException("A replacement action must be provided");
+      }
+    }
+
+    TextReplacementRenderer.State toState() {
+      this.validate();
+      return new TextReplacementRenderer.State(this.matchPattern, this.replacement, this.continuer);
+    }
+
+    @Override
+    public TextReplacementConfig build() {
+      this.validate();
+
+      return new TextReplacementConfigImpl(this);
+    }
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -141,7 +141,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .content("cat says ")
       .append(Component.translatable("cat.meow")) // or any non-text component
       .build();
-    final Component replaced = component.replaceText(Pattern.compile("says"), match -> match.color(NamedTextColor.DARK_PURPLE));
+    final Component replaced = component.replaceText(b -> b.match("says").replacement(match -> match.color(NamedTextColor.DARK_PURPLE)));
     assertEquals(Component.text()
       .content("cat ")
       .append(Component.text("says", NamedTextColor.DARK_PURPLE))
@@ -156,7 +156,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .content("Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo ")
       .append(Component.translatable("buffalo.buffalo")) // or any non-text component
       .build();
-    final Component replaced = component.replaceFirstText(Pattern.compile("buffalo"), match -> match.color(NamedTextColor.DARK_PURPLE));
+    final Component replaced = component.replaceText(b -> b.match("buffalo").once().replacement(match -> match.color(NamedTextColor.DARK_PURPLE)));
     assertEquals(Component.text()
       .content("Buffalo ")
       .append(Component.text("buffalo", NamedTextColor.DARK_PURPLE))
@@ -171,7 +171,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .content("Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo ")
       .append(Component.translatable("buffalo.buffalo")) // or any non-text component
       .build();
-    final Component replaced = component.replaceText(Pattern.compile("buffalo"), match -> match.color(NamedTextColor.DARK_PURPLE), 2);
+    final Component replaced = component.replaceText(b -> b.match("buffalo").replacement(match -> match.color(NamedTextColor.DARK_PURPLE)).times(2));
     assertEquals(Component.text()
       .content("Buffalo ")
       .append(Component.text("buffalo", NamedTextColor.DARK_PURPLE))
@@ -189,8 +189,9 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .append(Component.translatable("purple.purple")) // or any non-text component
       .build();
 
-    final Component replaced = component.replaceText(Pattern.compile("purple"), match -> match.color(NamedTextColor.DARK_PURPLE),
-      (index, replace) -> index % 2 == 0 ? PatternReplacementResult.REPLACE : PatternReplacementResult.CONTINUE);
+    final Component replaced = component.replaceText(b -> b.match("purple")
+      .replacement(match -> match.color(NamedTextColor.DARK_PURPLE))
+      .condition((index, replace) -> index % 2 == 0 ? PatternReplacementResult.REPLACE : PatternReplacementResult.CONTINUE));
 
     assertEquals(Component.text()
       .content("purple ")
@@ -215,7 +216,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .append(Component.text().append(Component.text("Parent")).append(Component.text(" 1")), Component.keybind("key.adventure.purr"), Component.text().append(Component.text("Parent")).append(Component.text(" 3")))
       .build();
 
-    assertEquals(expectedReplacement, original.replaceText(Pattern.compile("Child"), match -> match.content("Parent")));
+    assertEquals(expectedReplacement, original.replaceText(b -> b.match("Child").replacement(match -> match.content("Parent"))));
   }
 
   // https://github.com/KyoriPowered/adventure/issues/129
@@ -236,7 +237,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .append(Component.text(" under ").color(NamedTextColor.DARK_AQUA).append(Component.text("me")))
       .build();
 
-    assertEquals(expectedReplacement, component.replaceText(Pattern.compile("test"), match -> match.content("me")));
+    assertEquals(expectedReplacement, component.replaceText(b -> b.match("test").replacement("me")));
   }
 
   @Test
@@ -248,7 +249,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .hoverEvent(HoverEvent.showText(Component.text("meow", NamedTextColor.DARK_RED)))
       .build();
 
-    assertEquals(expectedReplacement, component.replaceText(Pattern.compile("meep"), builder -> builder.content("meow").color(NamedTextColor.DARK_RED)));
+    assertEquals(expectedReplacement, component.replaceText(b -> b.match("meep").replacement(builder -> builder.content("meow").color(NamedTextColor.DARK_RED))));
   }
 
   @Test
@@ -260,7 +261,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       .append(Component.translatable("my.translation", Component.text().content("cats ").append(Component.text("good"))))
       .build();
 
-    assertEquals(expectedReplacement, component.replaceText(Pattern.compile("bad"), builder -> builder.content("good")));
+    assertEquals(expectedReplacement, component.replaceText(b -> b.match(Pattern.compile("bad")).replacement(builder -> builder.content("good"))));
   }
 
   @Test
@@ -272,7 +273,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
         .append(Component.text(" world"));
     });
 
-    assertEquals(expectedReplacement, component.replaceText(Pattern.compile("Hello"), builder -> builder.content("Goodbye").color(NamedTextColor.LIGHT_PURPLE)));
+    assertEquals(expectedReplacement, component.replaceText(b -> b.match(Pattern.compile("Hello")).replacement(builder -> builder.content("Goodbye").color(NamedTextColor.LIGHT_PURPLE))));
   }
 
   // https://github.com/KyoriPowered/adventure/issues/197


### PR DESCRIPTION
This allows accessing the MatchResult directly when doing a replacement.