### PR TITLE
api: Add support for playing sound with an "emitter"

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -479,6 +479,17 @@ public interface Audience extends Pointered {
   }
 
   /**
+   * Plays a sound from a player, usually an entity.
+   *
+   * @param sound a sound
+   * @param player a player
+   * @see Sound
+   * @since 4.8.0
+   */
+  default void playSound(final @NonNull Sound sound, final Sound.@NonNull Player player) {
+  }
+
+  /**
    * Stops a sound, or many sounds.
    *
    * @param stop a sound stop

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -479,14 +479,14 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Plays a sound from a player, usually an entity.
+   * Plays a sound from an emitter, usually an entity.
    *
    * @param sound a sound
-   * @param player a player
+   * @param emitter an emitter
    * @see Sound
    * @since 4.8.0
    */
-  default void playSound(final @NonNull Sound sound, final Sound.@NonNull Player player) {
+  default void playSound(final @NonNull Sound sound, final Sound.@NonNull Emitter emitter) {
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -488,12 +488,12 @@ public interface Audience extends Pointered {
    *   In this case the sound will be played at the location of the emitter and will not follow them.
    * </p>
    *
+   * <p>To play a sound that follows the recipient, use {@link Sound.Emitter#self()}.</p>
+   *
    * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC-138832">MC-138832</a>, the volume and pitch may be ignored when using this method.</p>
    *
    * @param sound a sound
    * @param emitter an emitter
-   * @see Sound
-   * @see Sound.Emitter
    * @since 4.8.0
    */
   default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -445,7 +445,9 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Plays a sound.
+   * Plays a sound at the location of the recipient of the sound.
+   *
+   * <p>To play a sound that follows the recipient, use {@link #playSound(Sound, Sound.Emitter)} with {@link Sound.Emitter#self()}.</p>
    *
    * @param sound a sound
    * @see Sound
@@ -482,8 +484,8 @@ public interface Audience extends Pointered {
    * Plays a sound from an emitter, usually an entity.
    *
    * <p>
-   *   Sounds played from an emitter will follow the entity unless the sound is custom sound.
-   *   In the case where a custom sound is provided, the sound will be played at the location of the emitter at the time of calling.
+   *   Sounds played using this method will follow the emitter unless the sound is a custom sound.
+   *   In this case the sound will be played at the location of the emitter and will not follow them.
    * </p>
    *
    * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC-138832">MC-138832</a>, the volume and pitch may be ignored when using this method.</p>
@@ -491,6 +493,7 @@ public interface Audience extends Pointered {
    * @param sound a sound
    * @param emitter an emitter
    * @see Sound
+   * @see Sound.Emitter
    * @since 4.8.0
    */
   default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -481,12 +481,19 @@ public interface Audience extends Pointered {
   /**
    * Plays a sound from an emitter, usually an entity.
    *
+   * <p>
+   *   Sounds played from an emitter will follow the entity unless the sound is custom sound.
+   *   In the case where a custom sound is provided, the sound will be played at the location of the emitter at the time of calling.
+   * </p>
+   *
+   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC-138832">MC-138832</a>, the volume and pitch may be ignored when using this method.</p>
+   *
    * @param sound a sound
    * @param emitter an emitter
    * @see Sound
    * @since 4.8.0
    */
-  default void playSound(final @NonNull Sound sound, final Sound.@NonNull Emitter emitter) {
+  default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -144,7 +144,7 @@ public interface ForwardingAudience extends Audience {
 
   @Override
   default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {
-    for(final Audience audience : this.audiences()) audience.playSound(sound, emitter);
+    for (final Audience audience : this.audiences()) audience.playSound(sound, emitter);
   }
 
   @Override
@@ -266,7 +266,7 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void playSound(final @NonNull Sound sound, final Sound.@NonNull Emitter emitter) {
+    default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {
       this.audience().playSound(sound, emitter);
     }
 

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -143,8 +143,8 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void playSound(final @NotNull Sound sound, final Sound.@NotNull Player player) {
-    for(final Audience audience : this.audiences()) audience.playSound(sound, player);
+  default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {
+    for(final Audience audience : this.audiences()) audience.playSound(sound, emitter);
   }
 
   @Override
@@ -266,8 +266,8 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void playSound(final @NonNull Sound sound, final Sound.@NonNull Player player) {
-      this.audience().playSound(sound, player);
+    default void playSound(final @NonNull Sound sound, final Sound.@NonNull Emitter emitter) {
+      this.audience().playSound(sound, emitter);
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -266,6 +266,11 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
+    default void playSound(final @NonNull Sound sound, final Sound.@NonNull Player player) {
+      this.audience().playSound(sound, player);
+    }
+
+    @Override
     default void stopSound(final @NotNull SoundStop stop) {
       this.audience().stopSound(stop);
     }

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -143,6 +143,11 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
+  default void playSound(final @NotNull Sound sound, final Sound.@NotNull Player player) {
+    for(final Audience audience : this.audiences()) audience.playSound(sound, player);
+  }
+
+  @Override
   default void stopSound(final @NotNull SoundStop stop) {
     for (final Audience audience : this.audiences()) audience.stopSound(stop);
   }

--- a/api/src/main/java/net/kyori/adventure/sound/Sound.java
+++ b/api/src/main/java/net/kyori/adventure/sound/Sound.java
@@ -256,11 +256,10 @@ public interface Sound extends Examinable {
   }
 
   /**
-   * A emitter of sounds.
+   * An emitter of sounds.
    *
    * @since 4.8.0
    */
   interface Emitter {
-
   }
 }

--- a/api/src/main/java/net/kyori/adventure/sound/Sound.java
+++ b/api/src/main/java/net/kyori/adventure/sound/Sound.java
@@ -262,5 +262,16 @@ public interface Sound extends Examinable {
    * @since 4.8.0
    */
   interface Emitter {
+    /**
+     * An emitter representing the recipient of a sound.
+     *
+     * <p>When used with {@link net.kyori.adventure.audience.Audience#playSound(Sound, Emitter)}, the sound will be emitted from the recipient of the sound.</p>
+     *
+     * @return the emitter
+     * @since 4.8.0
+     */
+    static @NotNull Emitter self() {
+      return SoundImpl.SELF;
+    }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/sound/Sound.java
+++ b/api/src/main/java/net/kyori/adventure/sound/Sound.java
@@ -258,6 +258,7 @@ public interface Sound extends Examinable {
   /**
    * An emitter of sounds.
    *
+   * @see net.kyori.adventure.audience.Audience#playSound(Sound, Emitter)
    * @since 4.8.0
    */
   interface Emitter {

--- a/api/src/main/java/net/kyori/adventure/sound/Sound.java
+++ b/api/src/main/java/net/kyori/adventure/sound/Sound.java
@@ -254,4 +254,13 @@ public interface Sound extends Examinable {
     @Override
     @NotNull Key key();
   }
+
+  /**
+   * A player of sounds.
+   *
+   * @since 4.8.0
+   */
+  interface Player {
+
+  }
 }

--- a/api/src/main/java/net/kyori/adventure/sound/Sound.java
+++ b/api/src/main/java/net/kyori/adventure/sound/Sound.java
@@ -271,7 +271,7 @@ public interface Sound extends Examinable {
      * @since 4.8.0
      */
     static @NotNull Emitter self() {
-      return SoundImpl.SELF;
+      return SoundImpl.EMITTER_SELF;
     }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/sound/Sound.java
+++ b/api/src/main/java/net/kyori/adventure/sound/Sound.java
@@ -256,11 +256,11 @@ public interface Sound extends Examinable {
   }
 
   /**
-   * A player of sounds.
+   * A emitter of sounds.
    *
    * @since 4.8.0
    */
-  interface Player {
+  interface Emitter {
 
   }
 }

--- a/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
@@ -31,6 +31,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 abstract class SoundImpl implements Sound {
+  static final Emitter SELF = new Emitter() {};
+
   private final Source source;
   private final float volume;
   private final float pitch;

--- a/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
@@ -31,7 +31,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 abstract class SoundImpl implements Sound {
-  static final Emitter SELF = new Emitter() {};
+  static final Emitter EMITTER_SELF = new Emitter() {
+    @Override
+    public String toString() {
+      return "SelfSoundEmitter";
+    }
+  };
 
   private final Source source;
   private final float volume;


### PR DESCRIPTION
This is a simple PR that adds the concept of a sound "player". The interface for `Sound.Player` is intentionally empty, as the way the client/server identifies a sound player is with the entity ID, an implementation detail that some platforms may not wish to expose. 

The general idea is that a native implementation will implement `Sound.Player` on their entity class, allowing it to be passed directly as an argument into the `playSound` method. For platforms, they could provide utility methods to convert their entity class to an implementation of the `Sound.Player` interface which provides an entity object, or some other form of identifier. This can then be used to convert to the platform specific way of sending the entity sound effect packet.

Alternatively, the `Sound.Player` could provide an integer ID, but this is just exposing what is essentially a magic number, not something as constant as, say, a UUID. I'm also not 100% sold on the `Player` part, I think it's potentially too confusing with the actual player. Perhaps something like `Sound.Maker` or `Sound.EntitySource`?