### PR TITLE
api: Add Translatable interface

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -42,6 +43,7 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
+import net.kyori.adventure.translation.Translatable;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.Examinable;
@@ -1082,6 +1084,18 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key.
+   *
+   * @param translatable the translatable object to get the key from
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), Style.empty());
+  }
+
+  /**
    * Creates a translatable component with a translation key and styling.
    *
    * @param key the translation key
@@ -1095,6 +1109,19 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key and styling.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param style the style
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull Style style) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), style);
+  }
+
+  /**
    * Creates a translatable component with a translation key, and optional color.
    *
    * @param key the translation key
@@ -1105,6 +1132,19 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color) {
     return translatable(key, Style.style(color));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, and optional color.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param color the color
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color);
   }
 
   /**
@@ -1124,6 +1164,20 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   /**
    * Creates a translatable component with a translation key, and optional color and decorations.
    *
+   * @param translatable the translatable object to get the key from
+   * @param color the color
+   * @param decorations the decorations
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, decorations);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, and optional color and decorations.
+   *
    * @param key the translation key
    * @param color the color
    * @param decorations the decorations
@@ -1133,6 +1187,20 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
     return translatable(key, Style.style(color, decorations));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, and optional color and decorations.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param color the color
+   * @param decorations the decorations
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, decorations);
   }
 
   /**
@@ -1146,6 +1214,19 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NonNull TranslatableComponent translatable(final @NonNull String key, final @NonNull ComponentLike@NonNull... args) {
     return translatable(key, Style.empty(), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key and arguments.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull ComponentLike@NonNull... args) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), args);
   }
 
   /**
@@ -1163,6 +1244,20 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key and styling.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull Style style, final @NonNull ComponentLike@NonNull... args) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), style, args);
+  }
+
+  /**
    * Creates a translatable component with a translation key, arguments, and optional color.
    *
    * @param key the translation key
@@ -1174,6 +1269,20 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull ComponentLike@NonNull... args) {
     return translatable(key, Style.style(color), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, arguments, and optional color.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param color the color
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull ComponentLike@NonNull... args) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, args);
   }
 
   /**
@@ -1192,6 +1301,21 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key, arguments, and optional color and decorations.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param color the color
+   * @param decorations the decorations
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations, final @NonNull ComponentLike@NonNull... args) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, decorations, args);
+  }
+
+  /**
    * Creates a translatable component with a translation key and arguments.
    *
    * @param key the translation key
@@ -1202,6 +1326,19 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NonNull TranslatableComponent translatable(final @NonNull String key, final @NonNull List<? extends ComponentLike> args) {
     return new TranslatableComponentImpl(Collections.emptyList(), Style.empty(), key, args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key and arguments.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull List<? extends ComponentLike> args) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), args);
   }
 
   /**
@@ -1219,6 +1356,20 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key and styling.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull Style style, final @NonNull List<? extends ComponentLike> args) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), style, args);
+  }
+
+  /**
    * Creates a translatable component with a translation key, arguments, and optional color.
    *
    * @param key the translation key
@@ -1230,6 +1381,20 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _ -> new", pure = true)
   static TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull List<? extends ComponentLike> args) {
     return translatable(key, Style.style(color), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, arguments, and optional color.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param color the color
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull List<? extends ComponentLike> args) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, args);
   }
 
   /**
@@ -1245,6 +1410,21 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations, final @NonNull List<? extends ComponentLike> args) {
     return translatable(key, Style.style(color, decorations), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, arguments, and optional color and decorations.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param color the color
+   * @param decorations the decorations
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations, final @NonNull List<? extends ComponentLike> args) {
+    return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, decorations, args);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -25,8 +25,10 @@ package net.kyori.adventure.text;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.translation.Translatable;
 import net.kyori.adventure.translation.TranslationRegistry;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
@@ -64,6 +66,18 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @since 4.0.0
    */
   @NonNull String key();
+
+  /**
+   * Sets the translation key.
+   *
+   * @param translatable the translatable object to get the key from
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(pure = true)
+  default @NonNull TranslatableComponent key(final @NonNull Translatable translatable) {
+    return this.key(Objects.requireNonNull(translatable, "translatable").translationKey());
+  }
 
   /**
    * Sets the translation key.
@@ -109,6 +123,18 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @since 4.0.0
    */
   interface Builder extends ComponentBuilder<TranslatableComponent, Builder> {
+    /**
+     * Sets the translation key.
+     *
+     * @param translatable the translatable object to get the key from
+     * @return this builder
+     * @since 4.8.0
+     */
+    @Contract(pure = true)
+    default @NonNull Builder key(final @NonNull Translatable translatable) {
+      return this.key(Objects.requireNonNull(translatable, "translatable").translationKey());
+    }
+
     /**
      * Sets the translation key.
      *

--- a/api/src/main/java/net/kyori/adventure/translation/Translatable.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translatable.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.translation;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Something that has a translation key.
+ *
+ * @since 4.8.0
+ */
+public interface Translatable {
+  /**
+   * Gets the translation key.
+   *
+   * @return the translation key
+   * @since 4.8.0
+   */
+  @NonNull String translationKey();
+}


### PR DESCRIPTION
This PR adds a `Translatable` interface with the intention of allowing implementations to implement this interface on objects which can be translated.