### PR TITLE
WIP: Add weather API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@
 /serializer-configurate*/out/
 /text-serializer-*/build/
 /text-serializer-*/out/
+/weather/build/
+/weather/out/
 /*.iml

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -20,7 +20,8 @@ dependencies {
       "text-serializer-gson",
       "text-serializer-gson-legacy-impl",
       "text-serializer-legacy",
-      "text-serializer-plain"
+      "text-serializer-plain",
+      "weather"
     ].each {
       api(project(":adventure-$it"))
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ include "text-serializer-gson"
 include "text-serializer-gson-legacy-impl"
 include "text-serializer-legacy"
 include "text-serializer-plain"
+include "weather"
 
 [
   "api",
@@ -27,7 +28,8 @@ include "text-serializer-plain"
   "text-serializer-gson",
   "text-serializer-gson-legacy-impl",
   "text-serializer-legacy",
-  "text-serializer-plain"
+  "text-serializer-plain",
+  "weather"
 ].each {
   findProject(":$it")?.name = "adventure-$it"
 }

--- a/weather/build.gradle
+++ b/weather/build.gradle
@@ -1,0 +1,13 @@
+configurations.testCompileOnly {
+  extendsFrom(configurations.compileOnlyApi)
+}
+
+dependencies {
+  api("net.kyori:examination-api:1.1.0")
+  api("net.kyori:examination-string:1.1.0")
+  compileOnlyApi("org.checkerframework:checker-qual:3.11.0")
+  compileOnlyApi("org.jetbrains:annotations:20.1.0")
+  testImplementation("com.google.guava:guava:23.0")
+}
+
+applyJarMetadata(this, "net.kyori.adventure.weather")

--- a/weather/src/main/java/net/kyori/adventure/weather/ChildWeatherHolder.java
+++ b/weather/src/main/java/net/kyori/adventure/weather/ChildWeatherHolder.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.weather;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Something that optionally has it's own weather, otherwise it has the weather of it's parent.
+ *
+ * @since 4.8.0
+ */
+public interface ChildWeatherHolder extends WeatherHolder {
+
+  /**
+   * Gets the parent of this child.
+   *
+   * @return the parent
+   * @since 4.8.0
+   */
+  @NonNull WeatherHolder weatherParent();
+
+  /**
+   * Checks if this child has any weather set.
+   *
+   * @return {@code true} if it does
+   * @since 4.8.0
+   */
+  boolean hasWeather();
+
+  @Override
+  default @NonNull Weather weather() {
+    if(this.hasWeather()) return this.weather();
+    return this.weatherParent().weather();
+  }
+}

