### PR TITLE
api: Component iterator

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -49,6 +49,7 @@ import net.kyori.adventure.translation.Translatable;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.adventure.util.ForwardingIterator;
 import net.kyori.adventure.util.IntFunction2;
+import net.kyori.adventure.util.MonkeyBars;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -2023,12 +2024,26 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * Returns an iterable view of this component.
    *
    * @param type the type
+   * @param flags the flags
    * @return the iterable
    * @since 4.9.0
    */
-  default @NotNull Iterable<Component> iterable(final @NotNull ComponentIteratorType type) {
+  default @NotNull Iterable<Component> iterable(final @NotNull ComponentIteratorType type, final @NotNull ComponentIteratorFlag@Nullable... flags) {
+    return this.iterable(type, flags == null ? Collections.emptySet() : MonkeyBars.enumSet(ComponentIteratorFlag.class, flags));
+  }
+
+  /**
+   * Returns an iterable view of this component.
+   *
+   * @param type the type
+   * @param flags the flags
+   * @return the iterable
+   * @since 4.9.0
+   */
+  default @NotNull Iterable<Component> iterable(final @NotNull ComponentIteratorType type, final @NotNull Set<ComponentIteratorFlag> flags) {
     Objects.requireNonNull(type, "type");
-    return new ForwardingIterator<>(() -> this.iterator(type), () -> this.spliterator(type));
+    Objects.requireNonNull(flags, "flags");
+    return new ForwardingIterator<>(() -> this.iterator(type, flags), () -> this.spliterator(type, flags));
   }
 
   /**
@@ -2036,12 +2051,27 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *
    * <p>As components are immutable, this iterator does not support removal.</p>
    *
-   * @param type the type of the iterator
+   * @param type the type
+   * @param flags the flags
    * @return the iterator
    * @since 4.9.0
    */
-  default @NotNull Iterator<Component> iterator(final @NotNull ComponentIteratorType type) {
-    return new ComponentIterator(this, type);
+  default @NotNull Iterator<Component> iterator(final @NotNull ComponentIteratorType type, final @NotNull ComponentIteratorFlag@Nullable... flags) {
+    return this.iterator(type, flags == null ? Collections.emptySet() : MonkeyBars.enumSet(ComponentIteratorFlag.class, flags));
+  }
+
+  /**
+   * Returns an iterator for this component.
+   *
+   * <p>As components are immutable, this iterator does not support removal.</p>
+   *
+   * @param type the type
+   * @param flags the flags
+   * @return the iterator
+   * @since 4.9.0
+   */
+  default @NotNull Iterator<Component> iterator(final @NotNull ComponentIteratorType type, final @NotNull Set<ComponentIteratorFlag> flags) {
+    return new ComponentIterator(this, Objects.requireNonNull(type, "type"), Objects.requireNonNull(flags, "flags"));
   }
 
   /**
@@ -2049,12 +2079,27 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *
    * <p>The resulting spliterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
    *
-   * @param type the type of the underlying iterator
-   * @return the iterator
+   * @param type the type
+   * @param flags the flags
+   * @return the spliterator
    * @since 4.9.0
    */
-  default @NotNull Spliterator<Component> spliterator(final @NotNull ComponentIteratorType type) {
-    return Spliterators.spliteratorUnknownSize(this.iterator(type), Spliterator.IMMUTABLE & Spliterator.NONNULL & Spliterator.ORDERED);
+  default @NotNull Spliterator<Component> spliterator(final @NotNull ComponentIteratorType type, final @NotNull ComponentIteratorFlag@Nullable... flags) {
+    return this.spliterator(type, flags == null ? Collections.emptySet() : MonkeyBars.enumSet(ComponentIteratorFlag.class, flags));
+  }
+
+  /**
+   * Returns a spliterator for this component.
+   *
+   * <p>The resulting spliterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
+   *
+   * @param type the type
+   * @param flags the flags
+   * @return the spliterator
+   * @since 4.9.0
+   */
+  default @NotNull Spliterator<Component> spliterator(final @NotNull ComponentIteratorType type, final @NotNull Set<ComponentIteratorFlag> flags) {
+    return Spliterators.spliteratorUnknownSize(this.iterator(type, flags), Spliterator.IMMUTABLE & Spliterator.NONNULL & Spliterator.ORDERED);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2024,8 +2024,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *
    * @param type the type
    * @return the iterable
-   * @see ComponentIteratorType
-   * @since 4.8.0
+   * @since 4.9.0
    */
   default @NotNull Iterable<Component> iterable(final @NotNull ComponentIteratorType type) {
     Objects.requireNonNull(type, "type");
@@ -2039,8 +2038,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *
    * @param type the type of the iterator
    * @return the iterator
-   * @see ComponentIteratorType
-   * @since 4.8.0
+   * @since 4.9.0
    */
   default @NotNull Iterator<Component> iterator(final @NotNull ComponentIteratorType type) {
     return new ComponentIterator(this, type);
@@ -2053,8 +2051,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *
    * @param type the type of the underlying iterator
    * @return the iterator
-   * @see ComponentIteratorType
-   * @since 4.8.0
+   * @since 4.9.0
    */
   default @NotNull Spliterator<Component> spliterator(final @NotNull ComponentIteratorType type) {
     return Spliterators.spliteratorUnknownSize(this.iterator(type), Spliterator.IMMUTABLE & Spliterator.NONNULL & Spliterator.ORDERED);

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -94,7 +96,7 @@ import org.jetbrains.annotations.Unmodifiable;
  * @since 4.0.0
  */
 @ApiStatus.NonExtendable
-public interface Component extends ComponentBuilderApplicable, ComponentLike, Examinable, HoverEventSource<Component> {
+public interface Component extends ComponentBuilderApplicable, ComponentLike, Examinable, HoverEventSource<Component>, Iterable<Component> {
   /**
    * A predicate that checks equality of two {@code Component}s using {@link Objects#equals(Object, Object)}.
    *
@@ -107,7 +109,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   BiPredicate<? super Component, ? super Component> EQUALS_IDENTITY = (a, b) -> a == b;
-
   /**
    * Gets an empty component.
    *
@@ -2015,6 +2016,18 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @NotNull Component compact();
+
+  /**
+   * Returns a breadth-first iterator over this component and it's children.
+   * <p>As components are immutable, this iterator does not support removal.</p>
+   *
+   * @return the iterator
+   * @since 4.8.0
+   */
+  @Override
+  default @NonNull Iterator<Component> iterator() {
+    return ComponentIterator.iterator(this, ComponentIterator.Type.BREADTH_FIRST);
+  }
 
   /**
    * Finds and replaces text within any {@link Component}s using a string literal.

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -47,6 +47,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.translation.Translatable;
 import net.kyori.adventure.util.Buildable;
+import net.kyori.adventure.util.DelegatingIterable;
 import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
@@ -2018,27 +2019,73 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @NotNull Component compact();
 
   /**
+   * Creates an iterable over this component with a given type.
+   *
+   * @param type the type
+   * @return the iterable
+   * @see ComponentIteratorType
+   * @since 4.8.0
+   */
+  default @NonNull Iterable<Component> iterable(final @NonNull ComponentIteratorType type) {
+    Objects.requireNonNull(type, "type");
+    if(type == ComponentIteratorType.defaultType()) return this;
+    return new DelegatingIterable<>(() -> this.iterator(type), () -> this.spliterator(type));
+  }
+
+  /**
    * Returns a breadth-first iterator over this component and it's children.
+   *
    * <p>As components are immutable, this iterator does not support removal.</p>
    *
    * @return the iterator
+   * @see ComponentIteratorType#BREADTH_FIRST
    * @since 4.8.0
    */
   @Override
   default @NonNull Iterator<Component> iterator() {
-    return ComponentIterator.iterator(this, ComponentIterator.Type.BREADTH_FIRST);
+    return this.iterator(ComponentIteratorType.defaultType());
   }
 
   /**
-   * Returns a spliterator from this component's iterator.
-   * <p>The resulting iterator has the {@link Spliterator#IMMUTABLE} and {@link Spliterator#NONNULL} characteristics.</p>
+   * Returns a breadth-first iterator over this component and it's children.
+   *
+   * <p>As components are immutable, this iterator does not support removal.</p>
+   *
+   * @param type the type of the iterator
+   * @return the iterator
+   * @see ComponentIteratorType
+   * @since 4.8.0
+   */
+  default @NonNull Iterator<Component> iterator(final @NonNull ComponentIteratorType type) {
+    return new ComponentIterator(this, type);
+  }
+
+  /**
+   * Returns a spliterator from a breadth-first iterator over this component.
+   *
+   * <p>The resulting iterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
    *
    * @return the iterator
+   * @see ComponentIteratorType#BREADTH_FIRST
    * @since 4.8.0
    */
   @Override
   default @NonNull Spliterator<Component> spliterator() {
-    return Spliterators.spliteratorUnknownSize(this.iterator(), Spliterator.IMMUTABLE & Spliterator.NONNULL);
+    return this.spliterator(ComponentIteratorType.defaultType());
+  }
+
+  /**
+   * Returns a spliterator from this component's iterator.
+   *
+   * <p>The resulting iterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
+   *
+   * @param type the type of the underlying iterator
+   * @return the iterator
+   * @see ComponentIteratorType
+   * @since 4.8.0
+   */
+  default @NonNull Spliterator<Component> spliterator(final @NonNull ComponentIteratorType type) {
+    return Spliterators.spliteratorUnknownSize(this.iterator(type), Spliterator.IMMUTABLE & Spliterator.NONNULL & Spliterator.ORDERED);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2033,12 +2033,12 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Returns a breadth-first iterator over this component and it's children.
+   * Returns an iterator over this component and it's children using the default iterator type.
    *
    * <p>As components are immutable, this iterator does not support removal.</p>
    *
    * @return the iterator
-   * @see ComponentIteratorType#BREADTH_FIRST
+   * @see ComponentIteratorType#defaultType()
    * @since 4.8.0
    */
   @Override
@@ -2047,7 +2047,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Returns a breadth-first iterator over this component and it's children.
+   * Returns an iterator of a given type over this component and it's children.
    *
    * <p>As components are immutable, this iterator does not support removal.</p>
    *
@@ -2061,12 +2061,12 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Returns a spliterator from a breadth-first iterator over this component.
+   * Returns a spliterator over this component backed by an iterator with the default type.
    *
-   * <p>The resulting iterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
+   * <p>The resulting spliterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
    *
    * @return the iterator
-   * @see ComponentIteratorType#BREADTH_FIRST
+   * @see ComponentIteratorType#defaultType()
    * @since 4.8.0
    */
   @Override
@@ -2075,9 +2075,9 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Returns a spliterator from this component's iterator.
+   * Returns a spliterator over this component backed by an iterator with a given type.
    *
-   * <p>The resulting iterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
+   * <p>The resulting spliterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
    *
    * @param type the type of the underlying iterator
    * @return the iterator

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -97,7 +97,7 @@ import org.jetbrains.annotations.Unmodifiable;
  * @since 4.0.0
  */
 @ApiStatus.NonExtendable
-public interface Component extends ComponentBuilderApplicable, ComponentLike, Examinable, HoverEventSource<Component>, Iterable<Component> {
+public interface Component extends ComponentBuilderApplicable, ComponentLike, Examinable, HoverEventSource<Component> {
   /**
    * A predicate that checks equality of two {@code Component}s using {@link Objects#equals(Object, Object)}.
    *
@@ -110,6 +110,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   BiPredicate<? super Component, ? super Component> EQUALS_IDENTITY = (a, b) -> a == b;
+
   /**
    * Gets an empty component.
    *
@@ -2019,35 +2020,20 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @NotNull Component compact();
 
   /**
-   * Creates an iterable over this component with a given type.
+   * Returns an iterable view of this component.
    *
    * @param type the type
    * @return the iterable
    * @see ComponentIteratorType
    * @since 4.8.0
    */
-  default @NonNull Iterable<Component> iterable(final @NonNull ComponentIteratorType type) {
+  default @NotNull Iterable<Component> iterable(final @NotNull ComponentIteratorType type) {
     Objects.requireNonNull(type, "type");
-    if(type == ComponentIteratorType.defaultType()) return this;
     return new ForwardingIterator<>(() -> this.iterator(type), () -> this.spliterator(type));
   }
 
   /**
-   * Returns an iterator over this component and it's children using the default iterator type.
-   *
-   * <p>As components are immutable, this iterator does not support removal.</p>
-   *
-   * @return the iterator
-   * @see ComponentIteratorType#defaultType()
-   * @since 4.8.0
-   */
-  @Override
-  default @NonNull Iterator<Component> iterator() {
-    return this.iterator(ComponentIteratorType.defaultType());
-  }
-
-  /**
-   * Returns an iterator of a given type over this component and it's children.
+   * Returns an iterator for this component.
    *
    * <p>As components are immutable, this iterator does not support removal.</p>
    *
@@ -2056,26 +2042,12 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @see ComponentIteratorType
    * @since 4.8.0
    */
-  default @NonNull Iterator<Component> iterator(final @NonNull ComponentIteratorType type) {
+  default @NotNull Iterator<Component> iterator(final @NotNull ComponentIteratorType type) {
     return new ComponentIterator(this, type);
   }
 
   /**
-   * Returns a spliterator over this component backed by an iterator with the default type.
-   *
-   * <p>The resulting spliterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
-   *
-   * @return the iterator
-   * @see ComponentIteratorType#defaultType()
-   * @since 4.8.0
-   */
-  @Override
-  default @NonNull Spliterator<Component> spliterator() {
-    return this.spliterator(ComponentIteratorType.defaultType());
-  }
-
-  /**
-   * Returns a spliterator over this component backed by an iterator with a given type.
+   * Returns a spliterator for this component.
    *
    * <p>The resulting spliterator has the {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED} characteristics.</p>
    *
@@ -2084,7 +2056,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @see ComponentIteratorType
    * @since 4.8.0
    */
-  default @NonNull Spliterator<Component> spliterator(final @NonNull ComponentIteratorType type) {
+  default @NotNull Spliterator<Component> spliterator(final @NotNull ComponentIteratorType type) {
     return Spliterators.spliteratorUnknownSize(this.iterator(type), Spliterator.IMMUTABLE & Spliterator.NONNULL & Spliterator.ORDERED);
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2030,6 +2030,18 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Returns a spliterator from this component's iterator.
+   * <p>The resulting iterator has the {@link Spliterator#IMMUTABLE} and {@link Spliterator#NONNULL} characteristics.</p>
+   *
+   * @return the iterator
+   * @since 4.8.0
+   */
+  @Override
+  default @NonNull Spliterator<Component> spliterator() {
+    return Spliterators.spliteratorUnknownSize(this.iterator(), Spliterator.IMMUTABLE & Spliterator.NONNULL);
+  }
+
+  /**
    * Finds and replaces text within any {@link Component}s using a string literal.
    *
    * @param search a string literal

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -47,7 +47,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.translation.Translatable;
 import net.kyori.adventure.util.Buildable;
-import net.kyori.adventure.util.DelegatingIterable;
+import net.kyori.adventure.util.ForwardingIterator;
 import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
@@ -2029,7 +2029,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   default @NonNull Iterable<Component> iterable(final @NonNull ComponentIteratorType type) {
     Objects.requireNonNull(type, "type");
     if(type == ComponentIteratorType.defaultType()) return this;
-    return new DelegatingIterable<>(() -> this.iterator(type), () -> this.spliterator(type));
+    return new ForwardingIterator<>(() -> this.iterator(type), () -> this.spliterator(type));
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
@@ -30,22 +30,22 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 final class ComponentIterator implements Iterator<Component> {
-  static final BiConsumer<Component, Deque<Component>> HOVER_EVENT_CONSUMER = (component, deque) -> {
+  static final BiConsumer<Deque<Component>, Component> HOVER_EVENT_CONSUMER = (deque, component) -> {
     final HoverEvent<?> hoverEvent = component.hoverEvent();
 
-    if(hoverEvent == null) return;
+    if (hoverEvent == null) return;
 
     final Object value = hoverEvent.value();
 
-    if(value instanceof Component) {
+    if (value instanceof Component) {
       deque.addFirst((Component) value);
-    } else if(value instanceof HoverEvent.ShowEntity) {
+    } else if (value instanceof HoverEvent.ShowEntity) {
       final Component name = ((HoverEvent.ShowEntity) value).name();
 
-      if(name != null) {
+      if (name != null) {
         deque.addFirst(name);
       }
     }
@@ -55,7 +55,7 @@ final class ComponentIterator implements Iterator<Component> {
   private final ComponentIteratorType type;
   private final Deque<Component> deque;
 
-  ComponentIterator(final @NonNull Component component, final @NonNull ComponentIteratorType type) {
+  ComponentIterator(final @NotNull Component component, final @NotNull ComponentIteratorType type) {
     this.component = Objects.requireNonNull(component, "component");
     this.type = Objects.requireNonNull(type, "type");
     this.deque = new ArrayDeque<>();
@@ -68,13 +68,13 @@ final class ComponentIterator implements Iterator<Component> {
 
   @Override
   public Component next() {
-    if(this.component != null) {
+    if (this.component != null) {
       final Component next = this.component;
       this.component = null;
       this.type.populate(next, this.deque);
       return next;
     } else {
-      if(this.deque.isEmpty()) throw new NoSuchElementException();
+      if (this.deque.isEmpty()) throw new NoSuchElementException();
       this.component = this.deque.poll();
       return this.next();
     }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
@@ -31,46 +31,15 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-/**
- * An iterator that traverses a component and it's children.
- * <p>As components are immutable, this iterator does not support removal.</p>
- *
- * @see Component#iterator()
- * @since 4.8.0
- */
-public final class ComponentIterator implements Iterator<Component> {
-  private final Deque<Component> queue;
-  private final boolean bfs;
+final class ComponentIterator implements Iterator<Component> {
   private Component component;
+  private final ComponentIteratorType type;
+  private final Deque<Component> queue;
 
-  /**
-   * Creates an iterable for a component with a given type.
-   *
-   * @param component the component
-   * @param type the type
-   * @return the iterable
-   * @since 4.8.0
-   */
-  public static Iterable<Component> iterable(final @NonNull Component component, final @NonNull Type type) {
-    return () -> iterator(component, type);
-  }
-
-  /**
-   * Creates an iterator on a component with a given type.
-   *
-   * @param component the component
-   * @param type the type
-   * @return the iterable
-   * @since 4.8.0
-   */
-  public static Iterator<Component> iterator(final @NonNull Component component, final @NonNull Type type) {
-    return new ComponentIterator(component, type);
-  }
-
-  private ComponentIterator(final @NonNull Component component, final @NonNull Type type) {
+  ComponentIterator(final @NonNull Component component, final @NonNull ComponentIteratorType type) {
     this.component = Objects.requireNonNull(component, "component");
+    this.type = Objects.requireNonNull(type, "type");
     this.queue = new ArrayDeque<>();
-    this.bfs = Objects.requireNonNull(type, "type") == Type.BREADTH_FIRST;
   }
 
   @Override
@@ -86,13 +55,7 @@ public final class ComponentIterator implements Iterator<Component> {
 
       final List<Component> children = next.children();
       if(!children.isEmpty()) {
-        if(this.bfs) {
-          this.queue.addAll(next.children());
-        } else {
-          for(int i = children.size() - 1; i >= 0; i--) {
-            this.queue.addFirst(children.get(i));
-          }
-        }
+        this.addChildren(children);
       }
 
       return next;
@@ -103,24 +66,16 @@ public final class ComponentIterator implements Iterator<Component> {
     }
   }
 
-  /**
-   * The iterator types.
-   *
-   * @since 4.8.0
-   */
-  public enum Type {
-    /**
-     * A depth first search.
-     *
-     * @since 4.8.0
-     */
-    DEPTH_FIRST,
-
-    /**
-     * A breadth first search.
-     *
-     * @since 4.8.0
-     */
-    BREADTH_FIRST;
+  private void addChildren(final @NonNull List<Component> children) {
+    switch(this.type) {
+      case DEPTH_FIRST:
+        for(int i = children.size() - 1; i >= 0; i--) {
+          this.queue.addFirst(children.get(i));
+        }
+        break;
+      case BREADTH_FIRST:
+        this.queue.addAll(children);
+        break;
+    }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
@@ -40,8 +40,15 @@ final class ComponentIterator implements Iterator<Component> {
 
     final Object value = hoverEvent.value();
 
-    if(value instanceof Component) deque.addFirst((Component) value);
-    else if(value instanceof HoverEvent.ShowEntity) deque.addFirst(((HoverEvent.ShowEntity) value).name());
+    if(value instanceof Component) {
+      deque.addFirst((Component) value);
+    } else if(value instanceof HoverEvent.ShowEntity) {
+      final HoverEvent.ShowEntity showEntity = (HoverEvent.ShowEntity) value;
+
+      if (showEntity.name() != null) {
+        deque.addFirst(((HoverEvent.ShowEntity) value).name());
+      }
+    }
   };
 
   private Component component;

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
@@ -43,10 +43,10 @@ final class ComponentIterator implements Iterator<Component> {
     if(value instanceof Component) {
       deque.addFirst((Component) value);
     } else if(value instanceof HoverEvent.ShowEntity) {
-      final HoverEvent.ShowEntity showEntity = (HoverEvent.ShowEntity) value;
+      final Component name = ((HoverEvent.ShowEntity) value).name();
 
-      if (showEntity.name() != null) {
-        deque.addFirst(((HoverEvent.ShowEntity) value).name());
+      if(name != null) {
+        deque.addFirst(name);
       }
     }
   };
@@ -71,11 +71,7 @@ final class ComponentIterator implements Iterator<Component> {
     if(this.component != null) {
       final Component next = this.component;
       this.component = null;
-
-      if(!next.children().isEmpty()) {
-        this.type.populate(next, this.deque);
-      }
-
+      this.type.populate(next, this.deque);
       return next;
     } else {
       if(this.deque.isEmpty()) throw new NoSuchElementException();

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
@@ -1,0 +1,103 @@
+package net.kyori.adventure.text;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * An iterator that traverses a component and it's children.
+ * <p>As components are immutable, this iterator does not support removal.</p>
+ *
+ * @see Component#iterator()
+ * @since 4.8.0
+ */
+public final class ComponentIterator implements Iterator<Component> {
+  private final Deque<Component> queue;
+  private final boolean bfs;
+  private Component component;
+
+  /**
+   * Creates an iterable for a component with a given type.
+   *
+   * @param component the component
+   * @param type the type
+   * @return the iterable
+   * @since 4.8.0
+   */
+  public static Iterable<Component> iterable(@NonNull Component component, @NonNull Type type) {
+    return () -> iterator(component, type);
+  }
+
+  /**
+   * Creates an iterator on a component with a given type.
+   *
+   * @param component the component
+   * @param type the type
+   * @return the iterable
+   * @since 4.8.0
+   */
+  public static Iterator<Component> iterator(@NonNull Component component, @NonNull Type type) {
+    return new ComponentIterator(component, type);
+  }
+
+  private ComponentIterator(@NonNull Component component, @NonNull Type type) {
+    this.component = Objects.requireNonNull(component, "component");
+    this.queue = new ArrayDeque<>();
+    this.bfs = Objects.requireNonNull(type, "type") == Type.BREADTH_FIRST;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return this.component != null || !this.queue.isEmpty();
+  }
+
+  @Override
+  public Component next() {
+    if(this.component != null) {
+      final Component next = this.component;
+      this.component = null;
+
+      final List<Component> children = next.children();
+      if(!children.isEmpty()) {
+        if(this.bfs) {
+          this.queue.addAll(next.children());
+        } else {
+          for(int i = children.size() - 1; i >= 0; i--) {
+            this.queue.addFirst(children.get(i));
+          }
+        }
+      }
+
+      return next;
+    } else {
+      if(this.queue.isEmpty()) throw new NoSuchElementException();
+      this.component = this.queue.poll();
+      return this.next();
+    }
+  }
+
+  /**
+   * The iterator types.
+   *
+   * @since 4.8.0
+   */
+  public enum Type {
+    /**
+     * A depth first search.
+     *
+     * @since 4.8.0
+     */
+    DEPTH_FIRST,
+
+    /**
+     * A breadth first search.
+     *
+     * @since 4.8.0
+     */
+    BREADTH_FIRST;
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package net.kyori.adventure.text;
 
 import java.util.ArrayDeque;
@@ -28,7 +51,7 @@ public final class ComponentIterator implements Iterator<Component> {
    * @return the iterable
    * @since 4.8.0
    */
-  public static Iterable<Component> iterable(@NonNull Component component, @NonNull Type type) {
+  public static Iterable<Component> iterable(final @NonNull Component component, final @NonNull Type type) {
     return () -> iterator(component, type);
   }
 
@@ -40,11 +63,11 @@ public final class ComponentIterator implements Iterator<Component> {
    * @return the iterable
    * @since 4.8.0
    */
-  public static Iterator<Component> iterator(@NonNull Component component, @NonNull Type type) {
+  public static Iterator<Component> iterator(final @NonNull Component component, final @NonNull Type type) {
     return new ComponentIterator(component, type);
   }
 
-  private ComponentIterator(@NonNull Component component, @NonNull Type type) {
+  private ComponentIterator(final @NonNull Component component, final @NonNull Type type) {
     this.component = Objects.requireNonNull(component, "component");
     this.queue = new ArrayDeque<>();
     this.bfs = Objects.requireNonNull(type, "type") == Type.BREADTH_FIRST;

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorFlag.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorFlag.java
@@ -23,42 +23,34 @@
  */
 package net.kyori.adventure.text;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.ApiStatus;
 
-final class ComponentIterator implements Iterator<Component> {
-  private Component component;
-  private final ComponentIteratorType type;
-  private final Set<ComponentIteratorFlag> flags;
-  private final Deque<Component> deque;
-
-  ComponentIterator(final @NotNull Component component, final @NotNull ComponentIteratorType type, final @NotNull Set<ComponentIteratorFlag> flags) {
-    this.component = component;
-    this.type = type;
-    this.flags = flags;
-    this.deque = new ArrayDeque<>();
-  }
-
-  @Override
-  public boolean hasNext() {
-    return this.component != null || !this.deque.isEmpty();
-  }
-
-  @Override
-  public Component next() {
-    if (this.component != null) {
-      final Component next = this.component;
-      this.component = null;
-      this.type.populate(next, this.deque, this.flags);
-      return next;
-    } else {
-      if (this.deque.isEmpty()) throw new NoSuchElementException();
-      this.component = this.deque.poll();
-      return this.next();
-    }
-  }
+/**
+ * Flags to modify the behaviour of a component iterator.
+ *
+ * @see Component#iterator(ComponentIteratorType, java.util.Set)
+ * @see Component#iterable(ComponentIteratorType, java.util.Set)
+ * @see Component#spliterator(ComponentIteratorType, java.util.Set)
+ * @since 4.9.0
+ */
+@ApiStatus.NonExtendable
+public enum ComponentIteratorFlag {
+  /**
+   * Includes the name of entities inside {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_ENTITY entity} hover events.
+   *
+   * @since 4.9.0
+   */
+  INCLUDE_SHOW_ENTITY_NAME,
+  /**
+   * Includes the components inside {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT text} hover events.
+   *
+   * @since 4.9.0
+   */
+  INCLUDE_SHOW_TEXT_COMPONENT,
+  /**
+   * Includes the arguments of {@link TranslatableComponent translatable components}.
+   *
+   * @since 4.9.0
+   */
+  INCLUDE_TRANSLATABLE_COMPONENT_ARGUMENTS;
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorFlag.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorFlag.java
@@ -40,13 +40,13 @@ public enum ComponentIteratorFlag {
    *
    * @since 4.9.0
    */
-  INCLUDE_SHOW_ENTITY_NAME,
+  INCLUDE_HOVER_SHOW_ENTITY_NAME,
   /**
    * Includes the components inside {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT text} hover events.
    *
    * @since 4.9.0
    */
-  INCLUDE_SHOW_TEXT_COMPONENT,
+  INCLUDE_HOVER_SHOW_TEXT_COMPONENT,
   /**
    * Includes the arguments of {@link TranslatableComponent translatable components}.
    *

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
@@ -37,13 +37,13 @@ import static net.kyori.adventure.text.ComponentIterator.HOVER_EVENT_CONSUMER;
  * @see Component#iterator(ComponentIteratorType)
  * @see Component#spliterator(ComponentIteratorType)
  * @see Component#iterable(ComponentIteratorType)
- * @since 4.8.0
+ * @since 4.9.0
  */
 public enum ComponentIteratorType {
   /**
    * A depth-first iteration.
    *
-   * @since 4.8.0
+   * @since 4.9.0
    */
   DEPTH_FIRST((deque, component) -> {
     final List<Component> children = component.children();
@@ -55,23 +55,21 @@ public enum ComponentIteratorType {
   /**
    * A breadth-first iteration.
    *
-   * @since 4.8.0
+   * @since 4.9.0
    */
   BREADTH_FIRST((deque, component) -> deque.addAll(component.children())),
 
   /**
    * A depth-first iteration that includes components from the {@link HoverEvent} class where the value is a component or the type is an entity with a name.
    *
-   * @see HoverEvent
-   * @since 4.8.0
+   * @since 4.9.0
    */
   DEPTH_FIRST_WITH_HOVER(HOVER_EVENT_CONSUMER.andThen(DEPTH_FIRST.consumer)),
 
   /**
    * A breadth-first iteration that includes components from the {@link HoverEvent} class where the value is a component or the type is an entity with a name.
    *
-   * @see HoverEvent
-   * @since 4.8.0
+   * @since 4.9.0
    */
   BREADTH_FIRST_WITH_HOVER(HOVER_EVENT_CONSUMER.andThen(BREADTH_FIRST.consumer));
 
@@ -86,7 +84,7 @@ public enum ComponentIteratorType {
    *
    * @param component the component
    * @param deque the deque
-   * @since 4.8.0
+   * @since 4.9.0
    */
   void populate(final @NonNull Component component, final @NonNull Deque<Component> deque) {
     this.consumer.accept(deque, component);

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * The iterator types.
+ *
+ * @see Component#iterator(ComponentIteratorType)
+ * @see Component#spliterator(ComponentIteratorType)
+ * @see Component#iterable(ComponentIteratorType)
+ * @since 4.8.0
+ */
+public enum ComponentIteratorType {
+  /**
+   * A depth first search.
+   *
+   * @since 4.8.0
+   */
+  DEPTH_FIRST,
+
+  /**
+   * A breadth first search.
+   *
+   * @since 4.8.0
+   */
+  BREADTH_FIRST;
+
+  /**
+   * The default iterator type used in the implementation of {@link Iterable} in {@link Component}.
+   *
+   * @return the default type
+   * @see Component#iterator()
+   * @see Component#spliterator()
+   * @since 4.8.0
+   */
+  public static @NonNull ComponentIteratorType defaultType() {
+    return DEPTH_FIRST;
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
@@ -41,26 +41,26 @@ import static net.kyori.adventure.text.ComponentIterator.HOVER_EVENT_CONSUMER;
  */
 public enum ComponentIteratorType {
   /**
-   * A depth-first search.
+   * A depth-first iteration.
    *
    * @since 4.8.0
    */
-  DEPTH_FIRST((component, deque) -> {
+  DEPTH_FIRST((deque, component) -> {
     final List<Component> children = component.children();
-    for(int i = children.size() - 1; i >= 0; i--) {
+    for (int i = children.size() - 1; i >= 0; i--) {
       deque.addFirst(children.get(i));
     }
   }),
 
   /**
-   * A breadth-first search.
+   * A breadth-first iteration.
    *
    * @since 4.8.0
    */
-  BREADTH_FIRST((component, deque) -> deque.addAll(component.children())),
+  BREADTH_FIRST((deque, component) -> deque.addAll(component.children())),
 
   /**
-   * A depth-first search that includes components from the {@link HoverEvent} class where the value is a component or the type is an entity with a name.
+   * A depth-first iteration that includes components from the {@link HoverEvent} class where the value is a component or the type is an entity with a name.
    *
    * @see HoverEvent
    * @since 4.8.0
@@ -68,30 +68,16 @@ public enum ComponentIteratorType {
   DEPTH_FIRST_WITH_HOVER(HOVER_EVENT_CONSUMER.andThen(DEPTH_FIRST.consumer)),
 
   /**
-   * A breadth-first search that includes components from the {@link HoverEvent} class where the value is a component or the type is an entity with a name.
+   * A breadth-first iteration that includes components from the {@link HoverEvent} class where the value is a component or the type is an entity with a name.
    *
    * @see HoverEvent
    * @since 4.8.0
    */
   BREADTH_FIRST_WITH_HOVER(HOVER_EVENT_CONSUMER.andThen(BREADTH_FIRST.consumer));
 
-  /**
-   * The default iterator type used in the implementation of {@link Iterable} in {@link Component}.
-   *
-   * <p>Currently set to {@link #DEPTH_FIRST}.</p>
-   *
-   * @return the default type
-   * @see Component#iterator()
-   * @see Component#spliterator()
-   * @since 4.8.0
-   */
-  public static @NonNull ComponentIteratorType defaultType() {
-    return DEPTH_FIRST;
-  }
+  private final BiConsumer<Deque<Component>, Component> consumer;
 
-  private final BiConsumer<Component, Deque<Component>> consumer;
-
-  ComponentIteratorType(final @NonNull BiConsumer<Component, Deque<Component>> consumer) {
+  ComponentIteratorType(final @NonNull BiConsumer<Deque<Component>, Component> consumer) {
     this.consumer = consumer;
   }
 
@@ -103,6 +89,6 @@ public enum ComponentIteratorType {
    * @since 4.8.0
    */
   void populate(final @NonNull Component component, final @NonNull Deque<Component> deque) {
-    this.consumer.accept(component, deque);
+    this.consumer.accept(deque, component);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
@@ -96,7 +96,7 @@ public enum ComponentIteratorType {
   }
 
   /**
-   * Populates a deque wth the children of this component, based on the iterator type.
+   * Populates a deque with the children of this component, based on the iterator type.
    *
    * @param component the component
    * @param deque the deque

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
@@ -46,6 +46,15 @@ public enum ComponentIteratorType {
    * @since 4.9.0
    */
   DEPTH_FIRST((deque, component) -> {
+    if (component instanceof TranslatableComponent) {
+      final TranslatableComponent translatable = (TranslatableComponent) component;
+      final List<Component> args = translatable.args();
+
+      for (int i = args.size() - 1; i >= 0; i--) {
+        deque.addFirst(args.get(i));
+      }
+    }
+
     final List<Component> children = component.children();
     for (int i = children.size() - 1; i >= 0; i--) {
       deque.addFirst(children.get(i));
@@ -57,7 +66,13 @@ public enum ComponentIteratorType {
    *
    * @since 4.9.0
    */
-  BREADTH_FIRST((deque, component) -> deque.addAll(component.children())),
+  BREADTH_FIRST((deque, component) -> {
+    if (component instanceof TranslatableComponent) {
+      deque.addAll(((TranslatableComponent) component).args());
+    }
+
+    deque.addAll(component.children());
+  }),
 
   /**
    * A depth-first iteration that includes components from the {@link HoverEvent} class where the value is a component or the type is an entity with a name.

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
@@ -60,9 +60,9 @@ public interface ComponentIteratorType {
     if (hoverEvent != null) {
       final HoverEvent.Action<?> action = hoverEvent.action();
 
-      if (flags.contains(ComponentIteratorFlag.INCLUDE_SHOW_ENTITY_NAME) && action == HoverEvent.Action.SHOW_ENTITY) {
+      if (flags.contains(ComponentIteratorFlag.INCLUDE_HOVER_SHOW_ENTITY_NAME) && action == HoverEvent.Action.SHOW_ENTITY) {
         deque.addFirst(((HoverEvent.ShowEntity) hoverEvent.value()).name());
-      } else if (flags.contains(ComponentIteratorFlag.INCLUDE_SHOW_TEXT_COMPONENT) && action == HoverEvent.Action.SHOW_TEXT) {
+      } else if (flags.contains(ComponentIteratorFlag.INCLUDE_HOVER_SHOW_TEXT_COMPONENT) && action == HoverEvent.Action.SHOW_TEXT) {
         deque.addFirst((Component) hoverEvent.value());
       }
     }
@@ -86,9 +86,9 @@ public interface ComponentIteratorType {
     if (hoverEvent != null) {
       final HoverEvent.Action<?> action = hoverEvent.action();
 
-      if (flags.contains(ComponentIteratorFlag.INCLUDE_SHOW_ENTITY_NAME) && action == HoverEvent.Action.SHOW_ENTITY) {
+      if (flags.contains(ComponentIteratorFlag.INCLUDE_HOVER_SHOW_ENTITY_NAME) && action == HoverEvent.Action.SHOW_ENTITY) {
         deque.addLast(((HoverEvent.ShowEntity) hoverEvent.value()).name());
-      } else if (flags.contains(ComponentIteratorFlag.INCLUDE_SHOW_TEXT_COMPONENT) && action == HoverEvent.Action.SHOW_TEXT) {
+      } else if (flags.contains(ComponentIteratorFlag.INCLUDE_HOVER_SHOW_TEXT_COMPONENT) && action == HoverEvent.Action.SHOW_TEXT) {
         deque.addLast((Component) hoverEvent.value());
       }
     }

--- a/api/src/main/java/net/kyori/adventure/util/DelegatingIterable.java
+++ b/api/src/main/java/net/kyori/adventure/util/DelegatingIterable.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.util;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.function.Supplier;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * An iterable that delegates the {@link #iterator()} and {@link #spliterator()} calls to a {@link Supplier}.
+ *
+ * @param <T> the type of the iterable
+ * @since 4.8.0
+ */
+public final class DelegatingIterable<T> implements Iterable<T> {
+  private final Supplier<Iterator<T>> iteratorSupplier;
+  private final Supplier<Spliterator<T>> spliteratorSupplier;
+
+  /**
+   * Creates a new delegating iterable.
+   *
+   * @param iteratorSupplier the iterator supplier
+   * @param spliteratorSupplier the spliterator supplier
+   * @since 4.8.0
+   */
+  public DelegatingIterable(final @NonNull Supplier<Iterator<T>> iteratorSupplier, final @NonNull Supplier<Spliterator<T>> spliteratorSupplier) {
+    this.iteratorSupplier = Objects.requireNonNull(iteratorSupplier, "iteratorSupplier");
+    this.spliteratorSupplier = Objects.requireNonNull(spliteratorSupplier, "spliteratorSupplier");
+  }
+
+  @Override
+  public @NonNull Iterator<T> iterator() {
+    return this.iteratorSupplier.get();
+  }
+
+  @Override
+  public @NonNull Spliterator<T> spliterator() {
+    return this.spliteratorSupplier.get();
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/util/ForwardingIterator.java
+++ b/api/src/main/java/net/kyori/adventure/util/ForwardingIterator.java
@@ -30,34 +30,34 @@ import java.util.function.Supplier;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
- * An iterable that delegates the {@link #iterator()} and {@link #spliterator()} calls to a {@link Supplier}.
+ * An iterable that forwards the {@link #iterator()} and {@link #spliterator()} calls to some {@link Supplier suppliers}.
  *
  * @param <T> the type of the iterable
  * @since 4.8.0
  */
-public final class DelegatingIterable<T> implements Iterable<T> {
-  private final Supplier<Iterator<T>> iteratorSupplier;
-  private final Supplier<Spliterator<T>> spliteratorSupplier;
+public final class ForwardingIterator<T> implements Iterable<T> {
+  private final Supplier<Iterator<T>> iterator;
+  private final Supplier<Spliterator<T>> spliterator;
 
   /**
-   * Creates a new delegating iterable.
+   * Creates a new forwarding iterable.
    *
-   * @param iteratorSupplier the iterator supplier
-   * @param spliteratorSupplier the spliterator supplier
+   * @param iterator the iterator supplier
+   * @param spliterator the spliterator supplier
    * @since 4.8.0
    */
-  public DelegatingIterable(final @NonNull Supplier<Iterator<T>> iteratorSupplier, final @NonNull Supplier<Spliterator<T>> spliteratorSupplier) {
-    this.iteratorSupplier = Objects.requireNonNull(iteratorSupplier, "iteratorSupplier");
-    this.spliteratorSupplier = Objects.requireNonNull(spliteratorSupplier, "spliteratorSupplier");
+  public ForwardingIterator(final @NonNull Supplier<Iterator<T>> iterator, final @NonNull Supplier<Spliterator<T>> spliterator) {
+    this.iterator = Objects.requireNonNull(iterator, "iterator");
+    this.spliterator = Objects.requireNonNull(spliterator, "spliterator");
   }
 
   @Override
   public @NonNull Iterator<T> iterator() {
-    return this.iteratorSupplier.get();
+    return this.iterator.get();
   }
 
   @Override
   public @NonNull Spliterator<T> spliterator() {
-    return this.spliteratorSupplier.get();
+    return this.spliterator.get();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/ForwardingIterator.java
+++ b/api/src/main/java/net/kyori/adventure/util/ForwardingIterator.java
@@ -33,7 +33,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * An iterable that forwards the {@link #iterator()} and {@link #spliterator()} calls to some {@link Supplier suppliers}.
  *
  * @param <T> the type of the iterable
- * @since 4.8.0
+ * @since 4.9.0
  */
 public final class ForwardingIterator<T> implements Iterable<T> {
   private final Supplier<Iterator<T>> iterator;
@@ -44,7 +44,7 @@ public final class ForwardingIterator<T> implements Iterable<T> {
    *
    * @param iterator the iterator supplier
    * @param spliterator the spliterator supplier
-   * @since 4.8.0
+   * @since 4.9.0
    */
   public ForwardingIterator(final @NonNull Supplier<Iterator<T>> iterator, final @NonNull Supplier<Spliterator<T>> spliterator) {
     this.iterator = Objects.requireNonNull(iterator, "iterator");

--- a/api/src/main/java/net/kyori/adventure/util/ForwardingIterator.java
+++ b/api/src/main/java/net/kyori/adventure/util/ForwardingIterator.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.function.Supplier;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An iterable that forwards the {@link #iterator()} and {@link #spliterator()} calls to some {@link Supplier suppliers}.
@@ -46,18 +46,18 @@ public final class ForwardingIterator<T> implements Iterable<T> {
    * @param spliterator the spliterator supplier
    * @since 4.9.0
    */
-  public ForwardingIterator(final @NonNull Supplier<Iterator<T>> iterator, final @NonNull Supplier<Spliterator<T>> spliterator) {
+  public ForwardingIterator(final @NotNull Supplier<Iterator<T>> iterator, final @NotNull Supplier<Spliterator<T>> spliterator) {
     this.iterator = Objects.requireNonNull(iterator, "iterator");
     this.spliterator = Objects.requireNonNull(spliterator, "spliterator");
   }
 
   @Override
-  public @NonNull Iterator<T> iterator() {
+  public @NotNull Iterator<T> iterator() {
     return this.iterator.get();
   }
 
   @Override
-  public @NonNull Spliterator<T> spliterator() {
+  public @NotNull Spliterator<T> spliterator() {
     return this.spliterator.get();
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text;
 
 import java.util.UUID;
-import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -123,7 +122,7 @@ class ComponentIteratorTest {
     boolean foundEntity = false;
 
     for(final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST_WITH_HOVER)) {
-      if (inner instanceof TextComponent) {
+      if(inner instanceof TextComponent) {
         final TextComponent text = (TextComponent) inner;
 
         if(text.content().equals("TEXT")) foundText = true;

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -50,7 +50,7 @@ public class ComponentIteratorTest {
 
   @Test
   public void testOfEmpty() {
-    for(Component component : Component.empty()) {
+    for(final Component component : Component.empty()) {
       if(component.equals(Component.empty())) {
         return;
       }
@@ -67,7 +67,7 @@ public class ComponentIteratorTest {
       .append(Component.text("WIDE"))
       .build();
 
-    for(Component inner : ComponentIterator.iterable(component, ComponentIterator.Type.DEPTH_FIRST)) {
+    for(final Component inner : ComponentIterator.iterable(component, ComponentIterator.Type.DEPTH_FIRST)) {
       if(inner instanceof TextComponent) {
         final String content = ((TextComponent) inner).content();
 
@@ -91,7 +91,7 @@ public class ComponentIteratorTest {
       .append(Component.text("WIDE"))
       .build();
 
-    for(Component inner : ComponentIterator.iterable(component, ComponentIterator.Type.BREADTH_FIRST)) {
+    for(final Component inner : ComponentIterator.iterable(component, ComponentIterator.Type.BREADTH_FIRST)) {
       if(inner instanceof TextComponent) {
         final String content = ((TextComponent) inner).content();
 

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -46,15 +46,17 @@ class ComponentIteratorTest {
       .append(Component.translatable("some.adjective"))
       .append(Component.text(" band", NamedTextColor.GREEN).hoverEvent(HoverEvent.showText(Component.text("ever"))))
       .append(Component.text("."))
-      .build().forEach(component -> hits[0]++);
+      .build()
+      .iterable(ComponentIteratorType.DEPTH_FIRST)
+      .forEach(component -> hits[0]++);
 
     assertEquals(6, hits[0]);
   }
 
   @Test
   public void testOfEmpty() {
-    for(final Component component : Component.empty()) {
-      if(component.equals(Component.empty())) {
+    for (final Component component : Component.empty().iterable(ComponentIteratorType.DEPTH_FIRST)) {
+      if (component.equals(Component.empty())) {
         return;
       }
     }
@@ -70,14 +72,14 @@ class ComponentIteratorTest {
       .append(Component.text("WIDE"))
       .build();
 
-    for(final Component inner : component.iterable(ComponentIteratorType.DEPTH_FIRST)) {
-      if(inner instanceof TextComponent) {
+    for (final Component inner : component.iterable(ComponentIteratorType.DEPTH_FIRST)) {
+      if (inner instanceof TextComponent) {
         final String content = ((TextComponent) inner).content();
 
-        if(content.equals("WIDE")) {
+        if (content.equals("WIDE")) {
           fail("WIDE before DEEP");
           return;
-        } else if(content.equals("DEEP")) {
+        } else if (content.equals("DEEP")) {
           return;
         }
       }
@@ -94,14 +96,14 @@ class ComponentIteratorTest {
       .append(Component.text("WIDE"))
       .build();
 
-    for(final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST)) {
-      if(inner instanceof TextComponent) {
+    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST)) {
+      if (inner instanceof TextComponent) {
         final String content = ((TextComponent) inner).content();
 
-        if(content.equals("DEEP")) {
+        if (content.equals("DEEP")) {
           fail("DEEP before WIDE");
           return;
-        } else if(content.equals("WIDE")) {
+        } else if (content.equals("WIDE")) {
           return;
         }
       }
@@ -121,12 +123,12 @@ class ComponentIteratorTest {
     boolean foundText = false;
     boolean foundEntity = false;
 
-    for(final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST_WITH_HOVER)) {
-      if(inner instanceof TextComponent) {
+    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST_WITH_HOVER)) {
+      if (inner instanceof TextComponent) {
         final TextComponent text = (TextComponent) inner;
 
-        if(text.content().equals("TEXT")) foundText = true;
-        else if(text.content().equals("ENTITY")) foundEntity = true;
+        if (text.content().equals("TEXT")) foundText = true;
+        else if (text.content().equals("ENTITY")) foundEntity = true;
       }
     }
 

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -23,11 +23,15 @@
  */
 package net.kyori.adventure.text;
 
+import java.util.UUID;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class ComponentIteratorTest {
@@ -105,5 +109,29 @@ class ComponentIteratorTest {
     }
 
     fail("target component not found");
+  }
+
+  @Test
+  public void testOfHover() {
+    final Component component = Component.text()
+      .append(Component.text("WITH TEXT").hoverEvent(Component.text("TEXT")))
+      .append(Component.text("WITH ENTITY")
+        .hoverEvent(HoverEvent.showEntity(Key.key("minecraft:pig"), UUID.randomUUID(), Component.text("ENTITY"))))
+      .build();
+
+    boolean foundText = false;
+    boolean foundEntity = false;
+
+    for(final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST_WITH_HOVER)) {
+      if (inner instanceof TextComponent) {
+        final TextComponent text = (TextComponent) inner;
+
+        if(text.content().equals("TEXT")) foundText = true;
+        else if(text.content().equals("ENTITY")) foundEntity = true;
+      }
+    }
+
+    assertTrue(foundText, "Could not locate text in component hover event.");
+    assertTrue(foundEntity, "Could not locate entity display name in entity hover event.");
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -67,7 +67,7 @@ public class ComponentIteratorTest {
       .append(Component.text("WIDE"))
       .build();
 
-    for(final Component inner : ComponentIterator.iterable(component, ComponentIterator.Type.DEPTH_FIRST)) {
+    for(final Component inner : component.iterable(ComponentIteratorType.DEPTH_FIRST)) {
       if(inner instanceof TextComponent) {
         final String content = ((TextComponent) inner).content();
 
@@ -91,7 +91,7 @@ public class ComponentIteratorTest {
       .append(Component.text("WIDE"))
       .build();
 
-    for(final Component inner : ComponentIterator.iterable(component, ComponentIterator.Type.BREADTH_FIRST)) {
+    for(final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST)) {
       if(inner instanceof TextComponent) {
         final String content = ((TextComponent) inner).content();
 

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ComponentIteratorTest {
+
+  @Test
+  public void testOf() {
+    final int[] hits = {0};
+
+    Component.text()
+      .content("Purity Ring ")
+      .append(Component.text("are absolutely ", NamedTextColor.DARK_PURPLE))
+      .append(Component.text("the best "))
+      .append(Component.translatable("some.adjective"))
+      .append(Component.text(" band", NamedTextColor.GREEN).hoverEvent(HoverEvent.showText(Component.text("ever"))))
+      .append(Component.text("."))
+      .build().forEach(component -> hits[0]++);
+
+    assertEquals(6, hits[0]);
+  }
+
+  @Test
+  public void testOfEmpty() {
+    for(Component component : Component.empty()) {
+      if(component.equals(Component.empty())) {
+        return;
+      }
+    }
+
+    fail("root component wasn't located");
+  }
+
+  @Test
+  public void testOfDfs() {
+    final Component component = Component.text()
+      .content("SKIP")
+      .append(Component.text("SKIP").append(Component.text("DEEP")))
+      .append(Component.text("WIDE"))
+      .build();
+
+    for(Component inner : ComponentIterator.iterable(component, ComponentIterator.Type.DEPTH_FIRST)) {
+      if(inner instanceof TextComponent) {
+        final String content = ((TextComponent) inner).content();
+
+        if(content.equals("WIDE")) {
+          fail("WIDE before DEEP");
+          return;
+        } else if(content.equals("DEEP")) {
+          return;
+        }
+      }
+    }
+
+    fail("target component not found");
+  }
+
+  @Test
+  public void testOfBfs() {
+    final Component component = Component.text()
+      .content("SKIP")
+      .append(Component.text("SKIP").append(Component.text("DEEP")))
+      .append(Component.text("WIDE"))
+      .build();
+
+    for(Component inner : ComponentIterator.iterable(component, ComponentIterator.Type.BREADTH_FIRST)) {
+      if(inner instanceof TextComponent) {
+        final String content = ((TextComponent) inner).content();
+
+        if(content.equals("DEEP")) {
+          fail("DEEP before WIDE");
+          return;
+        } else if(content.equals("WIDE")) {
+          return;
+        }
+      }
+    }
+
+    fail("target component not found");
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ComponentIteratorTest {
+class ComponentIteratorTest {
 
   @Test
   public void testOf() {

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -123,7 +123,7 @@ class ComponentIteratorTest {
     boolean foundText = false;
     boolean foundEntity = false;
 
-    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST_WITH_HOVER)) {
+    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST, ComponentIteratorFlag.INCLUDE_SHOW_TEXT_COMPONENT, ComponentIteratorFlag.INCLUDE_SHOW_ENTITY_NAME)) {
       if (inner instanceof TextComponent) {
         final TextComponent text = (TextComponent) inner;
 
@@ -143,7 +143,7 @@ class ComponentIteratorTest {
       .append(Component.translatable("translatable", Component.text("ARG")))
       .build();
 
-    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST)) {
+    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST, ComponentIteratorFlag.INCLUDE_TRANSLATABLE_COMPONENT_ARGUMENTS)) {
       if (inner instanceof TextComponent) {
         final TextComponent text = (TextComponent) inner;
 

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -123,7 +123,7 @@ class ComponentIteratorTest {
     boolean foundText = false;
     boolean foundEntity = false;
 
-    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST, ComponentIteratorFlag.INCLUDE_SHOW_TEXT_COMPONENT, ComponentIteratorFlag.INCLUDE_SHOW_ENTITY_NAME)) {
+    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST, ComponentIteratorFlag.INCLUDE_HOVER_SHOW_TEXT_COMPONENT, ComponentIteratorFlag.INCLUDE_HOVER_SHOW_ENTITY_NAME)) {
       if (inner instanceof TextComponent) {
         final TextComponent text = (TextComponent) inner;
 

--- a/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentIteratorTest.java
@@ -135,4 +135,22 @@ class ComponentIteratorTest {
     assertTrue(foundText, "Could not locate text in component hover event.");
     assertTrue(foundEntity, "Could not locate entity display name in entity hover event.");
   }
+
+  @Test
+  public void testOfTranslatableArguments() {
+    final Component component = Component.text()
+      .append(Component.text("TEXT"))
+      .append(Component.translatable("translatable", Component.text("ARG")))
+      .build();
+
+    for (final Component inner : component.iterable(ComponentIteratorType.BREADTH_FIRST)) {
+      if (inner instanceof TextComponent) {
+        final TextComponent text = (TextComponent) inner;
+
+        if (text.content().equals("ARG")) return;
+      }
+    }
+
+    fail("Could not locale the arg of a translatable component.");
+  }
 }


### PR DESCRIPTION
Following the discussion in https://github.com/KyoriPowered/adventure/pull/310#discussion_r599837951, this PR makes the `Component` class implement `Iterable<Component>`, allowing developers to iterate through a component and their children recursively. As component are immutable, the iterator does not support removal and it will throw an exception as per the definition of the class where removal isn't supported.

There are two types of iterator included, a depth first and a breadth first one. As the breadth first iterator is slightly more performant, this is the iterator type that is returned by the implementation of the `Iterable` class in the `Component` class. The other iterator can be obtained from `ComponentIterator.iterator(component, ComponentIterator.Type.DEPTH_FIRST)`. Additionally, this class also contains a method that returns an `Iterable` using a similar method, in order to allow for each looping over a component using the other iterator type.