### PR TITLE
api: Clarify Audience#playSound methods

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -451,12 +451,14 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   default void playSound(final @NotNull Sound sound) {
-    this.playSound(sound, false);
   }
 
   /**
    * Plays a sound.
+   *
    * <p>Custom sounds cannot be made to follow the receiver and they will fall back to playing at the location of the receiver.</p>
+   *
+   * <p><b>Note</b>: Due to <a href="https://bugs.mojang.com/browse/MC-138832">MC-138832</a>, the volume and pitch may be ignored when using this method to follow the receiver.</p>
    *
    * @param sound a sound
    * @param followReceiver if the sound should follow the receiver
@@ -464,6 +466,7 @@ public interface Audience extends Pointered {
    * @since 4.8.0
    */
   default void playSound(final @NotNull Sound sound, final boolean followReceiver) {
+    if (!followReceiver) this.playSound(sound);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -444,13 +444,26 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Plays a sound.
+   * Plays a sound at the location of the receiver.
    *
    * @param sound a sound
    * @see Sound
    * @since 4.0.0
    */
   default void playSound(final @NotNull Sound sound) {
+    this.playSound(sound, false);
+  }
+
+  /**
+   * Plays a sound.
+   * <p>Custom sounds cannot be made to follow the receiver and they will fall back to playing at the location of the receiver.</p>
+   *
+   * @param sound a sound
+   * @param followReceiver if the sound should follow the receiver
+   * @see Sound
+   * @since 4.8.0
+   */
+  default void playSound(final @NotNull Sound sound, final boolean followReceiver) {
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -138,6 +138,11 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
+  default void playSound(final @NonNull Sound sound, final boolean followReceiver) {
+    for(final Audience audience : this.audiences()) audience.playSound(sound, followReceiver);
+  }
+
+  @Override
   default void playSound(final @NotNull Sound sound, final double x, final double y, final double z) {
     for (final Audience audience : this.audiences()) audience.playSound(sound, x, y, z);
   }
@@ -253,6 +258,11 @@ public interface ForwardingAudience extends Audience {
     @Override
     default void playSound(final @NotNull Sound sound) {
       this.audience().playSound(sound);
+    }
+
+    @Override
+    default void playSound(final @NonNull Sound sound, final boolean followReceiver) {
+      this.audience().playSound(sound, followReceiver);
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -138,8 +138,8 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void playSound(final @NonNull Sound sound, final boolean followReceiver) {
-    for(final Audience audience : this.audiences()) audience.playSound(sound, followReceiver);
+  default void playSound(final @NotNull Sound sound, final boolean followReceiver) {
+    for (final Audience audience : this.audiences()) audience.playSound(sound, followReceiver);
   }
 
   @Override
@@ -261,7 +261,7 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void playSound(final @NonNull Sound sound, final boolean followReceiver) {
+    default void playSound(final @NotNull Sound sound, final boolean followReceiver) {
       this.audience().playSound(sound, followReceiver);
     }
 


### PR DESCRIPTION
Following my comment in https://github.com/KyoriPowered/adventure/pull/316#issuecomment-816734116, this PR clarifies exactly what the `Audience#playSound(Sound)` method does, essentially binding implementations into a contract as to how they implement this method. Additionally, a new method is added that allows "both" behaviours of the `Audience#playSound` method to be run.