### PR TITLE
Customize Debugger Output

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -35,6 +35,7 @@ import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,6 +44,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 4.0.0
  */
+@Debug.Renderer(text = "this.debuggerString()", childrenArray = "this.children().toArray()", hasChildren = "!this.children().isEmpty()")
 public abstract class AbstractComponent implements Component {
   static List<Component> asComponents(final List<? extends ComponentLike> list) {
     return asComponents(list, false);
@@ -128,11 +130,21 @@ public abstract class AbstractComponent implements Component {
     return result;
   }
 
+  private String debuggerString() {
+    return StringExaminer.simpleEscaping().examine(this.examinableName(), this.examinablePropertiesWithoutChildren());
+  }
+
+  protected Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+    return Stream.of(ExaminableProperty.of("style", this.style));
+  }
+
   @Override
   public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
-    return Stream.of(
-      ExaminableProperty.of("children", this.children),
-      ExaminableProperty.of("style", this.style)
+    return Stream.concat(
+      this.examinablePropertiesWithoutChildren(),
+      Stream.of(
+        ExaminableProperty.of("style", this.style)
+      )
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -143,7 +143,7 @@ public abstract class AbstractComponent implements Component {
     return Stream.concat(
       this.examinablePropertiesWithoutChildren(),
       Stream.of(
-        ExaminableProperty.of("style", this.style)
+        ExaminableProperty.of("children", this.children)
       )
     );
   }

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
@@ -92,12 +92,12 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("pos", this.pos)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/EntityNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/EntityNBTComponentImpl.java
@@ -89,12 +89,12 @@ final class EntityNBTComponentImpl extends NBTComponentImpl<EntityNBTComponent, 
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("selector", this.selector)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponentImpl.java
@@ -79,12 +79,12 @@ final class KeybindComponentImpl extends AbstractComponent implements KeybindCom
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("keybind", this.keybind)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
@@ -70,13 +70,13 @@ abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTCompo
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("nbtPath", this.nbtPath),
         ExaminableProperty.of("interpret", this.interpret)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
@@ -109,14 +109,14 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("name", this.name),
         ExaminableProperty.of("objective", this.objective),
         ExaminableProperty.of("value", this.value)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/SelectorComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/SelectorComponentImpl.java
@@ -79,12 +79,12 @@ final class SelectorComponentImpl extends AbstractComponent implements SelectorC
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("pattern", this.pattern)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/StorageNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/StorageNBTComponentImpl.java
@@ -91,12 +91,12 @@ final class StorageNBTComponentImpl extends NBTComponentImpl<StorageNBTComponent
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("storage", this.storage)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -88,12 +88,12 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("content", this.content)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
@@ -105,13 +105,13 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("key", this.key),
         ExaminableProperty.of("args", this.args)
       ),
-      super.examinableProperties()
+      super.examinablePropertiesWithoutChildren()
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
@@ -24,7 +24,9 @@
 package net.kyori.adventure.text.format;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
+@Debug.Renderer(text = "asHexString()")
 final class TextColorImpl implements TextColor {
   private final int value;
 

--- a/nbt/build.gradle
+++ b/nbt/build.gradle
@@ -2,6 +2,7 @@ dependencies {
   api("net.kyori:examination-api:1.1.0")
   api("net.kyori:examination-string:1.1.0")
   compileOnlyApi("org.checkerframework:checker-qual:3.10.0")
+  compileOnlyApi("org.jetbrains:annotations:20.1.0")
 }
 
 jar {

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
@@ -29,7 +29,9 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
+@Debug.Renderer(text = "\"byte[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class ByteArrayBinaryTagImpl extends ArrayBinaryTagImpl implements ByteArrayBinaryTag {
   final byte[] value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteBinaryTag.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 /**
  * A binary tag holding a {@code byte} value.
@@ -79,6 +80,7 @@ public interface ByteBinaryTag extends NumberBinaryTag {
   byte value();
 }
 
+@Debug.Renderer(text = "\"0x\" + Integer.toString(this.value, 16)", hasChildren = "false")
 final class ByteBinaryTagImpl extends AbstractBinaryTag implements ByteBinaryTag {
   private final byte value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -33,9 +33,11 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 import static java.util.Objects.requireNonNull;
 
+@Debug.Renderer(text = "\"CompoundBinaryTag[length=\" + this.tags.size() + \"]\"", childrenArray = "this.tags.entrySet().toArray()", hasChildren = "!this.tags.isEmpty()")
 final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundBinaryTag {
   static final CompoundBinaryTag EMPTY = new CompoundBinaryTagImpl(Collections.emptyMap());
   private final Map<String, BinaryTag> tags;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/DoubleBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/DoubleBinaryTag.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 /**
  * A binary tag holding a {@code double} value.
@@ -59,6 +60,7 @@ public interface DoubleBinaryTag extends NumberBinaryTag {
   double value();
 }
 
+@Debug.Renderer(text = "String.valueOf(this.value) + \"d\"", hasChildren = "false")
 final class DoubleBinaryTagImpl extends AbstractBinaryTag implements DoubleBinaryTag {
   private final double value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTag.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 /**
  * A binary tag holding a {@code float} value.
@@ -59,6 +60,7 @@ public interface FloatBinaryTag extends NumberBinaryTag {
   float value();
 }
 
+@Debug.Renderer(text = "String.valueOf(this.value) + \"f\"", hasChildren = "false")
 final class FloatBinaryTagImpl extends AbstractBinaryTag implements FloatBinaryTag {
   private final float value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
@@ -33,7 +33,9 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
+@Debug.Renderer(text = "\"int[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArrayBinaryTag {
   final int[] value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntBinaryTag.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 /**
  * A binary tag holding an {@code int} value.
@@ -59,6 +60,7 @@ public interface IntBinaryTag extends NumberBinaryTag {
   int value();
 }
 
+@Debug.Renderer(text = "String.valueOf(this.value) + \"i\"", hasChildren = "false")
 final class IntBinaryTagImpl extends AbstractBinaryTag implements IntBinaryTag {
   private final int value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -36,7 +36,9 @@ import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
+@Debug.Renderer(text = "\"ListBinaryTag[type=\" + this.type.toString() + \"]\"", childrenArray = "this.tags.toArray()", hasChildren = "!this.tags.isEmpty()")
 final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag {
   static final ListBinaryTag EMPTY = new ListBinaryTagImpl(BinaryTagTypes.END, Collections.emptyList());
   private final List<BinaryTag> tags;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
@@ -33,7 +33,9 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
+@Debug.Renderer(text = "\"long[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArrayBinaryTag {
   final long[] value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongBinaryTag.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 /**
  * A binary tag holding a {@code long} value.
@@ -59,6 +60,7 @@ public interface LongBinaryTag extends NumberBinaryTag {
   long value();
 }
 
+@Debug.Renderer(text = "String.valueOf(this.value) + \"l\"", hasChildren = "false")
 final class LongBinaryTagImpl extends AbstractBinaryTag implements LongBinaryTag {
   private final long value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ShortBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ShortBinaryTag.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 /**
  * A binary tag holding a {@code short} value.
@@ -59,6 +60,7 @@ public interface ShortBinaryTag extends NumberBinaryTag {
   short value();
 }
 
+@Debug.Renderer(text = "String.valueOf(this.value) + \"s\"", hasChildren = "false")
 final class ShortBinaryTagImpl extends AbstractBinaryTag implements ShortBinaryTag {
   private final short value;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/StringBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/StringBinaryTag.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Debug;
 
 /**
  * A binary tag holding a {@link String} value.
@@ -59,6 +60,7 @@ public interface StringBinaryTag extends BinaryTag {
   @NonNull String value();
 }
 
+@Debug.Renderer(text = "\"\\\"\" + this.value + \"\\\"\"", hasChildren = "false")
 final class StringBinaryTagImpl extends AbstractBinaryTag implements StringBinaryTag {
   private final String value;
 


### PR DESCRIPTION
This adds some extra annotations to our main hierarchical data structures -- `Component`s and NBT that give a more streamlined view of objects in the debugger.

## Component

**Before:** 
![Before](https://cdn.discordapp.com/attachments/439651296434454529/786462343399604224/unknown.png)

**After:**
![After](https://cdn.discordapp.com/attachments/439651296434454529/786461378910093352/unknown.png)

(the implementation of this is a bit ugly at the moment -- perhaps there's space to improve it with changes to `examination`?)

## NBT

**Before:** 
![image](https://user-images.githubusercontent.com/629092/101734920-e6a3a100-3a75-11eb-8eeb-c2dca0eb0b61.png)

**After:**: 
![image](https://user-images.githubusercontent.com/629092/101735089-2e2a2d00-3a76-11eb-8b33-42731068097a.png)
