### PR TITLE
serializer-configurate*: Fix handling of string component output

### DIFF
--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
@@ -191,6 +191,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
     } else if(this.stringSerial != null && this.preferString) {
       try {
         value.setValue(this.stringSerial.serialize(src));
+        return;
       } catch(final Exception ex) {
         throw new ObjectMappingException(ex);
       }

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/ComponentSerializerTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/ComponentSerializerTest.java
@@ -25,13 +25,27 @@ package net.kyori.adventure.serializer.configurate3;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import ninja.leaping.configurate.ConfigurationNode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ComponentSerializerTest implements ConfigurateTestBase {
+  @Test
+  void testSerializeToString() {
+    final ConfigurationNode serialized = ConfigurateComponentSerializer.builder()
+      .scalarSerializer(GsonComponentSerializer.gson())
+      .outputStringComponents(true)
+      .build()
+      .serialize(Component.text("Hello", Style.style(TextDecoration.BOLD)));
+
+    assertEquals("{\"text\":\"Hello\",\"bold\":true}", serialized.getString());
+  }
+
   @Test
   void testTextComponent() {
     final ConfigurationNode serialized = this.node(n -> {

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
@@ -189,6 +189,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
     } else if(this.stringSerial != null && this.preferString) {
       try {
         value.set(this.stringSerial.serialize(src));
+        return;
       } catch(final Exception ex) {
         throw new SerializationException(ex);
       }

--- a/serializer-configurate4/src/test/java/net/kyori/adventure/serializer/configurate4/ComponentSerializerTest.java
+++ b/serializer-configurate4/src/test/java/net/kyori/adventure/serializer/configurate4/ComponentSerializerTest.java
@@ -25,13 +25,27 @@ package net.kyori.adventure.serializer.configurate4;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ComponentSerializerTest implements ConfigurateTestBase {
+  @Test
+  void testSerializeToString() {
+    final ConfigurationNode serialized = ConfigurateComponentSerializer.builder()
+      .scalarSerializer(GsonComponentSerializer.gson())
+      .outputStringComponents(true)
+      .build()
+      .serialize(Component.text("Hello", Style.style(TextDecoration.BOLD)));
+
+    assertEquals("{\"text\":\"Hello\",\"bold\":true}", serialized.getString());
+  }
+
   @Test
   void testTextComponent() {
     final ConfigurationNode serialized = this.node(n -> {


### PR DESCRIPTION
Without this change, the `preferString` flag would be effectively ignored.