### PR TITLE
api: Make contains check for entity name

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1313,10 +1313,16 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
     }
     final @Nullable HoverEvent<?> hoverEvent = this.hoverEvent();
     if(hoverEvent != null) {
-      if(hoverEvent.action().type().isAssignableFrom(Component.class)) {
-        final Component hover = (Component) hoverEvent.value();
-        if(that == hover) return true;
-        for(final Component child : hover.children()) {
+      final Object value = hoverEvent.value();
+      Component component = null;
+      if(value instanceof Component) {
+        component = (Component) hoverEvent.value();
+      } else if(value instanceof HoverEvent.ShowEntity) {
+        component = ((HoverEvent.ShowEntity) value).name();
+      }
+      if(component != null) {
+        if(equals.test(that, component)) return true;
+        for(final Component child : component.children()) {
           if(child.contains(that, equals)) return true;
         }
       }

--- a/api/src/test/java/net/kyori/adventure/text/ComponentContainsTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentContainsTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.UUID;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.event.HoverEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ComponentContainsTest {
+  @Test
+  public void testOf() {
+    final Component c0 = Component.text("best!");
+    final Component c1 = Component.text()
+      .append(Component.text("Nero "))
+      .append(Component.text(" are the ").append(c0))
+      .build();
+
+    assertTrue(c1.contains(c0));
+  }
+
+  @Test
+  public void testOfHoverShowText() {
+    final Component c0 = Component.text("A great EDM trio");
+    final Component c1 = Component.text()
+      .append(Component.text("Nero ").hoverEvent(c0))
+      .append(Component.text(" are the best!"))
+      .build();
+
+    assertTrue(c1.contains(c0));
+  }
+
+  @Test
+  public void testOfHoverShowEntity() {
+    final Component c0 = Component.text("Joe Ray");
+    final Component c1 = Component.text()
+      .append(Component.text("One member").hoverEvent(HoverEvent.showEntity(Key.key("minecraft:player"), UUID.randomUUID(), c0)))
+      .append(Component.text(" launched a solo project in 2017."))
+      .build();
+
+    assertTrue(c1.contains(c0));
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/ComponentContainsTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentContainsTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+// https://github.com/KyoriPowered/adventure/issues/363
 class ComponentContainsTest {
   @Test
   public void testOf() {

--- a/api/src/test/java/net/kyori/adventure/text/ComponentContainsTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentContainsTest.java
@@ -40,6 +40,7 @@ class ComponentContainsTest {
       .build();
 
     assertTrue(c1.contains(c0));
+    assertTrue(c1.contains(Component.text("best!"), Component.EQUALS));
   }
 
   @Test
@@ -51,6 +52,7 @@ class ComponentContainsTest {
       .build();
 
     assertTrue(c1.contains(c0));
+    assertTrue(c1.contains(Component.text("A great EDM trio"), Component.EQUALS));
   }
 
   @Test
@@ -62,5 +64,6 @@ class ComponentContainsTest {
       .build();
 
     assertTrue(c1.contains(c0));
+    assertTrue(c1.contains(Component.text("Joe Ray"), Component.EQUALS));
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -142,18 +142,6 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
     assertTrue(component.contains(child));
   }
 
-  // https://github.com/KyoriPowered/adventure/issues/363
-  @Test
-  void testContainsEquality() {
-    final Component c0 = Component.text("best!");
-    final Component c1 = Component.text()
-      .append(Component.text("Nero "))
-      .append(Component.text(" are the ").append(c0))
-      .build();
-
-    assertTrue(c1.contains(Component.text("best!"), Component.EQUALS));
-  }
-
   @Test
   void testContent() {
     final TextComponent c0 = Component.text("foo");


### PR DESCRIPTION
This PR modifies `Component#contains(Component)` to check for the name of an entity in a `ShowEntity` hover event and adds some tests.