### PR TITLE
Some tidying and checkstyle revisions

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -93,7 +93,7 @@
 
     <!-- https://checkstyle.org/config_coding.html#IllegalTokenText -->
     <module name="IllegalTokenText">
-      <property name="format" value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+      <property name="format" value="($|[^\\])\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
       <property name="message" value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
       <property name="tokens" value="CHAR_LITERAL, STRING_LITERAL"/>
     </module>
@@ -200,6 +200,18 @@
       <property name="tokens" value="LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_IF, LITERAL_TRY"/> <!-- add LITERAL_DO -->
     </module>
 
+    <!-- https://checkstyle.org/config_whitespace.html#SeparatorWrap -->
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapEol"/>
+      <property name="option" value="eol"/>
+      <property name="tokens" value="COMMA, SEMI, ELLIPSIS, RBRACK, ARRAY_DECLARATOR, METHOD_REF"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapNl"/>
+      <property name="option" value="nl"/>
+      <property name="tokens" value="DOT, AT"/>
+    </module>
+
     <!-- https://checkstyle.org/config_coding.html#SimplifyBooleanExpression -->
     <module name="SimplifyBooleanExpression"/>
 
@@ -226,6 +238,11 @@
     <!-- https://checkstyle.org/config_imports.html#UnusedImports -->
     <module name="UnusedImports"/>
 
+    <!-- https://checkstyle.org/config_whitespace.html#WhitespaceAfter -->
+    <module name="WhitespaceAfter">
+      <property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+    </module>
+
     <!--
     #####################
     #### third-party ####
@@ -241,9 +258,6 @@
       <property name="minimumScope" value="public"/>
       <property name="tokens" value="INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, RECORD_DEF, COMPACT_CTOR_DEF"/>
     </module>
-
-    <!-- https://gitlab.com/stellardrift/stylecheck/-/blob/dev/src/main/java/ca/stellardrift/stylecheck/NoLvTypeAnnotations.java -->
-    <module name="NoLvTypeAnnotations"/>
 
     <!-- https://gitlab.com/stellardrift/stylecheck/-/blob/dev/src/main/java/ca/stellardrift/stylecheck/StatementNoWhitespaceAfter.java -->
     <module name="StatementNoWhitespaceAfter">