--- a/weather/src/main/java/net/kyori/adventure/weather/Weather.java
+++ b/weather/src/main/java/net/kyori/adventure/weather/Weather.java
@@ -1,0 +1,224 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.weather;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+import net.kyori.examination.Examinable;
+import net.kyori.examination.ExaminableProperty;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static net.kyori.adventure.weather.WeatherImpl.DEFAULT_LENGTH;
+
+/**
+ * Some weather.
+ *
+ * @since 4.8.0
+ */
+public interface Weather extends Examinable {
+
+  /**
+   * Clear skies with the default length of 5 minutes.
+   *
+   * @return the weather
+   * @since 4.8.0
+   */
+  static @NonNull Weather clear() {
+    return clear(DEFAULT_LENGTH);
+  }
+
+  /**
+   * Clear skies with a specific length.
+   *
+   * @param length the length
+   * @return the weather
+   * @since 4.8.0
+   */
+  static @NonNull Weather clear(Weather.@NonNull Length length) {
+    return weather(Type.CLEAR, length);
+  }
+
+  /**
+   * Rain with the default length of 5 minutes.
+   *
+   * @return the weather
+   * @since 4.8.0
+   */
+  static @NonNull Weather rain() {
+    return rain(DEFAULT_LENGTH);
+  }
+
+  /**
+   * Rain with a specific length.
+   *
+   * @param length the length
+   * @return the weather
+   * @since 4.8.0
+   */
+  static @NonNull Weather rain(Weather.@NonNull Length length) {
+    return weather(Type.RAIN, length);
+  }
+
+  /**
+   * Thunder with the default length of 5 minutes.
+   *
+   * @return the weather
+   * @since 4.8.0
+   */
+  static @NonNull Weather thunder() {
+    return thunder(DEFAULT_LENGTH);
+  }
+
+  /**
+   * Thunder with a specific length.
+   *
+   * @param length the length
+   * @return the weather
+   * @since 4.8.0
+   */
+  static @NonNull Weather thunder(Weather.@NonNull Length length) {
+    return weather(Type.THUNDER, length);
+  }
+
+  /**
+   * Weather with a specific type and length.
+   *
+   * @param type the type
+   * @param length the length
+   * @return the weather
+   * @since 4.8.0
+   */
+  static @NonNull Weather weather(final @NonNull Type type, Weather.@NonNull Length length) {
+    return new WeatherImpl(type, length);
+  }
+
+  /**
+   * Gets the length of this weather.
+   *
+   * @return the duration
+   * @since 4.8.0
+   */
+  Weather.@NonNull Length length();
+
+  /**
+   * Gets the type of this weather.
+   *
+   * @return the type
+   * @see Type
+   * @since 4.8.0
+   */
+  @NonNull Type type();
+
+  @Override
+  default @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("type", this.type()),
+      ExaminableProperty.of("length", this.length())
+    );
+  }
+
+  /**
+   * The types of weather.
+   *
+   * @since 4.8.0
+   */
+  enum Type {
+    /**
+     * Clear skies.
+     *
+     * @since 4.8.0
+     */
+    CLEAR,
+
+    /**
+     * Rain.
+     *
+     * @since 4.8.0
+     */
+    RAIN,
+
+    /**
+     * Thunder.
+     *
+     * @since 4.8.0
+     */
+    THUNDER
+  }
+
+  /**
+   * The length of the weather.
+   *
+   * @since 4.8.0
+   */
+  interface Length extends Examinable {
+    /**
+     * A random weather length.
+     *
+     * @return the length
+     * @since 4.8.0
+     */
+    static Length random() {
+      return WeatherImpl.RANDOM;
+    }
+
+    /**
+     * A specific weather length.
+     *
+     * @param duration the duration
+     * @return the length
+     * @throws IllegalArgumentException if the duration is not positive
+     * @since 4.8.0
+     */
+    static Length of(final @NonNull Duration duration) {
+      if(duration.isNegative() || duration.isZero()) throw new IllegalArgumentException("duration must be positive");
+      return new WeatherImpl.LengthImpl(duration);
+    }
+
+    /**
+     * Checks if the length is random.
+     *
+     * @return {@code true} if the length is random
+     * @since 4.8.0
+     */
+    boolean isRandom();
+
+    /**
+     * Gets the duration, if any.
+     *
+     * @return the duration
+     * @since 4.8.0
+     */
+    @Nullable Duration duration();
+
+    @Override
+    @NonNull
+    default Stream<? extends ExaminableProperty> examinableProperties() {
+      return Stream.of(
+        ExaminableProperty.of("random", this.isRandom()),
+        ExaminableProperty.of("duration", this.duration())
+      );
+    }
+  }
+}

--- a/weather/src/main/java/net/kyori/adventure/weather/Weather.java
+++ b/weather/src/main/java/net/kyori/adventure/weather/Weather.java
@@ -24,13 +24,12 @@
 package net.kyori.adventure.weather;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import static net.kyori.adventure.weather.WeatherImpl.DEFAULT_LENGTH;
 
 /**
  * Some weather.
@@ -40,13 +39,13 @@ import static net.kyori.adventure.weather.WeatherImpl.DEFAULT_LENGTH;
 public interface Weather extends Examinable {
 
   /**
-   * Clear skies with the default length of 5 minutes.
+   * Clear skies for a random length of time.
    *
    * @return the weather
    * @since 4.8.0
    */
   static @NonNull Weather clear() {
-    return clear(DEFAULT_LENGTH);
+    return clear(Length.random());
   }
 
   /**
@@ -56,18 +55,18 @@ public interface Weather extends Examinable {
    * @return the weather
    * @since 4.8.0
    */
