### PR TITLE
api: add support for pixel width calculation

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/width/CharacterWidthFunction.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/CharacterWidthFunction.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.width;
+
+import net.kyori.adventure.text.format.Style;
+
+/**
+ * A function that takes a character(represented by its UTF-16 codepoint) and a {@link Style} and returns
+ * the characters width as an {@code int}.
+ *
+ * @since 4.7.0
+ */
+@FunctionalInterface
+public interface CharacterWidthFunction {
+  /**
+   * Gets the width for the given character(represented by its UTF-16 codepoint). {@code char}s will
+   * automatically be converted to codepoints.
+   *
+   * @since 4.7.0
+   */
+  int widthOf(int codepoint, Style style);
+}

--- a/api/src/main/java/net/kyori/adventure/text/width/DefaultCharacterWidthFunction.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/DefaultCharacterWidthFunction.java
@@ -1,0 +1,228 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.width;
+
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Generated with <a href="https://github.com/KingOfSquares/MinecraftFontPixelWidth">MinecraftFontPixelWidth</a>.
+ * <p>Can calculate for all characters found in the default ascii.png file</p>
+ *
+ * @since 4.10.0
+ */
+public class DefaultCharacterWidthFunction implements CharacterWidthFunction {
+  public static final DefaultCharacterWidthFunction INSTANCE = new DefaultCharacterWidthFunction();
+
+  @Override
+  public final float widthOf(final int c, @NotNull final Style style) {
+    float i = -1;
+    switch(c) {
+      case 33:
+      case 39:
+      case 44:
+      case 46:
+      case 58:
+      case 59:
+      case 105:
+      case 124:
+        i = 2.0F;
+        break;
+      case 96:
+      case 108:
+        i = 3.0F;
+        break;
+      case 34:
+      case 40:
+      case 41:
+      case 42:
+      case 73:
+      case 91:
+      case 93:
+      case 116:
+      case 123:
+      case 125:
+        i = 4.0F;
+        break;
+      case 35:
+      case 36:
+      case 37:
+      case 38:
+      case 43:
+      case 45:
+      case 47:
+      case 48:
+      case 49:
+      case 50:
+      case 51:
+      case 52:
+      case 53:
+      case 54:
+      case 55:
+      case 56:
+      case 57:
+      case 61:
+      case 63:
+      case 65:
+      case 66:
+      case 67:
+      case 68:
+      case 69:
+      case 70:
+      case 71:
+      case 72:
+      case 74:
+      case 75:
+      case 76:
+      case 77:
+      case 78:
+      case 79:
+      case 80:
+      case 81:
+      case 82:
+      case 83:
+      case 84:
+      case 85:
+      case 86:
+      case 87:
+      case 88:
+      case 89:
+      case 90:
+      case 92:
+      case 94:
+      case 95:
+      case 97:
+      case 98:
+      case 99:
+      case 100:
+      case 101:
+      case 103:
+      case 104:
+      case 106:
+      case 109:
+      case 110:
+      case 111:
+      case 112:
+      case 113:
+      case 114:
+      case 115:
+      case 117:
+      case 118:
+      case 119:
+      case 120:
+      case 121:
+      case 122:
+      case 163:
+      case 172:
+      case 177:
+      case 247:
+      case 402:
+      case 8712:
+      case 8729:
+      case 8804:
+      case 8805:
+      case 9474:
+      case 9488:
+      case 9496:
+      case 9508:
+      case 9557:
+      case 9563:
+      case 9569:
+      case 9632:
+        i = 6.0F;
+        break;
+      case 8709:
+      case 8992:
+      case 9553:
+      case 9558:
+      case 9559:
+      case 9564:
+      case 9565:
+      case 9570:
+      case 9571:
+      case 9617:
+        i = 12.0F;
+        break;
+      case 9472:
+      case 9484:
+      case 9492:
+      case 9500:
+      case 9516:
+      case 9524:
+      case 9532:
+      case 9552:
+      case 9554:
+      case 9555:
+      case 9556:
+      case 9560:
+      case 9561:
+      case 9562:
+      case 9566:
+      case 9567:
+      case 9568:
+      case 9572:
+      case 9573:
+      case 9574:
+      case 9575:
+      case 9576:
+      case 9577:
+      case 9578:
+      case 9579:
+      case 9580:
+      case 9600:
+      case 9604:
+      case 9608:
+      case 9616:
+      case 9618:
+      case 9619:
+        i = 13.0F;
+        break;
+      case 60:
+      case 62:
+      case 102:
+      case 107:
+      case 170:
+      case 176:
+      case 178:
+      case 186:
+      case 8319:
+      case 8993:
+      case 9612:
+        i = 5.0F;
+        break;
+      case 64:
+      case 126:
+      case 171:
+      case 187:
+      case 8730:
+      case 8776:
+      case 8801:
+        i = 15.0F;
+        break;
+    }
+    if (i != -1 && style.hasDecoration(TextDecoration.BOLD)) i++;
+    return i;
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/width/DefaultCharacterWidthFunction.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/DefaultCharacterWidthFunction.java
@@ -30,6 +30,8 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Generated with <a href="https://github.com/KingOfSquares/MinecraftFontPixelWidth">MinecraftFontPixelWidth</a>.
  * <p>Can calculate for all characters found in the default ascii.png file</p>
+ * <p>NB: this function includes the spacing after each character before the next,
+ * this means that if the last character is at the end of a line it will be calculated as one(1) pixel "too long"</p>
  *
  * @since 4.10.0
  */
@@ -38,7 +40,7 @@ public class DefaultCharacterWidthFunction implements CharacterWidthFunction {
 
   @Override
   public final float widthOf(final int c, @NotNull final Style style) {
-    float i = -1;
+    float width = -1;
     switch(c) {
       case 33:
       case 39:
@@ -48,11 +50,11 @@ public class DefaultCharacterWidthFunction implements CharacterWidthFunction {
       case 59:
       case 105:
       case 124:
-        i = 2.0F;
+        width = 2.0F;
         break;
       case 96:
       case 108:
-        i = 3.0F;
+        width = 3.0F;
         break;
       case 34:
       case 40:
@@ -64,7 +66,20 @@ public class DefaultCharacterWidthFunction implements CharacterWidthFunction {
       case 116:
       case 123:
       case 125:
-        i = 4.0F;
+        width = 4.0F;
+        break;
+      case 60:
+      case 62:
+      case 102:
+      case 107:
+      case 170:
+      case 176:
+      case 178:
+      case 186:
+      case 8319:
+      case 8993:
+      case 9612:
+        width = 5.0F;
         break;
       case 35:
       case 36:
@@ -151,7 +166,16 @@ public class DefaultCharacterWidthFunction implements CharacterWidthFunction {
       case 9563:
       case 9569:
       case 9632:
-        i = 6.0F;
+        width = 6.0F;
+        break;
+      case 64:
+      case 126:
+      case 171:
+      case 187:
+      case 8730:
+      case 8776:
+      case 8801:
+        width = 7.0F;
         break;
       case 8709:
       case 8992:
@@ -163,7 +187,7 @@ public class DefaultCharacterWidthFunction implements CharacterWidthFunction {
       case 9570:
       case 9571:
       case 9617:
-        i = 12.0F;
+        width = 8.0F;
         break;
       case 9472:
       case 9484:
@@ -197,32 +221,11 @@ public class DefaultCharacterWidthFunction implements CharacterWidthFunction {
       case 9616:
       case 9618:
       case 9619:
-        i = 13.0F;
-        break;
-      case 60:
-      case 62:
-      case 102:
-      case 107:
-      case 170:
-      case 176:
-      case 178:
-      case 186:
-      case 8319:
-      case 8993:
-      case 9612:
-        i = 5.0F;
-        break;
-      case 64:
-      case 126:
-      case 171:
-      case 187:
-      case 8730:
-      case 8776:
-      case 8801:
-        i = 15.0F;
+        width = 9.0F;
         break;
     }
-    if (i != -1 && style.hasDecoration(TextDecoration.BOLD)) i++;
-    return i;
+    if (width != -1 && style.hasDecoration(TextDecoration.BOLD))
+      width++;
+    return width;
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSource.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSource.java
@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Providing context to this source is only necessary if a custom {@code Function<CX, CharacterWidthFunction>} is provided on creation</p>
  *
  * @param <CX> a context type (player, server, locale)
- * @since 4.7.0
+ * @since 4.10.0
  */
 @ApiStatus.NonExtendable
 public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, PixelWidthSource.Builder<CX>> {
@@ -48,13 +48,15 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
   /**
    * A pixel width source calculating width using the provided flattener and character width function.
    *
-   * <p>A null value results in using the basic counterpart</p>
+   * <p>A null value results in using a basic counterpart:</p>
+   * <p>{@link net.kyori.adventure.text.flattener.ComponentFlattener#basic()}</p>
+   * <p>{@link net.kyori.adventure.text.width.DefaultCharacterWidthFunction#INSTANCE}</p>
    *
    * @param flattener a flattener used to turn components into linear text
    * @param function a function that provides a character width function
    * @param <CX> context a context type (player, server, locale)
    * @return a pixel width source
-   * @since 4.7.0
+   * @since 4.10.0
    */
   static <CX> @NotNull PixelWidthSource<CX> pixelWidthSource(final @Nullable ComponentFlattener flattener, final @Nullable Function<@Nullable CX, CharacterWidthFunction> function) {
     return new PixelWidthSourceImpl<>(flattener == null ? ComponentFlattener.basic() : flattener, function == null ? cx -> DefaultCharacterWidthFunction.INSTANCE : function);
@@ -66,7 +68,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @param component a component
    * @param context the context of this calculation
    * @return the pixel width of the component
-   * @since 4.7.0
+   * @since 4.10.0
    */
   float width(final @NotNull Component component, final @Nullable CX context);
 
@@ -75,7 +77,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    *
    * @param component a component
    * @return the pixel width of the component
-   * @since 4.7.0
+   * @since 4.10.0
    */
   default float width(final @NotNull Component component) {
     return this.width(component, null);
@@ -88,7 +90,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @param style the style of the string
    * @param context the context of this calculation
    * @return the pixel width of the string
-   * @since 4.7.0
+   * @since 4.10.0
    */
   float width(final @NotNull String string, final @NotNull Style style, final @Nullable CX context);
 
@@ -98,7 +100,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @param string a string
    * @param style the style of the string
    * @return the pixel width of the string
-   * @since 4.7.0
+   * @since 4.10.0
    */
   default float width(final @NotNull String string, final @NotNull Style style) {
     return this.width(string, style, null);
@@ -111,7 +113,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @param style the style of the character
    * @param context the context of this calculation
    * @return the pixel width of the character
-   * @since 4.7.0
+   * @since 4.10.0
    */
   float width(final char character, final @NotNull Style style, final @Nullable CX context);
 
@@ -121,7 +123,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @param character a character
    * @param style the style of the character
    * @return the pixel width of the character
-   * @since 4.7.0
+   * @since 4.10.0
    */
   default float width(final char character, final @NotNull Style style) {
     return this.width(character, style, null);
@@ -134,7 +136,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @param style the style of the character
    * @param context the context of this calculation
    * @return the pixel width of the character
-   * @since 4.7.0
+   * @since 4.10.0
    */
   float width(final int codepoint, final @NotNull Style style, final @Nullable CX context);
 
@@ -144,7 +146,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @param codepoint a codepoint representing a character
    * @param style the style of the character
    * @return the pixel width of the character
-   * @since 4.7.0
+   * @since 4.10.0
    */
   default float width(final int codepoint, final @NotNull Style style) {
     return this.width(codepoint, style, null);
@@ -153,10 +155,10 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
   /**
    * A builder for a pixel width source.
    *
-   * <p>A new builder will start a default value for each part, see the methods for each part for these values</p>
+   * <p>A new builder will start with a default value for each part, see the methods for each part for these values</p>
    *
    * @param <CX> a context type (player, server, locale)
-   * @since 4.7.0
+   * @since 4.10.0
    */
   interface Builder<CX> extends Buildable.Builder<PixelWidthSource<CX>> {
     /**
@@ -166,7 +168,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
      *
      * @param flattener the flattener
      * @return this builder
-     * @since 4.8.0
+     * @since 4.10.0
      */
     @NotNull Builder<CX> flattener(final @NotNull ComponentFlattener flattener);
 
@@ -177,7 +179,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
      *
      * @param characterWidthFunction the function
      * @return this builder
-     * @since 4.8.0
+     * @since 4.10.0
      */
     @NotNull Builder<CX> characterWidthFunction(final @NotNull Function<@Nullable CX, CharacterWidthFunction> characterWidthFunction);
   }

--- a/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSource.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSource.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.width;
 
+import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
@@ -31,8 +32,6 @@ import net.kyori.adventure.util.Buildable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Function;
 
 /**
  * A source able to return the width of text. By default accuracy can only be guaranteed for {@link TextComponent}s
@@ -58,7 +57,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @since 4.7.0
    */
   static <CX> @NotNull PixelWidthSource<CX> pixelWidthSource(final @Nullable ComponentFlattener flattener, final @Nullable Function<@Nullable CX, CharacterWidthFunction> function) {
-    return new PixelWidthSourceImpl<>(flattener == null ? ComponentFlattener.basic() : flattener, function == null ? cx -> PixelWidthSourceImpl.DEFAULT_FONT_WIDTH : function);
+    return new PixelWidthSourceImpl<>(flattener == null ? ComponentFlattener.basic() : flattener, function == null ? cx -> DefaultCharacterWidthFunction.INSTANCE : function);
   }
 
   /**
@@ -69,7 +68,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @return the pixel width of the component
    * @since 4.7.0
    */
-  int width(final @NotNull Component component, final @Nullable CX context);
+  float width(final @NotNull Component component, final @Nullable CX context);
 
   /**
    * Calculates the pixel width of a component without any context.
@@ -78,7 +77,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @return the pixel width of the component
    * @since 4.7.0
    */
-  default int width(final @NotNull Component component) {
+  default float width(final @NotNull Component component) {
     return this.width(component, null);
   }
 
@@ -91,7 +90,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @return the pixel width of the string
    * @since 4.7.0
    */
-  int width(final @NotNull String string, final @NotNull Style style, final @Nullable CX context);
+  float width(final @NotNull String string, final @NotNull Style style, final @Nullable CX context);
 
   /**
    * Calculates the pixel width of a string without any context.
@@ -101,7 +100,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @return the pixel width of the string
    * @since 4.7.0
    */
-  default int width(final @NotNull String string, final @NotNull Style style) {
+  default float width(final @NotNull String string, final @NotNull Style style) {
     return this.width(string, style, null);
   }
 
@@ -114,7 +113,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @return the pixel width of the character
    * @since 4.7.0
    */
-  int width(final char character, final @NotNull Style style, final @Nullable CX context);
+  float width(final char character, final @NotNull Style style, final @Nullable CX context);
 
   /**
    * Calculates the pixel width of a character without any context.
@@ -124,7 +123,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @return the pixel width of the character
    * @since 4.7.0
    */
-  default int width(final char character, final @NotNull Style style) {
+  default float width(final char character, final @NotNull Style style) {
     return this.width(character, style, null);
   }
 
@@ -137,7 +136,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @return the pixel width of the character
    * @since 4.7.0
    */
-  int width(final int codepoint, final @NotNull Style style, final @Nullable CX context);
+  float width(final int codepoint, final @NotNull Style style, final @Nullable CX context);
 
   /**
    * Calculates the pixel width of a character represented by a codepoint without any context.
@@ -147,7 +146,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
    * @return the pixel width of the character
    * @since 4.7.0
    */
-  default int width(final int codepoint, final @NotNull Style style) {
+  default float width(final int codepoint, final @NotNull Style style) {
     return this.width(codepoint, style, null);
   }
 
@@ -174,7 +173,7 @@ public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, Pi
     /**
      * Set the function used to figure out which {@link CharacterWidthFunction} to use based on the context provided at calculation time.
      *
-     * <p>The default value for this is {@link PixelWidthSourceImpl#DEFAULT_FONT_WIDTH}</p>
+     * <p>The default value for this is {@link net.kyori.adventure.text.width.DefaultCharacterWidthFunction#INSTANCE}</p>
      *
      * @param characterWidthFunction the function
      * @return this builder

--- a/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSource.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSource.java
@@ -1,0 +1,185 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.width;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.flattener.ComponentFlattener;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.util.Buildable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Function;
+
+/**
+ * A source able to return the width of text. By default accuracy can only be guaranteed for {@link TextComponent}s
+ * in the standard minecraft font.
+ *
+ * <p>Providing context to this source is only necessary if a custom {@code Function<CX, CharacterWidthFunction>} is provided on creation</p>
+ *
+ * @param <CX> a context type (player, server, locale)
+ * @since 4.7.0
+ */
+@ApiStatus.NonExtendable
+public interface PixelWidthSource<CX> extends Buildable<PixelWidthSource<CX>, PixelWidthSource.Builder<CX>> {
+
+  /**
+   * A pixel width source calculating width using the provided flattener and character width function.
+   *
+   * <p>A null value results in using the basic counterpart</p>
+   *
+   * @param flattener a flattener used to turn components into linear text
+   * @param function a function that provides a character width function
+   * @param <CX> context a context type (player, server, locale)
+   * @return a pixel width source
+   * @since 4.7.0
+   */
+  static <CX> @NotNull PixelWidthSource<CX> pixelWidthSource(final @Nullable ComponentFlattener flattener, final @Nullable Function<@Nullable CX, CharacterWidthFunction> function) {
+    return new PixelWidthSourceImpl<>(flattener == null ? ComponentFlattener.basic() : flattener, function == null ? cx -> PixelWidthSourceImpl.DEFAULT_FONT_WIDTH : function);
+  }
+
+  /**
+   * Calculates the pixel width of a component, given a context.
+   *
+   * @param component a component
+   * @param context the context of this calculation
+   * @return the pixel width of the component
+   * @since 4.7.0
+   */
+  int width(final @NotNull Component component, final @Nullable CX context);
+
+  /**
+   * Calculates the pixel width of a component without any context.
+   *
+   * @param component a component
+   * @return the pixel width of the component
+   * @since 4.7.0
+   */
+  default int width(final @NotNull Component component) {
+    return this.width(component, null);
+  }
+
+  /**
+   * Calculates the pixel width of a string, given a context.
+   *
+   * @param string a string
+   * @param style the style of the string
+   * @param context the context of this calculation
+   * @return the pixel width of the string
+   * @since 4.7.0
+   */
+  int width(final @NotNull String string, final @NotNull Style style, final @Nullable CX context);
+
+  /**
+   * Calculates the pixel width of a string without any context.
+   *
+   * @param string a string
+   * @param style the style of the string
+   * @return the pixel width of the string
+   * @since 4.7.0
+   */
+  default int width(final @NotNull String string, final @NotNull Style style) {
+    return this.width(string, style, null);
+  }
+
+  /**
+   * Calculates the pixel width of a character, given a context.
+   *
+   * @param character a character
+   * @param style the style of the character
+   * @param context the context of this calculation
+   * @return the pixel width of the character
+   * @since 4.7.0
+   */
+  int width(final char character, final @NotNull Style style, final @Nullable CX context);
+
+  /**
+   * Calculates the pixel width of a character without any context.
+   *
+   * @param character a character
+   * @param style the style of the character
+   * @return the pixel width of the character
+   * @since 4.7.0
+   */
+  default int width(final char character, final @NotNull Style style) {
+    return this.width(character, style, null);
+  }
+
+  /**
+   * Calculates the pixel width of a character represented by a codepoint, given a context.
+   *
+   * @param codepoint a codepoint representing a character
+   * @param style the style of the character
+   * @param context the context of this calculation
+   * @return the pixel width of the character
+   * @since 4.7.0
+   */
+  int width(final int codepoint, final @NotNull Style style, final @Nullable CX context);
+
+  /**
+   * Calculates the pixel width of a character represented by a codepoint without any context.
+   *
+   * @param codepoint a codepoint representing a character
+   * @param style the style of the character
+   * @return the pixel width of the character
+   * @since 4.7.0
+   */
+  default int width(final int codepoint, final @NotNull Style style) {
+    return this.width(codepoint, style, null);
+  }
+
+  /**
+   * A builder for a pixel width source.
+   *
+   * <p>A new builder will start a default value for each part, see the methods for each part for these values</p>
+   *
+   * @param <CX> a context type (player, server, locale)
+   * @since 4.7.0
+   */
+  interface Builder<CX> extends Buildable.Builder<PixelWidthSource<CX>> {
+    /**
+     * Set the {@link ComponentFlattener} used by this pixel width source to turn components into plain text.
+     *
+     * <p>The default value for this is {@link ComponentFlattener#basic()}</p>
+     *
+     * @param flattener the flattener
+     * @return this builder
+     * @since 4.8.0
+     */
+    @NotNull Builder<CX> flattener(final @NotNull ComponentFlattener flattener);
+
+    /**
+     * Set the function used to figure out which {@link CharacterWidthFunction} to use based on the context provided at calculation time.
+     *
+     * <p>The default value for this is {@link PixelWidthSourceImpl#DEFAULT_FONT_WIDTH}</p>
+     *
+     * @param characterWidthFunction the function
+     * @return this builder
+     * @since 4.8.0
+     */
+    @NotNull Builder<CX> characterWidthFunction(final @NotNull Function<@Nullable CX, CharacterWidthFunction> characterWidthFunction);
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSourceImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSourceImpl.java
@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
  * for resolving all components except {@link TextComponent}s.
  *
  * @param <CX> a context (player, server, locale)
- * @since 4.7.0
+ * @since 4.10.0
  */
 
 final class PixelWidthSourceImpl<CX> implements PixelWidthSource<CX> {
@@ -56,7 +56,7 @@ final class PixelWidthSourceImpl<CX> implements PixelWidthSource<CX> {
    * See {@link net.kyori.adventure.text.width.DefaultCharacterWidthFunction#INSTANCE} for an example.</p>
    *
    * @param characterWidthFunction a function that can provide a {@link CharacterWidthFunction} given a context
-   * @since 4.5.0
+   * @since 4.10.0
    */
   PixelWidthSourceImpl(final @NotNull ComponentFlattener flattener, final @NotNull Function<@Nullable CX, CharacterWidthFunction> characterWidthFunction) {
     this.flattener = flattener;

--- a/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSourceImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/PixelWidthSourceImpl.java
@@ -1,0 +1,253 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.width;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.flattener.ComponentFlattener;
+import net.kyori.adventure.text.flattener.FlattenerListener;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * An implementation of the pixel width source which handles serialization with a set of functions
+ * for resolving all components except {@link TextComponent}s.
+ *
+ * @param <CX> a context (player, server, locale)
+ * @since 4.7.0
+ */
+
+final class PixelWidthSourceImpl<CX> implements PixelWidthSource<CX> {
+
+  private final ComponentFlattener flattener;
+  private final Function<CX, CharacterWidthFunction> characterWidthFunction;
+
+  /**
+   * Get the pixel width of the given character in the Minecraft font, excluding the space between
+   * characters and drop shadow. Handles alphanumerics and most common english punctuation.
+   */
+  static final CharacterWidthFunction DEFAULT_FONT_WIDTH = (codepoint, style) -> {
+    int i;
+    if(Character.isUpperCase(codepoint)) {
+      i = codepoint == 'I' ? 3 : 5;
+    } else if(Character.isDigit(codepoint)) {
+      i = 5;
+    } else if(Character.isLowerCase(codepoint)) {
+      switch (codepoint) {
+        case 'i':
+          i = 1;
+          break;
+
+        case 'l':
+          i = 2;
+          break;
+
+        case 't':
+          i = 3;
+          break;
+
+        case 'f':
+        case 'k':
+          i = 4;
+          break;
+
+        default:
+          i = 5;
+          break;
+      }
+    } else {
+      switch (codepoint) {
+        case '!':
+        case '.':
+        case ',':
+        case ';':
+        case ':':
+        case '|':
+          i = 1;
+          break;
+
+        case '\'':
+          i = 2;
+          break;
+
+        case '[':
+        case ']':
+        case ' ':
+          i = 3;
+          break;
+
+        case '*':
+        case '(':
+        case ')':
+        case '{':
+        case '}':
+        case '<':
+        case '>':
+          i = 4;
+          break;
+
+        case '@':
+          i = 6;
+          break;
+
+        default:
+          i = 5;
+          break;
+      }
+    }
+
+    if(style.hasDecoration(TextDecoration.BOLD)) {
+      i++;
+    }
+
+    return i;
+  };
+
+  /**
+   * Creates a pixel width source with a function used for getting a {@link CharacterWidthFunction}.
+   *
+   * <p>Any {@link CharacterWidthFunction} returned by the function should accept at least all
+   * english alphanumerics and most punctuation and handle {@link TextDecoration#BOLD} in the style.
+   * See {@link PixelWidthSourceImpl#DEFAULT_FONT_WIDTH} for an example.</p>
+   *
+   * @param characterWidthFunction a function that can provide a {@link CharacterWidthFunction} given a context
+   * @since 4.5.0
+   */
+  PixelWidthSourceImpl(final @NotNull ComponentFlattener flattener, final @NotNull Function<@Nullable CX, CharacterWidthFunction> characterWidthFunction) {
+    this.flattener = flattener;
+    this.characterWidthFunction = characterWidthFunction;
+  }
+
+  @Override
+  public int width(final @NotNull Component component, final @Nullable CX context) {
+    final AtomicInteger length = new AtomicInteger();
+
+    this.flattener.flatten(component, new FlattenerListener() {
+      final List<Style> styles = new LinkedList<>();
+      Style currentStyle = Style.empty();
+
+      @Override
+      public void pushStyle(final @NotNull Style style) {
+        this.styles.add(style);
+        this.calculateStyle();
+      }
+
+      @Override
+      public void component(final @NotNull String text) {
+        length.addAndGet(PixelWidthSourceImpl.this.width(text, this.currentStyle, context));
+      }
+
+      @Override
+      public void popStyle(final @NotNull Style style) {
+        this.styles.remove(this.styles.size() - 1);
+        this.calculateStyle();
+      }
+
+      private void calculateStyle() {
+        final Style.Builder newStyle = Style.style();
+        for(final Style style : this.styles) {
+          newStyle.merge(style);
+        }
+        this.currentStyle = newStyle.build();
+      }
+    });
+
+    return length.get();
+  }
+
+  @Override
+  public int width(final @NotNull String string, final @NotNull Style style, final @Nullable CX context) {
+    int length = 0;
+
+    final char[] chars = string.toCharArray();
+    for(int i = 0; i < chars.length; i++) {
+      final char c = chars[i];
+
+      if(Character.isLowSurrogate(c)) continue; //this character was handled on the previous iteration
+
+      final int codepoint;
+      if(Character.isHighSurrogate(c)) {
+        codepoint = Character.codePointAt(chars, i);
+      } else codepoint = c;
+
+      length += this.characterWidthFunction.apply(context).widthOf(codepoint, style);
+    }
+
+    return length;
+  }
+
+  @Override
+  public int width(final char c, final @NotNull Style style, final @Nullable CX context) {
+    return this.characterWidthFunction.apply(context).widthOf(c, style);
+  }
+
+  @Override
+  public int width(final int codepoint, final @NotNull Style style, final @Nullable CX context) {
+    return this.characterWidthFunction.apply(context).widthOf(codepoint, style);
+  }
+
+  @Override
+  public @NotNull Builder<CX> toBuilder() {
+    return new BuilderImpl<>(this.flattener, this.characterWidthFunction);
+  }
+
+  static final class BuilderImpl<CX> implements Builder<CX> {
+    private ComponentFlattener flattener;
+    private Function<CX, CharacterWidthFunction> characterWidthFunction;
+
+    BuilderImpl() {
+      this.flattener = ComponentFlattener.basic();
+      this.characterWidthFunction = cx -> DEFAULT_FONT_WIDTH;
+    }
+
+    BuilderImpl(final @NotNull ComponentFlattener flattener, final @NotNull Function<@Nullable CX, CharacterWidthFunction> characterWidthFunction) {
+      this.flattener = flattener;
+      this.characterWidthFunction = characterWidthFunction;
+    }
+
+    @Override
+    public @NotNull Builder<CX> flattener(final @NotNull ComponentFlattener flattener) {
+      this.flattener = flattener;
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder<CX> characterWidthFunction(final @NotNull Function<@Nullable CX, CharacterWidthFunction> characterWidthFunction) {
+      this.characterWidthFunction = characterWidthFunction;
+      return this;
+    }
+
+    @Override
+    public @NotNull PixelWidthSource<CX> build() {
+      return new PixelWidthSourceImpl<>(this.flattener, this.characterWidthFunction);
+    }
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/width/package-info.java
+++ b/api/src/main/java/net/kyori/adventure/text/width/package-info.java
@@ -21,23 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package net.kyori.adventure.text.width;
-
-import net.kyori.adventure.text.format.Style;
-
 /**
- * A function that takes a character(represented by its UTF-16 codepoint) and a {@link Style} and returns
- * the characters width as an {@code int}.
- *
- * @since 4.7.0
+ * Pixel width calculation of in game characters.
  */
-@FunctionalInterface
-public interface CharacterWidthFunction {
-  /**
-   * Gets the width for the given character(represented by its UTF-16 codepoint). {@code char}s will
-   * automatically be converted to codepoints.
-   *
-   * @since 4.7.0
-   */
-  float widthOf(int codepoint, Style style);
-}
+package net.kyori.adventure.text.width;

--- a/api/src/test/java/net/kyori/adventure/text/width/CustomFontCharacterWidthFunction.java
+++ b/api/src/test/java/net/kyori/adventure/text/width/CustomFontCharacterWidthFunction.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.width;
+
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.jetbrains.annotations.NotNull;
+
+public class CustomFontCharacterWidthFunction implements CharacterWidthFunction {
+  @Override
+  public int widthOf(final int codepoint, final @NotNull Style style) {
+    if(Character.isLowerCase(codepoint)) return 3;
+    if(Character.isUpperCase(codepoint)) return 5;
+    if(Character.isDigit(codepoint)) return style.hasDecoration(TextDecoration.OBFUSCATED) ? 4 : 3;
+    if(Character.isSpaceChar(codepoint)) return 2;
+    if(codepoint == 65938) return 8; //𐆒
+    return 0;
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/width/CustomFontCharacterWidthFunction.java
+++ b/api/src/test/java/net/kyori/adventure/text/width/CustomFontCharacterWidthFunction.java
@@ -29,12 +29,12 @@ import org.jetbrains.annotations.NotNull;
 
 public class CustomFontCharacterWidthFunction implements CharacterWidthFunction {
   @Override
-  public int widthOf(final int codepoint, final @NotNull Style style) {
-    if(Character.isLowerCase(codepoint)) return 3;
-    if(Character.isUpperCase(codepoint)) return 5;
-    if(Character.isDigit(codepoint)) return style.hasDecoration(TextDecoration.OBFUSCATED) ? 4 : 3;
-    if(Character.isSpaceChar(codepoint)) return 2;
-    if(codepoint == 65938) return 8; //𐆒
+  public float widthOf(final int codepoint, final @NotNull Style style) {
+    if (Character.isLowerCase(codepoint)) return 3;
+    if (Character.isUpperCase(codepoint)) return 5;
+    if (Character.isDigit(codepoint)) return style.hasDecoration(TextDecoration.OBFUSCATED) ? 4 : 3;
+    if (Character.isSpaceChar(codepoint)) return 2;
+    if (codepoint == 65938) return 8; //𐆒
     return 0;
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/width/DummyContext.java
+++ b/api/src/test/java/net/kyori/adventure/text/width/DummyContext.java
@@ -23,11 +23,10 @@
  */
 package net.kyori.adventure.text.width;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
 
 class DummyContext {
   private final @NotNull Locale locale;

--- a/api/src/test/java/net/kyori/adventure/text/width/DummyContext.java
+++ b/api/src/test/java/net/kyori/adventure/text/width/DummyContext.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.width;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+class DummyContext {
+  private final @NotNull Locale locale;
+  private final @NotNull Map<String, String> keybinds = new HashMap<>();
+
+  DummyContext(final @NotNull Locale locale) {
+    this.locale = locale;
+
+    this.keybinds.put("key.jump", "spacebar");
+    this.keybinds.put("key.forward", "w");
+  }
+
+  public @NotNull Locale locale() {
+    return this.locale;
+  }
+
+  public @NotNull Map<String, String> keybinds() {
+    return this.keybinds;
+  }
+}
+

--- a/api/src/test/java/net/kyori/adventure/text/width/PixelWidthSourceTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/width/PixelWidthSourceTest.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.width;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.KeybindComponent;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.flattener.ComponentFlattener;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.translation.TranslationRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
+import static net.kyori.adventure.text.Component.keybind;
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.format.Style.empty;
+import static net.kyori.adventure.text.format.Style.style;
+import static net.kyori.adventure.text.width.PixelWidthSource.pixelWidthSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PixelWidthSourceTest {
+
+  private static final TranslationRegistry DUMMY_REGISTRY = TranslationRegistry.create(Key.key("adventure-test", "width"));
+  //This has a hardcoded language for translation as a preparation for when context can be applied in the ComponentFlattener
+  private final PixelWidthSource<DummyContext> defaultPixelWidth =
+    pixelWidthSource(
+      ComponentFlattener.builder()
+        .complexMapper(TranslatableComponent.class, (t, cc) -> cc.accept(GlobalTranslator.render(t.children(new ArrayList<>()), Locale.US)))
+        .mapper(TextComponent.class, TextComponent::content).build(), null);
+  private final DummyContext context = new DummyContext(Locale.US);
+
+  private final Style bold = style(TextDecoration.BOLD);
+
+  static {
+    final Map<String, MessageFormat> translations = new HashMap<>();
+    translations.put("dummy.welcome", new MessageFormat("Welcome {0}!"));
+    translations.put("dummy.news", new MessageFormat("News: {0}"));
+    translations.put("dummy.level", new MessageFormat("{0} just achieved level 99!"));
+    translations.put("dummy.wow", new MessageFormat("wow"));
+
+    DUMMY_REGISTRY.registerAll(Locale.US, translations);
+
+    GlobalTranslator.get().addSource(DUMMY_REGISTRY);
+  }
+
+  @Test
+  public void testDefaultSimpleWidth() {
+    assertEquals(21, this.defaultPixelWidth.width("wowie", empty(), this.context));
+    assertEquals(5, this.defaultPixelWidth.width(text(2), this.context));
+    assertEquals(6, this.defaultPixelWidth.width('@', empty(), this.context));
+    assertEquals(15, this.defaultPixelWidth.width(translatable("dummy.wow"), this.context));
+  }
+
+  @Test
+  public void testDefaultWidthBold() {
+    assertEquals(26, this.defaultPixelWidth.width(text("wowie", this.bold), this.context));
+    assertEquals(7, this.defaultPixelWidth.width('@', this.bold, this.context));
+  }
+
+  @Test
+  public void testWidthInheritedStyle() {
+    assertEquals(33, this.defaultPixelWidth.width(text("wowie", this.bold).append(text('@')), this.context));
+  }
+
+  @Test
+  public void testWidthChildrenAndArgs() {
+    final Component component0 = text("kashike", this.bold); //29 + (1*7)
+    final Component component1 = translatable("dummy.welcome", component0); //36 + 36
+    final Component component2 = translatable("dummy.level", text("electroid", style(TextDecoration.ITALIC))).decoration(TextDecoration.BOLD, false); //96 + 36
+    final Component component3 = translatable("dummy.news", this.bold, component2); //30 + 132
+
+    final Component welcomePrompt = component1.append(component3);
+
+    assertEquals(36, this.defaultPixelWidth.width(component0, this.context));
+    assertEquals(72, this.defaultPixelWidth.width(component1, this.context)); //includes component
+    assertEquals(132, this.defaultPixelWidth.width(component2, this.context));
+    assertEquals(162, this.defaultPixelWidth.width(component3, this.context)); //includes component2
+    assertEquals(234, this.defaultPixelWidth.width(welcomePrompt, this.context)); //includes all components
+  }
+
+  @Test
+  public void testWidthCustomResolver() {
+    final ComponentFlattener keybindFlattener = ComponentFlattener.builder().mapper(KeybindComponent.class, k -> this.context.keybinds().get(k.keybind())).build();
+    final PixelWidthSource<DummyContext> custom = pixelWidthSource(keybindFlattener, null);
+    assertEquals(40, custom.width(keybind("key.jump"), this.context));
+  }
+
+  @Test
+  public void testWidthUsingCustomCharacterFunction() {
+    final Function<DummyContext, CharacterWidthFunction> customFunction = cx -> new CustomFontCharacterWidthFunction();
+    final PixelWidthSource<DummyContext> custom = pixelWidthSource(null, customFunction);
+    assertEquals(17, custom.width(text("aA1 ").append(text("2", NamedTextColor.RED, TextDecoration.OBFUSCATED)), this.context));
+  }
+
+  @Test
+  public void testWidthNonBMPCharacter() {
+    final Function<DummyContext, CharacterWidthFunction> customFunction = cx -> new CustomFontCharacterWidthFunction();
+    final PixelWidthSource<DummyContext> custom = pixelWidthSource(null, customFunction);
+    assertEquals(8, custom.width(text("\uD800\uDD92"), this.context)); // 𐆒
+  }
+
+}

--- a/api/src/test/java/net/kyori/adventure/text/width/PixelWidthSourceTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/width/PixelWidthSourceTest.java
@@ -23,6 +23,12 @@
  */
 package net.kyori.adventure.text.width;
 
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.KeybindComponent;
@@ -35,13 +41,6 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.translation.TranslationRegistry;
 import org.junit.jupiter.api.Test;
-
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.function.Function;
 
 import static net.kyori.adventure.text.Component.keybind;
 import static net.kyori.adventure.text.Component.text;

--- a/api/src/test/java/net/kyori/adventure/text/width/PixelWidthSourceTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/width/PixelWidthSourceTest.java
@@ -59,6 +59,7 @@ public class PixelWidthSourceTest {
       ComponentFlattener.builder()
         .complexMapper(TranslatableComponent.class, (t, cc) -> cc.accept(GlobalTranslator.render(t.children(new ArrayList<>()), Locale.US)))
         .mapper(TextComponent.class, TextComponent::content).build(), null);
+  private final CharacterWidthFunction reference = DefaultCharacterWidthFunction.INSTANCE;
   private final DummyContext context = new DummyContext(Locale.US);
 
   private final Style bold = style(TextDecoration.BOLD);
@@ -77,44 +78,44 @@ public class PixelWidthSourceTest {
 
   @Test
   public void testDefaultSimpleWidth() {
-    assertEquals(21, this.defaultPixelWidth.width("wowie", empty(), this.context));
-    assertEquals(5, this.defaultPixelWidth.width(text(2), this.context));
-    assertEquals(6, this.defaultPixelWidth.width('@', empty(), this.context));
-    assertEquals(15, this.defaultPixelWidth.width(translatable("dummy.wow"), this.context));
+    assertEquals(26, this.defaultPixelWidth.width("wowie", empty(), this.context));
+    assertEquals(6, this.defaultPixelWidth.width(text(2), this.context));
+    assertEquals(7, this.defaultPixelWidth.width('@', empty(), this.context));
+    assertEquals(18, this.defaultPixelWidth.width(translatable("dummy.wow"), this.context));
   }
 
   @Test
   public void testDefaultWidthBold() {
-    assertEquals(26, this.defaultPixelWidth.width(text("wowie", this.bold), this.context));
-    assertEquals(7, this.defaultPixelWidth.width('@', this.bold, this.context));
+    assertEquals(31, this.defaultPixelWidth.width(text("wowie", this.bold), this.context));
+    assertEquals(8, this.defaultPixelWidth.width('@', this.bold, this.context));
   }
 
   @Test
   public void testWidthInheritedStyle() {
-    assertEquals(33, this.defaultPixelWidth.width(text("wowie", this.bold).append(text('@')), this.context));
+    assertEquals(39, this.defaultPixelWidth.width(text("wowie", this.bold).append(text('@')), this.context));
   }
 
   @Test
   public void testWidthChildrenAndArgs() {
-    final Component component0 = text("kashike", this.bold); //29 + (1*7)
-    final Component component1 = translatable("dummy.welcome", component0); //36 + 36
-    final Component component2 = translatable("dummy.level", text("electroid", style(TextDecoration.ITALIC))).decoration(TextDecoration.BOLD, false); //96 + 36
-    final Component component3 = translatable("dummy.news", this.bold, component2); //30 + 132
+    final Component component0 = text("kashike", this.bold);
+    final Component component1 = translatable("dummy.welcome", component0);
+    final Component component2 = translatable("dummy.level", text("electroid", style(TextDecoration.ITALIC))).decoration(TextDecoration.BOLD, false);
+    final Component component3 = translatable("dummy.news", this.bold, component2);
 
     final Component welcomePrompt = component1.append(component3);
 
-    assertEquals(36, this.defaultPixelWidth.width(component0, this.context));
-    assertEquals(72, this.defaultPixelWidth.width(component1, this.context)); //includes component
-    assertEquals(132, this.defaultPixelWidth.width(component2, this.context));
-    assertEquals(162, this.defaultPixelWidth.width(component3, this.context)); //includes component2
-    assertEquals(234, this.defaultPixelWidth.width(welcomePrompt, this.context)); //includes all components
+    assertEquals(43, this.defaultPixelWidth.width(component0, this.context));
+    assertEquals(83, this.defaultPixelWidth.width(component1, this.context)); //includes component
+    assertEquals(145, this.defaultPixelWidth.width(component2, this.context));
+    assertEquals(175, this.defaultPixelWidth.width(component3, this.context)); //includes component2
+    assertEquals(258, this.defaultPixelWidth.width(welcomePrompt, this.context)); //includes all components
   }
 
   @Test
   public void testWidthCustomResolver() {
     final ComponentFlattener keybindFlattener = ComponentFlattener.builder().mapper(KeybindComponent.class, k -> this.context.keybinds().get(k.keybind())).build();
     final PixelWidthSource<DummyContext> custom = pixelWidthSource(keybindFlattener, null);
-    assertEquals(40, custom.width(keybind("key.jump"), this.context));
+    assertEquals(48, custom.width(keybind("key.jump"), this.context));
   }
 
   @Test


### PR DESCRIPTION
This PR adds support for pixel width calculation in adventure. (Closes #59)

I've provided a function able to calculate width for the default Minecraft font, but a custom function could also be used.

I have a few problems about my design which I hope I will be able to solve with some feedback:

1. The use of the term "resolve"
I opted to call the small functions users can insert into a source to turn components into text `ComponentResolver`s, trying to avoid "render" since I felt that belonged to the renderers, which has different behavior and standards. I think "resolve" works ok, but unsure if it's the best word to use.
2. How to distribute a source
Right now sources has to be made using one of the static methods in `PixelWidthSource`, which means users gets the responsibility of distributing the source internally. Generally adventure seems to stray away from this (Except for the platform audience creation), and I'm not sure how to solve the problem if it needs to be solved. The context necessary for calculation is hard to generalize further than it currently is.

Any additional feedback is also appreciated! 😎 👍 