### PR TITLE
serializer-gson: Add deserializers for JsonElement, Reader and JsonReader

### DIFF
--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -100,7 +100,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return the component
    * @since 4.7.0
    */
-  @NonNull Component deserialize(@NonNull JsonElement input);
+  @NonNull Component deserialize(final @NonNull JsonElement input);
 
   /**
    * Deserialize a component from input of type {@link Reader}.
@@ -109,7 +109,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return the component
    * @since 4.7.0
    */
-  @NonNull Component deserialize(@NonNull Reader input);
+  @NonNull Component deserialize(final @NonNull Reader input);
 
   /**
    * Deserialize a component from input of type {@link JsonReader}.
@@ -118,7 +118,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return the component
    * @since 4.7.0
    */
-  @NonNull Component deserialize(@NonNull JsonReader input);
+  @NonNull Component deserialize(final @NonNull JsonReader input);
 
   /**
    * A builder for {@link GsonComponentSerializer}.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -25,12 +25,10 @@ package net.kyori.adventure.text.serializer.gson;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
-import java.io.Reader;
-import java.util.function.UnaryOperator;
-
 import com.google.gson.JsonElement;
 import com.google.gson.stream.JsonReader;
+import java.io.Reader;
+import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -25,7 +25,12 @@ package net.kyori.adventure.text.serializer.gson;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import java.io.Reader;
 import java.util.function.UnaryOperator;
+
+import com.google.gson.JsonElement;
+import com.google.gson.stream.JsonReader;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;
@@ -89,6 +94,33 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @since 4.0.0
    */
   @NonNull UnaryOperator<GsonBuilder> populator();
+
+  /**
+   * Deserialize a component from input of type {@link JsonElement}.
+   *
+   * @param input the input
+   * @return the component
+   * @since 4.7.0
+   */
+  @NonNull Component deserialize(@NonNull JsonElement input);
+
+  /**
+   * Deserialize a component from input of type {@link Reader}.
+   *
+   * @param input the input
+   * @return the component
+   * @since 4.7.0
+   */
+  @NonNull Component deserialize(@NonNull Reader input);
+
+  /**
+   * Deserialize a component from input of type {@link JsonReader}.
+   *
+   * @param input the input
+   * @return the component
+   * @since 4.7.0
+   */
+  @NonNull Component deserialize(@NonNull JsonReader input);
 
   /**
    * A builder for {@link GsonComponentSerializer}.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -25,7 +25,12 @@ package net.kyori.adventure.text.serializer.gson;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import java.io.Reader;
 import java.util.function.UnaryOperator;
+
+import com.google.gson.JsonElement;
+import com.google.gson.stream.JsonReader;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.BlockNBTComponent;
 import net.kyori.adventure.text.Component;
@@ -88,6 +93,27 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   @Override
   public @NonNull String serialize(final @NonNull Component component) {
     return this.serializer().toJson(component);
+  }
+
+  @Override
+  public @NonNull Component deserialize(final @NonNull JsonElement input) {
+    final Component component = this.serializer().fromJson(input, Component.class);
+    if(component == null) throw ComponentSerializerImpl.notSureHowToDeserialize(input);
+    return component;
+  }
+
+  @Override
+  public @NonNull Component deserialize(final @NonNull Reader input) {
+    final Component component = this.serializer().fromJson(input, Component.class);
+    if(component == null) throw ComponentSerializerImpl.notSureHowToDeserialize(input);
+    return component;
+  }
+
+  @Override
+  public @NonNull Component deserialize(final @NonNull JsonReader input) {
+    final Component component = this.serializer().fromJson(input, Component.class);
+    if(component == null) throw ComponentSerializerImpl.notSureHowToDeserialize(input);
+    return component;
   }
 
   @NonNull

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -25,12 +25,10 @@ package net.kyori.adventure.text.serializer.gson;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
-import java.io.Reader;
-import java.util.function.UnaryOperator;
-
 import com.google.gson.JsonElement;
 import com.google.gson.stream.JsonReader;
+import java.io.Reader;
+import java.util.function.UnaryOperator;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.BlockNBTComponent;
 import net.kyori.adventure.text.Component;


### PR DESCRIPTION
This PR adds three new `deserialize` methods in `GsonComponentSerializer` and the respective implementation that enable the deserialisation of `JsonReader`, `JsonElement` and `Reader` objects.

I'm not sure if this was the best way to add them as they won't be accessible using the `ComponentSerializer` interface. I suppose each new deserialisation method could be put in it's own `ComponentSerializer` but it feels best suited to the `GsonComponentSerializer`.

I also haven't introduced any tests yet. I was not sure what the best way to go about introducing tests would be. Perhaps a separate class or mutating the existing ones to test against all the deserialisers? I'd appreciate some pointers!

Merging this PR will close #293.