### PR TITLE
api: Add component visitor

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.util.Buildable;
@@ -112,6 +113,17 @@ public abstract class AbstractComponent implements Component {
       throw new IllegalArgumentException("Provided replacement was a custom TextReplacementConfig implementation, which is not supported.");
     }
     return TextReplacementRenderer.INSTANCE.render(this, ((TextReplacementConfigImpl) config).createState());
+  }
+
+  @Override
+  public void visitWhile(final @NonNull Predicate<Component> visitor) {
+    if(visitor.test(this)) {
+      for(final Component child : this.children) {
+        if(!visitor.test(child)) {
+          return;
+        }
+      }
+    }
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Collector;
@@ -1655,6 +1656,42 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(pure = true)
   @NonNull Component replaceText(final @NonNull TextReplacementConfig config);
+
+  /**
+   * Calls the provided visitor for this component and all of the component's children.
+   * There is no guarantee of the order in which each component will be visited.
+   *
+   * @param visitor the component visitor
+   * @since 4.8.0
+   */
+  default void visit(final @NonNull Consumer<Component> visitor) {
+    this.visitWhile(component -> {
+      visitor.accept(component);
+      return true;
+    });
+  }
+
+  /**
+   * Calls the provided visitor for each component and all of the component's children in
+   * this component until the visitor returns {@code true}. There is no guarantee of the
+   * order in which each component will be visited.
+   *
+   * @param visitor the component visitor
+   * @since 4.8.0
+   */
+  default void visitUntil(final @NonNull Predicate<Component> visitor) {
+    this.visitWhile(visitor.negate());
+  }
+
+  /**
+   * Calls the provided visitor for each component and all of the component's children in
+   * this component while the visitor returns {@code true}. There is no guarantee of the
+   * order in which each component will be visited.
+   *
+   * @param visitor the component visitor
+   * @since 4.8.0
+   */
+  void visitWhile(final @NonNull Predicate<Component> visitor);
 
   /**
    * Finds and replaces text within any {@link Component}s using a string literal.

--- a/api/src/test/java/net/kyori/adventure/text/ComponentVisitorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentVisitorTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentVisitorTest {
+
+  @Test
+  public void testOf() {
+    final int[] hits = {0};
+
+    Component.text()
+      .content("Purity Ring ")
+      .append(Component.text("are absolutely", NamedTextColor.DARK_PURPLE))
+      .append(Component.text(" the best "))
+      .append(Component.translatable("some.adjective"))
+      .append(Component.text(" band", NamedTextColor.GREEN).hoverEvent(HoverEvent.showText(Component.text("ever"))))
+      .append(Component.text("."))
+      .build().visit(component -> hits[0]++);
+
+    assertEquals(6, hits[0]);
+  }
+
+  @Test
+  public void testOfWhile() {
+    final int[] hits = {0};
+
+    Component.text()
+      .content("Purity Ring ")
+      .append(Component.text("are absolutely", NamedTextColor.DARK_PURPLE))
+      .append(Component.text(" the best "))
+      .append(Component.translatable("some.adjective"))
+      .append(Component.text(" band", NamedTextColor.GREEN).hoverEvent(HoverEvent.showText(Component.text("ever"))))
+      .append(Component.text("."))
+      .build().visitWhile(component -> {
+        hits[0]++;
+        return component instanceof TextComponent;
+      });
+
+    assertEquals(4, hits[0]);
+  }
+
+  @Test
+  public void testOfUntil() {
+    final int[] hits = {0};
+
+    Component.text()
+      .content("Purity Ring ")
+      .append(Component.text("are absolutely", NamedTextColor.DARK_PURPLE))
+      .append(Component.text(" the best "))
+      .append(Component.translatable("some.adjective"))
+      .append(Component.text(" band", NamedTextColor.GREEN).hoverEvent(HoverEvent.showText(Component.text("ever"))))
+      .append(Component.text("."))
+      .build().visitUntil(component -> {
+        hits[0]++;
+        return component.hoverEvent() != null;
+      });
+
+    assertEquals(5, hits[0]);
+  }
+}


### PR DESCRIPTION
This PR adds three simple methods to visit a component alongside some simple unit tests. These three methods are:

- `visit(Consumer<Component>)`: calls `#accept` on the consumer for each element in the component,
- `visitUntil(Predicate<Component>)`: calls `#test` on the predicate for each element in the component until the predicate returns `true`, and
- `visitWhile(Predicate<Component>)`: calls `#test` on the predicate for each element in the component while the predicate returns true.

I'm not sure if this could be written in such a way that we can guarantee the order in which components can be visited. I'm not sure I'm knowledgeable enough of the internals to know if that's something that can be done or even should be done. I'll investigate further if needs be.