### PR TITLE
api: Add joinWithFinalSeparator

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -146,17 +146,57 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _ -> new", pure = true)
   static @NonNull TextComponent join(final @NonNull ComponentLike separator, final Iterable<? extends ComponentLike> components) {
+    return joinWithFinalSeparator(separator, separator, components);
+  }
+
+  /**
+   * Joins {@code components} using {@code separator} with {@code finalSeparator} between the last two components.
+   *
+   * @param separator the separator
+   * @param finalSeparator the final separator
+   * @param components the components
+   * @return a text component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NonNull TextComponent joinWithFinalSeparator(final @NonNull ComponentLike separator, final @NonNull ComponentLike finalSeparator, final @NonNull ComponentLike@NonNull... components) {
+    return joinWithFinalSeparator(separator, finalSeparator, Arrays.asList(components));
+  }
+
+  /**
+   * Joins {@code components} using {@code separator} with {@code finalSeparator} between the last two components.
+   *
+   * @param separator the separator
+   * @param finalSeparator the final separator
+   * @param components the components
+   * @return a text component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NonNull TextComponent joinWithFinalSeparator(final @NonNull ComponentLike separator, final @NonNull ComponentLike finalSeparator, final @NonNull Iterable<? extends ComponentLike> components) {
     final Iterator<? extends ComponentLike> it = components.iterator();
     if(!it.hasNext()) {
       return Component.empty();
     }
+
     final TextComponent.Builder builder = text();
-    while(it.hasNext()) {
-      builder.append(it.next());
-      if(it.hasNext()) {
-        builder.append(separator);
+    ComponentLike component = it.next();
+    while(true) {
+      builder.append(component);
+
+      if(!it.hasNext()) {
+        break;
+      } else {
+        component = it.next();
+
+        if(it.hasNext()) {
+          builder.append(separator);
+        } else {
+          builder.append(finalSeparator);
+        }
       }
     }
+
     return builder.build();
   }
 

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -176,4 +176,42 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       c0
     );
   }
+
+  @Test
+  void testJoinWithFinalSeparator() {
+    assertEquals(Component.empty(), Component.joinWithFinalSeparator(Component.space(), Component.space(), Collections.emptyList()));
+
+    final Component c0 = Component.joinWithFinalSeparator(
+      Component.space(),
+      Component.text(" and "),
+      IntStream.range(0, 3)
+        .mapToObj(Component::text)
+      .toArray(Component[]::new)
+    );
+    assertEquals(
+      Component.text()
+        .append(Component.text(0))
+        .append(Component.space())
+        .append(Component.text(1))
+        .append(Component.text(" and "))
+        .append(Component.text(2))
+        .build(),
+      c0
+    );
+
+    final Component c1 = Component.joinWithFinalSeparator(
+      Component.space(),
+      Component.text(" or "),
+      Component.text(0),
+      Component.text(1)
+    );
+    assertEquals(
+      Component.text()
+        .append(Component.text(0))
+        .append(Component.text(" or "))
+        .append(Component.text(1))
+        .build(),
+      c1
+    );
+  }
 }


### PR DESCRIPTION
This PR adds a sister method of `Component#join` which is functionally the same but with the final separator being separate from the rest. This allows for joining components into strings like `1, 2 or 3`.

Tests are also added and the current `join` method has been modified to just overload the current.

Open for feedback on the name as it feels a bit shit :grimacing: 