### PR TITLE
key: Namespaced

### DIFF
--- a/key/src/main/java/net/kyori/adventure/key/Key.java
+++ b/key/src/main/java/net/kyori/adventure/key/Key.java
@@ -94,6 +94,19 @@ public interface Key extends Comparable<Key>, Examinable {
   /**
    * Creates a key.
    *
+   * @param namespaced the namespace source
+   * @param value the value
+   * @return the key
+   * @throws InvalidKeyException if the namespace or value contains an invalid character
+   * @since 4.4.0
+   */
+  static @NonNull Key key(final @NonNull Namespaced namespaced, final @NonNull @Pattern(KeyImpl.VALUE_PATTERN) String value) {
+    return key(namespaced.namespace(), value);
+  }
+
+  /**
+   * Creates a key.
+   *
    * @param namespace the namespace
    * @param value the value
    * @return the key

--- a/key/src/main/java/net/kyori/adventure/key/Namespaced.java
+++ b/key/src/main/java/net/kyori/adventure/key/Namespaced.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.key;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.intellij.lang.annotations.Pattern;
+
+/**
+ * Something that has a namespace.
+ *
+ * @since 4.4.0
+ */
+public interface Namespaced {
+  /**
+   * Gets the namespace.
+   *
+   * @return the namespace
+   * @since 4.4.0
+   */
+  @NonNull @Pattern(KeyImpl.NAMESPACE_PATTERN) String namespace();
+}


### PR DESCRIPTION
Allows something like a `Plugin` to implement `Namespaced`, and then do:
```java
final Plugin plugin = ...;
final Key key = Key.key(plugin, "foo");
```