### PR TITLE
text-serializer-gson: Add color stripping serializer

### DIFF
--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -110,6 +110,34 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
   @NonNull JsonElement serializeToTree(final @NonNull Component component);
 
   /**
+   * Color modes for serializing colors.
+   *
+   * @since 4.8.0
+   */
+  enum ColorMode {
+    /**
+     * The default color mode. All colors will be serialized as they are.
+     *
+     * @since 4.8.0
+     */
+    STANDARD,
+
+    /**
+     * Colors will be downsampled to the nearest named color.
+     *
+     * @since 4.8.0
+     */
+    DOWNSAMPLE,
+
+    /**
+     * Colors will not be present in the output.
+     *
+     * @since 4.8.0
+     */
+    STRIP;
+  }
+
+  /**
    * A builder for {@link GsonComponentSerializer}.
    *
    * @since 4.0.0
@@ -120,8 +148,21 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      *
      * @return this builder
      * @since 4.0.0
+     * @deprecated Use {@link #colorMode(ColorMode)} with {@link ColorMode#DOWNSAMPLE}.
      */
-    @NonNull Builder downsampleColors();
+    @Deprecated
+    default @NonNull Builder downsampleColors() {
+      return this.colorMode(ColorMode.DOWNSAMPLE);
+    }
+
+    /**
+     * Sets the color mode for the serializer.
+     *
+     * @param colorMode the color mode
+     * @return this builder
+     * @since 4.8.0
+     */
+    @NonNull Builder colorMode(final @NonNull ColorMode colorMode);
 
     /**
      * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.

--- a/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerTest.java
+++ b/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerTest.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonPrimitive;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.serializer.gson.GsonTest.array;
@@ -77,6 +78,20 @@ class GsonComponentSerializerTest {
     final Component test = Component.text(builder -> builder.content("hey").append(Component.text("there", original)));
 
     assertEquals("{\"extra\":[{\"color\":\"" + name(downsampled) + "\",\"text\":\"there\"}],\"text\":\"hey\"}", GsonComponentSerializer.colorDownsamplingGson().serializer().toJson(test));
+  }
+
+  @Test
+  public void testColorStripping() {
+    final GsonComponentSerializer serializer = GsonComponentSerializer.builder().colorMode(GsonComponentSerializer.ColorMode.STRIP).build();
+    final Component c0 = Component.text()
+      .append(Component.text("Dogs ", NamedTextColor.RED))
+      .append(Component.text("suck!", NamedTextColor.BLACK, TextDecoration.BOLD, TextDecoration.UNDERLINED))
+      .build();
+
+    assertEquals("{\"extra\":[{\"text\":\"Dogs \"},{\"bold\":true,\"underlined\":true,\"text\":\"suck!\"}],\"text\":\"\"}", serializer.serialize(c0));
+
+    final Component c1 = Component.text("meow", TextColor.fromCSSHexString("#FF69B4"));
+    assertEquals("{\"text\":\"meow\"}", serializer.serialize(c1));
   }
 
   private static String name(final NamedTextColor color) {


### PR DESCRIPTION
This PR adds an additional way of serializing components that strips them of all color.

In order to facilitate this, a new enum is created that contains the different ways of processing colors.