### PR TITLE
Added ZLIB compression support for NBT

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
@@ -30,8 +30,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.InflaterInputStream;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -526,6 +529,27 @@ public final class BinaryTagIO {
       @Override
       public String toString() {
         return "Compression.GZIP";
+      }
+    };
+    /**
+     * <a href="https://en.wikipedia.org/wiki/Zlib">ZLIB</a> compression.
+     *
+     * @since 4.6.0
+     */
+    public static final Compression ZLIB = new Compression() {
+      @Override
+      @NonNull InputStream decompress(@NonNull InputStream is) {
+        return new InflaterInputStream(is);
+      }
+
+      @Override
+      @NonNull OutputStream compress(@NonNull OutputStream os) {
+        return new DeflaterOutputStream(os);
+      }
+
+      @Override
+      public String toString() {
+        return "Compression.ZLIB";
       }
     };
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
@@ -34,7 +34,6 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.InflaterInputStream;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -538,12 +537,12 @@ public final class BinaryTagIO {
      */
     public static final Compression ZLIB = new Compression() {
       @Override
-      @NonNull InputStream decompress(@NonNull InputStream is) {
+      @NonNull InputStream decompress(final @NonNull InputStream is) {
         return new InflaterInputStream(is);
       }
 
       @Override
-      @NonNull OutputStream compress(@NonNull OutputStream os) {
+      @NonNull OutputStream compress(final @NonNull OutputStream os) {
         return new DeflaterOutputStream(os);
       }
 

--- a/nbt/src/test/java/net/kyori/adventure/nbt/BinaryTagIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/BinaryTagIOTest.java
@@ -50,4 +50,14 @@ class BinaryTagIOTest {
     BinaryTagIO.writer().write(tag, output, BinaryTagIO.Compression.GZIP);
     assertEquals(tag, BinaryTagIO.reader().read(new ByteArrayInputStream(output.toByteArray()), BinaryTagIO.Compression.GZIP));
   }
+
+  @Test
+  void testWriteAndReadZLIBCompression() throws IOException {
+    final CompoundBinaryTag tag = CompoundBinaryTag.builder()
+      .putString("name", "test")
+      .build();
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    BinaryTagIO.writer().write(tag, output, BinaryTagIO.Compression.ZLIB);
+    assertEquals(tag, BinaryTagIO.reader().read(new ByteArrayInputStream(output.toByteArray()), BinaryTagIO.Compression.ZLIB));
+  }
 }


### PR DESCRIPTION
Added support for ZLIB using `InflatedInputStream` and `DeflatedOutputStream` to compress and decompress respectively. Has been tested.