### PR TITLE
Include empty components in translatable arguments

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -44,7 +44,7 @@ import static java.util.Objects.requireNonNull;
  * @since 4.0.0
  */
 public abstract class AbstractComponent implements Component {
-  static List<Component> asComponents(final List<? extends ComponentLike> list) {
+  static List<Component> asComponents(final List<? extends ComponentLike> list, final boolean includeEmpty) {
     if(list.isEmpty()) {
       // We do not need to create a new list if the one we are copying is empty - we can
       // simply just return our known-empty list instead.
@@ -54,11 +54,15 @@ public abstract class AbstractComponent implements Component {
     for(int i = 0, size = list.size(); i < size; i++) {
       final ComponentLike like = list.get(i);
       final Component component = like.asComponent();
-      if(component != Component.empty()) {
+      if(includeEmpty || component != Component.empty()) {
         components.add(component);
       }
     }
     return Collections.unmodifiableList(components);
+  }
+
+  static List<Component> asComponents(final List<? extends ComponentLike> list) {
+    return asComponents(list, false);
   }
 
   static <T> List<T> addOne(final List<T> oldList, final T newElement) {

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
@@ -47,7 +47,8 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   TranslatableComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final @NonNull String key, final @NonNull List<? extends ComponentLike> args) {
     super(children, style);
     this.key = requireNonNull(key, "key");
-    this.args = AbstractComponent.asComponents(args);
+    // Since translation arguments can be indexed, empty components are also included.
+    this.args = AbstractComponent.asComponents(args, true);
   }
 
   @Override
@@ -163,7 +164,7 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
 
     @Override
     public @NonNull Builder args(final @NonNull List<? extends ComponentLike> args) {
-      this.args = AbstractComponent.asComponents(args);
+      this.args = AbstractComponent.asComponents(args, true);
       return this;
     }
 

--- a/api/src/test/java/net/kyori/adventure/text/TranslatableComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TranslatableComponentTest.java
@@ -156,4 +156,20 @@ class TranslatableComponentTest extends AbstractComponentTest<TranslatableCompon
       Component.text("lucko")
     ).inOrder();
   }
+
+  @Test
+  void testBuilderArgs_multipleWithEmpty() {
+    final TranslatableComponent c0 = Component.translatable()
+      .key("multiplayer.player.joined")
+      .args(
+        Component.empty(),
+        Component.text().content("kashike")
+      )
+      .build();
+    assertThat(c0.args()).hasSize(2);
+    assertThat(c0.args()).containsExactly(
+      Component.empty(),
+      Component.text("kashike")
+    ).inOrder();
+  }
 }


### PR DESCRIPTION
Consider the following scenario: 
```java
MessageFormat format = new MessageFormat("{1} was killed by {2}"); // key = player.death

Component message = translatable()
  .key("player.death")
  .args(empty(), text("Bob"), text("Alice"))
  .build()
```

If you translate `message` today, you'll get `"Alice was killed by {2}"`. This is because `AbstractComponent#asComponents` filters out `Component#empty`. While this works in most situations, it causes index-skew with `TranslatableComponent`.