### PR TITLE
Annotate more deprecated methods with `ScheduledForRemoval`

### DIFF
--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
@@ -71,6 +71,7 @@ public interface BossBar extends Examinable {
    * @deprecated for removal since 4.2.0, use {@link #MIN_PROGRESS}
    * @since 4.0.0
    */
+  @ApiStatus.ScheduledForRemoval
   @Deprecated
   float MIN_PERCENT = MIN_PROGRESS;
   /**
@@ -79,6 +80,7 @@ public interface BossBar extends Examinable {
    * @deprecated for removal since 4.2.0, use {@link #MAX_PROGRESS}
    * @since 4.0.0
    */
+  @ApiStatus.ScheduledForRemoval
   @Deprecated
   float MAX_PERCENT = MAX_PROGRESS;
 
@@ -210,6 +212,7 @@ public interface BossBar extends Examinable {
    * @deprecated for removal since 4.2.0, use {@link #progress()}
    * @since 4.0.0
    */
+  @ApiStatus.ScheduledForRemoval
   @Deprecated
   default float percent() {
     return this.progress();
@@ -226,6 +229,7 @@ public interface BossBar extends Examinable {
    * @deprecated for removal since 4.2.0, use {@link #progress(float)}
    * @since 4.0.0
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract("_ -> this")
   @Deprecated
   default @NonNull BossBar percent(final float progress) {
@@ -414,7 +418,9 @@ public interface BossBar extends Examinable {
      * @deprecated for removal since 4.2.0, use {@link #bossBarProgressChanged(BossBar, float, float)}
      * @since 4.0.0
      */
+    @ApiStatus.ScheduledForRemoval
     @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
     default void bossBarPercentChanged(final @NonNull BossBar bar, final float oldProgress, final float newProgress) {
     }
 

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1665,6 +1665,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
   default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement) {
@@ -1680,6 +1681,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
   default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
@@ -1695,6 +1697,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
   default @NonNull Component replaceFirstText(final @NonNull String search, final @Nullable ComponentLike replacement) {
@@ -1710,6 +1713,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
   default @NonNull Component replaceFirstText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
@@ -1726,6 +1730,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
   default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement, final int numberOfReplacements) {
@@ -1742,6 +1747,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
   default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final int numberOfReplacements) {
@@ -1760,6 +1766,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
   default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {
@@ -1778,6 +1785,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    * @deprecated for removal since 4.2.0, use {@link #replaceText(Consumer)} or {@link #replaceText(TextReplacementConfig)} instead.
    */
+  @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
   default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {


### PR DESCRIPTION
This PR annotates all deprecated methods which are currently manually marked as "for removal" with the `ScheduledForRemoval` annotation.