### PR TITLE
api: Mark ScoreComponent's value as deprecated since it is no longer supported

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -441,8 +441,10 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param value the value
    * @return a score component
    * @since 4.0.0
+   * @deprecated since 4.7.0, not for removal, with no replacement. The {@code value} field is no longer supported in 1.16.5.
    */
   @Contract(value = "_, _, _ -> new", pure = true)
+  @Deprecated
   static @NonNull ScoreComponent score(final @NonNull String name, final @NonNull String objective, final @Nullable String value) {
     return new ScoreComponentImpl(Collections.emptyList(), Style.empty(), name, objective, value);
   }

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponent.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.Contract;
  *   <dt>objective</dt>
  *   <dd>a scoreboard objective</dd>
  *   <dt>value(optional)</dt>
- *   <dd>a fallback value to be used if the search fails.
+ *   <dd>a value to use that will override any queried scoreboard value
  *   <p>This field is no longer present in the game from 1.16,
  *   which means it will be ignored</p></dd>
  * </dl>
@@ -91,7 +91,9 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
    *
    * @return the value
    * @since 4.0.0
+   * @deprecated since 4.7.0, not for removal, with no replacement. This field is no longer supported in 1.16.5.
    */
+  @Deprecated
   @Nullable String value();
 
   /**
@@ -100,7 +102,9 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
    * @param value the value
    * @return a score component
    * @since 4.0.0
+   * @deprecated since 4.7.0, not for removal, with no replacement. This field is no longer supported in 1.16.5.
    */
+  @Deprecated
   @Contract(pure = true)
   @NonNull ScoreComponent value(final @Nullable String value);
 
@@ -136,7 +140,9 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
      * @param value the value
      * @return this builder
      * @since 4.0.0
+     * @deprecated since 4.7.0, not for removal, with no replacement. This field is no longer supported in 1.16.5.
      */
+    @Deprecated
     @Contract("_ -> this")
     @NonNull Builder value(final @Nullable String value);
   }

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
@@ -36,6 +36,7 @@ import static java.util.Objects.requireNonNull;
 final class ScoreComponentImpl extends AbstractComponent implements ScoreComponent {
   private final String name;
   private final String objective;
+  @Deprecated
   private final @Nullable String value;
 
   ScoreComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final @NonNull String name, final @NonNull String objective, final @Nullable String value) {
@@ -68,11 +69,13 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
   }
 
   @Override
+  @Deprecated
   public @Nullable String value() {
     return this.value;
   }
 
   @Override
+  @Deprecated
   public @NonNull ScoreComponent value(final @Nullable String value) {
     if(Objects.equals(this.value, value)) return this;
     return new ScoreComponentImpl(this.children, this.style, this.name, this.objective, value);
@@ -89,6 +92,7 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public boolean equals(final @Nullable Object other) {
     if(this == other) return true;
     if(!(other instanceof ScoreComponent)) return false;
@@ -133,6 +137,7 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
     BuilderImpl() {
     }
 
+    @SuppressWarnings("deprecation")
     BuilderImpl(final @NonNull ScoreComponent component) {
       super(component);
       this.name = component.name();
@@ -153,6 +158,7 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
     }
 
     @Override
+    @Deprecated
     public @NonNull Builder value(final @Nullable String value) {
       this.value = value;
       return this;

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -119,6 +119,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   protected @NonNull Component renderScore(final @NonNull ScoreComponent component, final @NonNull C context) {
     final ScoreComponent.Builder builder = Component.score()
       .name(component.name())

--- a/api/src/test/java/net/kyori/adventure/text/ScoreComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ScoreComponentTest.java
@@ -63,6 +63,7 @@ class ScoreComponentTest extends AbstractComponentTest<ScoreComponent, ScoreComp
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void testValue() {
     final ScoreComponent c0 = Component.score("abc", "def");
     final ScoreComponent c1 = c0.value("ghi");

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
@@ -213,6 +213,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
       score.getNode(SCORE_NAME).setValue(sc.name());
       score.getNode(SCORE_OBJECTIVE).setValue(sc.objective());
       // score component value is optional
+      @SuppressWarnings("deprecation")
       final @Nullable String scoreValue = sc.value();
       if(scoreValue != null) score.getNode(SCORE_VALUE).setValue(scoreValue);
     } else if(src instanceof SelectorComponent) {

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
@@ -211,6 +211,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
       score.node(SCORE_NAME).set(sc.name());
       score.node(SCORE_OBJECTIVE).set(sc.objective());
       // score component value is optional
+      @SuppressWarnings("deprecation")
       final @Nullable String scoreValue = sc.value();
       if(scoreValue != null) score.node(SCORE_VALUE).set(scoreValue);
     } else if(src instanceof SelectorComponent) {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
@@ -209,6 +209,7 @@ final class ComponentSerializerImpl implements JsonDeserializer<Component>, Json
       score.addProperty(SCORE_NAME, sc.name());
       score.addProperty(SCORE_OBJECTIVE, sc.objective());
       // score component value is optional
+      @SuppressWarnings("deprecation")
       final @Nullable String value = sc.value();
       if(value != null) score.addProperty(SCORE_VALUE, value);
       object.add(SCORE, score);

--- a/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainComponentSerializer.java
+++ b/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainComponentSerializer.java
@@ -100,6 +100,7 @@ public class PlainComponentSerializer implements ComponentSerializer<Component, 
    * @param component the component
    * @since 4.0.0
    */
+  @SuppressWarnings("deprecation")
   public void serialize(final @NonNull StringBuilder sb, final @NonNull Component component) {
     if(component instanceof KeybindComponent) {
       if(this.keybind != null) sb.append(this.keybind.apply((KeybindComponent) component));


### PR DESCRIPTION
Mojang removed this field from 1.16, so it will be ignored when used there.