### PR TITLE
API addition for translations

### DIFF
--- a/api/src/main/java/net/kyori/adventure/translation/TranslationRegistry.java
+++ b/api/src/main/java/net/kyori/adventure/translation/TranslationRegistry.java
@@ -72,6 +72,15 @@ public interface TranslationRegistry extends Translator {
   }
 
   /**
+   * Checks if any translations are explicitly registered for the specified key.
+   *
+   * @param key a translation key
+   * @return whether the registry contains a value for the translation key
+   * @since 4.7.0
+   */
+  boolean contains(final @NonNull String key);
+
+  /**
    * Gets a message format from a key and locale.
    *
    * <p>If a translation for {@code locale} is not found, we will then try {@code locale} without a country code, and then finally fallback to a default locale.</p>

--- a/api/src/main/java/net/kyori/adventure/translation/TranslationRegistryImpl.java
+++ b/api/src/main/java/net/kyori/adventure/translation/TranslationRegistryImpl.java
@@ -63,6 +63,11 @@ final class TranslationRegistryImpl implements Examinable, TranslationRegistry {
   }
 
   @Override
+  public boolean contains(final @NonNull String key) {
+    return this.translations.containsKey(key);
+  }
+
+  @Override
   public @Nullable MessageFormat translate(final @NonNull String key, final @NonNull Locale locale) {
     final Translation translation = this.translations.get(key);
     if(translation == null) return null;


### PR DESCRIPTION
Adds a method to check if a translation key has any registered translations.

This allows one to easily handle a missing translation key using a custom fallback.