### PR TITLE
text-serializer-legacy: Vanilla implementation for URL conversion

### DIFF
--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -47,7 +47,7 @@ import static java.util.Objects.requireNonNull;
 
 final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
-  static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*://");
+  static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*:");
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
   private static final char LEGACY_BUNGEE_HEX_CHAR = 'x';
   private static final List<TextFormat> FORMATS;

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -47,6 +47,7 @@ import static java.util.Objects.requireNonNull;
 
 final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
+  static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*://");
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
   private static final char LEGACY_BUNGEE_HEX_CHAR = 'x';
   private static final List<TextFormat> FORMATS;
@@ -474,7 +475,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         .match(pattern)
         .replacement(url -> {
           String clickUrl = url.content();
-          if(!(clickUrl.startsWith("http://") || clickUrl.startsWith("https://"))) {
+          if(!URL_SCHEME_PATTERN.matcher(clickUrl).find()) {
             clickUrl = "http://" + clickUrl;
           }
           return (style == null ? url : url.style(style)).clickEvent(ClickEvent.openUrl(clickUrl));

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -472,7 +472,13 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
       requireNonNull(pattern, "pattern");
       this.urlReplacementConfig = TextReplacementConfig.builder()
         .match(pattern)
-        .replacement(url -> (style == null ? url : url.style(style)).clickEvent(ClickEvent.openUrl(url.content())))
+        .replacement(url -> {
+          String clickUrl = url.content();
+          if(!(clickUrl.startsWith("http://") || clickUrl.startsWith("https://"))) {
+            clickUrl = "http://" + clickUrl;
+          }
+          return (style == null ? url : url.style(style)).clickEvent(ClickEvent.openUrl(clickUrl));
+        })
         .build();
       return this;
     }

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
@@ -85,6 +85,14 @@ class LinkingLegacyComponentSerializerTest {
   }
 
   @Test
+  void testSchemelessUrl() {
+    final String schemelessBareUrl = "example.com";
+    final String bareUrl = "http://example.com";
+    final TextComponent expectedHasScheme = Component.text(schemelessBareUrl).clickEvent(ClickEvent.openUrl(bareUrl));
+    assertEquals(expectedHasScheme, LegacyComponentSerializer.builder().extractUrls().build().deserialize(schemelessBareUrl));
+  }
+
+  @Test
   void testMultipleUrls() {
     final String manyUrls = "go to https://www.example.com and https://www.example.net for cat videos";
     final TextComponent expectedManyUrls = Component.text().content("go to ")

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.serializer.legacy;
 
+import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -90,6 +91,14 @@ class LinkingLegacyComponentSerializerTest {
     final String bareUrl = "http://example.com";
     final TextComponent expectedHasScheme = Component.text(schemelessBareUrl).clickEvent(ClickEvent.openUrl(bareUrl));
     assertEquals(expectedHasScheme, LegacyComponentSerializer.builder().extractUrls().build().deserialize(schemelessBareUrl));
+  }
+
+  @Test
+  void testMailUrl() {
+    final String mailUrl = "mailto:example@example.com";
+    final TextComponent expectedComponent = Component.text(mailUrl).clickEvent(ClickEvent.openUrl(mailUrl));
+    assertEquals(expectedComponent, LegacyComponentSerializer.builder().extractUrls().extractUrls(
+      Pattern.compile("([a-z][a-z0-9+\\-.]*:)?([-\\w_.@]+\\.\\w{2,})(/\\S*)?")).build().deserialize(mailUrl));
   }
 
   @Test


### PR DESCRIPTION
Fixes a bug where legacy text containing URLs without protocol specification would cause a crash on old minecraft versions.
Modern minecraft versions just refuse to open the URL dialog without this.