### PR TITLE
api: Add support for 'compacting' components

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -5,9 +5,9 @@
   <suppress files="api[\\/]src[\\/]main[\\/]java[\\/]net[\\/]kyori[\\/]adventure[\\/]Adventure.java" checks="SummaryJavadoc"/>
 
   <!-- no javadoc on test classes -->
-  <suppress files="src[\\/]test[\\/]java[\\/].*" checks="FilteringWriteTag"/>
-  <suppress files="src[\\/]test[\\/]java[\\/].*" checks="JavadocPackage"/>
-  <suppress files="src[\\/]test[\\/]java[\\/].*" checks="MissingJavadoc.*"/>
+  <suppress files="src[\\/](test|jmh)[\\/]java[\\/].*" checks="FilteringWriteTag"/>
+  <suppress files="src[\\/](test|jmh)[\\/]java[\\/].*" checks="JavadocPackage"/>
+  <suppress files="src[\\/](test|jmh)[\\/]java[\\/].*" checks="MissingJavadoc.*"/>
 
   <suppress files=".*[\\/]nbt[\\/](List|Compound)BinaryTag.java" checks="MethodName"/>
 </suppressions>

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("adventure.common-conventions")
+  id("me.champeau.jmh")
 }
 
 configurations {

--- a/api/src/jmh/java/net/kyori/adventure/text/ComponentCompactionBenchmark.java
+++ b/api/src/jmh/java/net/kyori/adventure/text/ComponentCompactionBenchmark.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static net.kyori.adventure.key.Key.key;
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.Style.style;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ComponentCompactionBenchmark {
+
+  private Component alreadyCompactedInput;
+  private Component simpleScenarioInput;
+  private Component moreComplexInput;
+
+  @Setup(Level.Trial)
+  public void prepare() {
+    this.alreadyCompactedInput = Component.text()
+      .content("Hello World!")
+      .color(NamedTextColor.RED)
+      .append(Component.text(" aaaa", style(b -> b.color(NamedTextColor.BLUE).font(Key.key("uniform")))))
+      .build();
+
+    final Style simpleScenarioStyle = style()
+      .color(NamedTextColor.AQUA)
+      .font(key("uniform"))
+      .decorate(TextDecoration.BOLD, TextDecoration.ITALIC)
+      .build();
+    this.simpleScenarioInput = text()
+      .content("Hello ")
+      .style(simpleScenarioStyle)
+      .append(text("World!", style(TextDecoration.BOLD).font(key("uniform"))))
+      .build();
+
+    this.moreComplexInput =
+      text().content("Hello ")
+        .style(style(NamedTextColor.RED, TextDecoration.BOLD, TextDecoration.OBFUSCATED))
+        .append(text("World! "))
+        .append(text("What a ", NamedTextColor.RED))
+        .append(text(c -> c.content("beautiful day ")
+          .color(NamedTextColor.BLUE)
+          .append(text("to create ", style(TextDecoration.ITALIC)))
+          .append(text("a PR ", style(TextDecoration.BOLD)))
+          .append(text("on Adventure!"))
+        ))
+        .build();
+  }
+
+  @Benchmark
+  public Component alreadyCompacted() {
+    return this.alreadyCompactedInput.compact();
+  }
+
+  @Benchmark
+  public Component simpleScenario() {
+    return this.simpleScenarioInput.compact();
+  }
+
+  @Benchmark
+  public Component moreComplex() {
+    return this.moreComplexInput.compact();
+  }
+
+  public static void main(final String[] args) throws RunnerException {
+    final Options opt = new OptionsBuilder()
+      .include(ComponentCompactionBenchmark.class.getSimpleName())
+      .forks(1)
+      .build();
+
+    new Runner(opt).run();
+  }
+
+}

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -102,6 +102,11 @@ public abstract class AbstractComponent implements Component {
       optimized = optimized.style(simplifyStyle(this.style(), parentStyle));
     }
 
+    if (this.children.isEmpty()) {
+      // leaf nodes do not need to be further optimized - there is no point
+      return optimized;
+    }
+
     // propagate the parent style context to children
     // by merging this component's style into the parent style
     Style childParentStyle = optimized.style();

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -174,6 +174,11 @@ public abstract class AbstractComponent implements Component {
    * @return a new, simplified style
    */
   private static @NotNull Style simplifyStyle(final @NotNull Style style, final @NotNull Style parentStyle) {
+    if (style.isEmpty()) {
+      // the target style is empty, so there is nothing to simplify
+      return style;
+    }
+
     final Style.Builder builder = style.toBuilder();
     if (Objects.equals(style.font(), parentStyle.font())) {
       builder.font(null);

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -121,18 +120,18 @@ public abstract class AbstractComponent implements Component {
     }
 
     // try to merge children into this parent component
-    for (final ListIterator<Component> it = childrenToAppend.listIterator(); it.hasNext();) {
-      final Component child = it.next();
+    while (!childrenToAppend.isEmpty()) {
+      final Component child = childrenToAppend.get(0);
       final Style childStyle = child.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
 
       if (optimized instanceof TextComponent && child instanceof TextComponent && Objects.equals(childStyle, childParentStyle)) {
         // merge child components into the parent if they are a text component with the same effective style
         // in context of their parent style
         optimized = joinText((TextComponent) optimized, (TextComponent) child);
-        it.remove();
+        childrenToAppend.remove(0);
 
         // if the merged child had any children, retain them
-        child.children().forEach(it::add);
+        childrenToAppend.addAll(0, child.children());
       } else {
         // this child can't be merged into the parent, so all children from now on must remain children
         break;

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -23,15 +23,12 @@
  */
 package net.kyori.adventure.text;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
-import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
@@ -49,7 +46,6 @@ import static java.util.Objects.requireNonNull;
 @Debug.Renderer(text = "this.debuggerString()", childrenArray = "this.children().toArray()", hasChildren = "!this.children().isEmpty()")
 public abstract class AbstractComponent implements Component {
   private static final Predicate<Component> NOT_EMPTY = component -> component != Component.empty();
-  private static final TextDecoration[] DECORATIONS = TextDecoration.values();
 
   /**
    * The list of children.
@@ -92,124 +88,7 @@ public abstract class AbstractComponent implements Component {
 
   @Override
   public @NotNull Component compact() {
-    return this.optimize(null);
-  }
-
-  private Component optimize(final @Nullable Style parentStyle) {
-    Component optimized = this.children(Collections.emptyList());
-    if (parentStyle != null) {
-      optimized = optimized.style(simplifyStyle(this.style(), parentStyle));
-    }
-
-    if (this.children.isEmpty()) {
-      // leaf nodes do not need to be further optimized - there is no point
-      return optimized;
-    }
-
-    // propagate the parent style context to children
-    // by merging this component's style into the parent style
-    Style childParentStyle = optimized.style();
-    if (parentStyle != null) {
-      childParentStyle = parentStyle.merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
-    }
-
-    // optimize all children
-    final List<Component> childrenToAppend = new ArrayList<>(this.children.size());
-    for (int i = 0; i < this.children.size(); ++i) {
-      childrenToAppend.add(((AbstractComponent) this.children.get(i)).optimize(childParentStyle));
-    }
-
-    // try to merge children into this parent component
-    while (!childrenToAppend.isEmpty()) {
-      final Component child = childrenToAppend.get(0);
-      final Style childStyle = child.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
-
-      if (optimized instanceof TextComponent && child instanceof TextComponent && Objects.equals(childStyle, childParentStyle)) {
-        // merge child components into the parent if they are a text component with the same effective style
-        // in context of their parent style
-        optimized = joinText((TextComponent) optimized, (TextComponent) child);
-        childrenToAppend.remove(0);
-
-        // if the merged child had any children, retain them
-        childrenToAppend.addAll(0, child.children());
-      } else {
-        // this child can't be merged into the parent, so all children from now on must remain children
-        break;
-      }
-    }
-
-    // try to concatenate any further children with their neighbor
-    // until no further joining is possible
-    for (int i = 0; i + 1 < childrenToAppend.size();) {
-      final Component child = childrenToAppend.get(i);
-      final Component neighbor = childrenToAppend.get(i + 1);
-
-      // calculate the children's styles in context of their parent style
-      final Style childStyle = child.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
-      final Style neighborStyle = neighbor.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
-
-      if (child instanceof TextComponent && neighbor instanceof TextComponent && childStyle.equals(neighborStyle)) {
-        final Component combined = joinText((TextComponent) child, (TextComponent) neighbor);
-
-        // replace the child and its neighbor with the single, combined component
-        childrenToAppend.set(i, combined);
-        childrenToAppend.remove(i + 1);
-
-        // don't increment the index -
-        // we want to try and optimize this combined component even further
-      } else {
-        i++;
-      }
-    }
-
-    return optimized.children(childrenToAppend);
-  }
-
-  /**
-   * Simplify the provided style to remove any information that is redundant.
-   *
-   * @param style style to simplify
-   * @param parentStyle parent to compare against
-   * @return a new, simplified style
-   */
-  private static @NotNull Style simplifyStyle(final @NotNull Style style, final @NotNull Style parentStyle) {
-    if (style.isEmpty()) {
-      // the target style is empty, so there is nothing to simplify
-      return style;
-    }
-
-    final Style.Builder builder = style.toBuilder();
-    if (Objects.equals(style.font(), parentStyle.font())) {
-      builder.font(null);
-    }
-
-    if (Objects.equals(style.color(), parentStyle.color())) {
-      builder.color(null);
-    }
-
-    for (final TextDecoration decoration : DECORATIONS) {
-      if (style.decoration(decoration) == parentStyle.decoration(decoration)) {
-        builder.decoration(decoration, TextDecoration.State.NOT_SET);
-      }
-    }
-
-    if (Objects.equals(style.clickEvent(), parentStyle.clickEvent())) {
-      builder.clickEvent(null);
-    }
-
-    if (Objects.equals(style.hoverEvent(), parentStyle.hoverEvent())) {
-      builder.hoverEvent(null);
-    }
-
-    if (Objects.equals(style.insertion(), parentStyle.insertion())) {
-      builder.insertion(null);
-    }
-
-    return builder.build();
-  }
-
-  private static TextComponent joinText(final TextComponent one, final TextComponent two) {
-    return Component.text(one.content() + two.content(), one.style());
+    return ComponentCompaction.compact(this, null);
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1916,6 +1916,14 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @NotNull Component replaceText(final @NotNull TextReplacementConfig config);
 
   /**
+   * Create a new component with any redundant style elements or children removed.
+   *
+   * @return the optimized component
+   * @since 4.9.0
+   */
+  @NotNull Component compact();
+
+  /**
    * Finds and replaces text within any {@link Component}s using a string literal.
    *
    * @param search a string literal

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class ComponentCompaction {
+  private static final TextDecoration[] DECORATIONS = TextDecoration.values();
+
+  private ComponentCompaction() {
+  }
+
+  static Component compact(final @NotNull Component self, final @Nullable Style parentStyle) {
+    final List<Component> children = self.children();
+    Component optimized = self.children(Collections.emptyList());
+    if (parentStyle != null) {
+      optimized = optimized.style(simplifyStyle(self.style(), parentStyle));
+    }
+
+    if (children.isEmpty()) {
+      // leaf nodes do not need to be further optimized - there is no point
+      return optimized;
+    }
+
+    // propagate the parent style context to children
+    // by merging this component's style into the parent style
+    Style childParentStyle = optimized.style();
+    if (parentStyle != null) {
+      childParentStyle = parentStyle.merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
+    }
+
+    // optimize all children
+    final List<Component> childrenToAppend = new ArrayList<>(children.size());
+    for (int i = 0; i < children.size(); ++i) {
+      childrenToAppend.add(compact(children.get(i), childParentStyle));
+    }
+
+    // try to merge children into this parent component
+    while (!childrenToAppend.isEmpty()) {
+      final Component child = childrenToAppend.get(0);
+      final Style childStyle = child.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
+
+      if (optimized instanceof TextComponent && child instanceof TextComponent && Objects.equals(childStyle, childParentStyle)) {
+        // merge child components into the parent if they are a text component with the same effective style
+        // in context of their parent style
+        optimized = joinText((TextComponent) optimized, (TextComponent) child);
+        childrenToAppend.remove(0);
+
+        // if the merged child had any children, retain them
+        childrenToAppend.addAll(0, child.children());
+      } else {
+        // this child can't be merged into the parent, so all children from now on must remain children
+        break;
+      }
+    }
+
+    // try to concatenate any further children with their neighbor
+    // until no further joining is possible
+    for (int i = 0; i + 1 < childrenToAppend.size();) {
+      final Component child = childrenToAppend.get(i);
+      final Component neighbor = childrenToAppend.get(i + 1);
+
+      // calculate the children's styles in context of their parent style
+      final Style childStyle = child.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
+      final Style neighborStyle = neighbor.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
+
+      if (child instanceof TextComponent && neighbor instanceof TextComponent && childStyle.equals(neighborStyle)) {
+        final Component combined = joinText((TextComponent) child, (TextComponent) neighbor);
+
+        // replace the child and its neighbor with the single, combined component
+        childrenToAppend.set(i, combined);
+        childrenToAppend.remove(i + 1);
+
+        // don't increment the index -
+        // we want to try and optimize this combined component even further
+      } else {
+        i++;
+      }
+    }
+
+    return optimized.children(childrenToAppend);
+  }
+
+  /**
+   * Simplify the provided style to remove any information that is redundant.
+   *
+   * @param style style to simplify
+   * @param parentStyle parent to compare against
+   * @return a new, simplified style
+   */
+  private static @NotNull Style simplifyStyle(final @NotNull Style style, final @NotNull Style parentStyle) {
+    if (style.isEmpty()) {
+      // the target style is empty, so there is nothing to simplify
+      return style;
+    }
+
+    final Style.Builder builder = style.toBuilder();
+    if (Objects.equals(style.font(), parentStyle.font())) {
+      builder.font(null);
+    }
+
+    if (Objects.equals(style.color(), parentStyle.color())) {
+      builder.color(null);
+    }
+
+    for (final TextDecoration decoration : DECORATIONS) {
+      if (style.decoration(decoration) == parentStyle.decoration(decoration)) {
+        builder.decoration(decoration, TextDecoration.State.NOT_SET);
+      }
+    }
+
+    if (Objects.equals(style.clickEvent(), parentStyle.clickEvent())) {
+      builder.clickEvent(null);
+    }
+
+    if (Objects.equals(style.hoverEvent(), parentStyle.hoverEvent())) {
+      builder.hoverEvent(null);
+    }
+
+    if (Objects.equals(style.insertion(), parentStyle.insertion())) {
+      builder.insertion(null);
+    }
+
+    return builder.build();
+  }
+
+  private static TextComponent joinText(final TextComponent one, final TextComponent two) {
+    return Component.text(one.content() + two.content(), one.style());
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -42,16 +42,17 @@ import static java.util.Objects.requireNonNull;
 final class StyleImpl implements Style {
   static final StyleImpl EMPTY = new StyleImpl(null, null, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, null, null, null);
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
-  private final @Nullable Key font;
-  private final @Nullable TextColor color;
-  private final TextDecoration.State obfuscated;
-  private final TextDecoration.State bold;
-  private final TextDecoration.State strikethrough;
-  private final TextDecoration.State underlined;
-  private final TextDecoration.State italic;
-  private final @Nullable ClickEvent clickEvent;
-  private final @Nullable HoverEvent<?> hoverEvent;
-  private final @Nullable String insertion;
+  // visible to avoid generating accessors when creating a builder
+  final @Nullable Key font;
+  final @Nullable TextColor color;
+  final TextDecoration.State obfuscated;
+  final TextDecoration.State bold;
+  final TextDecoration.State strikethrough;
+  final TextDecoration.State underlined;
+  final TextDecoration.State italic;
+  final @Nullable ClickEvent clickEvent;
+  final @Nullable HoverEvent<?> hoverEvent;
+  final @Nullable String insertion;
 
   static void decorate(final Builder builder, final TextDecoration[] decorations) {
     for (int i = 0, length = decorations.length; i < length; i++) {

--- a/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
@@ -1,0 +1,233 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.stream.Stream;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import static net.kyori.adventure.key.Key.key;
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.format.Style.style;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+class ComponentCompactingTest {
+  @TestFactory
+  Stream<DynamicTest> testNestedComponentsWithSameStyleAreCombined() {
+    final Style style = style()
+      .color(NamedTextColor.AQUA)
+      .font(key("uniform"))
+      .decorate(TextDecoration.BOLD, TextDecoration.ITALIC)
+      .build();
+
+    return Stream.of(
+      dynamicTest("child's style fully inherited", () -> {
+        final Component input = text()
+          .content("Hello ")
+          .style(style)
+          .append(text("World!"))
+          .build();
+
+        assertEquals(text("Hello World!", style), input.compact());
+      }),
+      dynamicTest("child's style partially redeclared, but effectively redundant", () -> {
+        final Component input = text()
+          .content("Hello ")
+          .style(style)
+          .append(text("World!", style(TextDecoration.BOLD).font(key("uniform"))))
+          .build();
+
+        assertEquals(text("Hello World!", style), input.compact());
+      }),
+      dynamicTest("multiple layers of nesting, with some children redeclaring styles", () -> {
+        final Component input = text()
+          .content("Hello ")
+          .style(style)
+          .append(text(c -> c.content("World! ")
+            .decorate(TextDecoration.BOLD)
+            .append(text("What a ")
+              .append(text("beautiful day!", style(s -> s.font(key("uniform"))))))
+          ))
+          .build();
+
+        assertEquals(text("Hello World! What a beautiful day!", style), input.compact());
+      }),
+      dynamicTest("multiple sibling children", () -> {
+        final Component input = text()
+          .content("Hello ")
+          .style(style)
+          .append(text("World! "))
+          .append(text("What a ", style().font(key("uniform")).build()))
+          .append(text("beautiful day!"))
+          .build();
+
+        assertEquals(text("Hello World! What a beautiful day!", style), input.compact());
+      }),
+      dynamicTest("multiple siblings across multiple layers", () -> {
+        final Component input = text()
+          .content("Hello ")
+          .style(style)
+          .append(text("World! "))
+          .append(text("What a ", style().font(key("uniform")).build()))
+          .append(text(c -> c.content("beautiful day ")
+            .decorate(TextDecoration.BOLD)
+            .append(text("to stay inside "))
+            .append(text("and hone your "))
+            .append(text("development skills!", style(TextDecoration.ITALIC)))
+          ))
+          .build();
+
+        assertEquals(text("Hello World! What a beautiful day to stay inside and hone your development skills!", style), input.compact());
+      })
+    );
+  }
+
+  @TestFactory
+  Stream<DynamicTest> testCompactingNestedComponentsInterruptedByDifferentlyStyledComponents() {
+    final Style baseStyle = style(NamedTextColor.RED, TextDecoration.BOLD, TextDecoration.OBFUSCATED);
+    return Stream.of(
+      dynamicTest("simple component with most joinable, and an unjoinable in the middle", () -> {
+        final Component component =
+          text().content("Hello ")
+            .style(baseStyle)
+            .append(text("World! "))
+            .append(text("What a ", NamedTextColor.RED))
+            .append(text("beautiful day ", NamedTextColor.BLUE))
+            .append(text("to create "))
+            .append(text("a PR on Adventure!", style(TextDecoration.BOLD)))
+            .build();
+
+        assertEquals(
+          text()
+            .content("Hello World! What a ")
+            .style(baseStyle)
+
+            .append(text("beautiful day ", NamedTextColor.BLUE))
+            .append(text("to create a PR on Adventure!"))
+            .build(),
+          component.compact());
+      }),
+      dynamicTest("simple component with joinable children, and an unjoinable child with joinable children", () -> {
+        final Component component =
+          text().content("Hello ")
+            .style(baseStyle)
+
+            .append(text("World! "))
+            .append(text("What a ", NamedTextColor.RED))
+            .append(text(c -> c.content("beautiful day ")
+              .color(NamedTextColor.BLUE)
+              .append(text("to create ", style(TextDecoration.ITALIC)))
+              .append(text("a PR ", style(TextDecoration.BOLD)))
+              .append(text("on Adventure!"))
+            ))
+            .build();
+
+        assertEquals(
+          text()
+            .content("Hello World! What a ")
+            .style(baseStyle)
+            .append(text(c -> c.content("beautiful day ")
+              .color(NamedTextColor.BLUE)
+              .append(text("to create ", style(TextDecoration.ITALIC)))
+              .append(text("a PR on Adventure!"))))
+            .build(),
+          component.compact());
+      })
+    );
+  }
+
+  @Test
+  void testCompactingNestedComponentsInterruptedByOthers() {
+    final Style baseStyle = style(NamedTextColor.RED, TextDecoration.BOLD, TextDecoration.OBFUSCATED);
+    final Component input = translatable()
+      .key("some.language.key")
+      .style(baseStyle)
+      .append(
+        text(c -> c.content("Hello World! ")
+          .append(text("What a ", style(TextDecoration.BOLD)))
+          .append(text("beautiful ", style(TextDecoration.OBFUSCATED)))
+          .append(translatable(t -> t.key("unit.day")
+            .append(text(" to create ")
+              .append(text("a PR on Adventure!")))))
+        ))
+      .build();
+
+    assertEquals(translatable("some.language.key", baseStyle)
+      .append(text("Hello World! What a beautiful ")
+        .append(translatable("unit.day")
+          .append(text(" to create a PR on Adventure!")))), input.compact());
+  }
+
+  @TestFactory
+  Stream<DynamicTest> testCompactWithEmptyComponentsInHierarchy() {
+    return Stream.of(
+      dynamicTest("1", () -> {
+        final Component component = text().content("Hello ").append(text().append(text("World!"))).build();
+        assertEquals(text("Hello World!"), component.compact());
+      }),
+      dynamicTest("2", () -> {
+        final Component component = text()
+          .append(text().content("Hello ").append(text().append(text("World!"))))
+          .build();
+        assertEquals(text("Hello World!"), component.compact());
+      }),
+      dynamicTest("3", () -> {
+        final Component component = text()
+          .append(text()
+            .append(text("Hello ")
+              .append(text()
+                .append(text("World!")))))
+          .build();
+        assertEquals(text("Hello World!"), component.compact());
+      }),
+      dynamicTest("4", () -> {
+        final Component component = text()
+          .append(text("Hello "))
+          .append(text("World!"))
+          .build();
+        assertEquals(text("Hello World!"), component.compact());
+      }),
+      dynamicTest("5", () -> {
+        final Component component = text()
+          .append(text()
+            .append(text("Hello ", style().font(key("alt")).build()))
+            .append(text("World!", style().font(key("uniform")).build()))
+          )
+          .build();
+
+        assertEquals(text()
+            .append(text("Hello ", style().font(key("alt")).build()))
+            .append(text("World!", style().font(key("uniform")).build()))
+            .build(),
+          component.compact());
+      })
+    );
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
@@ -35,6 +35,7 @@ import static net.kyori.adventure.key.Key.key;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.format.Style.style;
+import static net.kyori.adventure.text.format.TextColor.color;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
@@ -228,6 +229,34 @@ class ComponentCompactingTest {
             .build(),
           component.compact());
       })
+    );
+  }
+
+  @Test
+  void testCompactTextSeries() {
+    final Component input = Component.text()
+      .decorate(TextDecoration.BOLD)
+      .append(text("one "))
+      .append(TextComponent.ofChildren(
+        Component.text("t", color(0xf3801f)),
+        text("w", color(0x18ed68)),
+        text("o", color(0x7412f7))
+      ))
+      .append(text(", three?"))
+      .build();
+
+    assertEquals(
+      text()
+        .content("one ")
+        .decorate(TextDecoration.BOLD)
+        .append(
+          text("t", color(0xf3801f)),
+          text("w", color(0x18ed68)),
+          text("o", color(0x7412f7)),
+          text(", three?")
+        )
+        .build(),
+      input.compact()
     );
   }
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
   implementation("net.kyori", "indra-common", indraVersion)
   implementation("net.kyori", "indra-publishing-sonatype", indraVersion)
   implementation("com.adarshr", "gradle-test-logger-plugin", "3.0.0")
+  implementation("me.champeau.jmh", "jmh-gradle-plugin", "0.6.5")
 }

--- a/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import com.adarshr.gradle.testlogger.theme.ThemeType
+import me.champeau.jmh.JmhParameters
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 
 plugins {
@@ -12,6 +13,16 @@ plugins {
 testlogger {
   theme = ThemeType.MOCHA_PARALLEL
   showPassed = false
+}
+
+plugins.withId("me.champeau.jmh") {
+  extensions.configure(JmhParameters::class) {
+    jmhVersion.set("1.32")
+  }
+  tasks.named("compileJmhJava") {
+    // avoid implicit task dependencies
+    dependsOn(tasks.compileTestJava, tasks.processTestResources)
+  }
 }
 
 configurations {

--- a/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   id("net.kyori.indra.checkstyle")
   id("net.kyori.indra.license-header")
   id("com.adarshr.test-logger")
+  jacoco
 }
 
 testlogger {
@@ -136,5 +137,9 @@ tasks {
     projectVersion.set(provider { project.version.toString() })
     javadocFiles.from(javadoc)
     rootDir.set(project.rootDir)
+  }
+
+  jacocoTestReport {
+    dependsOn(test)
   }
 }

--- a/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import com.adarshr.gradle.testlogger.theme.ThemeType
+import me.champeau.jmh.JMHPlugin
 import me.champeau.jmh.JmhParameters
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 
@@ -18,11 +19,14 @@ testlogger {
 
 plugins.withId("me.champeau.jmh") {
   extensions.configure(JmhParameters::class) {
-    jmhVersion.set("1.32")
+    jmhVersion.set(providers.gradleProperty("jmhVersion").forUseAtConfigurationTime())
   }
   tasks.named("compileJmhJava") {
     // avoid implicit task dependencies
     dependsOn(tasks.compileTestJava, tasks.processTestResources)
+  }
+  tasks.named(JMHPlugin.JMH_TASK_COMPILE_GENERATED_CLASSES_NAME, JavaCompile::class) {
+    classpath += configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).incoming.files
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 
 javadocPublishRoot=https://jd.adventure.kyori.net/
+jmhVersion=1.32


### PR DESCRIPTION
Closes GH-114

This ports the implementation of component compacting over from the original Kotlin provided by @CrushedPixel (see that [here](https://paste.gg/p/zml/89fb51d013064ad6b6bb279c7486d378)) 

While this component optimization is expensive enough that it shouldn't be used on every message sent, it can be useful for ensuring components of unknown origin (such as loaded from a configuration, or built from multiple sources) are as compact as possible before being sent to users.

Some things to discuss:

- The name: Does `compact` make sense, or should we use something else like `optimize` or `pack`?
- Should a setting be added to the serializers (mainly the Configurate serializer, but possibly others) to auto-compact when loading?