### PR TITLE
api: Add Pointers

### DIFF
--- a/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
@@ -88,6 +88,6 @@ public interface Pointered {
    * @since 4.8.0
    */
   default @NotNull Pointers pointers() {
-    return Pointers.EMPTY;
+    return Pointers.empty();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
@@ -82,7 +82,7 @@ public interface Pointered {
   }
 
   /**
-   * Gets the pointers for this audience.
+   * Gets the pointers for this object.
    *
    * @return the pointers
    * @since 4.8.0

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
@@ -45,7 +45,7 @@ public interface Pointered {
    * @since 4.8.0
    */
   default <T> @NotNull Optional<T> get(final @NotNull Pointer<T> pointer) {
-    return Optional.empty();
+    return this.pointers().get(pointer);
   }
 
   /**
@@ -62,7 +62,7 @@ public interface Pointered {
   @Contract("_, null -> null; _, !null -> !null")
   @SuppressWarnings("checkstyle:MethodName")
   default <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
-    return this.get(pointer).orElse(defaultValue);
+    return this.pointers().getOrDefault(pointer, defaultValue);
   }
 
   /**
@@ -78,6 +78,16 @@ public interface Pointered {
    */
   @SuppressWarnings("checkstyle:MethodName")
   default <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
-    return this.get(pointer).orElseGet(defaultValue);
+    return this.pointers().getOrDefaultFrom(pointer, defaultValue);
+  }
+
+  /**
+   * Gets the pointers for this audience.
+   *
+   * @return the pointers
+   * @since 4.8.0
+   */
+  default @NotNull Pointers pointers() {
+    return Pointers.EMPTY;
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.pointer;
 import java.util.Optional;
 import java.util.function.Supplier;
 import net.kyori.adventure.util.Buildable;
-import net.kyori.adventure.util.TriState;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,7 +38,7 @@ import org.jetbrains.annotations.UnknownNullability;
  */
 public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
   /**
-   * An empty set of pointers.
+   * An empty collection of pointers.
    *
    * @since 4.8.0
    */
@@ -70,7 +69,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
   /**
    * Gets the value of {@code pointer}.
    *
-   * <p>If this {@code Audience} is unable to provide a value for {@code pointer}, {@code defaultValue} will be returned.</p>
+   * <p>If a value for {@code pointer} is unable to be provided, {@code defaultValue} will be returned.</p>
    *
    * @param pointer the pointer
    * @param defaultValue the default value
@@ -87,7 +86,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
   /**
    * Gets the value of {@code pointer}.
    *
-   * <p>If this {@code Audience} is unable to provide a value for {@code pointer}, the value supplied by {@code defaultValue} will be returned.</p>
+   * <p>If a value for {@code pointer} is unable to be provided, the value supplied by {@code defaultValue} will be returned.</p>
    *
    * @param pointer the pointer
    * @param defaultValue the default value supplier
@@ -101,14 +100,16 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
   }
 
   /**
-   * Checks if these pointers contain a value for the given pointer.
+   * Checks if a given pointer is supported.
+   *
+   * <p>This will return {@code true} when a mapping for the provided pointer exists, even if the value for the pointer is {@code null}.</p>
    *
    * @param pointer the pointer
    * @param <T> the type
-   * @return a tri-state
+   * @return if the pointer is supported
    * @since 4.8.0
    */
-  <T> @NotNull TriState has(final @NotNull Pointer<T> pointer);
+  <T> boolean supports(final @NotNull Pointer<T> pointer);
 
   /**
    * A builder of pointers.
@@ -145,10 +146,10 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
     }
 
     /**
-     * Adds a pointer with an optional value.
+     * Adds a pointer with a value provided by a supplier.
      *
      * @param pointer the pointer
-     * @param value the optional value
+     * @param value the value supplier
      * @param <T> the type
      * @return this builder
      * @since 4.8.0

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
@@ -123,20 +123,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
    */
   interface Builder extends Buildable.Builder<Pointers> {
     /**
-     * Adds a pointer without a value.
-     *
-     * @param pointer the pointer
-     * @param <T> the type
-     * @return this builder
-     * @since 4.8.0
-     */
-    @Contract("_ -> this")
-    default <T> @NotNull Builder addPointer(final @NotNull Pointer<T> pointer) {
-      return this.addPointerWithFixedValue(pointer, null);
-    }
-
-    /**
-     * Adds a pointer with an optional value.
+     * Adds a pointer with a static, optional value.
      *
      * @param pointer the pointer
      * @param value the optional value
@@ -145,12 +132,12 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      * @since 4.8.0
      */
     @Contract("_, _ -> this")
-    default <T> @NotNull Builder addPointerWithFixedValue(final @NotNull Pointer<T> pointer, final @Nullable T value) {
-      return this.addPointerWithVariableValue(pointer, () -> value);
+    default <T> @NotNull Builder withStatic(final @NotNull Pointer<T> pointer, final @Nullable T value) {
+      return this.withDynamic(pointer, () -> value);
     }
 
     /**
-     * Adds a pointer with a value provided by a supplier.
+     * Adds a pointer with a dynamic value provided by a supplier.
      *
      * @param pointer the pointer
      * @param value the value supplier
@@ -159,6 +146,6 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      * @since 4.8.0
      */
     @Contract("_, _ -> this")
-    <T> @NotNull Builder addPointerWithVariableValue(final @NotNull Pointer<T> pointer, @NotNull Supplier<@Nullable T> value);
+    <T> @NotNull Builder withDynamic(final @NotNull Pointer<T> pointer, @NotNull Supplier<@Nullable T> value);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
@@ -38,11 +38,15 @@ import org.jetbrains.annotations.UnknownNullability;
  */
 public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
   /**
-   * An empty collection of pointers.
+   * Gets an empty pointers collection.
    *
+   * @return the pointers
    * @since 4.8.0
    */
-  @NotNull Pointers EMPTY = PointersImpl.EMPTY;
+  @Contract(pure = true)
+  static @NotNull Pointers empty() {
+    return PointersImpl.EMPTY;
+  }
 
   /**
    * Gets a new pointers builder.

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.pointer;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import net.kyori.adventure.util.Buildable;
+import net.kyori.adventure.util.TriState;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
+import org.jetbrains.annotations.Contract;
+
+/**
+ * A collection of {@link Pointer pointers}.
+ *
+ * @since 4.8.0
+ */
+public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
+  /**
+   * An empty set of pointers.
+   *
+   * @since 4.8.0
+   */
+  @NonNull Pointers EMPTY = PointersImpl.EMPTY;
+
+  /**
+   * Gets a new pointers builder.
+   *
+   * @return the builder
+   * @see Builder
+   * @since 4.8.0
+   */
+  @Contract(value = "-> new", pure = true)
+  static @NonNull Builder builder() {
+    return new PointersImpl.BuilderImpl();
+  }
+
+  /**
+   * Gets the value of {@code pointer}.
+   *
+   * @param pointer the pointer
+   * @param <T> the type
+   * @return the value
+   * @since 4.8.0
+   */
+  <T> @NonNull Optional<T> get(final @NonNull Pointer<T> pointer);
+
+  /**
+   * Gets the value of {@code pointer}.
+   *
+   * <p>If this {@code Audience} is unable to provide a value for {@code pointer}, {@code defaultValue} will be returned.</p>
+   *
+   * @param pointer the pointer
+   * @param defaultValue the default value
+   * @param <T> the type
+   * @return the value
+   * @since 4.8.0
+   */
+  @SuppressWarnings("checkstyle:MethodName")
+  default <T> @PolyNull T getOrDefault(final @NonNull Pointer<T> pointer, final @PolyNull T defaultValue) {
+    return this.get(pointer).orElse(defaultValue);
+  }
+
+  /**
+   * Gets the value of {@code pointer}.
+   *
+   * <p>If this {@code Audience} is unable to provide a value for {@code pointer}, the value supplied by {@code defaultValue} will be returned.</p>
+   *
+   * @param pointer the pointer
+   * @param defaultValue the default value supplier
+   * @param <T> the type
+   * @return the value
+   * @since 4.8.0
+   */
+  @SuppressWarnings("checkstyle:MethodName")
+  default <T> @PolyNull T getOrDefaultFrom(final @NonNull Pointer<T> pointer, final @NonNull Supplier<? extends T> defaultValue) {
+    return this.get(pointer).orElseGet(defaultValue);
+  }
+
+  /**
+   * Checks if these pointers contain a value for the given pointer.
+   *
+   * @param pointer the pointer
+   * @param <T> the type
+   * @return a tri-state
+   * @since 4.8.0
+   */
+  <T> @NonNull TriState has(final @NonNull Pointer<T> pointer);
+
+  /**
+   * A builder of pointers.
+   *
+   * @see Pointers
+   * @since 4.8.0
+   */
+  interface Builder extends Buildable.Builder<Pointers> {
+    /**
+     * Adds a pointer without a value.
+     *
+     * @param pointer the pointer
+     * @param <T> the type
+     * @return this builder
+     * @since 4.8.0
+     */
+    @Contract("_ -> this")
+    default <T> @NonNull Builder addPointer(final @NonNull Pointer<T> pointer) {
+      return this.addPointerWithFixedValue(pointer, null);
+    }
+
+    /**
+     * Adds a pointer with an optional value.
+     *
+     * @param pointer the pointer
+     * @param value the optional value
+     * @param <T> the type
+     * @return this builder
+     * @since 4.8.0
+     */
+    @Contract("_, _ -> this")
+    default <T> @NonNull Builder addPointerWithFixedValue(final @NonNull Pointer<T> pointer, @Nullable T value) {
+      return this.addPointerWithVariableValue(pointer, () -> value);
+    }
+
+    /**
+     * Adds a pointer with an optional value.
+     *
+     * @param pointer the pointer
+     * @param value the optional value
+     * @param <T> the type
+     * @return this builder
+     * @since 4.8.0
+     */
+    @Contract("_, _ -> this")
+    <T> @NonNull Builder addPointerWithVariableValue(final @NonNull Pointer<T> pointer, @NonNull Supplier<@Nullable T> value);
+
+    /**
+     * Adds a parent from which values will be retrieved if they do not exist in this collection.
+     *
+     * @param parent the parent
+     * @return this builder
+     * @since 4.8.0
+     */
+    @Contract("_ -> this")
+    default @NonNull Builder parent(final @NonNull Pointered parent) {
+      return this.parent(() -> parent);
+    }
+
+    /**
+     * Adds a parent from which values will be retrieved if they do not exist in this collection.
+     *
+     * @param parent the parent
+     * @return this builder
+     * @since 4.8.0
+     */
+    @NonNull Builder parent(final @NonNull Supplier<Pointered> parent);
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
@@ -27,10 +27,10 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.adventure.util.TriState;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 /**
  * A collection of {@link Pointer pointers}.
@@ -43,7 +43,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
    *
    * @since 4.8.0
    */
-  @NonNull Pointers EMPTY = PointersImpl.EMPTY;
+  @NotNull Pointers EMPTY = PointersImpl.EMPTY;
 
   /**
    * Gets a new pointers builder.
@@ -52,8 +52,8 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
    * @see Builder
    * @since 4.8.0
    */
-  @Contract(value = "-> new", pure = true)
-  static @NonNull Builder builder() {
+  @Contract(pure = true)
+  static @NotNull Builder builder() {
     return new PointersImpl.BuilderImpl();
   }
 
@@ -65,7 +65,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
    * @return the value
    * @since 4.8.0
    */
-  <T> @NonNull Optional<T> get(final @NonNull Pointer<T> pointer);
+  <T> @NotNull Optional<T> get(final @NotNull Pointer<T> pointer);
 
   /**
    * Gets the value of {@code pointer}.
@@ -78,8 +78,9 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
    * @return the value
    * @since 4.8.0
    */
+  @Contract("_, !null -> !null; _, null -> null")
   @SuppressWarnings("checkstyle:MethodName")
-  default <T> @PolyNull T getOrDefault(final @NonNull Pointer<T> pointer, final @PolyNull T defaultValue) {
+  default <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
     return this.get(pointer).orElse(defaultValue);
   }
 
@@ -95,7 +96,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
    * @since 4.8.0
    */
   @SuppressWarnings("checkstyle:MethodName")
-  default <T> @PolyNull T getOrDefaultFrom(final @NonNull Pointer<T> pointer, final @NonNull Supplier<? extends T> defaultValue) {
+  default <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
     return this.get(pointer).orElseGet(defaultValue);
   }
 
@@ -107,7 +108,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
    * @return a tri-state
    * @since 4.8.0
    */
-  <T> @NonNull TriState has(final @NonNull Pointer<T> pointer);
+  <T> @NotNull TriState has(final @NotNull Pointer<T> pointer);
 
   /**
    * A builder of pointers.
@@ -125,7 +126,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      * @since 4.8.0
      */
     @Contract("_ -> this")
-    default <T> @NonNull Builder addPointer(final @NonNull Pointer<T> pointer) {
+    default <T> @NotNull Builder addPointer(final @NotNull Pointer<T> pointer) {
       return this.addPointerWithFixedValue(pointer, null);
     }
 
@@ -139,7 +140,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      * @since 4.8.0
      */
     @Contract("_, _ -> this")
-    default <T> @NonNull Builder addPointerWithFixedValue(final @NonNull Pointer<T> pointer, @Nullable T value) {
+    default <T> @NotNull Builder addPointerWithFixedValue(final @NotNull Pointer<T> pointer, @Nullable T value) {
       return this.addPointerWithVariableValue(pointer, () -> value);
     }
 
@@ -153,7 +154,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      * @since 4.8.0
      */
     @Contract("_, _ -> this")
-    <T> @NonNull Builder addPointerWithVariableValue(final @NonNull Pointer<T> pointer, @NonNull Supplier<@Nullable T> value);
+    <T> @NotNull Builder addPointerWithVariableValue(final @NotNull Pointer<T> pointer, @NotNull Supplier<@Nullable T> value);
 
     /**
      * Adds a parent from which values will be retrieved if they do not exist in this collection.
@@ -163,7 +164,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      * @since 4.8.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder parent(final @NonNull Pointered parent) {
+    default @NotNull Builder parent(final @NotNull Pointered parent) {
       return this.parent(() -> parent);
     }
 
@@ -174,6 +175,6 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      * @return this builder
      * @since 4.8.0
      */
-    @NonNull Builder parent(final @NonNull Supplier<Pointered> parent);
+    @NotNull Builder parent(final @NotNull Supplier<Pointered> parent);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
@@ -140,7 +140,7 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      * @since 4.8.0
      */
     @Contract("_, _ -> this")
-    default <T> @NotNull Builder addPointerWithFixedValue(final @NotNull Pointer<T> pointer, @Nullable T value) {
+    default <T> @NotNull Builder addPointerWithFixedValue(final @NotNull Pointer<T> pointer, final @Nullable T value) {
       return this.addPointerWithVariableValue(pointer, () -> value);
     }
 
@@ -155,26 +155,5 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
      */
     @Contract("_, _ -> this")
     <T> @NotNull Builder addPointerWithVariableValue(final @NotNull Pointer<T> pointer, @NotNull Supplier<@Nullable T> value);
-
-    /**
-     * Adds a parent from which values will be retrieved if they do not exist in this collection.
-     *
-     * @param parent the parent
-     * @return this builder
-     * @since 4.8.0
-     */
-    @Contract("_ -> this")
-    default @NotNull Builder parent(final @NotNull Pointered parent) {
-      return this.parent(() -> parent);
-    }
-
-    /**
-     * Adds a parent from which values will be retrieved if they do not exist in this collection.
-     *
-     * @param parent the parent
-     * @return this builder
-     * @since 4.8.0
-     */
-    @NotNull Builder parent(final @NotNull Supplier<Pointered> parent);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.pointer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import net.kyori.adventure.util.TriState;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class PointersImpl implements Pointers {
+  static final Pointers EMPTY = new Pointers() {
+    @Override
+    public @NonNull <T> Optional<T> get(final @NonNull Pointer<T> pointer) {
+      return Optional.empty();
+    }
+
+    @Override
+    public @NonNull <T> TriState has(final @NonNull Pointer<T> pointer) {
+      return TriState.NOT_SET;
+    }
+
+    @Override
+    public Pointers.@NonNull Builder toBuilder() {
+      return new PointersImpl.BuilderImpl();
+    }
+  };
+
+  private final Map<Pointer<?>, Supplier<?>> pointers;
+  private final Supplier<Pointered> parent;
+
+  PointersImpl(final @NonNull BuilderImpl builder) {
+    this.pointers = new HashMap<>(builder.pointers);
+    this.parent = builder.parent;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked") // all values are checked on entry
+  public @NonNull <T> Optional<T> get(final @NonNull Pointer<T> pointer) {
+    if(!this.pointers.containsKey(pointer)) return this.parent.get().pointers().get(pointer);
+    return Optional.ofNullable(((Supplier<T>) this.pointers.get(pointer)).get());
+  }
+
+  @Override
+  @SuppressWarnings("unchecked") // all values are checked on entry
+  public @NonNull <T> TriState has(final @NonNull Pointer<T> pointer) {
+    if(!this.pointers.containsKey(Objects.requireNonNull(pointer, "pointer"))) {
+      return this.parent.get().pointers().has(pointer);
+    }
+    return TriState.byBoolean(((Supplier<T>) this.pointers.get(pointer)).get() != null);
+  }
+
+  @Override
+  public Pointers.@NonNull Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  static final class BuilderImpl implements Builder {
+    private static final Pointered EMPTY_POINTERED = new Pointered() {};
+    private static final Supplier<Pointered> EMPTY_PARENT = () -> EMPTY_POINTERED;
+
+    private final Map<Pointer<?>, Supplier<?>> pointers;
+    private Supplier<Pointered> parent;
+
+    BuilderImpl() {
+      this.pointers = new HashMap<>();
+      this.parent = EMPTY_PARENT;
+    }
+
+    BuilderImpl(final @NonNull PointersImpl pointers) {
+      this.pointers = new HashMap<>(pointers.pointers);
+      this.parent = EMPTY_PARENT;
+    }
+
+    @Override
+    public @NonNull <T> Builder addPointerWithVariableValue(final @NonNull Pointer<T> pointer, final @NonNull Supplier<@Nullable T> value) {
+      this.pointers.put(Objects.requireNonNull(pointer, "pointer"), Objects.requireNonNull(value, "value"));
+      return this;
+    }
+
+    @Override
+    public @NonNull Builder parent(final @NonNull Supplier<Pointered> parent) {
+      this.parent = Objects.requireNonNull(parent, "parent");
+      return this;
+    }
+
+    @Override
+    public @NonNull Pointers build() {
+      return new PointersImpl(this);
+    }
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
@@ -90,7 +90,7 @@ final class PointersImpl implements Pointers {
     }
 
     @Override
-    public @NotNull <T> Builder addPointerWithVariableValue(final @NotNull Pointer<T> pointer, final @NotNull Supplier<@Nullable T> value) {
+    public @NotNull <T> Builder withDynamic(final @NotNull Pointer<T> pointer, final @NotNull Supplier<@Nullable T> value) {
       this.pointers.put(Objects.requireNonNull(pointer, "pointer"), Objects.requireNonNull(value, "value"));
       return this;
     }

--- a/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
@@ -29,87 +29,70 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import net.kyori.adventure.util.TriState;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class PointersImpl implements Pointers {
   static final Pointers EMPTY = new Pointers() {
     @Override
-    public @NonNull <T> Optional<T> get(final @NonNull Pointer<T> pointer) {
+    public @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
       return Optional.empty();
     }
 
     @Override
-    public @NonNull <T> TriState has(final @NonNull Pointer<T> pointer) {
+    public @NotNull <T> TriState has(final @NotNull Pointer<T> pointer) {
       return TriState.NOT_SET;
     }
 
     @Override
-    public Pointers.@NonNull Builder toBuilder() {
+    public Pointers.@NotNull Builder toBuilder() {
       return new PointersImpl.BuilderImpl();
     }
   };
 
   private final Map<Pointer<?>, Supplier<?>> pointers;
-  private final Supplier<Pointered> parent;
 
-  PointersImpl(final @NonNull BuilderImpl builder) {
+  PointersImpl(final @NotNull BuilderImpl builder) {
     this.pointers = new HashMap<>(builder.pointers);
-    this.parent = builder.parent;
   }
 
   @Override
   @SuppressWarnings("unchecked") // all values are checked on entry
-  public @NonNull <T> Optional<T> get(final @NonNull Pointer<T> pointer) {
-    if(!this.pointers.containsKey(pointer)) return this.parent.get().pointers().get(pointer);
+  public @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
     return Optional.ofNullable(((Supplier<T>) this.pointers.get(pointer)).get());
   }
 
   @Override
   @SuppressWarnings("unchecked") // all values are checked on entry
-  public @NonNull <T> TriState has(final @NonNull Pointer<T> pointer) {
-    if(!this.pointers.containsKey(Objects.requireNonNull(pointer, "pointer"))) {
-      return this.parent.get().pointers().has(pointer);
-    }
+  public @NotNull <T> TriState has(final @NotNull Pointer<T> pointer) {
+    if (!this.pointers.containsKey(pointer)) return TriState.NOT_SET;
     return TriState.byBoolean(((Supplier<T>) this.pointers.get(pointer)).get() != null);
   }
 
   @Override
-  public Pointers.@NonNull Builder toBuilder() {
+  public @NotNull Pointers.Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
   static final class BuilderImpl implements Builder {
-    private static final Pointered EMPTY_POINTERED = new Pointered() {};
-    private static final Supplier<Pointered> EMPTY_PARENT = () -> EMPTY_POINTERED;
-
     private final Map<Pointer<?>, Supplier<?>> pointers;
-    private Supplier<Pointered> parent;
 
     BuilderImpl() {
       this.pointers = new HashMap<>();
-      this.parent = EMPTY_PARENT;
     }
 
-    BuilderImpl(final @NonNull PointersImpl pointers) {
+    BuilderImpl(final @NotNull PointersImpl pointers) {
       this.pointers = new HashMap<>(pointers.pointers);
-      this.parent = EMPTY_PARENT;
     }
 
     @Override
-    public @NonNull <T> Builder addPointerWithVariableValue(final @NonNull Pointer<T> pointer, final @NonNull Supplier<@Nullable T> value) {
+    public @NotNull <T> Builder addPointerWithVariableValue(final @NotNull Pointer<T> pointer, final @NotNull Supplier<@Nullable T> value) {
       this.pointers.put(Objects.requireNonNull(pointer, "pointer"), Objects.requireNonNull(value, "value"));
       return this;
     }
 
     @Override
-    public @NonNull Builder parent(final @NonNull Supplier<Pointered> parent) {
-      this.parent = Objects.requireNonNull(parent, "parent");
-      return this;
-    }
-
-    @Override
-    public @NonNull Pointers build() {
+    public @NotNull Pointers build() {
       return new PointersImpl(this);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-import net.kyori.adventure.util.TriState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,13 +39,18 @@ final class PointersImpl implements Pointers {
     }
 
     @Override
-    public @NotNull <T> TriState has(final @NotNull Pointer<T> pointer) {
-      return TriState.NOT_SET;
+    public <T> boolean supports(final @NotNull Pointer<T> pointer) {
+      return false;
     }
 
     @Override
     public Pointers.@NotNull Builder toBuilder() {
       return new PointersImpl.BuilderImpl();
+    }
+
+    @Override
+    public String toString() {
+      return "EmptyPointers";
     }
   };
 
@@ -59,14 +63,14 @@ final class PointersImpl implements Pointers {
   @Override
   @SuppressWarnings("unchecked") // all values are checked on entry
   public @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
+    Objects.requireNonNull(pointer, "pointer");
     return Optional.ofNullable(((Supplier<T>) this.pointers.get(pointer)).get());
   }
 
   @Override
-  @SuppressWarnings("unchecked") // all values are checked on entry
-  public @NotNull <T> TriState has(final @NotNull Pointer<T> pointer) {
-    if (!this.pointers.containsKey(pointer)) return TriState.NOT_SET;
-    return TriState.byBoolean(((Supplier<T>) this.pointers.get(pointer)).get() != null);
+  public <T> boolean supports(final @NotNull Pointer<T> pointer) {
+    Objects.requireNonNull(pointer, "pointer");
+    return this.pointers.containsKey(pointer);
   }
 
   @Override

--- a/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
+++ b/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.pointer;
 
+import java.util.function.Supplier;
 import net.kyori.adventure.key.Key;
 import org.junit.jupiter.api.Test;
 
@@ -38,16 +39,30 @@ final class PointersTest {
     assertFalse(Pointers.empty().supports(pointer));
 
     final Pointers p0 = Pointers.builder()
-      .addPointer(pointer)
+      .withStatic(pointer, null)
       .build();
     assertTrue(p0.supports(pointer));
     assertFalse(p0.get(pointer).isPresent());
 
     final Pointers p1 = Pointers.builder()
-      .addPointerWithFixedValue(pointer, "test")
+      .withStatic(pointer, "test")
       .build();
     assertTrue(p1.supports(pointer));
     assertTrue(p1.get(pointer).isPresent());
     assertEquals("test", p1.get(pointer).get());
+    assertEquals("test", p1.get(pointer).get()); // make sure the value doesn't change
+
+    final StringBuilder s = new StringBuilder("test");
+    final Supplier<String> supplier = () -> {
+      final String result = s.toString();
+      s.reverse();
+      return result;
+    };
+    final Pointers p2 = Pointers.builder()
+      .withDynamic(pointer, supplier)
+      .build();
+    assertTrue(p2.supports(pointer));
+    assertEquals("test", p2.getOrDefault(pointer, null));
+    assertEquals("tset", p2.getOrDefault(pointer, null)); // make sure the value does change
   }
 }

--- a/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
+++ b/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.pointer;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.util.TriState;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,42 +50,5 @@ final class PointersTest {
     assertEquals(TriState.TRUE, p1.has(pointer));
     assertTrue(p1.get(pointer).isPresent());
     assertEquals("test", p1.get(pointer).get());
-
-    final Pointers p2 = Pointers.builder()
-      .parent(this.pointered(p0))
-      .build();
-    assertEquals(TriState.FALSE, p2.has(pointer));
-    assertFalse(p2.get(pointer).isPresent());
-
-    final Pointers p3 = Pointers.builder()
-      .parent(this.pointered(p1))
-      .build();
-    assertEquals(TriState.TRUE, p3.has(pointer));
-    assertTrue(p3.get(pointer).isPresent());
-    assertEquals("test", p3.get(pointer).get());
-
-    final Pointers p4 = Pointers.builder()
-      .parent(this.pointered(p1))
-      .addPointer(pointer)
-      .build();
-    assertEquals(TriState.FALSE, p4.has(pointer));
-    assertFalse(p4.get(pointer).isPresent());
-
-    final Pointers p5 = Pointers.builder()
-      .parent(this.pointered(p1))
-      .addPointerWithFixedValue(pointer, "not test")
-      .build();
-    assertEquals(TriState.TRUE, p5.has(pointer));
-    assertTrue(p5.get(pointer).isPresent());
-    assertEquals("not test", p5.get(pointer).get());
-  }
-
-  private @NotNull Pointered pointered(final @NotNull Pointers pointers) {
-    return new Pointered() {
-      @Override
-      public @NotNull Pointers pointers() {
-        return pointers;
-      }
-    };
   }
 }

--- a/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
+++ b/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
@@ -35,7 +35,7 @@ final class PointersTest {
   public void ofPointers() {
     final Pointer<String> pointer = Pointer.pointer(String.class, Key.key("adventure:test"));
 
-    assertFalse(Pointers.EMPTY.supports(pointer));
+    assertFalse(Pointers.empty().supports(pointer));
 
     final Pointers p0 = Pointers.builder()
       .addPointer(pointer)

--- a/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
+++ b/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
@@ -25,7 +25,7 @@ package net.kyori.adventure.pointer;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.util.TriState;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -81,10 +81,10 @@ final class PointersTest {
     assertEquals("not test", p5.get(pointer).get());
   }
 
-  private @NonNull Pointered pointered(final @NonNull Pointers pointers) {
+  private @NotNull Pointered pointered(final @NotNull Pointers pointers) {
     return new Pointered() {
       @Override
-      public @NonNull Pointers pointers() {
+      public @NotNull Pointers pointers() {
         return pointers;
       }
     };

--- a/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
+++ b/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.pointer;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.util.TriState;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class PointersTest {
+  @Test
+  public void ofPointers() {
+    final Pointer<String> pointer = Pointer.pointer(String.class, Key.key("adventure:test"));
+
+    assertEquals(TriState.NOT_SET, Pointers.EMPTY.has(pointer));
+
+    final Pointers p0 = Pointers.builder()
+      .addPointer(pointer)
+      .build();
+    assertEquals(TriState.FALSE, p0.has(pointer));
+    assertFalse(p0.get(pointer).isPresent());
+
+    final Pointers p1 = Pointers.builder()
+      .addPointerWithFixedValue(pointer, "test")
+      .build();
+    assertEquals(TriState.TRUE, p1.has(pointer));
+    assertTrue(p1.get(pointer).isPresent());
+    assertEquals("test", p1.get(pointer).get());
+
+    final Pointers p2 = Pointers.builder()
+      .parent(this.pointered(p0))
+      .build();
+    assertEquals(TriState.FALSE, p2.has(pointer));
+    assertFalse(p2.get(pointer).isPresent());
+
+    final Pointers p3 = Pointers.builder()
+      .parent(this.pointered(p1))
+      .build();
+    assertEquals(TriState.TRUE, p3.has(pointer));
+    assertTrue(p3.get(pointer).isPresent());
+    assertEquals("test", p3.get(pointer).get());
+
+    final Pointers p4 = Pointers.builder()
+      .parent(this.pointered(p1))
+      .addPointer(pointer)
+      .build();
+    assertEquals(TriState.FALSE, p4.has(pointer));
+    assertFalse(p4.get(pointer).isPresent());
+
+    final Pointers p5 = Pointers.builder()
+      .parent(this.pointered(p1))
+      .addPointerWithFixedValue(pointer, "not test")
+      .build();
+    assertEquals(TriState.TRUE, p5.has(pointer));
+    assertTrue(p5.get(pointer).isPresent());
+    assertEquals("not test", p5.get(pointer).get());
+  }
+
+  private @NonNull Pointered pointered(final @NonNull Pointers pointers) {
+    return new Pointered() {
+      @Override
+      public @NonNull Pointers pointers() {
+        return pointers;
+      }
+    };
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
+++ b/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.pointer;
 
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.util.TriState;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,18 +35,18 @@ final class PointersTest {
   public void ofPointers() {
     final Pointer<String> pointer = Pointer.pointer(String.class, Key.key("adventure:test"));
 
-    assertEquals(TriState.NOT_SET, Pointers.EMPTY.has(pointer));
+    assertFalse(Pointers.EMPTY.supports(pointer));
 
     final Pointers p0 = Pointers.builder()
       .addPointer(pointer)
       .build();
-    assertEquals(TriState.FALSE, p0.has(pointer));
+    assertTrue(p0.supports(pointer));
     assertFalse(p0.get(pointer).isPresent());
 
     final Pointers p1 = Pointers.builder()
       .addPointerWithFixedValue(pointer, "test")
       .build();
-    assertEquals(TriState.TRUE, p1.has(pointer));
+    assertTrue(p1.supports(pointer));
     assertTrue(p1.get(pointer).isPresent());
     assertEquals("test", p1.get(pointer).get());
   }


### PR DESCRIPTION
This PR adds a class that holds a collection of pointers and optional values. With this class, the following goals are achieved:

### Easier implementation
With a class such as this, implementing the pointered interface will only involve building a pointers instance and returning it. 

#### Before
```java
@Override
@SuppressWarnings("unchecked") // safe casts
public @NonNull <T> Optional<T> get(@NonNull Pointer<T> pointer) {
    if(pointer.equals(NAME)) return Optional.ofNullable((T) this.name());
    if(pointer.equals(SERVER_NAME)) return Optional.of(this.getServer().name());
    return Optional.empty();
}
```

#### After
```java
private Pointers pointers = null;

@Override
public @NonNull Pointers pointers() {
    if(this.pointers == null) {
        this.pointers = Pointers.builder()
            .addPointerWithVariableValue(NAME, this::name)
            .addPointerWithFixedValue(SERVER_NAME, this.getServer().name())
            .build();
    }

    return this.pointers;
}
```

### Distinction between null and not set values
With the existing system, there is no way to tell if a value is not set or if it isn't present. 
For example, if an implementation had a nullable display name, there is no way to tell if an empty optional means that the audience has no display name or if the audience cannot have a display name.
Alternatively, new pointers might be added and standardised but not implemented in some implementations, meaning that the difference between a not set value and a null value becomes more important.
With this, the pointers class introduces a method to check if a value is set using the tri-state class introduced earlier.