### PR TITLE
api: Add asHSV to RGBLike and use HSV for color comparisons in NamedTextColor.nearestTo

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.text.format;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import net.kyori.adventure.util.HSVLike;
 import net.kyori.adventure.util.Index;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -205,7 +206,7 @@ public final class NamedTextColor implements TextColor {
     NamedTextColor match = VALUES.get(0);
     for(int i = 0, length = VALUES.size(); i < length; i++) {
       final NamedTextColor potential = VALUES.get(i);
-      final float distance = hsvDistance(any, potential);
+      final float distance = distance(any.asHSV(), potential.asHSV());
       if(distance < matchedDistance) {
         match = potential;
         matchedDistance = distance;
@@ -225,27 +226,32 @@ public final class NamedTextColor implements TextColor {
    * @param other colour to compare to
    * @return distance metric
    */
-  private static float hsvDistance(final @NonNull TextColor self, final @NonNull TextColor other) {
-    final float[] hsvSelf = self.asHSV();
-    final float[] hsvOther = other.asHSV();
+  private static float distance(final @NonNull HSVLike self, final @NonNull HSVLike other) {
     // weight hue more heavily than saturation and brightness. kind of magic numbers, but is fine for our use case of downsampling to a set of colors
-    final float hueDistance = 3 * Math.abs(hsvSelf[0] - hsvOther[0]);
-    final float saturationDiff = hsvSelf[1] - hsvOther[1];
-    final float valueDiff = hsvSelf[2] - hsvOther[2];
+    final float hueDistance = 3 * Math.abs(self.h() - other.h());
+    final float saturationDiff = self.s() - other.s();
+    final float valueDiff = self.v() - other.v();
     return hueDistance * hueDistance + saturationDiff * saturationDiff + valueDiff * valueDiff;
   }
 
   private final String name;
   private final int value;
+  private final HSVLike hsv;
 
   private NamedTextColor(final String name, final int value) {
     this.name = name;
     this.value = value;
+    this.hsv = HSVLike.fromRGB(this.red(), this.green(), this.blue());
   }
 
   @Override
   public int value() {
     return this.value;
+  }
+
+  @Override
+  public @NonNull HSVLike asHSV() {
+    return this.hsv;
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -201,12 +201,11 @@ public final class NamedTextColor implements TextColor {
 
     requireNonNull(any, "color");
 
-    // TODO: This tends to match greys more than it should (rgb averages and all that)
-    int matchedDistance = Integer.MAX_VALUE;
+    float matchedDistance = Float.MAX_VALUE;
     NamedTextColor match = VALUES.get(0);
     for(int i = 0, length = VALUES.size(); i < length; i++) {
       final NamedTextColor potential = VALUES.get(i);
-      final int distance = distanceSquared(any, potential);
+      final float distance = hsvDistance(any, potential);
       if(distance < matchedDistance) {
         match = potential;
         matchedDistance = distance;
@@ -226,12 +225,14 @@ public final class NamedTextColor implements TextColor {
    * @param other colour to compare to
    * @return distance metric
    */
-  private static int distanceSquared(final @NonNull TextColor self, final @NonNull TextColor other) {
-    final int rAvg = (self.red() + other.red()) / 2;
-    final int dR = self.red() - other.red();
-    final int dG = self.green() - other.green();
-    final int dB = self.blue() - other.blue();
-    return ((2 + (rAvg / 256)) * (dR * dR)) + (4 * (dG * dG)) + ((2 + ((255 - rAvg) / 256)) * (dB * dB));
+  private static float hsvDistance(final @NonNull TextColor self, final @NonNull TextColor other) {
+    final float[] hsvSelf = self.asHSV();
+    final float[] hsvOther = other.asHSV();
+    // weight hue more heavily than saturation and brightness. kind of magic numbers, but is fine for our use case of downsampling to a set of colors
+    final float hueDistance = 3 * Math.abs(hsvSelf[0] - hsvOther[0]);
+    final float saturationDiff = hsvSelf[1] - hsvOther[1];
+    final float valueDiff = hsvSelf[2] - hsvOther[2];
+    return hueDistance * hueDistance + saturationDiff * saturationDiff + valueDiff * valueDiff;
   }
 
   private final String name;

--- a/api/src/main/java/net/kyori/adventure/util/HSVLike.java
+++ b/api/src/main/java/net/kyori/adventure/util/HSVLike.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.util;
+
+import net.kyori.examination.Examinable;
+import net.kyori.examination.ExaminableProperty;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.value.qual.IntRange;
+
+import java.util.stream.Stream;
+
+/**
+ * Something that can provide hue, saturation, and value color components.
+ *
+ * <p>Provided values should be in the range [0, 1].</p>
+ *
+ * @since 4.6.0
+ */
+public interface HSVLike extends Examinable {
+  /**
+   * Creates a new HSVLike.
+   *
+   * @param h hue color component
+   * @param s saturation color component
+   * @param v value color component
+   * @return a new HSVLike
+   * @since 4.6.0
+   */
+  static @NonNull HSVLike of(final float h, final float s, final float v) {
+    return new HSVLikeImpl(h, s, v);
+  }
+
+  /**
+   * Creates a new HSVLike from the given red, green, and blue color components.
+   *
+   * @param red red color component
+   * @param green green color component
+   * @param blue blue color component
+   * @return a new HSVLike
+   * @since 4.6.0
+   */
+  static @NonNull HSVLike fromRGB(@IntRange(from = 0x0, to = 0xff) final int red, @IntRange(from = 0x0, to = 0xff) final int green, @IntRange(from = 0x0, to = 0xff) final int blue) {
+    final float r = red / 255.0f;
+    final float g = green / 255.0f;
+    final float b = blue / 255.0f;
+
+    final float min = Math.min(r, Math.min(g, b));
+    final float max = Math.max(r, Math.max(g, b)); // v
+    final float delta = max - min;
+
+    final float s;
+    if(max != 0) {
+      s = delta / max; // s
+    } else {
+      // r = g = b = 0
+      s = 0;
+    }
+    if(s == 0) { // s = 0, h is undefined
+      return new HSVLikeImpl(0, s, max);
+    }
+
+    float h;
+    if(r == max) {
+      h = (g - b) / delta; // between yellow & magenta
+    } else if(g == max) {
+      h = 2 + (b - r) / delta; // between cyan & yellow
+    } else {
+      h = 4 + (r - g) / delta; // between magenta & cyan
+    }
+    h *= 60; // degrees
+    if(h < 0) {
+      h += 360;
+    }
+
+    return new HSVLikeImpl(h / 360.0f, s, max);
+  }
+
+  /**
+   * Gets the hue component.
+   *
+   * @return the hue component
+   * @since 4.6.0
+   */
+  float h();
+
+  /**
+   * Gets the saturation component.
+   *
+   * @return the saturation component
+   * @since 4.6.0
+   */
+  float s();
+
+  /**
+   * Gets the value component.
+   *
+   * @return the value component
+   * @since 4.6.0
+   */
+  float v();
+
+  @Override
+  default @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("h", this.h()),
+      ExaminableProperty.of("s", this.s()),
+      ExaminableProperty.of("v", this.v())
+    );
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/util/HSVLikeImpl.java
+++ b/api/src/main/java/net/kyori/adventure/util/HSVLikeImpl.java
@@ -23,46 +23,52 @@
  */
 package net.kyori.adventure.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.common.value.qual.IntRange;
+import net.kyori.examination.string.StringExaminer;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
-/**
- * Something that can provide red, green, and blue colour components.
- *
- * @since 4.0.0
- */
-public interface RGBLike {
-  /**
-   * Gets the red component.
-   *
-   * @return the red component
-   * @since 4.0.0
-   */
-  @IntRange(from = 0x0, to = 0xff) int red();
+import java.util.Objects;
 
-  /**
-   * Gets the green component.
-   *
-   * @return the green component
-   * @since 4.0.0
-   */
-  @IntRange(from = 0x0, to = 0xff) int green();
+final class HSVLikeImpl implements HSVLike {
+  private final float h;
+  private final float s;
+  private final float v;
 
-  /**
-   * Gets the blue component.
-   *
-   * @return the blue component
-   * @since 4.0.0
-   */
-  @IntRange(from = 0x0, to = 0xff) int blue();
+  HSVLikeImpl(final float h, final float s, final float v) {
+    this.h = h;
+    this.s = s;
+    this.v = v;
+  }
 
-  /**
-   * Converts the color represented by this RGBLike to the HSV color space.
-   *
-   * @return an HSVLike representing this RGBLike in the HSV color space
-   * @since 4.6.0
-   */
-  default @NonNull HSVLike asHSV() {
-    return HSVLike.fromRGB(this.red(), this.green(), this.blue());
+  @Override
+  public float h() {
+    return this.h;
+  }
+
+  @Override
+  public float s() {
+    return this.s;
+  }
+
+  @Override
+  public float v() {
+    return this.v;
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if(this == other) return true;
+    if(!(other instanceof HSVLikeImpl)) return false;
+    final HSVLikeImpl that = (HSVLikeImpl) other;
+    return ShadyPines.equals(that.h, this.h) && ShadyPines.equals(that.s, this.s) && ShadyPines.equals(that.v, this.v);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.h, this.s, this.v);
+  }
+
+  @Override
+  public String toString() {
+    return this.examine(StringExaminer.simpleEscaping());
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/RGBLike.java
+++ b/api/src/main/java/net/kyori/adventure/util/RGBLike.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.util;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.value.qual.IntRange;
 
 /**
@@ -54,4 +55,46 @@ public interface RGBLike {
    * @since 4.0.0
    */
   @IntRange(from = 0x0, to = 0xff) int blue();
+
+  /**
+   * Converts the color represented by this RGBLike to the HSV color space. Result values will be in the range [0, 1].
+   *
+   * @return an array of three elements containing the hue, saturation, and value (in that order), of the color represented by this RGBLike
+   * @since 4.6.0
+   */
+  default float@NonNull[] asHSV() {
+    final float r = this.red() / 255.0f;
+    final float g = this.green() / 255.0f;
+    final float b = this.blue() / 255.0f;
+
+    final float min = Math.min(r, Math.min(g, b));
+    final float max = Math.max(r, Math.max(g, b)); // v
+    final float delta = max - min;
+
+    final float s;
+    if(max != 0) {
+      s = delta / max; // s
+    } else {
+      // r = g = b = 0
+      s = 0;
+    }
+    if(s == 0) { // s = 0, h is undefined
+      return new float[]{0, s, max};
+    }
+
+    float h;
+    if(r == max) {
+      h = (g - b) / delta; // between yellow & magenta
+    } else if(g == max) {
+      h = 2 + (b - r) / delta; // between cyan & yellow
+    } else {
+      h = 4 + (r - g) / delta; // between magenta & cyan
+    }
+    h *= 60; // degrees
+    if(h < 0) {
+      h += 360;
+    }
+
+    return new float[]{h / 360.0f, s, max};
+  }
 }

--- a/api/src/test/java/net/kyori/adventure/text/format/NamedTextColorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/NamedTextColorTest.java
@@ -51,6 +51,8 @@ class NamedTextColorTest {
     assertNearest(NamedTextColor.DARK_PURPLE, 0xff00ff);
     assertNearest(NamedTextColor.DARK_AQUA, 0x11aabb);
     assertNearest(NamedTextColor.GREEN, 0x88ff88);
+    assertNearest(NamedTextColor.GRAY, 0xa2a2a2);
+    assertNearest(NamedTextColor.DARK_GRAY, 0x4c4c4c);
   }
 
   private static void assertNearest(final NamedTextColor expected, final int value) {

--- a/api/src/test/java/net/kyori/adventure/util/HSVLikeTest.java
+++ b/api/src/test/java/net/kyori/adventure/util/HSVLikeTest.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.util;
 
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextColor;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,17 +32,18 @@ import java.awt.Color;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-class RGBLikeTest {
+class HSVLikeTest {
   @Test
-  void testHSVConversionAgainstJavaAwtColor() {
-    NamedTextColor.NAMES.values().forEach(this::assertConversionRoughlyMatchesJavaAwtColor);
+  void compareRgbToHsvConversionToJavaAwtColor() {
+    NamedTextColor.NAMES.values().forEach(HSVLikeTest::assertRgbToHsvConversionRoughlyMatchesJavaAwtColor);
   }
 
-  private void assertConversionRoughlyMatchesJavaAwtColor(final @NonNull TextColor color) {
+  private static void assertRgbToHsvConversionRoughlyMatchesJavaAwtColor(final @NonNull RGBLike rgb) {
+    final HSVLike hsv = rgb.asHSV();
     Assertions.assertArrayEquals(
-      roundFloats(Color.RGBtoHSB(color.red(), color.green(), color.blue(), null)),
-      roundFloats(color.asHSV()),
-      color.toString()
+      roundFloats(Color.RGBtoHSB(rgb.red(), rgb.green(), rgb.blue(), null)),
+      roundFloats(new float[]{hsv.h(), hsv.s(), hsv.v()}),
+      rgb.toString()
     );
   }
 

--- a/api/src/test/java/net/kyori/adventure/util/RGBLikeTest.java
+++ b/api/src/test/java/net/kyori/adventure/util/RGBLikeTest.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.util;
+
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+class RGBLikeTest {
+  @Test
+  void testHSVConversionAgainstJavaAwtColor() {
+    NamedTextColor.NAMES.values().forEach(this::assertConversionRoughlyMatchesJavaAwtColor);
+  }
+
+  private void assertConversionRoughlyMatchesJavaAwtColor(final @NonNull TextColor color) {
+    Assertions.assertArrayEquals(
+      roundFloats(Color.RGBtoHSB(color.red(), color.green(), color.blue(), null)),
+      roundFloats(color.asHSV()),
+      color.toString()
+    );
+  }
+
+  private static float[] roundFloats(final float @NonNull [] floats) {
+    final float[] result = new float[floats.length];
+    for(int i = 0; i < floats.length; i++) {
+      result[i] = BigDecimal.valueOf(floats[i]).setScale(7, RoundingMode.UP).floatValue();
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
The code for RGB to HSV conversion is based on the example code [here](https://www.cs.rit.edu/~ncs/color/t_convert.html), modified to behave more like java.awt.Color.RGBtoHSB.

In my limited testing, this algorithm for color distance seems to match gray less often, leading to a more "correct" result for color down sampling.

comparison:

original:
![original](https://i.imgur.com/yUk1Uub.png)
![original](https://i.imgur.com/xsVoY7h.png)
old downsample:
![old](https://i.ibb.co/BT9LCqP/old.png)
![old](https://i.imgur.com/pqhc1Bv.png)
new downsample:
![original](https://i.ibb.co/sgZYnLk/new.png)
![new](https://i.imgur.com/4kU4fCp.png)