### PR TITLE
serializer-gson: Add serializer to JsonElement

### DIFF
--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -98,7 +98,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return the json element
    * @since 4.7.0
    */
-  @NonNull JsonElement serializeToJsonElement(@NonNull Component component);
+  @NonNull JsonElement serializeToElement(final @NonNull Component component);
 
   /**
    * A builder for {@link GsonComponentSerializer}.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.serializer.gson;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
@@ -89,6 +90,15 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @since 4.0.0
    */
   @NonNull UnaryOperator<GsonBuilder> populator();
+
+  /**
+   * Deserialize a component to output of type {@link JsonElement}.
+   *
+   * @param component the component
+   * @return the json element
+   * @since 4.7.0
+   */
+  @NonNull JsonElement serializeToJsonElement(@NonNull Component component);
 
   /**
    * A builder for {@link GsonComponentSerializer}.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -92,7 +92,7 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   }
 
   @Override
-  public @NonNull JsonElement serializeToJsonElement(@NonNull Component component) {
+  public @NonNull JsonElement serializeToElement(final @NonNull Component component) {
     return this.serializer().toJsonTree(component);
   }
 

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.serializer.gson;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.BlockNBTComponent;
@@ -88,6 +89,11 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   @Override
   public @NonNull String serialize(final @NonNull Component component) {
     return this.serializer().toJson(component);
+  }
+
+  @Override
+  public @NonNull JsonElement serializeToJsonElement(@NonNull Component component) {
+    return this.serializer().toJsonTree(component);
   }
 
   @NonNull


### PR DESCRIPTION
This PR is a companion of #296 that adds a method to turn a Component into a JsonElement.