-  static @NonNull Weather clear(Weather.@NonNull Length length) {
+  static @NonNull Weather clear(final Weather.@NonNull Length length) {
     return weather(Type.CLEAR, length);
   }
 
   /**
-   * Rain with the default length of 5 minutes.
+   * Rain for a random length of time.
    *
    * @return the weather
    * @since 4.8.0
    */
   static @NonNull Weather rain() {
-    return rain(DEFAULT_LENGTH);
+    return rain(Length.random());
   }
 
   /**
@@ -77,18 +76,18 @@ public interface Weather extends Examinable {
    * @return the weather
    * @since 4.8.0
    */
-  static @NonNull Weather rain(Weather.@NonNull Length length) {
+  static @NonNull Weather rain(final Weather.@NonNull Length length) {
     return weather(Type.RAIN, length);
   }
 
   /**
-   * Thunder with the default length of 5 minutes.
+   * Thunder for a random length of time.
    *
    * @return the weather
    * @since 4.8.0
    */
   static @NonNull Weather thunder() {
-    return thunder(DEFAULT_LENGTH);
+    return thunder(Length.random());
   }
 
   /**
@@ -98,7 +97,7 @@ public interface Weather extends Examinable {
    * @return the weather
    * @since 4.8.0
    */
-  static @NonNull Weather thunder(Weather.@NonNull Length length) {
+  static @NonNull Weather thunder(final Weather.@NonNull Length length) {
     return weather(Type.THUNDER, length);
   }
 
@@ -110,17 +109,9 @@ public interface Weather extends Examinable {
    * @return the weather
    * @since 4.8.0
    */
-  static @NonNull Weather weather(final @NonNull Type type, Weather.@NonNull Length length) {
+  static @NonNull Weather weather(final @NonNull Type type, final Weather.@NonNull Length length) {
     return new WeatherImpl(type, length);
   }
-
-  /**
-   * Gets the length of this weather.
-   *
-   * @return the duration
-   * @since 4.8.0
-   */
-  Weather.@NonNull Length length();
 
   /**
    * Gets the type of this weather.
@@ -130,6 +121,14 @@ public interface Weather extends Examinable {
    * @since 4.8.0
    */
   @NonNull Type type();
+
+  /**
+   * Gets the length of this weather.
+   *
+   * @return the duration
+   * @since 4.8.0
+   */
+  @NonNull Length length();
 
   @Override
   default @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
@@ -164,7 +163,7 @@ public interface Weather extends Examinable {
      *
      * @since 4.8.0
      */
-    THUNDER
+    THUNDER;
   }
 
   /**
@@ -174,13 +173,23 @@ public interface Weather extends Examinable {
    */
   interface Length extends Examinable {
     /**
-     * A random weather length.
+     * A random weather length. The actual length of this weather is left up to the implementation.
      *
      * @return the length
      * @since 4.8.0
      */
     static Length random() {
-      return WeatherImpl.RANDOM;
+      return WeatherImpl.LENGTH_RANDOM;
+    }
+
+    /**
+     * A weather length that lasts as long as {@link ChronoUnit#FOREVER}.
+     *
+     * @return the length
+     * @since 4.8.0
+     */
+    static Length forever() {
+      return WeatherImpl.LENGTH_FOREVER;
     }
 
     /**

--- a/weather/src/main/java/net/kyori/adventure/weather/WeatherHolder.java
+++ b/weather/src/main/java/net/kyori/adventure/weather/WeatherHolder.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.weather;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Something that can have weather.
+ *
+ * @see Weather
+ * @since 4.8.0
+ */
+public interface WeatherHolder {
+
+  /**
+   * Gets the weather.
+   *
+   * @return the weather
+   * @see Weather
+   * @since 4.8.0
+   */
+  @NonNull Weather weather();
+
+  /**
+   * Sets the weather.
+   *
+   * @param weather the weather
+   * @see Weather
+   * @since 4.8.0
+   */
+  void weather(@NonNull Weather weather);
+}

--- a/weather/src/main/java/net/kyori/adventure/weather/WeatherImpl.java
+++ b/weather/src/main/java/net/kyori/adventure/weather/WeatherImpl.java
@@ -24,14 +24,15 @@
 package net.kyori.adventure.weather;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import net.kyori.examination.string.StringExaminer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class WeatherImpl implements Weather {
-  static final Length DEFAULT_LENGTH = Length.of(Duration.ofMillis(5));
-  static final Length RANDOM = new LengthImpl(null);
+  static final Length LENGTH_RANDOM = new LengthImpl(null);
+  static final Length LENGTH_FOREVER = Length.of(ChronoUnit.FOREVER.getDuration());
   private final Type type;
   private final Length length;
 

--- a/weather/src/main/java/net/kyori/adventure/weather/WeatherImpl.java
+++ b/weather/src/main/java/net/kyori/adventure/weather/WeatherImpl.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.weather;
+
+import java.time.Duration;
+import java.util.Objects;
+import net.kyori.examination.string.StringExaminer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class WeatherImpl implements Weather {
+  static final Length DEFAULT_LENGTH = Length.of(Duration.ofMillis(5));
+  static final Length RANDOM = new LengthImpl(null);
+  private final Type type;
+  private final Length length;
+
+  WeatherImpl(final @NonNull Type type, final Weather.@NonNull Length length) {
+    this.type = type;
+    this.length = length;
+  }
+
+  @Override
+  public @NonNull Length length() {
+    return this.length;
+  }
+
+  @Override
+  public @NonNull Type type() {
+    return this.type;
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if(this == other) return true;
+    if(!(other instanceof WeatherImpl)) return false;
+    final WeatherImpl that = (WeatherImpl) other;
+    return that.type == this.type && this.length.equals(that.length);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.type, this.length);
+  }
+
+  @Override
+  public String toString() {
+    return this.examine(StringExaminer.simpleEscaping());
+  }
+
+  static class LengthImpl implements Length {
+    private final Duration duration;
+    private final boolean random;
+
+    LengthImpl(final @Nullable Duration duration) {
+      this.duration = duration;
+      this.random = duration == null;
+    }
+
+    @Override
+    public boolean isRandom() {
+      return this.random;
+    }
+
+    @Override
+    public @Nullable Duration duration() {
+      return this.duration;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object other) {
+      if(this == other) return true;
+      if(!(other instanceof LengthImpl)) return false;
+      final LengthImpl that = (LengthImpl) other;
+      return that.random == this.random && Objects.equals(that.duration, this.duration);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(this.random, this.duration);
+    }
+
+    @Override
+    public String toString() {
+      return this.examine(StringExaminer.simpleEscaping());
+    }
+  }
+}


### PR DESCRIPTION
# Weather
This PR adds a weather module to Adventure, providing an API for controlling the weather. The current implementation is more of a proof of concept then a final design. I'm not even 100% sure if such a thing fits in Adventure like this, or if it could be its own repo or something completely different. I'm most interested in hearing what everyone thinks!

## Holder
Similar to `Audience` the weather module includes the concept of a `WeatherHolder`, that being something that can have weather applied and checked. The current weather can be obtained from a holder using `WeatherHolder#weather()` and can be set using `WeatherHolder#weather(Weather)`.

Additionally, the concept of a `ChildWeatherHolder` exists. This represents an object that either has its own weather, or has the weather of it's parent. For example, a player could have their own weather overriding that of the world's weather.

## Weather
The `Weather` object itself is constructed using a type and a length. The type is one of rain, clear or thunder, mimicking the `/weather` command in vanilla Minecraft. The length object either holds an exact duration or is marked as random, mimicking the natural flow of weather in whatever platform you are using.

## Examples
Here's some examples of how the system would work.

```java
// clear the weather for a random amount of time
world.weather(Weather.clear());

// nope let's make it rain for exactly 10 minutes
world.weather(Weather.rain(Length.of(Duration.ofMinutes(5))));

// assuming player is a child of world, this would be true
var isTrue = player.weather().type() == Type.RAIN;

// however, we can override the weather for the child and make it permanent
player.weather(Weather.clear(Length.forever()));

// now the child has it's own weather, this will be false
var isFalse = player.weather.type() == Type.RAIN;
```