--- a/api/src/main/java/net/kyori/adventure/identity/Identities.java
+++ b/api/src/main/java/net/kyori/adventure/identity/Identities.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 final class Identities {
-  static Identity NIL = new Identity() {
+  static final Identity NIL = new Identity() {
     private final UUID uuid = new UUID(0, 0);
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1127,7 +1127,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
     for(final Component child : this.children()) {
       if(child.contains(that)) return true;
     }
-    final /* @Nullable */ HoverEvent<?> hoverEvent = this.hoverEvent();
+    final @Nullable HoverEvent<?> hoverEvent = this.hoverEvent();
     if(hoverEvent != null) {
       if(hoverEvent.action().type().isAssignableFrom(Component.class)) {
         final Component hover = (Component) hoverEvent.value();

--- a/api/src/main/java/net/kyori/adventure/text/PatternReplacementResult.java
+++ b/api/src/main/java/net/kyori/adventure/text/PatternReplacementResult.java
@@ -23,12 +23,8 @@
  */
 package net.kyori.adventure.text;
 
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import net.kyori.adventure.util.IntFunction2;
-
 /**
- * A result for {@link Component#replaceText(Pattern, Function, IntFunction2) pattern-based replacements}.
+ * A result for {@link Component#replaceText(TextReplacementConfig)}  pattern-based replacements}.
  *
  * @since 4.0.0
  */

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
@@ -169,9 +169,8 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @return this builder
      * @since 4.2.0
      */
-    default @NonNull Builder replacement(final @NonNull ComponentLike replacement) {
-      requireNonNull(replacement, "replacement");
-      final Component baked = replacement.asComponent();
+    default @NonNull Builder replacement(final @Nullable ComponentLike replacement) {
+      final @Nullable Component baked = replacement == null ? null : replacement.asComponent();
       return this.replacement((result, input) -> baked);
     }
 

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
@@ -108,7 +108,7 @@ final class TextReplacementConfigImpl implements TextReplacementConfig {
     }
 
     @Override
-    public TextReplacementConfig build() {
+    public @NonNull TextReplacementConfig build() {
       if(this.matchPattern == null) throw new IllegalStateException("A pattern must be provided to match against");
       if(this.replacement == null) throw new IllegalStateException("A replacement action must be provided");
       return new TextReplacementConfigImpl(this);

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -141,7 +141,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
 
   @Override
   protected @NonNull Component renderTranslatable(final @NonNull TranslatableComponent component, final @NonNull C context) {
-    final /* @Nullable */ MessageFormat format = this.translate(component.key(), context);
+    final @Nullable MessageFormat format = this.translate(component.key(), context);
     if(format == null) {
       // we don't have a translation for this component, but the arguments or children
       // of this component might need additional rendering
@@ -202,7 +202,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   protected <B extends ComponentBuilder<?, ?>> void mergeStyle(final Component component, final B builder, final C context) {
     builder.mergeStyle(component, MERGES);
     builder.clickEvent(component.clickEvent());
-    final /* @Nullable */ HoverEvent<?> hoverEvent = component.hoverEvent();
+    final @Nullable HoverEvent<?> hoverEvent = component.hoverEvent();
     if(hoverEvent != null) {
       builder.hoverEvent(hoverEvent.withRenderedValue(this, context));
     }

--- a/api/src/main/java/net/kyori/adventure/util/Index.java
+++ b/api/src/main/java/net/kyori/adventure/util/Index.java
@@ -77,6 +77,7 @@ public final class Index<K, V> {
    * @since 4.0.0
    */
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public static <K, V extends Enum<V>> @NonNull Index<K, V> create(final Class<V> type, final @NonNull Function<? super V, ? extends K> keyFunction, final @NonNull V@NonNull... values) {
     return create(values, length -> new EnumMap<>(type), keyFunction);
   }
@@ -92,9 +93,9 @@ public final class Index<K, V> {
    * @since 4.0.0
    */
   @SafeVarargs
-  @SuppressWarnings("RedundantTypeArguments") // explicit type parameters needed to fix build on JDK 1.8
+  @SuppressWarnings("varargs")
   public static <K, V> @NonNull Index<K, V> create(final @NonNull Function<? super V, ? extends K> keyFunction, final @NonNull V@NonNull... values) {
-    return create(values, HashMap<V, K>::new, keyFunction);
+    return create(values, HashMap::new, keyFunction);
   }
 
   /**
@@ -107,9 +108,8 @@ public final class Index<K, V> {
    * @return the key map
    * @since 4.0.0
    */
-  @SuppressWarnings("RedundantTypeArguments") // explicit type parameters needed to fix build on JDK 1.8
   public static <K, V> @NonNull Index<K, V> create(final @NonNull Function<? super V, ? extends K> keyFunction, final @NonNull List<V> constants) {
-    return create(constants, HashMap<V, K>::new, keyFunction);
+    return create(constants, HashMap::new, keyFunction);
   }
 
   private static <K, V> @NonNull Index<K, V> create(final V[] values, final IntFunction<Map<V, K>> valueToKeyFactory, final @NonNull Function<? super V, ? extends K> keyFunction) {

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -76,7 +75,7 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
     assertAllEqualToEachOther(
       Component.text("foo", Style.style(TextColor.color(0x0a1ab9))),
       Component.text("foo", TextColor.color(0x0a1ab9)),
-      Component.text("foo", TextColor.color(0x0a1ab9), ImmutableSet.<TextDecoration>of())
+      Component.text("foo", TextColor.color(0x0a1ab9), ImmutableSet.of())
     );
     assertAllEqualToEachOther(
       Component.text("foo", Style.style(TextColor.color(0x0a1ab9), TextDecoration.BOLD)),
@@ -267,11 +266,10 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
   @Test
   void testPartialReplaceHasIsolatedStyle() {
     final TextComponent component = Component.text("Hello world", NamedTextColor.DARK_PURPLE);
-    final TextComponent expectedReplacement = Component.text(b -> {
+    final TextComponent expectedReplacement = Component.text(b ->
       b.color(NamedTextColor.DARK_PURPLE)
-        .append(Component.text("Goodbye", NamedTextColor.LIGHT_PURPLE))
-        .append(Component.text(" world"));
-    });
+      .append(Component.text("Goodbye", NamedTextColor.LIGHT_PURPLE))
+      .append(Component.text(" world")));
 
     assertEquals(expectedReplacement, component.replaceText(b -> b.match(Pattern.compile("Hello")).replacement(builder -> builder.content("Goodbye").color(NamedTextColor.LIGHT_PURPLE))));
   }
@@ -294,13 +292,13 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
 
     final Pattern replaceWith = Pattern.compile("\\{(\\d+)}");
 
-    final Component replaced = original.replaceText(replaceWith, b -> {
-      final Matcher matcher = replaceWith.matcher(b.content());
-      assertTrue(matcher.find());
-      assertEquals(0, Integer.parseInt(matcher.group(1))); // only one index in our test case
+    final Component replaced = original.replaceText(builder ->
+      builder.match(replaceWith)
+        .replacement((matcher, comp) -> {
+          assertEquals(0, Integer.parseInt(matcher.group(1))); // only one index in our test case
 
-      return Component.text("mycommand");
-    });
+          return Component.text("mycommand");
+        }));
 
     assertEquals(expected, replaced);
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -47,7 +47,7 @@ final class CompoundBinaryTagImpl implements CompoundBinaryTag {
   }
 
   public boolean contains(final @NonNull String key, final @NonNull BinaryTagType<?> type) {
-    final /* @Nullable */ BinaryTag tag = this.tags.get(key);
+    final @Nullable BinaryTag tag = this.tags.get(key);
     return tag != null && type.test(tag.type());
   }
 

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
@@ -212,7 +212,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
       score.getNode(SCORE_NAME).setValue(sc.name());
       score.getNode(SCORE_OBJECTIVE).setValue(sc.objective());
       // score component value is optional
-      final /* @Nullable */ String scoreValue = sc.value();
+      final @Nullable String scoreValue = sc.value();
       if(scoreValue != null) score.getNode(SCORE_VALUE).setValue(scoreValue);
     } else if(src instanceof SelectorComponent) {
       value.getNode(SELECTOR).setValue(((SelectorComponent) src).pattern());

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializerImpl.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializerImpl.java
@@ -59,7 +59,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   @Override
   public @NonNull Component deserialize(final @NonNull ConfigurationNode input) {
     try {
-      final /* @Nullable */ Component deserialized = input.getValue(ComponentTypeSerializer.TYPE);
+      final @Nullable Component deserialized = input.getValue(ComponentTypeSerializer.TYPE);
       if(deserialized != null) {
         return deserialized;
       }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowEntitySerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowEntitySerializer.java
@@ -54,7 +54,7 @@ final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEvent.
     if(typeId == null || id == null) {
       throw new ObjectMappingException("A show entity hover event needs type and id fields to be deserialized");
     }
-    final /* @Nullable */ Component name = value.getNode(NAME).getValue(ComponentTypeSerializer.TYPE);
+    final @Nullable Component name = value.getNode(NAME).getValue(ComponentTypeSerializer.TYPE);
 
     return HoverEvent.ShowEntity.of(typeId, id, name);
   }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/StyleSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/StyleSerializer.java
@@ -70,11 +70,11 @@ final class StyleSerializer implements TypeSerializer<Style> {
 
     final Style.Builder builder = Style.style();
 
-    final /* @Nullable */ Key font = value.getNode(FONT).getValue(KeySerializer.INSTANCE.type());
+    final @Nullable Key font = value.getNode(FONT).getValue(KeySerializer.INSTANCE.type());
     if(font != null) {
       builder.font(font);
     }
-    final /* @Nullable */ TextColor color = value.getNode(COLOR).getValue(TextColorSerializer.INSTANCE.type());
+    final @Nullable TextColor color = value.getNode(COLOR).getValue(TextColorSerializer.INSTANCE.type());
     if(color != null) {
       builder.color(color);
     }
@@ -86,7 +86,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
       }
     }
 
-    final /* @Nullable */ String insertion = value.getNode(INSERTION).getString();
+    final @Nullable String insertion = value.getNode(INSERTION).getString();
     if(insertion != null) {
       builder.insertion(insertion);
     }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TitleSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TitleSerializer.java
@@ -78,7 +78,7 @@ final class TitleSerializer implements TypeSerializer<Title> {
 
     value.getNode(TITLE).setValue(ComponentTypeSerializer.TYPE, obj.title());
     value.getNode(SUBTITLE).setValue(ComponentTypeSerializer.TYPE, obj.subtitle());
-    final Title./* @Nullable */ Times times = obj.times();
+    final Title.@Nullable Times times = obj.times();
     value.getNode(TIMES, FADE_IN).setValue(DurationSerializer.INSTANCE.type(), times == null || times == Title.DEFAULT_TIMES ? null : times.fadeIn());
     value.getNode(TIMES, STAY).setValue(DurationSerializer.INSTANCE.type(), times == null || times == Title.DEFAULT_TIMES ? null : times.stay());
     value.getNode(TIMES, FADE_OUT).setValue(DurationSerializer.INSTANCE.type(), times == null || times == Title.DEFAULT_TIMES ? null : times.fadeOut());

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
@@ -210,7 +210,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
       score.node(SCORE_NAME).set(sc.name());
       score.node(SCORE_OBJECTIVE).set(sc.objective());
       // score component value is optional
-      final /* @Nullable */ String scoreValue = sc.value();
+      final @Nullable String scoreValue = sc.value();
       if(scoreValue != null) score.node(SCORE_VALUE).set(scoreValue);
     } else if(src instanceof SelectorComponent) {
       value.node(SELECTOR).set(((SelectorComponent) src).pattern());

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializerImpl.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializerImpl.java
@@ -64,7 +64,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   @Override
   public @NonNull Component deserialize(final @NonNull ConfigurationNode input) {
     try {
-      final /* @Nullable */ Component deserialized = input.get(Component.class);
+      final @Nullable Component deserialized = input.get(Component.class);
       if(deserialized != null) {
         return deserialized;
       }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowEntitySerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowEntitySerializer.java
@@ -51,7 +51,7 @@ final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEvent.
     if(typeId == null || id == null) {
       throw new SerializationException("A show entity hover event needs type and id fields to be deserialized");
     }
-    final /* @Nullable */ Component name = value.node(NAME).get(Component.class);
+    final @Nullable Component name = value.node(NAME).get(Component.class);
 
     return HoverEvent.ShowEntity.of(typeId, id, name);
   }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/StyleSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/StyleSerializer.java
@@ -67,11 +67,11 @@ final class StyleSerializer implements TypeSerializer<Style> {
 
     final Style.Builder builder = Style.style();
 
-    final /* @Nullable */ Key font = value.node(FONT).get(Key.class);
+    final @Nullable Key font = value.node(FONT).get(Key.class);
     if(font != null) {
       builder.font(font);
     }
-    final /* @Nullable */ TextColor color = value.node(COLOR).get(TextColor.class);
+    final @Nullable TextColor color = value.node(COLOR).get(TextColor.class);
     if(color != null) {
       builder.color(color);
     }
@@ -83,7 +83,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
       }
     }
 
-    final /* @Nullable */ String insertion = value.node(INSERTION).getString();
+    final @Nullable String insertion = value.node(INSERTION).getString();
     if(insertion != null) {
       builder.insertion(insertion);
     }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TitleSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TitleSerializer.java
@@ -76,7 +76,7 @@ final class TitleSerializer implements TypeSerializer<Title> {
 
     value.node(TITLE).set(Component.class, obj.title());
     value.node(SUBTITLE).set(Component.class, obj.subtitle());
-    final Title./* @Nullable */ Times times = obj.times();
+    final Title.@Nullable Times times = obj.times();
     value.node(TIMES, FADE_IN).set(Duration.class, times == null || times == Title.DEFAULT_TIMES ? null : times.fadeIn());
     value.node(TIMES, STAY).set(Duration.class, times == null || times == Title.DEFAULT_TIMES ? null : times.stay());
     value.node(TIMES, FADE_OUT).set(Duration.class, times == null || times == Title.DEFAULT_TIMES ? null : times.fadeOut());

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
@@ -50,6 +50,7 @@ import net.kyori.adventure.text.StorageNBTComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.Style;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ComponentSerializerImpl implements JsonDeserializer<Component>, JsonSerializer<Component> {
   static final String TEXT = "text";
@@ -189,7 +190,7 @@ final class ComponentSerializerImpl implements JsonDeserializer<Component>, Json
       score.addProperty(SCORE_NAME, sc.name());
       score.addProperty(SCORE_OBJECTIVE, sc.objective());
       // score component value is optional
-      final /* @Nullable */ String value = sc.value();
+      final @Nullable String value = sc.value();
       if(value != null) score.addProperty(SCORE_VALUE, value);
       object.add(SCORE, score);
     } else if(src instanceof SelectorComponent) {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowEntitySerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowEntitySerializer.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ShowEntitySerializer implements JsonDeserializer<HoverEvent.ShowEntity>, JsonSerializer<HoverEvent.ShowEntity> {
   static final String TYPE = "type";
@@ -52,7 +53,7 @@ final class ShowEntitySerializer implements JsonDeserializer<HoverEvent.ShowEnti
     final Key type = context.deserialize(object.getAsJsonPrimitive(TYPE), Key.class);
     final UUID id = UUID.fromString(object.getAsJsonPrimitive(ID).getAsString());
 
-    /* @Nullable */ Component name = null;
+    @Nullable Component name = null;
     if(object.has(NAME)) {
       name = context.deserialize(object.get(NAME), Component.class);
     }
@@ -67,7 +68,7 @@ final class ShowEntitySerializer implements JsonDeserializer<HoverEvent.ShowEnti
     json.add(TYPE, context.serialize(src.type()));
     json.addProperty(ID, src.id().toString());
 
-    final /* @Nullable */ Component name = src.name();
+    final @Nullable Component name = src.name();
     if(name != null) {
       json.add(NAME, context.serialize(name));
     }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Type;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.event.HoverEvent;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ShowItemSerializer implements JsonDeserializer<HoverEvent.ShowItem>, JsonSerializer<HoverEvent.ShowItem> {
   static final String ID = "id";
@@ -82,7 +83,7 @@ final class ShowItemSerializer implements JsonDeserializer<HoverEvent.ShowItem>,
       json.addProperty(COUNT, count);
     }
 
-    final /* @Nullable */ BinaryTagHolder nbt = src.nbt();
+    final @Nullable BinaryTagHolder nbt = src.nbt();
     if(nbt != null) {
       json.addProperty(TAG, nbt.string());
     }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -111,8 +111,8 @@ final class StyleSerializer implements JsonDeserializer<Style>, JsonSerializer<S
       if(clickEvent != null) {
         final ClickEvent./*@Nullable*/ Action action = optionallyDeserialize(clickEvent.getAsJsonPrimitive(CLICK_EVENT_ACTION), context, ClickEvent.Action.class);
         if(action != null && action.readable()) {
-          final /* @Nullable */ JsonPrimitive rawValue = clickEvent.getAsJsonPrimitive(CLICK_EVENT_VALUE);
-          final /* @Nullable */ String value = rawValue == null ? null : rawValue.getAsString();
+          final @Nullable JsonPrimitive rawValue = clickEvent.getAsJsonPrimitive(CLICK_EVENT_VALUE);
+          final @Nullable String value = rawValue == null ? null : rawValue.getAsString();
           if(value != null) {
             style.clickEvent(ClickEvent.clickEvent(action, value));
           }
@@ -125,9 +125,9 @@ final class StyleSerializer implements JsonDeserializer<Style>, JsonSerializer<S
       if(hoverEvent != null) {
         final HoverEvent./*@Nullable*/ Action action = optionallyDeserialize(hoverEvent.getAsJsonPrimitive(HOVER_EVENT_ACTION), context, HoverEvent.Action.class);
         if(action != null && action.readable()) {
-          final /* @Nullable */ Object value;
+          final @Nullable Object value;
           if(hoverEvent.has(HOVER_EVENT_CONTENTS)) {
-            final /* @Nullable */ JsonElement rawValue = hoverEvent.get(HOVER_EVENT_CONTENTS);
+            final @Nullable JsonElement rawValue = hoverEvent.get(HOVER_EVENT_CONTENTS);
             value = context.deserialize(rawValue, action.type());
           } else if(hoverEvent.has(HOVER_EVENT_VALUE)) {
             final Component rawValue = context.deserialize(hoverEvent.get(HOVER_EVENT_VALUE), Component.class);
@@ -183,12 +183,12 @@ final class StyleSerializer implements JsonDeserializer<Style>, JsonSerializer<S
   public JsonElement serialize(final Style src, final Type typeOfSrc, final JsonSerializationContext context) {
     final JsonObject json = new JsonObject();
 
-    final /* @Nullable */ Key font = src.font();
+    final @Nullable Key font = src.font();
     if(font != null) {
       json.add(FONT, context.serialize(font));
     }
 
-    final /* @Nullable */ TextColor color = src.color();
+    final @Nullable TextColor color = src.color();
     if(color != null) {
       json.add(COLOR, context.serialize(color));
     }
@@ -203,12 +203,12 @@ final class StyleSerializer implements JsonDeserializer<Style>, JsonSerializer<S
       }
     }
 
-    final /* @Nullable */ String insertion = src.insertion();
+    final @Nullable String insertion = src.insertion();
     if(insertion != null) {
       json.addProperty(INSERTION, insertion);
     }
 
-    final /* @Nullable */ ClickEvent clickEvent = src.clickEvent();
+    final @Nullable ClickEvent clickEvent = src.clickEvent();
     if(clickEvent != null) {
       final JsonObject eventJson = new JsonObject();
       eventJson.add(CLICK_EVENT_ACTION, context.serialize(clickEvent.action()));
@@ -216,7 +216,7 @@ final class StyleSerializer implements JsonDeserializer<Style>, JsonSerializer<S
       json.add(CLICK_EVENT, eventJson);
     }
 
-    final /* @Nullable */ HoverEvent<?> hoverEvent = src.hoverEvent();
+    final @Nullable HoverEvent<?> hoverEvent = src.hoverEvent();
     if(hoverEvent != null) {
       final JsonObject eventJson = new JsonObject();
       eventJson.add(HOVER_EVENT_ACTION, context.serialize(hoverEvent.action()));

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorSerializer.java
@@ -54,8 +54,10 @@ final class TextColorSerializer extends TypeAdapter<TextColor> {
   }
 
   @Override
-  public TextColor read(final JsonReader in) throws IOException {
-    final TextColor color = fromString(in.nextString());
+  public @Nullable TextColor read(final JsonReader in) throws IOException {
+    final @Nullable TextColor color = fromString(in.nextString());
+    if(color == null) return null;
+
     return this.downsampleColor ? NamedTextColor.nearestTo(color) : color;
   }
 


### PR DESCRIPTION
Now that we build using javac 11, we can use LVT type use annotations again -- so uncommenting those is the biggest change. Some other type inference things that javac 8 couldn't handle are added too.

This brings over a few whitespace checks from the checkstyling of MiniMessage as well -- though those didn't result in any actual code changes here.