### PR TITLE
Remove checker qual and migrate to jetbrains annotations

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
   api(project(":adventure-key"))
   api("net.kyori:examination-api:1.1.0")
   api("net.kyori:examination-string:1.1.0")
-  compileOnlyApi("org.checkerframework:checker-qual:3.13.0")
   compileOnlyApi("org.jetbrains:annotations:21.0.1")
   testImplementation("com.google.guava:guava:23.0")
 }

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -35,7 +35,7 @@ import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.title.Title;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A receiver of Minecraft media.
@@ -85,7 +85,7 @@ public interface Audience extends Pointered {
    * @return a do-nothing audience
    * @since 4.0.0
    */
-  static @NonNull Audience empty() {
+  static @NotNull Audience empty() {
     return EmptyAudience.INSTANCE;
   }
 
@@ -97,7 +97,7 @@ public interface Audience extends Pointered {
    * @see ForwardingAudience
    * @since 4.0.0
    */
-  static @NonNull Audience audience(final @NonNull Audience@NonNull... audiences) {
+  static @NotNull Audience audience(final @NotNull Audience@NotNull... audiences) {
     final int length = audiences.length;
     if (length == 0) {
       return empty();
@@ -118,7 +118,7 @@ public interface Audience extends Pointered {
    * @see ForwardingAudience
    * @since 4.0.0
    */
-  static @NonNull ForwardingAudience audience(final @NonNull Iterable<? extends Audience> audiences) {
+  static @NotNull ForwardingAudience audience(final @NotNull Iterable<? extends Audience> audiences) {
     return () -> audiences;
   }
 
@@ -130,7 +130,7 @@ public interface Audience extends Pointered {
    * @return a collector to create a forwarding audience
    * @since 4.0.0
    */
-  static @NonNull Collector<? super Audience, ?, ForwardingAudience> toAudience() {
+  static @NotNull Collector<? super Audience, ?, ForwardingAudience> toAudience() {
     return Audiences.COLLECTOR;
   }
 
@@ -144,7 +144,7 @@ public interface Audience extends Pointered {
    * @since 4.1.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull ComponentLike message) {
+  default void sendMessage(final @NotNull ComponentLike message) {
     this.sendMessage(Identity.nil(), message);
   }
 
@@ -157,7 +157,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull Identified source, final @NonNull ComponentLike message) {
+  default void sendMessage(final @NotNull Identified source, final @NotNull ComponentLike message) {
     this.sendMessage(source, message.asComponent());
   }
 
@@ -170,7 +170,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull Identity source, final @NonNull ComponentLike message) {
+  default void sendMessage(final @NotNull Identity source, final @NotNull ComponentLike message) {
     this.sendMessage(source, message.asComponent());
   }
 
@@ -184,7 +184,7 @@ public interface Audience extends Pointered {
    * @since 4.1.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull Component message) {
+  default void sendMessage(final @NotNull Component message) {
     this.sendMessage(Identity.nil(), message);
   }
 
@@ -197,7 +197,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull Identified source, final @NonNull Component message) {
+  default void sendMessage(final @NotNull Identified source, final @NotNull Component message) {
     this.sendMessage(source, message, MessageType.SYSTEM);
   }
 
@@ -210,7 +210,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull Identity source, final @NonNull Component message) {
+  default void sendMessage(final @NotNull Identity source, final @NotNull Component message) {
     this.sendMessage(source, message, MessageType.SYSTEM);
   }
 
@@ -225,7 +225,7 @@ public interface Audience extends Pointered {
    * @since 4.1.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull ComponentLike message, final @NonNull MessageType type) {
+  default void sendMessage(final @NotNull ComponentLike message, final @NotNull MessageType type) {
     this.sendMessage(Identity.nil(), message, type);
   }
 
@@ -239,7 +239,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull Identified source, final @NonNull ComponentLike message, final @NonNull MessageType type) {
+  default void sendMessage(final @NotNull Identified source, final @NotNull ComponentLike message, final @NotNull MessageType type) {
     this.sendMessage(source, message.asComponent(), type);
   }
 
@@ -253,7 +253,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull Identity source, final @NonNull ComponentLike message, final @NonNull MessageType type) {
+  default void sendMessage(final @NotNull Identity source, final @NotNull ComponentLike message, final @NotNull MessageType type) {
     this.sendMessage(source, message.asComponent(), type);
   }
 
@@ -268,7 +268,7 @@ public interface Audience extends Pointered {
    * @since 4.1.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NonNull Component message, final @NonNull MessageType type) {
+  default void sendMessage(final @NotNull Component message, final @NotNull MessageType type) {
     this.sendMessage(Identity.nil(), message, type);
   }
 
@@ -281,7 +281,7 @@ public interface Audience extends Pointered {
    * @see Component
    * @since 4.0.0
    */
-  default void sendMessage(final @NonNull Identified source, final @NonNull Component message, final @NonNull MessageType type) {
+  default void sendMessage(final @NotNull Identified source, final @NotNull Component message, final @NotNull MessageType type) {
     this.sendMessage(source.identity(), message, type);
   }
 
@@ -294,7 +294,7 @@ public interface Audience extends Pointered {
    * @see Component
    * @since 4.0.0
    */
-  default void sendMessage(final @NonNull Identity source, final @NonNull Component message, final @NonNull MessageType type) {
+  default void sendMessage(final @NotNull Identity source, final @NotNull Component message, final @NotNull MessageType type) {
   }
 
   /**
@@ -305,7 +305,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendActionBar(final @NonNull ComponentLike message) {
+  default void sendActionBar(final @NotNull ComponentLike message) {
     this.sendActionBar(message.asComponent());
   }
 
@@ -316,7 +316,7 @@ public interface Audience extends Pointered {
    * @see Component
    * @since 4.0.0
    */
-  default void sendActionBar(final @NonNull Component message) {
+  default void sendActionBar(final @NotNull Component message) {
   }
 
   /**
@@ -329,7 +329,7 @@ public interface Audience extends Pointered {
    * @since 4.3.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendPlayerListHeader(final @NonNull ComponentLike header) {
+  default void sendPlayerListHeader(final @NotNull ComponentLike header) {
     this.sendPlayerListHeader(header.asComponent());
   }
 
@@ -342,7 +342,7 @@ public interface Audience extends Pointered {
    * @param header the header
    * @since 4.3.0
    */
-  default void sendPlayerListHeader(final @NonNull Component header) {
+  default void sendPlayerListHeader(final @NotNull Component header) {
     this.sendPlayerListHeaderAndFooter(header, Component.empty());
   }
 
@@ -356,7 +356,7 @@ public interface Audience extends Pointered {
    * @since 4.3.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendPlayerListFooter(final @NonNull ComponentLike footer) {
+  default void sendPlayerListFooter(final @NotNull ComponentLike footer) {
     this.sendPlayerListFooter(footer.asComponent());
   }
 
@@ -369,7 +369,7 @@ public interface Audience extends Pointered {
    * @param footer the footer
    * @since 4.3.0
    */
-  default void sendPlayerListFooter(final @NonNull Component footer) {
+  default void sendPlayerListFooter(final @NotNull Component footer) {
     this.sendPlayerListHeaderAndFooter(Component.empty(), footer);
   }
 
@@ -381,7 +381,7 @@ public interface Audience extends Pointered {
    * @since 4.3.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendPlayerListHeaderAndFooter(final @NonNull ComponentLike header, final @NonNull ComponentLike footer) {
+  default void sendPlayerListHeaderAndFooter(final @NotNull ComponentLike header, final @NotNull ComponentLike footer) {
     this.sendPlayerListHeaderAndFooter(header.asComponent(), footer.asComponent());
   }
 
@@ -392,7 +392,7 @@ public interface Audience extends Pointered {
    * @param footer the footer
    * @since 4.3.0
    */
-  default void sendPlayerListHeaderAndFooter(final @NonNull Component header, final @NonNull Component footer) {
+  default void sendPlayerListHeaderAndFooter(final @NotNull Component header, final @NotNull Component footer) {
   }
 
   /**
@@ -402,7 +402,7 @@ public interface Audience extends Pointered {
    * @see Title
    * @since 4.0.0
    */
-  default void showTitle(final @NonNull Title title) {
+  default void showTitle(final @NotNull Title title) {
   }
 
   /**
@@ -430,7 +430,7 @@ public interface Audience extends Pointered {
    * @see BossBar
    * @since 4.0.0
    */
-  default void showBossBar(final @NonNull BossBar bar) {
+  default void showBossBar(final @NotNull BossBar bar) {
   }
 
   /**
@@ -440,7 +440,7 @@ public interface Audience extends Pointered {
    * @see BossBar
    * @since 4.0.0
    */
-  default void hideBossBar(final @NonNull BossBar bar) {
+  default void hideBossBar(final @NotNull BossBar bar) {
   }
 
   /**
@@ -450,7 +450,7 @@ public interface Audience extends Pointered {
    * @see Sound
    * @since 4.0.0
    */
-  default void playSound(final @NonNull Sound sound) {
+  default void playSound(final @NotNull Sound sound) {
   }
 
   /**
@@ -463,7 +463,7 @@ public interface Audience extends Pointered {
    * @see Sound
    * @since 4.0.0
    */
-  default void playSound(final @NonNull Sound sound, final double x, final double y, final double z) {
+  default void playSound(final @NotNull Sound sound, final double x, final double y, final double z) {
   }
 
   /**
@@ -473,7 +473,7 @@ public interface Audience extends Pointered {
    * @see SoundStop
    * @since 4.0.0
    */
-  default void stopSound(final @NonNull SoundStop stop) {
+  default void stopSound(final @NotNull SoundStop stop) {
   }
 
   /**
@@ -486,7 +486,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void openBook(final Book.@NonNull Builder book) {
+  default void openBook(final Book.@NotNull Builder book) {
     this.openBook(book.build());
   }
 
@@ -499,6 +499,6 @@ public interface Audience extends Pointered {
    * @see Book
    * @since 4.0.0
    */
-  default void openBook(final @NonNull Book book) {
+  default void openBook(final @NotNull Book book) {
   }
 }

--- a/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
@@ -30,69 +30,72 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.text.ComponentLike;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 final class EmptyAudience implements Audience {
   static final EmptyAudience INSTANCE = new EmptyAudience();
 
   @Override
-  public @NonNull <T> Optional<T> get(final @NonNull Pointer<T> pointer) {
+  public @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
     return Optional.empty();
   }
 
+  @Contract("_, null -> null; _, !null -> !null")
   @Override
-  public <T> @PolyNull T getOrDefault(final @NonNull Pointer<T> pointer, final @PolyNull T defaultValue) {
+  public <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
     return defaultValue;
   }
 
   @Override
-  public <T> @PolyNull T getOrDefaultFrom(final @NonNull Pointer<T> pointer, final @NonNull Supplier<? extends T> defaultValue) {
+  public <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
     return defaultValue.get();
   }
 
   @Override
-  public void sendMessage(final @NonNull ComponentLike message) {
+  public void sendMessage(final @NotNull ComponentLike message) {
   }
 
   @Override
-  public void sendMessage(final @NonNull Identified source, final @NonNull ComponentLike message) {
+  public void sendMessage(final @NotNull Identified source, final @NotNull ComponentLike message) {
   }
 
   @Override
-  public void sendMessage(final @NonNull Identity source, final @NonNull ComponentLike message) {
+  public void sendMessage(final @NotNull Identity source, final @NotNull ComponentLike message) {
   }
 
   @Override
-  public void sendMessage(final @NonNull ComponentLike message, final @NonNull MessageType type) {
+  public void sendMessage(final @NotNull ComponentLike message, final @NotNull MessageType type) {
   }
 
   @Override
-  public void sendMessage(final @NonNull Identified source, final @NonNull ComponentLike message, final @NonNull MessageType type) {
+  public void sendMessage(final @NotNull Identified source, final @NotNull ComponentLike message, final @NotNull MessageType type) {
   }
 
   @Override
-  public void sendMessage(final @NonNull Identity source, final @NonNull ComponentLike message, final @NonNull MessageType type) {
+  public void sendMessage(final @NotNull Identity source, final @NotNull ComponentLike message, final @NotNull MessageType type) {
   }
 
   @Override
-  public void sendActionBar(final @NonNull ComponentLike message) {
+  public void sendActionBar(final @NotNull ComponentLike message) {
   }
 
   @Override
-  public void sendPlayerListHeader(final @NonNull ComponentLike header) {
+  public void sendPlayerListHeader(final @NotNull ComponentLike header) {
   }
 
   @Override
-  public void sendPlayerListFooter(final @NonNull ComponentLike footer) {
+  public void sendPlayerListFooter(final @NotNull ComponentLike footer) {
   }
 
   @Override
-  public void sendPlayerListHeaderAndFooter(final @NonNull ComponentLike header, final @NonNull ComponentLike footer) {
+  public void sendPlayerListHeaderAndFooter(final @NotNull ComponentLike header, final @NotNull ComponentLike footer) {
   }
 
   @Override
-  public void openBook(final Book.@NonNull Builder book) {
+  public void openBook(final Book.@NotNull Builder book) {
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -35,9 +35,11 @@ import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 /**
  * A receiver that wraps one or more receivers.
@@ -57,55 +59,56 @@ public interface ForwardingAudience extends Audience {
    * @since 4.0.0
    */
   @ApiStatus.OverrideOnly
-  @NonNull Iterable<? extends Audience> audiences();
+  @NotNull Iterable<? extends Audience> audiences();
 
   @Override
-  default <T> @NonNull Optional<T> get(final @NonNull Pointer<T> pointer) {
+  default <T> @NotNull Optional<T> get(final @NotNull Pointer<T> pointer) {
     return Optional.empty(); // unsupported
   }
 
+  @Contract("_, null -> null; _, !null -> !null")
   @Override
-  default <T> @PolyNull T getOrDefault(final @NonNull Pointer<T> pointer, final @PolyNull T defaultValue) {
+  default <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
     return defaultValue; // unsupported
   }
 
   @Override
-  default <T> @PolyNull T getOrDefaultFrom(final @NonNull Pointer<T> pointer, final @NonNull Supplier<? extends T> defaultValue) {
+  default <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
     return defaultValue.get(); // unsupported
   }
 
   @Override
-  default void sendMessage(final @NonNull Identified source, final @NonNull Component message, final @NonNull MessageType type) {
+  default void sendMessage(final @NotNull Identified source, final @NotNull Component message, final @NotNull MessageType type) {
     for (final Audience audience : this.audiences()) audience.sendMessage(source, message, type);
   }
 
   @Override
-  default void sendMessage(final @NonNull Identity source, final @NonNull Component message, final @NonNull MessageType type) {
+  default void sendMessage(final @NotNull Identity source, final @NotNull Component message, final @NotNull MessageType type) {
     for (final Audience audience : this.audiences()) audience.sendMessage(source, message, type);
   }
 
   @Override
-  default void sendActionBar(final @NonNull Component message) {
+  default void sendActionBar(final @NotNull Component message) {
     for (final Audience audience : this.audiences()) audience.sendActionBar(message);
   }
 
   @Override
-  default void sendPlayerListHeader(final @NonNull Component header) {
+  default void sendPlayerListHeader(final @NotNull Component header) {
     for (final Audience audience : this.audiences()) audience.sendPlayerListHeader(header);
   }
 
   @Override
-  default void sendPlayerListFooter(final @NonNull Component footer) {
+  default void sendPlayerListFooter(final @NotNull Component footer) {
     for (final Audience audience : this.audiences()) audience.sendPlayerListFooter(footer);
   }
 
   @Override
-  default void sendPlayerListHeaderAndFooter(final @NonNull Component header, final @NonNull Component footer) {
+  default void sendPlayerListHeaderAndFooter(final @NotNull Component header, final @NotNull Component footer) {
     for (final Audience audience : this.audiences()) audience.sendPlayerListHeaderAndFooter(header, footer);
   }
 
   @Override
-  default void showTitle(final @NonNull Title title) {
+  default void showTitle(final @NotNull Title title) {
     for (final Audience audience : this.audiences()) audience.showTitle(title);
   }
 
@@ -120,32 +123,32 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void showBossBar(final @NonNull BossBar bar) {
+  default void showBossBar(final @NotNull BossBar bar) {
     for (final Audience audience : this.audiences()) audience.showBossBar(bar);
   }
 
   @Override
-  default void hideBossBar(final @NonNull BossBar bar) {
+  default void hideBossBar(final @NotNull BossBar bar) {
     for (final Audience audience : this.audiences()) audience.hideBossBar(bar);
   }
 
   @Override
-  default void playSound(final @NonNull Sound sound) {
+  default void playSound(final @NotNull Sound sound) {
     for (final Audience audience : this.audiences()) audience.playSound(sound);
   }
 
   @Override
-  default void playSound(final @NonNull Sound sound, final double x, final double y, final double z) {
+  default void playSound(final @NotNull Sound sound, final double x, final double y, final double z) {
     for (final Audience audience : this.audiences()) audience.playSound(sound, x, y, z);
   }
 
   @Override
-  default void stopSound(final @NonNull SoundStop stop) {
+  default void stopSound(final @NotNull SoundStop stop) {
     for (final Audience audience : this.audiences()) audience.stopSound(stop);
   }
 
   @Override
-  default void openBook(final @NonNull Book book) {
+  default void openBook(final @NotNull Book book) {
     for (final Audience audience : this.audiences()) audience.openBook(book);
   }
 
@@ -162,7 +165,7 @@ public interface ForwardingAudience extends Audience {
      * @since 4.0.0
      */
     @ApiStatus.OverrideOnly
-    @NonNull Audience audience();
+    @NotNull Audience audience();
 
     /**
      * {@inheritDoc}
@@ -172,57 +175,58 @@ public interface ForwardingAudience extends Audience {
      */
     @Deprecated(/* forRemoval = false */)
     @Override
-    default @NonNull Iterable<? extends Audience> audiences() {
+    default @NotNull Iterable<? extends Audience> audiences() {
       return Collections.singleton(this.audience());
     }
 
     @Override
-    default <T> @NonNull Optional<T> get(final @NonNull Pointer<T> pointer) {
+    default <T> @NotNull Optional<T> get(final @NotNull Pointer<T> pointer) {
       return this.audience().get(pointer);
     }
 
+    @Contract("_, null -> null; _, !null -> !null")
     @Override
-    default <T> @PolyNull T getOrDefault(final @NonNull Pointer<T> pointer, final @PolyNull T defaultValue) {
+    default <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
       return this.audience().getOrDefault(pointer, defaultValue);
     }
 
     @Override
-    default <T> @PolyNull T getOrDefaultFrom(final @NonNull Pointer<T> pointer, final @NonNull Supplier<? extends T> defaultValue) {
+    default <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
       return this.audience().getOrDefaultFrom(pointer, defaultValue);
     }
 
     @Override
-    default void sendMessage(final @NonNull Identified source, final @NonNull Component message, final @NonNull MessageType type) {
+    default void sendMessage(final @NotNull Identified source, final @NotNull Component message, final @NotNull MessageType type) {
       this.audience().sendMessage(source, message, type);
     }
 
     @Override
-    default void sendMessage(final @NonNull Identity source, final @NonNull Component message, final @NonNull MessageType type) {
+    default void sendMessage(final @NotNull Identity source, final @NotNull Component message, final @NotNull MessageType type) {
       this.audience().sendMessage(source, message, type);
     }
 
     @Override
-    default void sendActionBar(final @NonNull Component message) {
+    default void sendActionBar(final @NotNull Component message) {
       this.audience().sendActionBar(message);
     }
 
     @Override
-    default void sendPlayerListHeader(final @NonNull Component header) {
+    default void sendPlayerListHeader(final @NotNull Component header) {
       this.audience().sendPlayerListHeader(header);
     }
 
     @Override
-    default void sendPlayerListFooter(final @NonNull Component footer) {
+    default void sendPlayerListFooter(final @NotNull Component footer) {
       this.audience().sendPlayerListFooter(footer);
     }
 
     @Override
-    default void sendPlayerListHeaderAndFooter(final @NonNull Component header, final @NonNull Component footer) {
+    default void sendPlayerListHeaderAndFooter(final @NotNull Component header, final @NotNull Component footer) {
       this.audience().sendPlayerListHeaderAndFooter(header, footer);
     }
 
     @Override
-    default void showTitle(final @NonNull Title title) {
+    default void showTitle(final @NotNull Title title) {
       this.audience().showTitle(title);
     }
 
@@ -237,32 +241,32 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void showBossBar(final @NonNull BossBar bar) {
+    default void showBossBar(final @NotNull BossBar bar) {
       this.audience().showBossBar(bar);
     }
 
     @Override
-    default void hideBossBar(final @NonNull BossBar bar) {
+    default void hideBossBar(final @NotNull BossBar bar) {
       this.audience().hideBossBar(bar);
     }
 
     @Override
-    default void playSound(final @NonNull Sound sound) {
+    default void playSound(final @NotNull Sound sound) {
       this.audience().playSound(sound);
     }
 
     @Override
-    default void playSound(final @NonNull Sound sound, final double x, final double y, final double z) {
+    default void playSound(final @NotNull Sound sound, final double x, final double y, final double z) {
       this.audience().playSound(sound, x, y, z);
     }
 
     @Override
-    default void stopSound(final @NonNull SoundStop stop) {
+    default void stopSound(final @NotNull SoundStop stop) {
       this.audience().stopSound(stop);
     }
 
     @Override
-    default void openBook(final @NonNull Book book) {
+    default void openBook(final @NotNull Book book) {
       this.audience().openBook(book);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
@@ -28,9 +28,9 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.util.Index;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
 /**
@@ -95,7 +95,7 @@ public interface BossBar extends Examinable {
    * @throws IllegalArgumentException if progress is less than 0 or greater than 1
    * @since 4.3.0
    */
-  static @NonNull BossBar bossBar(final @NonNull ComponentLike name, final float progress, final @NonNull Color color, final @NonNull Overlay overlay) {
+  static @NotNull BossBar bossBar(final @NotNull ComponentLike name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay) {
     BossBarImpl.checkProgress(progress);
     return bossBar(name.asComponent(), progress, color, overlay);
   }
@@ -111,7 +111,7 @@ public interface BossBar extends Examinable {
    * @throws IllegalArgumentException if progress is less than 0 or greater than 1
    * @since 4.0.0
    */
-  static @NonNull BossBar bossBar(final @NonNull Component name, final float progress, final @NonNull Color color, final @NonNull Overlay overlay) {
+  static @NotNull BossBar bossBar(final @NotNull Component name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay) {
     BossBarImpl.checkProgress(progress);
     return new BossBarImpl(name, progress, color, overlay);
   }
@@ -128,7 +128,7 @@ public interface BossBar extends Examinable {
    * @throws IllegalArgumentException if progress is less than 0 or greater than 1
    * @since 4.3.0
    */
-  static @NonNull BossBar bossBar(final @NonNull ComponentLike name, final float progress, final @NonNull Color color, final @NonNull Overlay overlay, final @NonNull Set<Flag> flags) {
+  static @NotNull BossBar bossBar(final @NotNull ComponentLike name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay, final @NotNull Set<Flag> flags) {
     BossBarImpl.checkProgress(progress);
     return bossBar(name.asComponent(), progress, color, overlay, flags);
   }
@@ -145,7 +145,7 @@ public interface BossBar extends Examinable {
    * @throws IllegalArgumentException if progress is less than 0 or greater than 1
    * @since 4.0.0
    */
-  static @NonNull BossBar bossBar(final @NonNull Component name, final float progress, final @NonNull Color color, final @NonNull Overlay overlay, final @NonNull Set<Flag> flags) {
+  static @NotNull BossBar bossBar(final @NotNull Component name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay, final @NotNull Set<Flag> flags) {
     BossBarImpl.checkProgress(progress);
     return new BossBarImpl(name, progress, color, overlay, flags);
   }
@@ -156,7 +156,7 @@ public interface BossBar extends Examinable {
    * @return the name
    * @since 4.0.0
    */
-  @NonNull Component name();
+  @NotNull Component name();
 
   /**
    * Sets the name.
@@ -166,7 +166,7 @@ public interface BossBar extends Examinable {
    * @since 4.3.0
    */
   @Contract("_ -> this")
-  default @NonNull BossBar name(final @NonNull ComponentLike name) {
+  default @NotNull BossBar name(final @NotNull ComponentLike name) {
     return this.name(name.asComponent());
   }
 
@@ -178,7 +178,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar name(final @NonNull Component name);
+  @NotNull BossBar name(final @NotNull Component name);
 
   /**
    * Gets the progress.
@@ -201,7 +201,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar progress(final float progress);
+  @NotNull BossBar progress(final float progress);
 
   /**
    * Gets the progress.
@@ -232,7 +232,7 @@ public interface BossBar extends Examinable {
   @ApiStatus.ScheduledForRemoval
   @Contract("_ -> this")
   @Deprecated
-  default @NonNull BossBar percent(final float progress) {
+  default @NotNull BossBar percent(final float progress) {
     return this.progress(progress);
   }
 
@@ -242,7 +242,7 @@ public interface BossBar extends Examinable {
    * @return the color
    * @since 4.0.0
    */
-  @NonNull Color color();
+  @NotNull Color color();
 
   /**
    * Sets the color.
@@ -252,7 +252,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar color(final @NonNull Color color);
+  @NotNull BossBar color(final @NotNull Color color);
 
   /**
    * Gets the overlay.
@@ -260,7 +260,7 @@ public interface BossBar extends Examinable {
    * @return the overlay
    * @since 4.0.0
    */
-  @NonNull Overlay overlay();
+  @NotNull Overlay overlay();
 
   /**
    * Sets the overlay.
@@ -270,7 +270,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar overlay(final @NonNull Overlay overlay);
+  @NotNull BossBar overlay(final @NotNull Overlay overlay);
 
   /**
    * Gets the flags.
@@ -278,7 +278,7 @@ public interface BossBar extends Examinable {
    * @return the flags
    * @since 4.0.0
    */
-  @UnmodifiableView @NonNull Set<Flag> flags();
+  @UnmodifiableView @NotNull Set<Flag> flags();
 
   /**
    * Sets the flags.
@@ -288,7 +288,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar flags(final @NonNull Set<Flag> flags);
+  @NotNull BossBar flags(final @NotNull Set<Flag> flags);
 
   /**
    * Checks if this bossbar has a flag.
@@ -297,7 +297,7 @@ public interface BossBar extends Examinable {
    * @return {@code true} if this bossbar has the flag, {@code false} otherwise
    * @since 4.0.0
    */
-  boolean hasFlag(final @NonNull Flag flag);
+  boolean hasFlag(final @NotNull Flag flag);
 
   /**
    * Adds a flag to this bossbar.
@@ -307,7 +307,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar addFlag(final @NonNull Flag flag);
+  @NotNull BossBar addFlag(final @NotNull Flag flag);
 
   /**
    * Removes a flag from this bossbar.
@@ -317,7 +317,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar removeFlag(final @NonNull Flag flag);
+  @NotNull BossBar removeFlag(final @NotNull Flag flag);
 
   /**
    * Adds flags to this bossbar.
@@ -327,7 +327,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar addFlags(final @NonNull Flag@NonNull... flags);
+  @NotNull BossBar addFlags(final @NotNull Flag@NotNull... flags);
 
   /**
    * Removes flags from this bossbar.
@@ -337,7 +337,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar removeFlags(final @NonNull Flag@NonNull... flags);
+  @NotNull BossBar removeFlags(final @NotNull Flag@NotNull... flags);
 
   /**
    * Adds flags to this bossbar.
@@ -347,7 +347,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar addFlags(final @NonNull Iterable<Flag> flags);
+  @NotNull BossBar addFlags(final @NotNull Iterable<Flag> flags);
 
   /**
    * Removes flags from this bossbar.
@@ -357,7 +357,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar removeFlags(final @NonNull Iterable<Flag> flags);
+  @NotNull BossBar removeFlags(final @NotNull Iterable<Flag> flags);
 
   /**
    * Adds a listener.
@@ -367,7 +367,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract(value = "_ -> this")
-  @NonNull BossBar addListener(final @NonNull Listener listener);
+  @NotNull BossBar addListener(final @NotNull Listener listener);
 
   /**
    * Removes a listener.
@@ -377,7 +377,7 @@ public interface BossBar extends Examinable {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull BossBar removeListener(final @NonNull Listener listener);
+  @NotNull BossBar removeListener(final @NotNull Listener listener);
 
   /**
    * A listener for changes that happen on a {@link BossBar}.
@@ -394,7 +394,7 @@ public interface BossBar extends Examinable {
      * @param newName the new name
      * @since 4.0.0
      */
-    default void bossBarNameChanged(final @NonNull BossBar bar, final @NonNull Component oldName, final @NonNull Component newName) {
+    default void bossBarNameChanged(final @NotNull BossBar bar, final @NotNull Component oldName, final @NotNull Component newName) {
     }
 
     /**
@@ -405,7 +405,7 @@ public interface BossBar extends Examinable {
      * @param newProgress the new progress
      * @since 4.0.0
      */
-    default void bossBarProgressChanged(final @NonNull BossBar bar, final float oldProgress, final float newProgress) {
+    default void bossBarProgressChanged(final @NotNull BossBar bar, final float oldProgress, final float newProgress) {
       this.bossBarPercentChanged(bar, oldProgress, newProgress);
     }
 
@@ -421,7 +421,7 @@ public interface BossBar extends Examinable {
     @ApiStatus.ScheduledForRemoval
     @Deprecated
     @SuppressWarnings("DeprecatedIsStillUsed")
-    default void bossBarPercentChanged(final @NonNull BossBar bar, final float oldProgress, final float newProgress) {
+    default void bossBarPercentChanged(final @NotNull BossBar bar, final float oldProgress, final float newProgress) {
     }
 
     /**
@@ -432,7 +432,7 @@ public interface BossBar extends Examinable {
      * @param newColor the new color
      * @since 4.0.0
      */
-    default void bossBarColorChanged(final @NonNull BossBar bar, final @NonNull Color oldColor, final @NonNull Color newColor) {
+    default void bossBarColorChanged(final @NotNull BossBar bar, final @NotNull Color oldColor, final @NotNull Color newColor) {
     }
 
     /**
@@ -443,7 +443,7 @@ public interface BossBar extends Examinable {
      * @param newOverlay the new overlay
      * @since 4.0.0
      */
-    default void bossBarOverlayChanged(final @NonNull BossBar bar, final @NonNull Overlay oldOverlay, final @NonNull Overlay newOverlay) {
+    default void bossBarOverlayChanged(final @NotNull BossBar bar, final @NotNull Overlay oldOverlay, final @NotNull Overlay newOverlay) {
     }
 
     /**
@@ -454,7 +454,7 @@ public interface BossBar extends Examinable {
      * @param flagsRemoved the flags removed from the bossbar
      * @since 4.0.0
      */
-    default void bossBarFlagsChanged(final @NonNull BossBar bar, final @NonNull Set<Flag> flagsAdded, final @NonNull Set<Flag> flagsRemoved) {
+    default void bossBarFlagsChanged(final @NotNull BossBar bar, final @NotNull Set<Flag> flagsAdded, final @NotNull Set<Flag> flagsRemoved) {
     }
   }
 

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarImpl.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarImpl.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,25 +50,25 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   private Overlay overlay;
   private final Set<Flag> flags = EnumSet.noneOf(Flag.class);
 
-  BossBarImpl(final @NonNull Component name, final float progress, final @NonNull Color color, final @NonNull Overlay overlay) {
+  BossBarImpl(final @NotNull Component name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay) {
     this.name = requireNonNull(name, "name");
     this.progress = progress;
     this.color = requireNonNull(color, "color");
     this.overlay = requireNonNull(overlay, "overlay");
   }
 
-  BossBarImpl(final @NonNull Component name, final float progress, final @NonNull Color color, final @NonNull Overlay overlay, final @NonNull Set<Flag> flags) {
+  BossBarImpl(final @NotNull Component name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay, final @NotNull Set<Flag> flags) {
     this(name, progress, color, overlay);
     this.flags.addAll(flags);
   }
 
   @Override
-  public @NonNull Component name() {
+  public @NotNull Component name() {
     return this.name;
   }
 
   @Override
-  public @NonNull BossBar name(final @NonNull Component newName) {
+  public @NotNull BossBar name(final @NotNull Component newName) {
     requireNonNull(newName, "name");
     final Component oldName = this.name;
     if (!Objects.equals(newName, oldName)) {
@@ -84,7 +84,7 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NonNull BossBar progress(final float newProgress) {
+  public @NotNull BossBar progress(final float newProgress) {
     checkProgress(newProgress);
     final float oldProgress = this.progress;
     if (newProgress != oldProgress) {
@@ -101,12 +101,12 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NonNull Color color() {
+  public @NotNull Color color() {
     return this.color;
   }
 
   @Override
-  public @NonNull BossBar color(final @NonNull Color newColor) {
+  public @NotNull BossBar color(final @NotNull Color newColor) {
     requireNonNull(newColor, "color");
     final Color oldColor = this.color;
     if (newColor != oldColor) {
@@ -117,12 +117,12 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NonNull Overlay overlay() {
+  public @NotNull Overlay overlay() {
     return this.overlay;
   }
 
   @Override
-  public @NonNull BossBar overlay(final @NonNull Overlay newOverlay) {
+  public @NotNull BossBar overlay(final @NotNull Overlay newOverlay) {
     requireNonNull(newOverlay, "overlay");
     final Overlay oldOverlay = this.overlay;
     if (newOverlay != oldOverlay) {
@@ -133,12 +133,12 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NonNull Set<Flag> flags() {
+  public @NotNull Set<Flag> flags() {
     return Collections.unmodifiableSet(this.flags);
   }
 
   @Override
-  public @NonNull BossBar flags(final @NonNull Set<Flag> newFlags) {
+  public @NotNull BossBar flags(final @NotNull Set<Flag> newFlags) {
     if (newFlags.isEmpty()) {
       final Set<Flag> oldFlags = EnumSet.copyOf(this.flags);
       this.flags.clear();
@@ -157,21 +157,21 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public boolean hasFlag(final @NonNull Flag flag) {
+  public boolean hasFlag(final @NotNull Flag flag) {
     return this.flags.contains(flag);
   }
 
   @Override
-  public @NonNull BossBar addFlag(final @NonNull Flag flag) {
+  public @NotNull BossBar addFlag(final @NotNull Flag flag) {
     return this.editFlags(flag, Set::add, FLAGS_ADDED);
   }
 
   @Override
-  public @NonNull BossBar removeFlag(final @NonNull Flag flag) {
+  public @NotNull BossBar removeFlag(final @NotNull Flag flag) {
     return this.editFlags(flag, Set::remove, FLAGS_REMOVED);
   }
 
-  private @NonNull BossBar editFlags(final @NonNull Flag flag, final @NonNull BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
+  private @NotNull BossBar editFlags(final @NotNull Flag flag, final @NotNull BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
     if (predicate.test(this.flags, flag)) {
       onChange.accept(this, Collections.singleton(flag));
     }
@@ -179,16 +179,16 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NonNull BossBar addFlags(final @NonNull Flag@NonNull... flags) {
+  public @NotNull BossBar addFlags(final @NotNull Flag@NotNull... flags) {
     return this.editFlags(flags, Set::add, FLAGS_ADDED);
   }
 
   @Override
-  public @NonNull BossBar removeFlags(final @NonNull Flag@NonNull... flags) {
+  public @NotNull BossBar removeFlags(final @NotNull Flag@NotNull... flags) {
     return this.editFlags(flags, Set::remove, FLAGS_REMOVED);
   }
 
-  private @NonNull BossBar editFlags(final Flag[] flags, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
+  private @NotNull BossBar editFlags(final Flag[] flags, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
     if (flags.length == 0) return this;
     Set<Flag> changes = null;
     for (int i = 0, length = flags.length; i < length; i++) {
@@ -206,16 +206,16 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NonNull BossBar addFlags(final @NonNull Iterable<Flag> flags) {
+  public @NotNull BossBar addFlags(final @NotNull Iterable<Flag> flags) {
     return this.editFlags(flags, Set::add, FLAGS_ADDED);
   }
 
   @Override
-  public @NonNull BossBar removeFlags(final @NonNull Iterable<Flag> flags) {
+  public @NotNull BossBar removeFlags(final @NotNull Iterable<Flag> flags) {
     return this.editFlags(flags, Set::remove, FLAGS_REMOVED);
   }
 
-  private @NonNull BossBar editFlags(final Iterable<Flag> flags, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
+  private @NotNull BossBar editFlags(final Iterable<Flag> flags, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
     Set<Flag> changes = null;
     for (final Flag flag : flags) {
       if (predicate.test(this.flags, flag)) {
@@ -232,25 +232,25 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NonNull BossBar addListener(final @NonNull Listener listener) {
+  public @NotNull BossBar addListener(final @NotNull Listener listener) {
     this.listeners.add(listener);
     return this;
   }
 
   @Override
-  public @NonNull BossBar removeListener(final @NonNull Listener listener) {
+  public @NotNull BossBar removeListener(final @NotNull Listener listener) {
     this.listeners.remove(listener);
     return this;
   }
 
-  private void forEachListener(final @NonNull Consumer<Listener> consumer) {
+  private void forEachListener(final @NotNull Consumer<Listener> consumer) {
     for (final Listener listener : this.listeners) {
       consumer.accept(listener);
     }
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("name", this.name),
       ExaminableProperty.of("progress", this.progress),

--- a/api/src/main/java/net/kyori/adventure/identity/Identified.java
+++ b/api/src/main/java/net/kyori/adventure/identity/Identified.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.identity;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can be identified by an {@link Identity}.
@@ -37,5 +37,5 @@ public interface Identified {
    * @return the identity
    * @since 4.0.0
    */
-  @NonNull Identity identity();
+  @NotNull Identity identity();
 }

--- a/api/src/main/java/net/kyori/adventure/identity/Identities.java
+++ b/api/src/main/java/net/kyori/adventure/identity/Identities.java
@@ -24,14 +24,14 @@
 package net.kyori.adventure.identity;
 
 import java.util.UUID;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 final class Identities {
   static final Identity NIL = new Identity() {
     private final UUID uuid = new UUID(0, 0);
 
     @Override
-    public @NonNull UUID uuid() {
+    public @NotNull UUID uuid() {
       return this.uuid;
     }
 

--- a/api/src/main/java/net/kyori/adventure/identity/Identity.java
+++ b/api/src/main/java/net/kyori/adventure/identity/Identity.java
@@ -31,7 +31,7 @@ import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An identity used to track the sender of messages for the social interaction features
@@ -68,7 +68,7 @@ public interface Identity extends Examinable {
    * @return the {@code null} identity
    * @since 4.0.0
    */
-  static @NonNull Identity nil() {
+  static @NotNull Identity nil() {
     return Identities.NIL;
   }
 
@@ -79,7 +79,7 @@ public interface Identity extends Examinable {
    * @return an identity
    * @since 4.0.0
    */
-  static @NonNull Identity identity(final @NonNull UUID uuid) {
+  static @NotNull Identity identity(final @NotNull UUID uuid) {
     if (uuid.equals(Identities.NIL.uuid())) return Identities.NIL;
     return new IdentityImpl(uuid);
   }
@@ -90,10 +90,10 @@ public interface Identity extends Examinable {
    * @return the uuid
    * @since 4.0.0
    */
-  @NonNull UUID uuid();
+  @NotNull UUID uuid();
 
   @Override
-  default @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("uuid", this.uuid()));
   }
 }

--- a/api/src/main/java/net/kyori/adventure/identity/IdentityImpl.java
+++ b/api/src/main/java/net/kyori/adventure/identity/IdentityImpl.java
@@ -26,8 +26,8 @@ package net.kyori.adventure.identity;
 import java.util.UUID;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class IdentityImpl implements Examinable, Identity {
   private final UUID uuid;
@@ -37,7 +37,7 @@ final class IdentityImpl implements Examinable, Identity {
   }
 
   @Override
-  public @NonNull UUID uuid() {
+  public @NotNull UUID uuid() {
     return this.uuid;
   }
 

--- a/api/src/main/java/net/kyori/adventure/inventory/Book.java
+++ b/api/src/main/java/net/kyori/adventure/inventory/Book.java
@@ -31,9 +31,9 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
 /**
@@ -57,7 +57,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @return a book
    * @since 4.0.0
    */
-  static @NonNull Book book(final @NonNull Component title, final @NonNull Component author, final @NonNull Collection<Component> pages) {
+  static @NotNull Book book(final @NotNull Component title, final @NotNull Component author, final @NotNull Collection<Component> pages) {
     return new BookImpl(title, author, new ArrayList<>(pages));
   }
 
@@ -70,7 +70,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @return a book
    * @since 4.0.0
    */
-  static @NonNull Book book(final @NonNull Component title, final @NonNull Component author, final @NonNull Component@NonNull... pages) {
+  static @NotNull Book book(final @NotNull Component title, final @NotNull Component author, final @NotNull Component@NotNull... pages) {
     return book(title, author, Arrays.asList(pages));
   }
 
@@ -80,7 +80,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @return a builder
    * @since 4.0.0
    */
-  static @NonNull Builder builder() {
+  static @NotNull Builder builder() {
     return new BookImpl.BuilderImpl();
   }
 
@@ -90,7 +90,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @return the title
    * @since 4.0.0
    */
-  @NonNull Component title();
+  @NotNull Component title();
 
   /**
    * Changes the book's title.
@@ -100,7 +100,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  @NonNull Book title(final @NonNull Component title);
+  @NotNull Book title(final @NotNull Component title);
 
   /**
    * Gets the author.
@@ -108,7 +108,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @return the author
    * @since 4.0.0
    */
-  @NonNull Component author();
+  @NotNull Component author();
 
   /**
    * Changes the book's author.
@@ -118,7 +118,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  @NonNull Book author(final @NonNull Component author);
+  @NotNull Book author(final @NotNull Component author);
 
   /**
    * Gets the list of pages.
@@ -128,7 +128,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @return the list of pages
    * @since 4.0.0
    */
-  @Unmodifiable @NonNull List<Component> pages();
+  @Unmodifiable @NotNull List<Component> pages();
 
   /**
    * Returns an updated book with the provided pages.
@@ -138,7 +138,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  default @NonNull Book pages(final @NonNull Component@NonNull... pages) {
+  default @NotNull Book pages(final @NotNull Component@NotNull... pages) {
     return this.pages(Arrays.asList(pages));
   }
 
@@ -150,7 +150,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  @NonNull Book pages(final @NonNull List<Component> pages);
+  @NotNull Book pages(final @NotNull List<Component> pages);
 
   /**
    * Create a new builder initialized with the attributes of this book.
@@ -158,7 +158,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
    * @return the builder
    */
   @Override
-  default @NonNull Builder toBuilder() {
+  default @NotNull Builder toBuilder() {
     return builder()
       .title(this.title())
       .author(this.author())
@@ -179,7 +179,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder title(final @NonNull Component title);
+    @NotNull Builder title(final @NotNull Component title);
 
     /**
      * Set the author.
@@ -189,7 +189,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder author(final @NonNull Component author);
+    @NotNull Builder author(final @NotNull Component author);
 
     /**
      * Add a page to the book.
@@ -202,7 +202,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder addPage(final @NonNull Component page);
+    @NotNull Builder addPage(final @NotNull Component page);
 
     /**
      * Add pages to the book.
@@ -213,7 +213,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder pages(final @NonNull Component@NonNull... pages);
+    @NotNull Builder pages(final @NotNull Component@NotNull... pages);
 
     /**
      * Add pages to the book.
@@ -224,7 +224,7 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder pages(final @NonNull Collection<Component> pages);
+    @NotNull Builder pages(final @NotNull Collection<Component> pages);
 
     /**
      * Builds.
@@ -232,6 +232,6 @@ public interface Book extends Buildable<Book, Book.Builder>, Examinable {
      * @return a new book
      */
     @Override
-    @NonNull Book build();
+    @NotNull Book build();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/inventory/BookImpl.java
+++ b/api/src/main/java/net/kyori/adventure/inventory/BookImpl.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -40,44 +40,44 @@ final class BookImpl implements Book {
   private final Component author;
   private final List<Component> pages;
 
-  BookImpl(final @NonNull Component title, final @NonNull Component author, final @NonNull List<Component> pages) {
+  BookImpl(final @NotNull Component title, final @NotNull Component author, final @NotNull List<Component> pages) {
     this.title = requireNonNull(title, "title");
     this.author = requireNonNull(author, "author");
     this.pages = Collections.unmodifiableList(requireNonNull(pages, "pages"));
   }
 
   @Override
-  public @NonNull Component title() {
+  public @NotNull Component title() {
     return this.title;
   }
 
   @Override
-  public @NonNull Book title(final @NonNull Component title) {
+  public @NotNull Book title(final @NotNull Component title) {
     return new BookImpl(requireNonNull(title, "title"), this.author, this.pages);
   }
 
   @Override
-  public @NonNull Component author() {
+  public @NotNull Component author() {
     return this.author;
   }
 
   @Override
-  public @NonNull Book author(final @NonNull Component author) {
+  public @NotNull Book author(final @NotNull Component author) {
     return new BookImpl(this.title, requireNonNull(author, "author"), this.pages);
   }
 
   @Override
-  public @NonNull List<Component> pages() {
+  public @NotNull List<Component> pages() {
     return this.pages;
   }
 
   @Override
-  public @NonNull Book pages(final @NonNull List<Component> pages) {
+  public @NotNull Book pages(final @NotNull List<Component> pages) {
     return new BookImpl(this.title, this.author, new ArrayList<>(requireNonNull(pages, "pages")));
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("title", this.title),
       ExaminableProperty.of("author", this.author),
@@ -114,37 +114,37 @@ final class BookImpl implements Book {
     private final List<Component> pages = new ArrayList<>();
 
     @Override
-    public @NonNull Builder title(final @NonNull Component title) {
+    public @NotNull Builder title(final @NotNull Component title) {
       this.title = requireNonNull(title, "title");
       return this;
     }
 
     @Override
-    public @NonNull Builder author(final @NonNull Component author) {
+    public @NotNull Builder author(final @NotNull Component author) {
       this.author = requireNonNull(author, "author");
       return this;
     }
 
     @Override
-    public @NonNull Builder addPage(final @NonNull Component page) {
+    public @NotNull Builder addPage(final @NotNull Component page) {
       this.pages.add(requireNonNull(page, "page"));
       return this;
     }
 
     @Override
-    public @NonNull Builder pages(final @NonNull Collection<Component> pages) {
+    public @NotNull Builder pages(final @NotNull Collection<Component> pages) {
       this.pages.addAll(requireNonNull(pages, "pages"));
       return this;
     }
 
     @Override
-    public @NonNull Builder pages(final @NonNull Component@NonNull... pages) {
+    public @NotNull Builder pages(final @NotNull Component@NotNull... pages) {
       Collections.addAll(this.pages, pages);
       return this;
     }
 
     @Override
-    public @NonNull Book build() {
+    public @NotNull Book build() {
       return new BookImpl(this.title, this.author, new ArrayList<>(this.pages));
     }
   }

--- a/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolder.java
+++ b/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolder.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.nbt.api;
 
 import net.kyori.adventure.util.Codec;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Holds a compound binary tag.
@@ -48,7 +48,7 @@ public interface BinaryTagHolder {
    * @throws EX if an error occurred while encoding the binary tag
    * @since 4.0.0
    */
-  static <T, EX extends Exception> @NonNull BinaryTagHolder encode(final @NonNull T nbt, final @NonNull Codec<? super T, String, ?, EX> codec) throws EX {
+  static <T, EX extends Exception> @NotNull BinaryTagHolder encode(final @NotNull T nbt, final @NotNull Codec<? super T, String, ?, EX> codec) throws EX {
     return new BinaryTagHolderImpl(codec.encode(nbt));
   }
 
@@ -59,7 +59,7 @@ public interface BinaryTagHolder {
    * @return the encoded binary tag
    * @since 4.0.0
    */
-  static @NonNull BinaryTagHolder of(final @NonNull String string) {
+  static @NotNull BinaryTagHolder of(final @NotNull String string) {
     return new BinaryTagHolderImpl(string);
   }
 
@@ -69,7 +69,7 @@ public interface BinaryTagHolder {
    * @return the raw string value
    * @since 4.0.0
    */
-  @NonNull String string();
+  @NotNull String string();
 
   /**
    * Gets the held value as a binary tag.
@@ -81,5 +81,5 @@ public interface BinaryTagHolder {
    * @throws DX if an error occurred while retrieving the binary tag
    * @since 4.0.0
    */
-  <T, DX extends Exception> @NonNull T get(final @NonNull Codec<T, String, DX, ?> codec) throws DX;
+  <T, DX extends Exception> @NotNull T get(final @NotNull Codec<T, String, DX, ?> codec) throws DX;
 }

--- a/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolderImpl.java
+++ b/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolderImpl.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.nbt.api;
 
 import net.kyori.adventure.util.Codec;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -36,12 +36,12 @@ final class BinaryTagHolderImpl implements BinaryTagHolder {
   }
 
   @Override
-  public @NonNull String string() {
+  public @NotNull String string() {
     return this.string;
   }
 
   @Override
-  public <T, DX extends Exception> @NonNull T get(final @NonNull Codec<T, String, DX, ?> codec) throws DX {
+  public <T, DX extends Exception> @NotNull T get(final @NotNull Codec<T, String, DX, ?> codec) throws DX {
     return codec.decode(this.string);
   }
 

--- a/api/src/main/java/net/kyori/adventure/permission/PermissionChecker.java
+++ b/api/src/main/java/net/kyori/adventure/permission/PermissionChecker.java
@@ -28,7 +28,7 @@ import net.kyori.adventure.Adventure;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.util.TriState;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that has permissions.
@@ -50,7 +50,7 @@ public interface PermissionChecker extends Predicate<String> {
    * @return a {@link PermissionChecker}
    * @since 4.8.0
    */
-  static @NonNull PermissionChecker always(final TriState state) {
+  static @NotNull PermissionChecker always(final TriState state) {
     if (state == TriState.TRUE) return PermissionCheckers.TRUE;
     if (state == TriState.FALSE) return PermissionCheckers.FALSE;
     return PermissionCheckers.NOT_SET;
@@ -63,7 +63,7 @@ public interface PermissionChecker extends Predicate<String> {
    * @return a tri-state result
    * @since 4.8.0
    */
-  @NonNull TriState value(final String permission);
+  @NotNull TriState value(final String permission);
 
   @Override
   default boolean test(final String permission) {

--- a/api/src/main/java/net/kyori/adventure/permission/PermissionCheckers.java
+++ b/api/src/main/java/net/kyori/adventure/permission/PermissionCheckers.java
@@ -24,8 +24,8 @@
 package net.kyori.adventure.permission;
 
 import net.kyori.adventure.util.TriState;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class PermissionCheckers {
   static final PermissionChecker NOT_SET = new Always(TriState.NOT_SET);
@@ -43,7 +43,7 @@ final class PermissionCheckers {
     }
 
     @Override
-    public @NonNull TriState value(final String permission) {
+    public @NotNull TriState value(final String permission) {
       return this.value;
     }
 

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointer.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointer.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A pointer to a resource.
@@ -45,7 +45,7 @@ public interface Pointer<V> extends Examinable {
    * @return the pointer
    * @since 4.8.0
    */
-  static <V> @NonNull Pointer<V> pointer(final @NonNull Class<V> type, final @NonNull Key key) {
+  static <V> @NotNull Pointer<V> pointer(final @NotNull Class<V> type, final @NotNull Key key) {
     return new PointerImpl<>(type, key);
   }
 
@@ -55,7 +55,7 @@ public interface Pointer<V> extends Examinable {
    * @return the value type
    * @since 4.8.0
    */
-  @NonNull Class<V> type();
+  @NotNull Class<V> type();
 
   /**
    * Gets the key.
@@ -63,10 +63,10 @@ public interface Pointer<V> extends Examinable {
    * @return the key
    * @since 4.8.0
    */
-  @NonNull Key key();
+  @NotNull Key key();
 
   @Override
-  default @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("type", this.type()),
       ExaminableProperty.of("key", this.key())

--- a/api/src/main/java/net/kyori/adventure/pointer/PointerImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointerImpl.java
@@ -25,8 +25,8 @@ package net.kyori.adventure.pointer;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class PointerImpl<T> implements Pointer<T> {
   private final Class<T> type;
@@ -38,12 +38,12 @@ final class PointerImpl<T> implements Pointer<T> {
   }
 
   @Override
-  public @NonNull Class<T> type() {
+  public @NotNull Class<T> type() {
     return this.type;
   }
 
   @Override
-  public @NonNull Key key() {
+  public @NotNull Key key() {
     return this.key;
   }
 

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
@@ -25,8 +25,10 @@ package net.kyori.adventure.pointer;
 
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 /**
  * Something that can retrieve values based on a given {@link Pointer}.
@@ -42,7 +44,7 @@ public interface Pointered {
    * @return the value
    * @since 4.8.0
    */
-  default <T> @NonNull Optional<T> get(final @NonNull Pointer<T> pointer) {
+  default <T> @NotNull Optional<T> get(final @NotNull Pointer<T> pointer) {
     return Optional.empty();
   }
 
@@ -57,8 +59,9 @@ public interface Pointered {
    * @return the value
    * @since 4.8.0
    */
+  @Contract("_, null -> null; _, !null -> !null")
   @SuppressWarnings("checkstyle:MethodName")
-  default <T> @PolyNull T getOrDefault(final @NonNull Pointer<T> pointer, final @PolyNull T defaultValue) {
+  default <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
     return this.get(pointer).orElse(defaultValue);
   }
 
@@ -74,7 +77,7 @@ public interface Pointered {
    * @since 4.8.0
    */
   @SuppressWarnings("checkstyle:MethodName")
-  default <T> @PolyNull T getOrDefaultFrom(final @NonNull Pointer<T> pointer, final @NonNull Supplier<? extends T> defaultValue) {
+  default <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
     return this.get(pointer).orElseGet(defaultValue);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/sound/Sound.java
+++ b/api/src/main/java/net/kyori/adventure/sound/Sound.java
@@ -28,8 +28,8 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import net.kyori.adventure.util.Index;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -65,12 +65,12 @@ public interface Sound extends Examinable {
    * @return the sound
    * @since 4.0.0
    */
-  static @NonNull Sound sound(final @NonNull Key name, final @NonNull Source source, final float volume, final float pitch) {
+  static @NotNull Sound sound(final @NotNull Key name, final @NotNull Source source, final float volume, final float pitch) {
     requireNonNull(name, "name");
     requireNonNull(source, "source");
     return new SoundImpl(source, volume, pitch) {
       @Override
-      public @NonNull Key name() {
+      public @NotNull Key name() {
         return name;
       }
     };
@@ -86,7 +86,7 @@ public interface Sound extends Examinable {
    * @return the sound
    * @since 4.0.0
    */
-  static @NonNull Sound sound(final @NonNull Type type, final @NonNull Source source, final float volume, final float pitch) {
+  static @NotNull Sound sound(final @NotNull Type type, final @NotNull Source source, final float volume, final float pitch) {
     requireNonNull(type, "type");
     return sound(type.key(), source, volume, pitch);
   }
@@ -101,12 +101,12 @@ public interface Sound extends Examinable {
    * @return the sound
    * @since 4.0.0
    */
-  static @NonNull Sound sound(final @NonNull Supplier<? extends Type> type, final @NonNull Source source, final float volume, final float pitch) {
+  static @NotNull Sound sound(final @NotNull Supplier<? extends Type> type, final @NotNull Source source, final float volume, final float pitch) {
     requireNonNull(type, "type");
     requireNonNull(source, "source");
     return new SoundImpl(source, volume, pitch) {
       @Override
-      public @NonNull Key name() {
+      public @NotNull Key name() {
         return type.get().key();
       }
     };
@@ -122,7 +122,7 @@ public interface Sound extends Examinable {
    * @return the sound
    * @since 4.8.0
    */
-  static @NonNull Sound sound(final @NonNull Key name, final Source.@NonNull Provider source, final float volume, final float pitch) {
+  static @NotNull Sound sound(final @NotNull Key name, final Source.@NotNull Provider source, final float volume, final float pitch) {
     return sound(name, source.soundSource(), volume, pitch);
   }
 
@@ -136,7 +136,7 @@ public interface Sound extends Examinable {
    * @return the sound
    * @since 4.8.0
    */
-  static @NonNull Sound sound(final @NonNull Type type, final Source.@NonNull Provider source, final float volume, final float pitch) {
+  static @NotNull Sound sound(final @NotNull Type type, final Source.@NotNull Provider source, final float volume, final float pitch) {
     return sound(type, source.soundSource(), volume, pitch);
   }
 
@@ -150,7 +150,7 @@ public interface Sound extends Examinable {
    * @return the sound
    * @since 4.8.0
    */
-  static @NonNull Sound sound(final @NonNull Supplier<? extends Type> type, final Source.@NonNull Provider source, final float volume, final float pitch) {
+  static @NotNull Sound sound(final @NotNull Supplier<? extends Type> type, final Source.@NotNull Provider source, final float volume, final float pitch) {
     return sound(type, source.soundSource(), volume, pitch);
   }
 
@@ -160,7 +160,7 @@ public interface Sound extends Examinable {
    * @return the name
    * @since 4.0.0
    */
-  @NonNull Key name();
+  @NotNull Key name();
 
   /**
    * Gets the source.
@@ -168,7 +168,7 @@ public interface Sound extends Examinable {
    * @return the source
    * @since 4.0.0
    */
-  @NonNull Source source();
+  @NotNull Source source();
 
   /**
    * Gets the volume.
@@ -227,7 +227,7 @@ public interface Sound extends Examinable {
        * @return the source
        * @since 4.8.0
        */
-      @NonNull Source soundSource();
+      @NotNull Source soundSource();
     }
   }
 
@@ -244,6 +244,6 @@ public interface Sound extends Examinable {
      * @since 4.0.0
      */
     @Override
-    @NonNull Key key();
+    @NotNull Key key();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
@@ -27,22 +27,22 @@ import java.util.stream.Stream;
 import net.kyori.adventure.util.ShadyPines;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 abstract class SoundImpl implements Sound {
   private final Source source;
   private final float volume;
   private final float pitch;
 
-  SoundImpl(final @NonNull Source source, final float volume, final float pitch) {
+  SoundImpl(final @NotNull Source source, final float volume, final float pitch) {
     this.source = source;
     this.volume = volume;
     this.pitch = pitch;
   }
 
   @Override
-  public @NonNull Source source() {
+  public @NotNull Source source() {
     return this.source;
   }
 
@@ -77,7 +77,7 @@ abstract class SoundImpl implements Sound {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("name", this.name()),
       ExaminableProperty.of("source", this.source),

--- a/api/src/main/java/net/kyori/adventure/sound/SoundStop.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundStop.java
@@ -27,9 +27,9 @@ import java.util.function.Supplier;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +52,7 @@ public interface SoundStop extends Examinable {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NonNull SoundStop all() {
+  static @NotNull SoundStop all() {
     return SoundStopImpl.ALL;
   }
 
@@ -63,11 +63,11 @@ public interface SoundStop extends Examinable {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NonNull SoundStop named(final @NonNull Key sound) {
+  static @NotNull SoundStop named(final @NotNull Key sound) {
     requireNonNull(sound, "sound");
     return new SoundStopImpl(null) {
       @Override
-      public @NonNull Key sound() {
+      public @NotNull Key sound() {
         return sound;
       }
     };
@@ -80,11 +80,11 @@ public interface SoundStop extends Examinable {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NonNull SoundStop named(final Sound.@NonNull Type sound) {
+  static @NotNull SoundStop named(final Sound.@NotNull Type sound) {
     requireNonNull(sound, "sound");
     return new SoundStopImpl(null) {
       @Override
-      public @NonNull Key sound() {
+      public @NotNull Key sound() {
         return sound.key();
       }
     };
@@ -97,11 +97,11 @@ public interface SoundStop extends Examinable {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NonNull SoundStop named(final @NonNull Supplier<? extends Sound.Type> sound) {
+  static @NotNull SoundStop named(final @NotNull Supplier<? extends Sound.Type> sound) {
     requireNonNull(sound, "sound");
     return new SoundStopImpl(null) {
       @Override
-      public @NonNull Key sound() {
+      public @NotNull Key sound() {
         return sound.get().key();
       }
     };
@@ -114,7 +114,7 @@ public interface SoundStop extends Examinable {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NonNull SoundStop source(final Sound.@NonNull Source source) {
+  static @NotNull SoundStop source(final Sound.@NotNull Source source) {
     requireNonNull(source, "source");
     return new SoundStopImpl(source) {
       @Override
@@ -132,12 +132,12 @@ public interface SoundStop extends Examinable {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NonNull SoundStop namedOnSource(final @NonNull Key sound, final Sound.@NonNull Source source) {
+  static @NotNull SoundStop namedOnSource(final @NotNull Key sound, final Sound.@NotNull Source source) {
     requireNonNull(sound, "sound");
     requireNonNull(source, "source");
     return new SoundStopImpl(source) {
       @Override
-      public @NonNull Key sound() {
+      public @NotNull Key sound() {
         return sound;
       }
     };
@@ -151,7 +151,7 @@ public interface SoundStop extends Examinable {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NonNull SoundStop namedOnSource(final Sound.@NonNull Type sound, final Sound.@NonNull Source source) {
+  static @NotNull SoundStop namedOnSource(final Sound.@NotNull Type sound, final Sound.@NotNull Source source) {
     requireNonNull(sound, "sound");
     return namedOnSource(sound.key(), source);
   }
@@ -164,12 +164,12 @@ public interface SoundStop extends Examinable {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NonNull SoundStop namedOnSource(final @NonNull Supplier<? extends Sound.Type> sound, final Sound.@NonNull Source source) {
+  static @NotNull SoundStop namedOnSource(final @NotNull Supplier<? extends Sound.Type> sound, final Sound.@NotNull Source source) {
     requireNonNull(sound, "sound");
     requireNonNull(source, "source");
     return new SoundStopImpl(source) {
       @Override
-      public @NonNull Key sound() {
+      public @NotNull Key sound() {
         return sound.get().key();
       }
     };

--- a/api/src/main/java/net/kyori/adventure/sound/SoundStopImpl.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundStopImpl.java
@@ -28,8 +28,8 @@ import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 abstract class SoundStopImpl implements SoundStop {
   static final SoundStop ALL = new SoundStopImpl(null) {
@@ -66,7 +66,7 @@ abstract class SoundStopImpl implements SoundStop {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("name", this.sound()),
       ExaminableProperty.of("source", this.source)

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -32,9 +32,9 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -56,29 +56,29 @@ public abstract class AbstractComponent implements Component {
    */
   protected final Style style;
 
-  protected AbstractComponent(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style) {
+  protected AbstractComponent(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style) {
     this.children = ComponentLike.asComponents(children, NOT_EMPTY);
     this.style = style;
   }
 
   @Override
-  public final @NonNull List<Component> children() {
+  public final @NotNull List<Component> children() {
     return this.children;
   }
 
   @Override
-  public final @NonNull Style style() {
+  public final @NotNull Style style() {
     return this.style;
   }
 
   @Override
-  public @NonNull Component replaceText(final @NonNull Consumer<TextReplacementConfig.Builder> configurer) {
+  public @NotNull Component replaceText(final @NotNull Consumer<TextReplacementConfig.Builder> configurer) {
     requireNonNull(configurer, "configurer");
     return this.replaceText(Buildable.configureAndBuild(TextReplacementConfig.builder(), configurer));
   }
 
   @Override
-  public @NonNull Component replaceText(final @NonNull TextReplacementConfig config) {
+  public @NotNull Component replaceText(final @NotNull TextReplacementConfig config) {
     requireNonNull(config, "replacement");
     if (!(config instanceof TextReplacementConfigImpl)) {
       throw new IllegalArgumentException("Provided replacement was a custom TextReplacementConfig implementation, which is not supported.");
@@ -112,7 +112,7 @@ public abstract class AbstractComponent implements Component {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       this.examinablePropertiesWithoutChildren(),
       Stream.of(

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -36,8 +36,8 @@ import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An abstract implementation of a component builder.
@@ -65,7 +65,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   protected AbstractComponentBuilder() {
   }
 
-  protected AbstractComponentBuilder(final @NonNull C component) {
+  protected AbstractComponentBuilder(final @NotNull C component) {
     final List<Component> children = component.children();
     if (!children.isEmpty()) {
       this.children = new ArrayList<>(children);
@@ -77,7 +77,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B append(final @NonNull Component component) {
+  public @NotNull B append(final @NotNull Component component) {
     if (component == Component.empty()) return (B) this;
     this.prepareChildren();
     this.children.add(component);
@@ -86,7 +86,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B append(final @NonNull Component@NonNull... components) {
+  public @NotNull B append(final @NotNull Component@NotNull... components) {
     boolean prepared = false;
     for (int i = 0, length = components.length; i < length; i++) {
       final Component component = components[i];
@@ -103,7 +103,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B append(final @NonNull ComponentLike@NonNull... components) {
+  public @NotNull B append(final @NotNull ComponentLike@NotNull... components) {
     boolean prepared = false;
     for (int i = 0, length = components.length; i < length; i++) {
       final Component component = components[i].asComponent();
@@ -120,7 +120,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B append(final @NonNull Iterable<? extends ComponentLike> components) {
+  public @NotNull B append(final @NotNull Iterable<? extends ComponentLike> components) {
     boolean prepared = false;
     for (final ComponentLike like : components) {
       final Component component = like.asComponent();
@@ -143,7 +143,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B applyDeep(final @NonNull Consumer<? super ComponentBuilder<?, ?>> consumer) {
+  public @NotNull B applyDeep(final @NotNull Consumer<? super ComponentBuilder<?, ?>> consumer) {
     this.apply(consumer);
     if (this.children == Collections.<Component>emptyList()) {
       return (B) this;
@@ -163,7 +163,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B mapChildren(final @NonNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function) {
+  public @NotNull B mapChildren(final @NotNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function) {
     if (this.children == Collections.<Component>emptyList()) {
       return (B) this;
     }
@@ -184,7 +184,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B mapChildrenDeep(final @NonNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function) {
+  public @NotNull B mapChildrenDeep(final @NotNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function) {
     if (this.children == Collections.<Component>emptyList()) {
       return (B) this;
     }
@@ -210,13 +210,13 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   }
 
   @Override
-  public @NonNull List<Component> children() {
+  public @NotNull List<Component> children() {
     return Collections.unmodifiableList(this.children);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B style(final @NonNull Style style) {
+  public @NotNull B style(final @NotNull Style style) {
     this.style = style;
     this.styleBuilder = null;
     return (B) this;
@@ -224,76 +224,76 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B style(final @NonNull Consumer<Style.Builder> consumer) {
+  public @NotNull B style(final @NotNull Consumer<Style.Builder> consumer) {
     consumer.accept(this.styleBuilder());
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B font(final @Nullable Key font) {
+  public @NotNull B font(final @Nullable Key font) {
     this.styleBuilder().font(font);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B color(final @Nullable TextColor color) {
+  public @NotNull B color(final @Nullable TextColor color) {
     this.styleBuilder().color(color);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B colorIfAbsent(final @Nullable TextColor color) {
+  public @NotNull B colorIfAbsent(final @Nullable TextColor color) {
     this.styleBuilder().colorIfAbsent(color);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B decoration(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state) {
+  public @NotNull B decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     this.styleBuilder().decoration(decoration, state);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B clickEvent(final @Nullable ClickEvent event) {
+  public @NotNull B clickEvent(final @Nullable ClickEvent event) {
     this.styleBuilder().clickEvent(event);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B hoverEvent(final @Nullable HoverEventSource<?> source) {
+  public @NotNull B hoverEvent(final @Nullable HoverEventSource<?> source) {
     this.styleBuilder().hoverEvent(source);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B insertion(final @Nullable String insertion) {
+  public @NotNull B insertion(final @Nullable String insertion) {
     this.styleBuilder().insertion(insertion);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B mergeStyle(final @NonNull Component that, final @NonNull Set<Style.Merge> merges) {
+  public @NotNull B mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges) {
     this.styleBuilder().merge(that.style(), merges);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NonNull B resetStyle() {
+  public @NotNull B resetStyle() {
     this.style = null;
     this.styleBuilder = null;
     return (B) this;
   }
 
-  private Style.@NonNull Builder styleBuilder() {
+  private Style.@NotNull Builder styleBuilder() {
     if (this.styleBuilder == null) {
       if (this.style != null) {
         this.styleBuilder = this.style.toBuilder();
@@ -309,7 +309,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
     return this.styleBuilder != null || this.style != null;
   }
 
-  protected @NonNull Style buildStyle() {
+  protected @NotNull Style buildStyle() {
     if (this.styleBuilder != null) {
       return this.styleBuilder.build();
     } else if (this.style != null) {

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponent.java
@@ -25,8 +25,8 @@ package net.kyori.adventure.text;
 
 import java.util.regex.Matcher;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Given an in-game position, this component reads the NBT of the associated block and displays that information.
@@ -50,7 +50,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
    * @return the block position
    * @since 4.0.0
    */
-  @NonNull Pos pos();
+  @NotNull Pos pos();
 
   /**
    * Sets the block position.
@@ -60,7 +60,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull BlockNBTComponent pos(final @NonNull Pos pos);
+  @NotNull BlockNBTComponent pos(final @NotNull Pos pos);
 
   /**
    * Sets the block position to a {@link LocalPos} with the given coordinates.
@@ -72,7 +72,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull BlockNBTComponent localPos(final double left, final double up, final double forwards) {
+  default @NotNull BlockNBTComponent localPos(final double left, final double up, final double forwards) {
     return this.pos(LocalPos.of(left, up, forwards));
   }
 
@@ -86,7 +86,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull BlockNBTComponent worldPos(final WorldPos.@NonNull Coordinate x, final WorldPos.@NonNull Coordinate y, final WorldPos.@NonNull Coordinate z) {
+  default @NotNull BlockNBTComponent worldPos(final WorldPos.@NotNull Coordinate x, final WorldPos.@NotNull Coordinate y, final WorldPos.@NotNull Coordinate z) {
     return this.pos(WorldPos.of(x, y, z));
   }
 
@@ -100,7 +100,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull BlockNBTComponent absoluteWorldPos(final int x, final int y, final int z) {
+  default @NotNull BlockNBTComponent absoluteWorldPos(final int x, final int y, final int z) {
     return this.worldPos(WorldPos.Coordinate.absolute(x), WorldPos.Coordinate.absolute(y), WorldPos.Coordinate.absolute(z));
   }
 
@@ -114,7 +114,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull BlockNBTComponent relativeWorldPos(final int x, final int y, final int z) {
+  default @NotNull BlockNBTComponent relativeWorldPos(final int x, final int y, final int z) {
     return this.worldPos(WorldPos.Coordinate.relative(x), WorldPos.Coordinate.relative(y), WorldPos.Coordinate.relative(z));
   }
 
@@ -132,7 +132,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder pos(final @NonNull Pos pos);
+    @NotNull Builder pos(final @NotNull Pos pos);
 
     /**
      * Sets the block position to a {@link LocalPos} with the given values.
@@ -144,7 +144,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NonNull Builder localPos(final double left, final double up, final double forwards) {
+    default @NotNull Builder localPos(final double left, final double up, final double forwards) {
       return this.pos(LocalPos.of(left, up, forwards));
     }
 
@@ -158,7 +158,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NonNull Builder worldPos(final WorldPos.@NonNull Coordinate x, final WorldPos.@NonNull Coordinate y, final WorldPos.@NonNull Coordinate z) {
+    default @NotNull Builder worldPos(final WorldPos.@NotNull Coordinate x, final WorldPos.@NotNull Coordinate y, final WorldPos.@NotNull Coordinate z) {
       return this.pos(WorldPos.of(x, y, z));
     }
 
@@ -172,7 +172,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NonNull Builder absoluteWorldPos(final int x, final int y, final int z) {
+    default @NotNull Builder absoluteWorldPos(final int x, final int y, final int z) {
       return this.worldPos(WorldPos.Coordinate.absolute(x), WorldPos.Coordinate.absolute(y), WorldPos.Coordinate.absolute(z));
     }
 
@@ -186,7 +186,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NonNull Builder relativeWorldPos(final int x, final int y, final int z) {
+    default @NotNull Builder relativeWorldPos(final int x, final int y, final int z) {
       return this.worldPos(WorldPos.Coordinate.relative(x), WorldPos.Coordinate.relative(y), WorldPos.Coordinate.relative(z));
     }
   }
@@ -209,7 +209,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @throws IllegalArgumentException if the position was in an invalid format
      * @since 4.0.0
      */
-    static @NonNull Pos fromString(final @NonNull String input) throws IllegalArgumentException {
+    static @NotNull Pos fromString(final @NotNull String input) throws IllegalArgumentException {
       final Matcher localMatch = BlockNBTComponentImpl.Tokens.LOCAL_PATTERN.matcher(input);
       if (localMatch.matches()) {
         return BlockNBTComponent.LocalPos.of(
@@ -238,7 +238,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @see #fromString(String)
      * @since 4.0.0
      */
-    @NonNull String asString();
+    @NotNull String asString();
   }
 
   /**
@@ -256,7 +256,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @return a local position
      * @since 4.0.0
      */
-    static @NonNull LocalPos of(final double left, final double up, final double forwards) {
+    static @NotNull LocalPos of(final double left, final double up, final double forwards) {
       return new BlockNBTComponentImpl.LocalPosImpl(left, up, forwards);
     }
 
@@ -300,7 +300,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @return a world position
      * @since 4.0.0
      */
-    static @NonNull WorldPos of(final @NonNull Coordinate x, final @NonNull Coordinate y, final @NonNull Coordinate z) {
+    static @NotNull WorldPos of(final @NotNull Coordinate x, final @NotNull Coordinate y, final @NotNull Coordinate z) {
       return new BlockNBTComponentImpl.WorldPosImpl(x, y, z);
     }
 
@@ -310,7 +310,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @return the x coordinate
      * @since 4.0.0
      */
-    @NonNull Coordinate x();
+    @NotNull Coordinate x();
 
     /**
      * Gets the y coordinate.
@@ -318,7 +318,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @return the y coordinate
      * @since 4.0.0
      */
-    @NonNull Coordinate y();
+    @NotNull Coordinate y();
 
     /**
      * Gets the z coordinate.
@@ -326,7 +326,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @return the z coordinate
      * @since 4.0.0
      */
-    @NonNull Coordinate z();
+    @NotNull Coordinate z();
 
     /**
      * A coordinate component within a {@link WorldPos}.
@@ -341,7 +341,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
        * @return a coordinate
        * @since 4.0.0
        */
-      static @NonNull Coordinate absolute(final int value) {
+      static @NotNull Coordinate absolute(final int value) {
         return of(value, Type.ABSOLUTE);
       }
 
@@ -352,7 +352,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
        * @return a coordinate
        * @since 4.0.0
        */
-      static @NonNull Coordinate relative(final int value) {
+      static @NotNull Coordinate relative(final int value) {
         return of(value, Type.RELATIVE);
       }
 
@@ -364,7 +364,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
        * @return a coordinate
        * @since 4.0.0
        */
-      static @NonNull Coordinate of(final int value, final @NonNull Type type) {
+      static @NotNull Coordinate of(final int value, final @NotNull Type type) {
         return new BlockNBTComponentImpl.WorldPosImpl.CoordinateImpl(value, type);
       }
 
@@ -382,7 +382,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
        * @return the type
        * @since 4.0.0
        */
-      @NonNull Type type();
+      @NotNull Type type();
 
       /**
        * The type of a coordinate.

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
@@ -30,48 +30,48 @@ import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.util.ShadyPines;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, BlockNBTComponent.Builder> implements BlockNBTComponent {
   private final Pos pos;
 
-  BlockNBTComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final String nbtPath, final boolean interpret, final @NonNull Pos pos) {
+  BlockNBTComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final String nbtPath, final boolean interpret, final @NotNull Pos pos) {
     super(children, style, nbtPath, interpret);
     this.pos = pos;
   }
 
   @Override
-  public @NonNull BlockNBTComponent nbtPath(final @NonNull String nbtPath) {
+  public @NotNull BlockNBTComponent nbtPath(final @NotNull String nbtPath) {
     if (Objects.equals(this.nbtPath, nbtPath)) return this;
     return new BlockNBTComponentImpl(this.children, this.style, nbtPath, this.interpret, this.pos);
   }
 
   @Override
-  public @NonNull BlockNBTComponent interpret(final boolean interpret) {
+  public @NotNull BlockNBTComponent interpret(final boolean interpret) {
     if (this.interpret == interpret) return this;
     return new BlockNBTComponentImpl(this.children, this.style, this.nbtPath, interpret, this.pos);
   }
 
   @Override
-  public @NonNull Pos pos() {
+  public @NotNull Pos pos() {
     return this.pos;
   }
 
   @Override
-  public @NonNull BlockNBTComponent pos(final @NonNull Pos pos) {
+  public @NotNull BlockNBTComponent pos(final @NotNull Pos pos) {
     return new BlockNBTComponentImpl(this.children, this.style, this.nbtPath, this.interpret, pos);
   }
 
   @Override
-  public @NonNull BlockNBTComponent children(final @NonNull List<? extends ComponentLike> children) {
+  public @NotNull BlockNBTComponent children(final @NotNull List<? extends ComponentLike> children) {
     return new BlockNBTComponentImpl(children, this.style, this.nbtPath, this.interpret, this.pos);
   }
 
   @Override
-  public @NonNull BlockNBTComponent style(final @NonNull Style style) {
+  public @NotNull BlockNBTComponent style(final @NotNull Style style) {
     return new BlockNBTComponentImpl(this.children, style, this.nbtPath, this.interpret, this.pos);
   }
 
@@ -92,7 +92,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("pos", this.pos)
@@ -102,7 +102,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
   }
 
   @Override
-  public BlockNBTComponent.@NonNull Builder toBuilder() {
+  public BlockNBTComponent.@NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -112,19 +112,19 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull BlockNBTComponent component) {
+    BuilderImpl(final @NotNull BlockNBTComponent component) {
       super(component);
       this.pos = component.pos();
     }
 
     @Override
-    public BlockNBTComponent.@NonNull Builder pos(final @NonNull Pos pos) {
+    public BlockNBTComponent.@NotNull Builder pos(final @NotNull Pos pos) {
       this.pos = pos;
       return this;
     }
 
     @Override
-    public @NonNull BlockNBTComponent build() {
+    public @NotNull BlockNBTComponent build() {
       if (this.nbtPath == null) throw new IllegalStateException("nbt path must be set");
       if (this.pos == null) throw new IllegalStateException("pos must be set");
       return new BlockNBTComponentImpl(this.children, this.buildStyle(), this.nbtPath, this.interpret, this.pos);
@@ -158,7 +158,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
     }
 
     @Override
-    public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("left", this.left),
         ExaminableProperty.of("up", this.up),
@@ -190,7 +190,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
     }
 
     @Override
-    public @NonNull String asString() {
+    public @NotNull String asString() {
       return Tokens.serializeLocal(this.left) + ' ' + Tokens.serializeLocal(this.up) + ' ' + Tokens.serializeLocal(this.forwards);
     }
   }
@@ -207,22 +207,22 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
     }
 
     @Override
-    public @NonNull Coordinate x() {
+    public @NotNull Coordinate x() {
       return this.x;
     }
 
     @Override
-    public @NonNull Coordinate y() {
+    public @NotNull Coordinate y() {
       return this.y;
     }
 
     @Override
-    public @NonNull Coordinate z() {
+    public @NotNull Coordinate z() {
       return this.z;
     }
 
     @Override
-    public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("x", this.x),
         ExaminableProperty.of("y", this.y),
@@ -254,7 +254,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
     }
 
     @Override
-    public @NonNull String asString() {
+    public @NotNull String asString() {
       return Tokens.serializeCoordinate(this.x()) + ' ' + Tokens.serializeCoordinate(this.y()) + ' ' + Tokens.serializeCoordinate(this.z());
     }
 
@@ -262,7 +262,7 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
       private final int value;
       private final Type type;
 
-      CoordinateImpl(final int value, final @NonNull Type type) {
+      CoordinateImpl(final int value, final @NotNull Type type) {
         this.value = value;
         this.type = requireNonNull(type, "type");
       }
@@ -273,12 +273,12 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
       }
 
       @Override
-      public @NonNull Type type() {
+      public @NotNull Type type() {
         return this.type;
       }
 
       @Override
-      public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+      public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
         return Stream.of(
           ExaminableProperty.of("value", this.value),
           ExaminableProperty.of("type", this.type)

--- a/api/src/main/java/net/kyori/adventure/text/BuildableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/BuildableComponent.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.text;
 
 import net.kyori.adventure.util.Buildable;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A component which may be built.
@@ -40,5 +40,5 @@ public interface BuildableComponent<C extends BuildableComponent<C, B>, B extend
    * @return the builder
    */
   @Override
-  @NonNull B toBuilder();
+  @NotNull B toBuilder();
 }

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -48,10 +48,10 @@ import net.kyori.adventure.translation.Translatable;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 /**
@@ -115,7 +115,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return an empty component
    * @since 4.0.0
    */
-  static @NonNull TextComponent empty() {
+  static @NotNull TextComponent empty() {
     return TextComponentImpl.EMPTY;
   }
 
@@ -125,7 +125,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return a text component with a new line character as the content
    * @since 4.0.0
    */
-  static @NonNull TextComponent newline() {
+  static @NotNull TextComponent newline() {
     return TextComponentImpl.NEWLINE;
   }
 
@@ -135,7 +135,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return a text component with a single space as the content
    * @since 4.0.0
    */
-  static @NonNull TextComponent space() {
+  static @NotNull TextComponent space() {
     return TextComponentImpl.SPACE;
   }
 
@@ -148,7 +148,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent join(final @NonNull ComponentLike separator, final @NonNull ComponentLike@NonNull... components) {
+  static @NotNull TextComponent join(final @NotNull ComponentLike separator, final @NotNull ComponentLike@NotNull... components) {
     return join(separator, Arrays.asList(components));
   }
 
@@ -161,7 +161,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent join(final @NonNull ComponentLike separator, final Iterable<? extends ComponentLike> components) {
+  static @NotNull TextComponent join(final @NotNull ComponentLike separator, final Iterable<? extends ComponentLike> components) {
     final Iterator<? extends ComponentLike> it = components.iterator();
     if (!it.hasNext()) {
       return Component.empty();
@@ -182,7 +182,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return a collector that can join components
    * @since 4.6.0
    */
-  static @NonNull Collector<Component, ? extends ComponentBuilder<?, ?>, Component> toComponent() {
+  static @NotNull Collector<Component, ? extends ComponentBuilder<?, ?>, Component> toComponent() {
     return toComponent(Component.empty());
   }
 
@@ -193,7 +193,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return a collector that can join components
    * @since 4.6.0
    */
-  static @NonNull Collector<Component, ? extends ComponentBuilder<?, ?>, Component> toComponent(final @NonNull Component separator) {
+  static @NotNull Collector<Component, ? extends ComponentBuilder<?, ?>, Component> toComponent(final @NotNull Component separator) {
     return Collector.of(
       Component::text,
       (builder, add) -> {
@@ -227,7 +227,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static BlockNBTComponent.@NonNull Builder blockNBT() {
+  static BlockNBTComponent.@NotNull Builder blockNBT() {
     return new BlockNBTComponentImpl.BuilderImpl();
   }
 
@@ -239,7 +239,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NonNull BlockNBTComponent blockNBT(final @NonNull Consumer<? super BlockNBTComponent.Builder> consumer) {
+  static @NotNull BlockNBTComponent blockNBT(final @NotNull Consumer<? super BlockNBTComponent.Builder> consumer) {
     return Buildable.configureAndBuild(blockNBT(), consumer);
   }
 
@@ -252,7 +252,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull BlockNBTComponent blockNBT(final @NonNull String nbtPath, final BlockNBTComponent.@NonNull Pos pos) {
+  static @NotNull BlockNBTComponent blockNBT(final @NotNull String nbtPath, final BlockNBTComponent.@NotNull Pos pos) {
     return blockNBT(nbtPath, NBTComponentImpl.INTERPRET_DEFAULT, pos);
   }
 
@@ -266,7 +266,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull BlockNBTComponent blockNBT(final @NonNull String nbtPath, final boolean interpret, final BlockNBTComponent.@NonNull Pos pos) {
+  static @NotNull BlockNBTComponent blockNBT(final @NotNull String nbtPath, final boolean interpret, final BlockNBTComponent.@NotNull Pos pos) {
     return new BlockNBTComponentImpl(Collections.emptyList(), Style.empty(), nbtPath, interpret, pos);
   }
 
@@ -283,7 +283,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static EntityNBTComponent.@NonNull Builder entityNBT() {
+  static EntityNBTComponent.@NotNull Builder entityNBT() {
     return new EntityNBTComponentImpl.BuilderImpl();
   }
 
@@ -295,7 +295,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NonNull EntityNBTComponent entityNBT(final @NonNull Consumer<? super EntityNBTComponent.Builder> consumer) {
+  static @NotNull EntityNBTComponent entityNBT(final @NotNull Consumer<? super EntityNBTComponent.Builder> consumer) {
     return Buildable.configureAndBuild(entityNBT(), consumer);
   }
 
@@ -308,7 +308,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_, _ -> new")
-  static @NonNull EntityNBTComponent entityNBT(final @NonNull String nbtPath, final @NonNull String selector) {
+  static @NotNull EntityNBTComponent entityNBT(final @NotNull String nbtPath, final @NotNull String selector) {
     return entityNBT().nbtPath(nbtPath).selector(selector).build();
   }
 
@@ -325,7 +325,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static KeybindComponent.@NonNull Builder keybind() {
+  static KeybindComponent.@NotNull Builder keybind() {
     return new KeybindComponentImpl.BuilderImpl();
   }
 
@@ -337,7 +337,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NonNull KeybindComponent keybind(final @NonNull Consumer<? super KeybindComponent.Builder> consumer) {
+  static @NotNull KeybindComponent keybind(final @NotNull Consumer<? super KeybindComponent.Builder> consumer) {
     return Buildable.configureAndBuild(keybind(), consumer);
   }
 
@@ -349,7 +349,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull KeybindComponent keybind(final @NonNull String keybind) {
+  static @NotNull KeybindComponent keybind(final @NotNull String keybind) {
     return keybind(keybind, Style.empty());
   }
 
@@ -362,7 +362,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull KeybindComponent keybind(final @NonNull String keybind, final @NonNull Style style) {
+  static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @NotNull Style style) {
     return new KeybindComponentImpl(Collections.emptyList(), style, keybind);
   }
 
@@ -375,7 +375,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull KeybindComponent keybind(final @NonNull String keybind, final @Nullable TextColor color) {
+  static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @Nullable TextColor color) {
     return keybind(keybind, Style.style(color));
   }
 
@@ -389,7 +389,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull KeybindComponent keybind(final @NonNull String keybind, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return keybind(keybind, Style.style(color, decorations));
   }
 
@@ -403,7 +403,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull KeybindComponent keybind(final @NonNull String keybind, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return keybind(keybind, Style.style(color, decorations));
   }
 
@@ -420,7 +420,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static ScoreComponent.@NonNull Builder score() {
+  static ScoreComponent.@NotNull Builder score() {
     return new ScoreComponentImpl.BuilderImpl();
   }
 
@@ -432,7 +432,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NonNull ScoreComponent score(final @NonNull Consumer<? super ScoreComponent.Builder> consumer) {
+  static @NotNull ScoreComponent score(final @NotNull Consumer<? super ScoreComponent.Builder> consumer) {
     return Buildable.configureAndBuild(score(), consumer);
   }
 
@@ -445,7 +445,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull ScoreComponent score(final @NonNull String name, final @NonNull String objective) {
+  static @NotNull ScoreComponent score(final @NotNull String name, final @NotNull String objective) {
     return score(name, objective, null);
   }
 
@@ -461,7 +461,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   @Deprecated
-  static @NonNull ScoreComponent score(final @NonNull String name, final @NonNull String objective, final @Nullable String value) {
+  static @NotNull ScoreComponent score(final @NotNull String name, final @NotNull String objective, final @Nullable String value) {
     return new ScoreComponentImpl(Collections.emptyList(), Style.empty(), name, objective, value);
   }
 
@@ -478,7 +478,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static SelectorComponent.@NonNull Builder selector() {
+  static SelectorComponent.@NotNull Builder selector() {
     return new SelectorComponentImpl.BuilderImpl();
   }
 
@@ -490,7 +490,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NonNull SelectorComponent selector(final @NonNull Consumer<? super SelectorComponent.Builder> consumer) {
+  static @NotNull SelectorComponent selector(final @NotNull Consumer<? super SelectorComponent.Builder> consumer) {
     return Buildable.configureAndBuild(selector(), consumer);
   }
 
@@ -502,7 +502,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull SelectorComponent selector(final @NonNull String pattern) {
+  static @NotNull SelectorComponent selector(final @NotNull String pattern) {
     return new SelectorComponentImpl(Collections.emptyList(), Style.empty(), pattern);
   }
 
@@ -519,7 +519,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static StorageNBTComponent.@NonNull Builder storageNBT() {
+  static StorageNBTComponent.@NotNull Builder storageNBT() {
     return new StorageNBTComponentImpl.BuilderImpl();
   }
 
@@ -531,7 +531,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NonNull StorageNBTComponent storageNBT(final @NonNull Consumer<? super StorageNBTComponent.Builder> consumer) {
+  static @NotNull StorageNBTComponent storageNBT(final @NotNull Consumer<? super StorageNBTComponent.Builder> consumer) {
     return Buildable.configureAndBuild(storageNBT(), consumer);
   }
 
@@ -544,7 +544,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull StorageNBTComponent storageNBT(final @NonNull String nbtPath, final @NonNull Key storage) {
+  static @NotNull StorageNBTComponent storageNBT(final @NotNull String nbtPath, final @NotNull Key storage) {
     return storageNBT(nbtPath, NBTComponentImpl.INTERPRET_DEFAULT, storage);
   }
 
@@ -558,7 +558,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull StorageNBTComponent storageNBT(final @NonNull String nbtPath, final boolean interpret, final @NonNull Key storage) {
+  static @NotNull StorageNBTComponent storageNBT(final @NotNull String nbtPath, final boolean interpret, final @NotNull Key storage) {
     return new StorageNBTComponentImpl(Collections.emptyList(), Style.empty(), nbtPath, interpret, storage);
   }
 
@@ -575,7 +575,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static TextComponent.@NonNull Builder text() {
+  static TextComponent.@NotNull Builder text() {
     return new TextComponentImpl.BuilderImpl();
   }
 
@@ -587,7 +587,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NonNull TextComponent text(final @NonNull Consumer<? super TextComponent.Builder> consumer) {
+  static @NotNull TextComponent text(final @NotNull Consumer<? super TextComponent.Builder> consumer) {
     return Buildable.configureAndBuild(text(), consumer);
   }
 
@@ -599,7 +599,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull TextComponent text(final @NonNull String content) {
+  static @NotNull TextComponent text(final @NotNull String content) {
     if (content.isEmpty()) return empty();
     return new TextComponentImpl(Collections.emptyList(), Style.empty(), content);
   }
@@ -613,7 +613,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final @NonNull String content, final @NonNull Style style) {
+  static @NotNull TextComponent text(final @NotNull String content, final @NotNull Style style) {
     return new TextComponentImpl(Collections.emptyList(), style, content);
   }
 
@@ -626,7 +626,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final @NonNull String content, final @Nullable TextColor color) {
+  static @NotNull TextComponent text(final @NotNull String content, final @Nullable TextColor color) {
     return new TextComponentImpl(Collections.emptyList(), Style.style(color), content);
   }
 
@@ -640,7 +640,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final @NonNull String content, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TextComponent text(final @NotNull String content, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return new TextComponentImpl(Collections.emptyList(), Style.style(color, decorations), content);
   }
 
@@ -654,7 +654,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final @NonNull String content, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TextComponent text(final @NotNull String content, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return new TextComponentImpl(Collections.emptyList(), Style.style(color, decorations), content);
   }
 
@@ -666,7 +666,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull TextComponent text(final boolean value) {
+  static @NotNull TextComponent text(final boolean value) {
     return text(String.valueOf(value));
   }
 
@@ -679,7 +679,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final boolean value, final @NonNull Style style) {
+  static @NotNull TextComponent text(final boolean value, final @NotNull Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -692,7 +692,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final boolean value, final @Nullable TextColor color) {
+  static @NotNull TextComponent text(final boolean value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -706,7 +706,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final boolean value, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TextComponent text(final boolean value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -720,7 +720,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final boolean value, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TextComponent text(final boolean value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -732,7 +732,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static @NonNull TextComponent text(final char value) {
+  static @NotNull TextComponent text(final char value) {
     if (value == '\n') return newline();
     if (value == ' ') return space();
     return text(String.valueOf(value));
@@ -747,7 +747,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final char value, final @NonNull Style style) {
+  static @NotNull TextComponent text(final char value, final @NotNull Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -760,7 +760,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final char value, final @Nullable TextColor color) {
+  static @NotNull TextComponent text(final char value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -774,7 +774,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final char value, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TextComponent text(final char value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -788,7 +788,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final char value, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TextComponent text(final char value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -800,7 +800,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull TextComponent text(final double value) {
+  static @NotNull TextComponent text(final double value) {
     return text(String.valueOf(value));
   }
 
@@ -813,7 +813,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final double value, final @NonNull Style style) {
+  static @NotNull TextComponent text(final double value, final @NotNull Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -826,7 +826,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final double value, final @Nullable TextColor color) {
+  static @NotNull TextComponent text(final double value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -840,7 +840,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final double value, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TextComponent text(final double value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -854,7 +854,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final double value, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TextComponent text(final double value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -866,7 +866,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull TextComponent text(final float value) {
+  static @NotNull TextComponent text(final float value) {
     return text(String.valueOf(value));
   }
 
@@ -879,7 +879,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final float value, final @NonNull Style style) {
+  static @NotNull TextComponent text(final float value, final @NotNull Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -892,7 +892,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final float value, final @Nullable TextColor color) {
+  static @NotNull TextComponent text(final float value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -906,7 +906,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final float value, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TextComponent text(final float value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -920,7 +920,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final float value, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TextComponent text(final float value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -932,7 +932,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull TextComponent text(final int value) {
+  static @NotNull TextComponent text(final int value) {
     return text(String.valueOf(value));
   }
 
@@ -945,7 +945,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final int value, final @NonNull Style style) {
+  static @NotNull TextComponent text(final int value, final @NotNull Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -958,7 +958,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final int value, final @Nullable TextColor color) {
+  static @NotNull TextComponent text(final int value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -972,7 +972,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final int value, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TextComponent text(final int value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -986,7 +986,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final int value, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TextComponent text(final int value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -998,7 +998,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull TextComponent text(final long value) {
+  static @NotNull TextComponent text(final long value) {
     return text(String.valueOf(value));
   }
 
@@ -1011,7 +1011,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final long value, final @NonNull Style style) {
+  static @NotNull TextComponent text(final long value, final @NotNull Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -1024,7 +1024,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TextComponent text(final long value, final @Nullable TextColor color) {
+  static @NotNull TextComponent text(final long value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -1038,7 +1038,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final long value, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TextComponent text(final long value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1052,7 +1052,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TextComponent text(final long value, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TextComponent text(final long value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1069,7 +1069,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static TranslatableComponent.@NonNull Builder translatable() {
+  static TranslatableComponent.@NotNull Builder translatable() {
     return new TranslatableComponentImpl.BuilderImpl();
   }
 
@@ -1081,7 +1081,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NonNull TranslatableComponent translatable(final @NonNull Consumer<? super TranslatableComponent.Builder> consumer) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Consumer<? super TranslatableComponent.Builder> consumer) {
     return Buildable.configureAndBuild(translatable(), consumer);
   }
 
@@ -1093,7 +1093,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key) {
     return translatable(key, Style.empty());
   }
 
@@ -1105,7 +1105,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), Style.empty());
   }
 
@@ -1118,7 +1118,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @NonNull Style style) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style) {
     return new TranslatableComponentImpl(Collections.emptyList(), style, key, Collections.emptyList());
   }
 
@@ -1131,7 +1131,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull Style style) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull Style style) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), style);
   }
 
@@ -1144,7 +1144,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color) {
     return translatable(key, Style.style(color));
   }
 
@@ -1157,7 +1157,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color);
   }
 
@@ -1171,7 +1171,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return translatable(key, Style.style(color, decorations));
   }
 
@@ -1185,7 +1185,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, decorations);
   }
 
@@ -1199,7 +1199,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return translatable(key, Style.style(color, decorations));
   }
 
@@ -1213,7 +1213,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, decorations);
   }
 
@@ -1226,7 +1226,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @NonNull ComponentLike@NonNull... args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull ComponentLike@NotNull... args) {
     return translatable(key, Style.empty(), args);
   }
 
@@ -1239,7 +1239,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull ComponentLike@NonNull... args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull ComponentLike@NotNull... args) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), args);
   }
 
@@ -1253,7 +1253,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @NonNull Style style, final @NonNull ComponentLike@NonNull... args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
     return new TranslatableComponentImpl(Collections.emptyList(), style, key, args);
   }
 
@@ -1267,7 +1267,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull Style style, final @NonNull ComponentLike@NonNull... args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), style, args);
   }
 
@@ -1281,7 +1281,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull ComponentLike@NonNull... args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
     return translatable(key, Style.style(color), args);
   }
 
@@ -1295,7 +1295,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull ComponentLike@NonNull... args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, args);
   }
 
@@ -1310,7 +1310,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations, final @NonNull ComponentLike@NonNull... args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
     return translatable(key, Style.style(color, decorations), args);
   }
 
@@ -1325,7 +1325,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations, final @NonNull ComponentLike@NonNull... args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, decorations, args);
   }
 
@@ -1338,7 +1338,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @NonNull List<? extends ComponentLike> args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull List<? extends ComponentLike> args) {
     return new TranslatableComponentImpl(Collections.emptyList(), Style.empty(), key, args);
   }
 
@@ -1351,7 +1351,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull List<? extends ComponentLike> args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull List<? extends ComponentLike> args) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), args);
   }
 
@@ -1365,7 +1365,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @NonNull Style style, final @NonNull List<? extends ComponentLike> args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
     return new TranslatableComponentImpl(Collections.emptyList(), style, key, args);
   }
 
@@ -1379,7 +1379,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @NonNull Style style, final @NonNull List<? extends ComponentLike> args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), style, args);
   }
 
@@ -1393,7 +1393,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
     return translatable(key, Style.style(color), args);
   }
 
@@ -1407,7 +1407,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, args);
   }
 
@@ -1422,7 +1422,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull String key, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations, final @NonNull List<? extends ComponentLike> args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
     return translatable(key, Style.style(color, decorations), args);
   }
 
@@ -1437,7 +1437,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NonNull TranslatableComponent translatable(final @NonNull Translatable translatable, final @Nullable TextColor color, final @NonNull Set<TextDecoration> decorations, final @NonNull List<? extends ComponentLike> args) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
     return translatable(Objects.requireNonNull(translatable, "translatable").translationKey(), color, decorations, args);
   }
 
@@ -1447,7 +1447,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return the unmodifiable list of children
    * @since 4.0.0
    */
-  @Unmodifiable @NonNull List<Component> children();
+  @Unmodifiable @NotNull List<Component> children();
 
   /**
    * Sets the list of children.
@@ -1459,7 +1459,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull Component children(final @NonNull List<? extends ComponentLike> children);
+  @NotNull Component children(final @NotNull List<? extends ComponentLike> children);
 
   /**
    * Checks if this component contains a component.
@@ -1472,7 +1472,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *     component, {@code false} otherwise
    * @since 4.0.0
    */
-  default boolean contains(final @NonNull Component that) {
+  default boolean contains(final @NotNull Component that) {
     return this.contains(that, EQUALS_IDENTITY);
   }
 
@@ -1485,7 +1485,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *     component, {@code false} otherwise
    * @since 4.8.0
    */
-  default boolean contains(final @NonNull Component that, final @NonNull BiPredicate<? super Component, ? super Component> equals) {
+  default boolean contains(final @NotNull Component that, final @NotNull BiPredicate<? super Component, ? super Component> equals) {
     if (equals.test(this, that)) return true;
     for (final Component child : this.children()) {
       if (child.contains(that, equals)) return true;
@@ -1517,7 +1517,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Deprecated
-  default void detectCycle(final @NonNull Component that) {
+  default void detectCycle(final @NotNull Component that) {
     if (that.contains(this)) {
       throw new IllegalStateException("Component cycle detected between " + this + " and " + that);
     }
@@ -1531,7 +1531,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull Component append(final @NonNull Component component);
+  @NotNull Component append(final @NotNull Component component);
 
   /**
    * Appends a component to this component.
@@ -1540,7 +1540,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return a component with the component added
    * @since 4.0.0
    */
-  default @NonNull Component append(final @NonNull ComponentLike component) {
+  default @NotNull Component append(final @NotNull ComponentLike component) {
     return this.append(component.asComponent());
   }
 
@@ -1552,7 +1552,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component append(final @NonNull ComponentBuilder<?, ?> builder) {
+  default @NotNull Component append(final @NotNull ComponentBuilder<?, ?> builder) {
     return this.append(builder.build());
   }
 
@@ -1562,7 +1562,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return the style of this component
    * @since 4.0.0
    */
-  @NonNull Style style();
+  @NotNull Style style();
 
   /**
    * Sets the style of this component.
@@ -1572,7 +1572,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull Component style(final @NonNull Style style);
+  @NotNull Component style(final @NotNull Style style);
 
   /**
    * Sets the style of this component.
@@ -1582,7 +1582,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component style(final @NonNull Consumer<Style.Builder> consumer) {
+  default @NotNull Component style(final @NotNull Consumer<Style.Builder> consumer) {
     return this.style(this.style().edit(consumer));
   }
 
@@ -1595,7 +1595,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component style(final @NonNull Consumer<Style.Builder> consumer, final Style.Merge.@NonNull Strategy strategy) {
+  default @NotNull Component style(final @NotNull Consumer<Style.Builder> consumer, final Style.Merge.@NotNull Strategy strategy) {
     return this.style(this.style().edit(consumer, strategy));
   }
 
@@ -1607,7 +1607,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component style(final Style.@NonNull Builder style) {
+  default @NotNull Component style(final Style.@NotNull Builder style) {
     return this.style(style.build());
   }
 
@@ -1619,7 +1619,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component mergeStyle(final @NonNull Component that) {
+  default @NotNull Component mergeStyle(final @NotNull Component that) {
     return this.mergeStyle(that, Style.Merge.all());
   }
 
@@ -1632,7 +1632,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component mergeStyle(final @NonNull Component that, final Style.@NonNull Merge@NonNull... merges) {
+  default @NotNull Component mergeStyle(final @NotNull Component that, final Style.@NotNull Merge@NotNull... merges) {
     return this.mergeStyle(that, Style.Merge.of(merges));
   }
 
@@ -1645,7 +1645,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component mergeStyle(final @NonNull Component that, final @NonNull Set<Style.Merge> merges) {
+  default @NotNull Component mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges) {
     return this.style(this.style().merge(that.style(), merges));
   }
 
@@ -1667,7 +1667,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component color(final @Nullable TextColor color) {
+  default @NotNull Component color(final @Nullable TextColor color) {
     return this.style(this.style().color(color));
   }
 
@@ -1679,7 +1679,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component colorIfAbsent(final @Nullable TextColor color) {
+  default @NotNull Component colorIfAbsent(final @Nullable TextColor color) {
     if (this.color() == null) return this.color(color);
     return this;
   }
@@ -1692,7 +1692,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *     component does not have the decoration
    * @since 4.0.0
    */
-  default boolean hasDecoration(final @NonNull TextDecoration decoration) {
+  default boolean hasDecoration(final @NotNull TextDecoration decoration) {
     return this.decoration(decoration) == TextDecoration.State.TRUE;
   }
 
@@ -1704,7 +1704,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component decorate(final @NonNull TextDecoration decoration) {
+  default @NotNull Component decorate(final @NotNull TextDecoration decoration) {
     return this.decoration(decoration, TextDecoration.State.TRUE);
   }
 
@@ -1717,7 +1717,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    *     and {@link TextDecoration.State#NOT_SET} if not set
    * @since 4.0.0
    */
-  default TextDecoration.@NonNull State decoration(final @NonNull TextDecoration decoration) {
+  default TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
     return this.style().decoration(decoration);
   }
 
@@ -1731,7 +1731,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component decoration(final @NonNull TextDecoration decoration, final boolean flag) {
+  default @NotNull Component decoration(final @NotNull TextDecoration decoration, final boolean flag) {
     return this.decoration(decoration, TextDecoration.State.byBoolean(flag));
   }
 
@@ -1747,7 +1747,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component decoration(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state) {
+  default @NotNull Component decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     return this.style(this.style().decoration(decoration, state));
   }
 
@@ -1757,7 +1757,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @return a set of decorations this component has
    * @since 4.0.0
    */
-  default @NonNull Map<TextDecoration, TextDecoration.State> decorations() {
+  default @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
     return this.style().decorations();
   }
 
@@ -1771,7 +1771,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component decorations(final @NonNull Map<TextDecoration, TextDecoration.State> decorations) {
+  default @NotNull Component decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
     return this.style(this.style().decorations(decorations));
   }
 
@@ -1793,7 +1793,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component clickEvent(final @Nullable ClickEvent event) {
+  default @NotNull Component clickEvent(final @Nullable ClickEvent event) {
     return this.style(this.style().clickEvent(event));
   }
 
@@ -1815,7 +1815,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component hoverEvent(final @Nullable HoverEventSource<?> source) {
+  default @NotNull Component hoverEvent(final @Nullable HoverEventSource<?> source) {
     return this.style(this.style().hoverEvent(source));
   }
 
@@ -1837,7 +1837,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NonNull Component insertion(final @Nullable String insertion) {
+  default @NotNull Component insertion(final @Nullable String insertion) {
     return this.style(this.style().insertion(insertion));
   }
 
@@ -1860,7 +1860,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.2.0
    */
   @Contract(pure = true)
-  @NonNull Component replaceText(final @NonNull Consumer<TextReplacementConfig.Builder> configurer);
+  @NotNull Component replaceText(final @NotNull Consumer<TextReplacementConfig.Builder> configurer);
 
   /**
    * Finds and replaces any text with this or child {@link Component}s using the provided options.
@@ -1870,7 +1870,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.2.0
    */
   @Contract(pure = true)
-  @NonNull Component replaceText(final @NonNull TextReplacementConfig config);
+  @NotNull Component replaceText(final @NotNull TextReplacementConfig config);
 
   /**
    * Finds and replaces text within any {@link Component}s using a string literal.
@@ -1884,7 +1884,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
-  default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement) {
+  default @NotNull Component replaceText(final @NotNull String search, final @Nullable ComponentLike replacement) {
     return this.replaceText(b -> b.matchLiteral(search).replacement(replacement));
   }
 
@@ -1900,7 +1900,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
-  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
+  default @NotNull Component replaceText(final @NotNull Pattern pattern, final @NotNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
     return this.replaceText(b -> b.match(pattern).replacement(replacement));
   }
 
@@ -1916,7 +1916,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
-  default @NonNull Component replaceFirstText(final @NonNull String search, final @Nullable ComponentLike replacement) {
+  default @NotNull Component replaceFirstText(final @NotNull String search, final @Nullable ComponentLike replacement) {
     return this.replaceText(b -> b.matchLiteral(search).once().replacement(replacement));
   }
 
@@ -1932,7 +1932,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
-  default @NonNull Component replaceFirstText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
+  default @NotNull Component replaceFirstText(final @NotNull Pattern pattern, final @NotNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
     return this.replaceText(b -> b.match(pattern).once().replacement(replacement));
   }
 
@@ -1949,7 +1949,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
-  default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement, final int numberOfReplacements) {
+  default @NotNull Component replaceText(final @NotNull String search, final @Nullable ComponentLike replacement, final int numberOfReplacements) {
     return this.replaceText(b -> b.matchLiteral(search).times(numberOfReplacements).replacement(replacement));
   }
 
@@ -1966,7 +1966,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
-  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final int numberOfReplacements) {
+  default @NotNull Component replaceText(final @NotNull Pattern pattern, final @NotNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final int numberOfReplacements) {
     return this.replaceText(b -> b.match(pattern).times(numberOfReplacements).replacement(replacement));
   }
 
@@ -1985,7 +1985,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
-  default @NonNull Component replaceText(final @NonNull String search, final @Nullable ComponentLike replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {
+  default @NotNull Component replaceText(final @NotNull String search, final @Nullable ComponentLike replacement, final @NotNull IntFunction2<PatternReplacementResult> fn) {
     return this.replaceText(b -> b.matchLiteral(search).replacement(replacement).condition(fn));
   }
 
@@ -2004,22 +2004,22 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @ApiStatus.ScheduledForRemoval
   @Contract(pure = true)
   @Deprecated
-  default @NonNull Component replaceText(final @NonNull Pattern pattern, final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final @NonNull IntFunction2<PatternReplacementResult> fn) {
+  default @NotNull Component replaceText(final @NotNull Pattern pattern, final @NotNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement, final @NotNull IntFunction2<PatternReplacementResult> fn) {
     return this.replaceText(b -> b.match(pattern).replacement(replacement).condition(fn));
   }
 
   @Override
-  default void componentBuilderApply(final @NonNull ComponentBuilder<?, ?> component) {
+  default void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component) {
     component.append(this);
   }
 
   @Override
-  default @NonNull Component asComponent() {
+  default @NotNull Component asComponent() {
     return this;
   }
 
   @Override
-  default @NonNull HoverEvent<Component> asHoverEvent(final @NonNull UnaryOperator<Component> op) {
+  default @NotNull HoverEvent<Component> asHoverEvent(final @NotNull UnaryOperator<Component> op) {
     return HoverEvent.showText(op.apply(this));
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentApplicable.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentApplicable.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.text;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can be applied to a {@link Component}.
@@ -39,5 +39,5 @@ public interface ComponentApplicable {
    * @return a component with something applied.
    * @since 4.0.0
    */
-  @NonNull Component componentApply(final @NonNull Component component);
+  @NotNull Component componentApply(final @NotNull Component component);
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
@@ -34,9 +34,9 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.Buildable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A component builder.
@@ -54,7 +54,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B append(final @NonNull Component component);
+  @NotNull B append(final @NotNull Component component);
 
   /**
    * Appends a component to this component.
@@ -64,7 +64,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  default @NonNull B append(final @NonNull ComponentLike component) {
+  default @NotNull B append(final @NotNull ComponentLike component) {
     return this.append(component.asComponent());
   }
 
@@ -76,7 +76,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  default @NonNull B append(final @NonNull ComponentBuilder<?, ?> builder) {
+  default @NotNull B append(final @NotNull ComponentBuilder<?, ?> builder) {
     return this.append(builder.build());
   }
 
@@ -88,7 +88,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B append(final @NonNull Component@NonNull... components);
+  @NotNull B append(final @NotNull Component@NotNull... components);
 
   /**
    * Appends components to this component.
@@ -98,7 +98,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B append(final @NonNull ComponentLike@NonNull... components);
+  @NotNull B append(final @NotNull ComponentLike@NotNull... components);
 
   /**
    * Appends components to this component.
@@ -108,7 +108,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B append(final @NonNull Iterable<? extends ComponentLike> components);
+  @NotNull B append(final @NotNull Iterable<? extends ComponentLike> components);
 
   /**
    * Applies an action to this builder.
@@ -119,7 +119,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    */
   @Contract("_ -> this")
   @SuppressWarnings("unchecked")
-  default @NonNull B apply(final @NonNull Consumer<? super ComponentBuilder<?, ?>> consumer) {
+  default @NotNull B apply(final @NotNull Consumer<? super ComponentBuilder<?, ?>> consumer) {
     consumer.accept(this);
     return (B) this;
   }
@@ -133,7 +133,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B applyDeep(final @NonNull Consumer<? super ComponentBuilder<?, ?>> action);
+  @NotNull B applyDeep(final @NotNull Consumer<? super ComponentBuilder<?, ?>> action);
 
   /**
    * Replaces each child of this component with the resultant component from the function.
@@ -143,7 +143,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B mapChildren(final @NonNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function);
+  @NotNull B mapChildren(final @NotNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function);
 
   /**
    * Replaces each child and sub-child of this component with the resultant
@@ -154,7 +154,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B mapChildrenDeep(final @NonNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function);
+  @NotNull B mapChildrenDeep(final @NotNull Function<BuildableComponent<?, ?>, ? extends BuildableComponent<?, ?>> function);
 
   /**
    * Get an unmodifiable list containing all children currently in this builder.
@@ -162,7 +162,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @return the list of children
    * @since 4.6.0
    */
-  @NonNull List<Component> children();
+  @NotNull List<Component> children();
 
   /**
    * Sets the style.
@@ -172,7 +172,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B style(final @NonNull Style style);
+  @NotNull B style(final @NotNull Style style);
 
   /**
    * Configures the style.
@@ -182,7 +182,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B style(final @NonNull Consumer<Style.Builder> consumer);
+  @NotNull B style(final @NotNull Consumer<Style.Builder> consumer);
 
   /**
    * Sets the font of this component.
@@ -192,7 +192,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B font(final @Nullable Key font);
+  @NotNull B font(final @Nullable Key font);
 
   /**
    * Sets the color of this component.
@@ -202,7 +202,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B color(final @Nullable TextColor color);
+  @NotNull B color(final @Nullable TextColor color);
 
   /**
    * Sets the color of this component if there isn't one set already.
@@ -212,7 +212,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B colorIfAbsent(final @Nullable TextColor color);
+  @NotNull B colorIfAbsent(final @Nullable TextColor color);
 
   /**
    * Sets the state of a set of decorations to {@code flag} on this component.
@@ -225,7 +225,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    */
   @Contract("_, _ -> this")
   @SuppressWarnings("unchecked")
-  default @NonNull B decorations(final @NonNull Set<TextDecoration> decorations, final boolean flag) {
+  default @NotNull B decorations(final @NotNull Set<TextDecoration> decorations, final boolean flag) {
     final TextDecoration.State state = TextDecoration.State.byBoolean(flag);
     decorations.forEach(decoration -> this.decoration(decoration, state));
     return (B) this;
@@ -239,7 +239,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  default @NonNull B decorate(final @NonNull TextDecoration decoration) {
+  default @NotNull B decorate(final @NotNull TextDecoration decoration) {
     return this.decoration(decoration, TextDecoration.State.TRUE);
   }
 
@@ -252,7 +252,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    */
   @Contract("_ -> this")
   @SuppressWarnings("unchecked")
-  default @NonNull B decorate(final @NonNull TextDecoration@NonNull... decorations) {
+  default @NotNull B decorate(final @NotNull TextDecoration@NotNull... decorations) {
     for (int i = 0, length = decorations.length; i < length; i++) {
       this.decorate(decorations[i]);
     }
@@ -269,7 +269,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_, _ -> this")
-  default @NonNull B decoration(final @NonNull TextDecoration decoration, final boolean flag) {
+  default @NotNull B decoration(final @NotNull TextDecoration decoration, final boolean flag) {
     return this.decoration(decoration, TextDecoration.State.byBoolean(flag));
   }
 
@@ -285,7 +285,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_, _ -> this")
-  @NonNull B decoration(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state);
+  @NotNull B decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
   /**
    * Sets the click event of this component.
@@ -295,7 +295,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B clickEvent(final @Nullable ClickEvent event);
+  @NotNull B clickEvent(final @Nullable ClickEvent event);
 
   /**
    * Sets the hover event of this component.
@@ -305,7 +305,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B hoverEvent(final @Nullable HoverEventSource<?> source);
+  @NotNull B hoverEvent(final @Nullable HoverEventSource<?> source);
 
   /**
    * Sets the string to be inserted when this component is shift-clicked.
@@ -315,7 +315,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B insertion(final @Nullable String insertion);
+  @NotNull B insertion(final @Nullable String insertion);
 
   /**
    * Merges styling from another component into this component.
@@ -325,7 +325,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  default @NonNull B mergeStyle(final @NonNull Component that) {
+  default @NotNull B mergeStyle(final @NotNull Component that) {
     return this.mergeStyle(that, Style.Merge.all());
   }
 
@@ -338,7 +338,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_, _ -> this")
-  default @NonNull B mergeStyle(final @NonNull Component that, final Style.@NonNull Merge@NonNull... merges) {
+  default @NotNull B mergeStyle(final @NotNull Component that, final Style.@NotNull Merge@NotNull... merges) {
     return this.mergeStyle(that, Style.Merge.of(merges));
   }
 
@@ -351,7 +351,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @since 4.0.0
    */
   @Contract("_, _ -> this")
-  @NonNull B mergeStyle(final @NonNull Component that, final @NonNull Set<Style.Merge> merges);
+  @NotNull B mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges);
 
   /**
    * Resets all styling on this component.
@@ -359,7 +359,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @return this builder
    * @since 4.0.0
    */
-  @NonNull B resetStyle();
+  @NotNull B resetStyle();
 
   /**
    * Build a component.
@@ -367,7 +367,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    * @return the component
    */
   @Override
-  @NonNull C build();
+  @NotNull C build();
 
   /**
    * Applies {@code applicable}.
@@ -378,18 +378,18 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    */
   @Contract("_ -> this")
   @SuppressWarnings("unchecked")
-  default @NonNull B applicableApply(final @NonNull ComponentBuilderApplicable applicable) {
+  default @NotNull B applicableApply(final @NotNull ComponentBuilderApplicable applicable) {
     applicable.componentBuilderApply(this);
     return (B) this;
   }
 
   @Override
-  default void componentBuilderApply(final @NonNull ComponentBuilder<?, ?> component) {
+  default void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component) {
     component.append(this);
   }
 
   @Override
-  default @NonNull Component asComponent() {
+  default @NotNull Component asComponent() {
     return this.build();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentBuilderApplicable.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentBuilderApplicable.java
@@ -24,8 +24,8 @@
 package net.kyori.adventure.text;
 
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can be applied to a {@link ComponentBuilder}.
@@ -42,5 +42,5 @@ public interface ComponentBuilderApplicable {
    * @since 4.0.0
    */
   @Contract(mutates = "param")
-  void componentBuilderApply(final @NonNull ComponentBuilder<?, ?> component);
+  void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component);
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentLike.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentLike.java
@@ -27,9 +27,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Something that can be represented as a {@link Component}.
@@ -45,7 +45,7 @@ public interface ComponentLike {
    * @return the components
    * @since 4.8.0
    */
-  static @NonNull List<Component> asComponents(final @NonNull List<? extends ComponentLike> likes) {
+  static @NotNull List<Component> asComponents(final @NotNull List<? extends ComponentLike> likes) {
     return asComponents(likes, null);
   }
 
@@ -59,7 +59,7 @@ public interface ComponentLike {
    * @return the components
    * @since 4.8.0
    */
-  static @NonNull List<Component> asComponents(final @NonNull List<? extends ComponentLike> likes, final @Nullable Predicate<? super Component> filter) {
+  static @NotNull List<Component> asComponents(final @NotNull List<? extends ComponentLike> likes, final @Nullable Predicate<? super Component> filter) {
     if (likes.isEmpty()) {
       // We do not need to create a new list if the one we are copying is empty - we can
       // simply just return our known-empty list instead.
@@ -94,5 +94,5 @@ public interface ComponentLike {
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull Component asComponent();
+  @NotNull Component asComponent();
 }

--- a/api/src/main/java/net/kyori/adventure/text/EntityNBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/EntityNBTComponent.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.text;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Given a Minecraft selector, this component reads the NBT of the associated entity and displays that information.
@@ -48,7 +48,7 @@ public interface EntityNBTComponent extends NBTComponent<EntityNBTComponent, Ent
    * @return the entity selector
    * @since 4.0.0
    */
-  @NonNull String selector();
+  @NotNull String selector();
 
   /**
    * Sets the entity selector.
@@ -58,7 +58,7 @@ public interface EntityNBTComponent extends NBTComponent<EntityNBTComponent, Ent
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull EntityNBTComponent selector(final @NonNull String selector);
+  @NotNull EntityNBTComponent selector(final @NotNull String selector);
 
   /**
    * An entity NBT component builder.
@@ -74,6 +74,6 @@ public interface EntityNBTComponent extends NBTComponent<EntityNBTComponent, Ent
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder selector(final @NonNull String selector);
+    @NotNull Builder selector(final @NotNull String selector);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/EntityNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/EntityNBTComponentImpl.java
@@ -28,47 +28,47 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class EntityNBTComponentImpl extends NBTComponentImpl<EntityNBTComponent, EntityNBTComponent.Builder> implements EntityNBTComponent {
   private final String selector;
 
-  EntityNBTComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final String nbtPath, final boolean interpret, final String selector) {
+  EntityNBTComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final String nbtPath, final boolean interpret, final String selector) {
     super(children, style, nbtPath, interpret);
     this.selector = selector;
   }
 
   @Override
-  public @NonNull EntityNBTComponent nbtPath(final @NonNull String nbtPath) {
+  public @NotNull EntityNBTComponent nbtPath(final @NotNull String nbtPath) {
     if (Objects.equals(this.nbtPath, nbtPath)) return this;
     return new EntityNBTComponentImpl(this.children, this.style, nbtPath, this.interpret, this.selector);
   }
 
   @Override
-  public @NonNull EntityNBTComponent interpret(final boolean interpret) {
+  public @NotNull EntityNBTComponent interpret(final boolean interpret) {
     if (this.interpret == interpret) return this;
     return new EntityNBTComponentImpl(this.children, this.style, this.nbtPath, interpret, this.selector);
   }
 
   @Override
-  public @NonNull String selector() {
+  public @NotNull String selector() {
     return this.selector;
   }
 
   @Override
-  public @NonNull EntityNBTComponent selector(final @NonNull String selector) {
+  public @NotNull EntityNBTComponent selector(final @NotNull String selector) {
     if (Objects.equals(this.selector, selector)) return this;
     return new EntityNBTComponentImpl(this.children, this.style, this.nbtPath, this.interpret, selector);
   }
 
   @Override
-  public @NonNull EntityNBTComponent children(final @NonNull List<? extends ComponentLike> children) {
+  public @NotNull EntityNBTComponent children(final @NotNull List<? extends ComponentLike> children) {
     return new EntityNBTComponentImpl(children, this.style, this.nbtPath, this.interpret, this.selector);
   }
 
   @Override
-  public @NonNull EntityNBTComponent style(final @NonNull Style style) {
+  public @NotNull EntityNBTComponent style(final @NotNull Style style) {
     return new EntityNBTComponentImpl(this.children, style, this.nbtPath, this.interpret, this.selector);
   }
 
@@ -89,7 +89,7 @@ final class EntityNBTComponentImpl extends NBTComponentImpl<EntityNBTComponent, 
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("selector", this.selector)
@@ -99,7 +99,7 @@ final class EntityNBTComponentImpl extends NBTComponentImpl<EntityNBTComponent, 
   }
 
   @Override
-  public EntityNBTComponent.@NonNull Builder toBuilder() {
+  public EntityNBTComponent.@NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -109,19 +109,19 @@ final class EntityNBTComponentImpl extends NBTComponentImpl<EntityNBTComponent, 
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull EntityNBTComponent component) {
+    BuilderImpl(final @NotNull EntityNBTComponent component) {
       super(component);
       this.selector = component.selector();
     }
 
     @Override
-    public EntityNBTComponent.@NonNull Builder selector(final @NonNull String selector) {
+    public EntityNBTComponent.@NotNull Builder selector(final @NotNull String selector) {
       this.selector = selector;
       return this;
     }
 
     @Override
-    public @NonNull EntityNBTComponent build() {
+    public @NotNull EntityNBTComponent build() {
       if (this.nbtPath == null) throw new IllegalStateException("nbt path must be set");
       if (this.selector == null) throw new IllegalStateException("selector must be set");
       return new EntityNBTComponentImpl(this.children, this.buildStyle(), this.nbtPath, this.interpret, this.selector);

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.text;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A {@link Component} that displays the client's current keybind for the supplied action.
@@ -45,7 +45,7 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
    * @return the keybind
    * @since 4.0.0
    */
-  @NonNull String keybind();
+  @NotNull String keybind();
 
   /**
    * Sets the keybind.
@@ -55,7 +55,7 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull KeybindComponent keybind(final @NonNull String keybind);
+  @NotNull KeybindComponent keybind(final @NotNull String keybind);
 
   /**
    * A keybind component builder.
@@ -71,6 +71,6 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder keybind(final @NonNull String keybind);
+    @NotNull Builder keybind(final @NotNull String keybind);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponentImpl.java
@@ -28,37 +28,37 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 final class KeybindComponentImpl extends AbstractComponent implements KeybindComponent {
   private final String keybind;
 
-  KeybindComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final @NonNull String keybind) {
+  KeybindComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String keybind) {
     super(children, style);
     this.keybind = requireNonNull(keybind, "keybind");
   }
 
   @Override
-  public @NonNull String keybind() {
+  public @NotNull String keybind() {
     return this.keybind;
   }
 
   @Override
-  public @NonNull KeybindComponent keybind(final @NonNull String keybind) {
+  public @NotNull KeybindComponent keybind(final @NotNull String keybind) {
     if (Objects.equals(this.keybind, keybind)) return this;
     return new KeybindComponentImpl(this.children, this.style, requireNonNull(keybind, "keybind"));
   }
 
   @Override
-  public @NonNull KeybindComponent children(final @NonNull List<? extends ComponentLike> children) {
+  public @NotNull KeybindComponent children(final @NotNull List<? extends ComponentLike> children) {
     return new KeybindComponentImpl(children, this.style, this.keybind);
   }
 
   @Override
-  public @NonNull KeybindComponent style(final @NonNull Style style) {
+  public @NotNull KeybindComponent style(final @NotNull Style style) {
     return new KeybindComponentImpl(this.children, style, this.keybind);
   }
 
@@ -79,7 +79,7 @@ final class KeybindComponentImpl extends AbstractComponent implements KeybindCom
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("keybind", this.keybind)
@@ -89,7 +89,7 @@ final class KeybindComponentImpl extends AbstractComponent implements KeybindCom
   }
 
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -99,19 +99,19 @@ final class KeybindComponentImpl extends AbstractComponent implements KeybindCom
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull KeybindComponent component) {
+    BuilderImpl(final @NotNull KeybindComponent component) {
       super(component);
       this.keybind = component.keybind();
     }
 
     @Override
-    public @NonNull Builder keybind(final @NonNull String keybind) {
+    public @NotNull Builder keybind(final @NotNull String keybind) {
       this.keybind = keybind;
       return this;
     }
 
     @Override
-    public @NonNull KeybindComponent build() {
+    public @NotNull KeybindComponent build() {
       if (this.keybind == null) throw new IllegalStateException("keybind must be set");
       return new KeybindComponentImpl(this.children, this.buildStyle(), this.keybind);
     }

--- a/api/src/main/java/net/kyori/adventure/text/LinearComponents.java
+++ b/api/src/main/java/net/kyori/adventure/text/LinearComponents.java
@@ -25,7 +25,7 @@ package net.kyori.adventure.text;
 
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A utility class that allows {@link Component components} to be created where {@link Style styles} can be specified inline.
@@ -51,7 +51,7 @@ public final class LinearComponents {
    * @return a component
    * @since 4.0.0
    */
-  public static @NonNull Component linear(final @NonNull ComponentBuilderApplicable@NonNull... applicables) {
+  public static @NotNull Component linear(final @NotNull ComponentBuilderApplicable@NotNull... applicables) {
     final int length = applicables.length;
     if (length == 0) return Component.empty();
     if (length == 1) {

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponent.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.text;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A component that can display NBT fetched from different locations, optionally trying to interpret the NBT as JSON
@@ -53,7 +53,7 @@ public interface NBTComponent<C extends NBTComponent<C, B>, B extends NBTCompone
    * @return the NBT path
    * @since 4.0.0
    */
-  @NonNull String nbtPath();
+  @NotNull String nbtPath();
 
   /**
    * Sets the NBT path.
@@ -63,7 +63,7 @@ public interface NBTComponent<C extends NBTComponent<C, B>, B extends NBTCompone
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull C nbtPath(final @NonNull String nbtPath);
+  @NotNull C nbtPath(final @NotNull String nbtPath);
 
   /**
    * Gets if we should be interpreting.
@@ -81,5 +81,5 @@ public interface NBTComponent<C extends NBTComponent<C, B>, B extends NBTCompone
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull C interpret(final boolean interpret);
+  @NotNull C interpret(final boolean interpret);
 }

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponentBuilder.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.text;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /*
  * This can't be a child of NBTComponent.
@@ -44,7 +44,7 @@ public interface NBTComponentBuilder<C extends NBTComponent<C, B>, B extends NBT
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B nbtPath(final @NonNull String nbtPath);
+  @NotNull B nbtPath(final @NotNull String nbtPath);
 
   /**
    * Sets whether to interpret.
@@ -54,5 +54,5 @@ public interface NBTComponentBuilder<C extends NBTComponent<C, B>, B extends NBT
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NonNull B interpret(final boolean interpret);
+  @NotNull B interpret(final boolean interpret);
 }

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponentImpl.java
@@ -28,22 +28,22 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> extends AbstractComponent implements NBTComponent<C, B> {
   static final boolean INTERPRET_DEFAULT = false;
   final String nbtPath;
   final boolean interpret;
 
-  NBTComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final String nbtPath, final boolean interpret) {
+  NBTComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final String nbtPath, final boolean interpret) {
     super(children, style);
     this.nbtPath = nbtPath;
     this.interpret = interpret;
   }
 
   @Override
-  public @NonNull String nbtPath() {
+  public @NotNull String nbtPath() {
     return this.nbtPath;
   }
 
@@ -70,7 +70,7 @@ abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTCompo
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("nbtPath", this.nbtPath),
@@ -87,7 +87,7 @@ abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTCompo
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull C component) {
+    BuilderImpl(final @NotNull C component) {
       super(component);
       this.nbtPath = component.nbtPath();
       this.interpret = component.interpret();
@@ -95,14 +95,14 @@ abstract class NBTComponentImpl<C extends NBTComponent<C, B>, B extends NBTCompo
 
     @Override
     @SuppressWarnings("unchecked")
-    public @NonNull B nbtPath(final @NonNull String nbtPath) {
+    public @NotNull B nbtPath(final @NotNull String nbtPath) {
       this.nbtPath = nbtPath;
       return (B) this;
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public @NonNull B interpret(final boolean interpret) {
+    public @NotNull B interpret(final boolean interpret) {
       this.interpret = interpret;
       return (B) this;
     }

--- a/api/src/main/java/net/kyori/adventure/text/ScopedComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScopedComponent.java
@@ -32,8 +32,8 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.MonkeyBars;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Some magic to change return types.
@@ -43,38 +43,38 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public interface ScopedComponent<C extends Component> extends Component {
   @Override
-  @NonNull C children(final @NonNull List<? extends ComponentLike> children);
+  @NotNull C children(final @NotNull List<? extends ComponentLike> children);
 
   @Override
-  @NonNull C style(final @NonNull Style style);
+  @NotNull C style(final @NotNull Style style);
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C style(final @NonNull Consumer<Style.Builder> style) {
+  default @NotNull C style(final @NotNull Consumer<Style.Builder> style) {
     return (C) Component.super.style(style);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C style(final Style.@NonNull Builder style) {
+  default @NotNull C style(final Style.@NotNull Builder style) {
     return (C) Component.super.style(style);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C mergeStyle(final @NonNull Component that) {
+  default @NotNull C mergeStyle(final @NotNull Component that) {
     return (C) Component.super.mergeStyle(that);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C mergeStyle(final @NonNull Component that, final Style.@NonNull Merge@NonNull... merges) {
+  default @NotNull C mergeStyle(final @NotNull Component that, final Style.@NotNull Merge@NotNull... merges) {
     return (C) Component.super.mergeStyle(that, merges);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C append(final @NonNull Component component) {
+  default @NotNull C append(final @NotNull Component component) {
     if (component == Component.empty()) return (C) this;
     final List<Component> oldChildren = this.children();
     return this.children(MonkeyBars.addOne(oldChildren, component));
@@ -82,67 +82,67 @@ public interface ScopedComponent<C extends Component> extends Component {
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C append(final @NonNull ComponentLike component) {
+  default @NotNull C append(final @NotNull ComponentLike component) {
     return (C) Component.super.append(component);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C append(final @NonNull ComponentBuilder<?, ?> builder) {
+  default @NotNull C append(final @NotNull ComponentBuilder<?, ?> builder) {
     return (C) Component.super.append(builder);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C mergeStyle(final @NonNull Component that, final @NonNull Set<Style.Merge> merges) {
+  default @NotNull C mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges) {
     return (C) Component.super.mergeStyle(that, merges);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C color(final @Nullable TextColor color) {
+  default @NotNull C color(final @Nullable TextColor color) {
     return (C) Component.super.color(color);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C colorIfAbsent(final @Nullable TextColor color) {
+  default @NotNull C colorIfAbsent(final @Nullable TextColor color) {
     return (C) Component.super.colorIfAbsent(color);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull Component decorate(final @NonNull TextDecoration decoration) {
+  default @NotNull Component decorate(final @NotNull TextDecoration decoration) {
     return (C) Component.super.decorate(decoration);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C decoration(final @NonNull TextDecoration decoration, final boolean flag) {
+  default @NotNull C decoration(final @NotNull TextDecoration decoration, final boolean flag) {
     return (C) Component.super.decoration(decoration, flag);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C decoration(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state) {
+  default @NotNull C decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     return (C) Component.super.decoration(decoration, state);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C clickEvent(final @Nullable ClickEvent event) {
+  default @NotNull C clickEvent(final @Nullable ClickEvent event) {
     return (C) Component.super.clickEvent(event);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C hoverEvent(final @Nullable HoverEventSource<?> event) {
+  default @NotNull C hoverEvent(final @Nullable HoverEventSource<?> event) {
     return (C) Component.super.hoverEvent(event);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NonNull C insertion(final @Nullable String insertion) {
+  default @NotNull C insertion(final @Nullable String insertion) {
     return (C) Component.super.insertion(insertion);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponent.java
@@ -23,9 +23,9 @@
  */
 package net.kyori.adventure.text;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A component that can display a player's score from a scoreboard objective,
@@ -56,7 +56,7 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
    * @return the score name
    * @since 4.0.0
    */
-  @NonNull String name();
+  @NotNull String name();
 
   /**
    * Sets the score name.
@@ -66,7 +66,7 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull ScoreComponent name(final @NonNull String name);
+  @NotNull ScoreComponent name(final @NotNull String name);
 
   /**
    * Gets the objective name.
@@ -74,7 +74,7 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
    * @return the objective name
    * @since 4.0.0
    */
-  @NonNull String objective();
+  @NotNull String objective();
 
   /**
    * Sets the score objective.
@@ -84,7 +84,7 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull ScoreComponent objective(final @NonNull String objective);
+  @NotNull ScoreComponent objective(final @NotNull String objective);
 
   /**
    * Gets the value.
@@ -106,7 +106,7 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
    */
   @Deprecated
   @Contract(pure = true)
-  @NonNull ScoreComponent value(final @Nullable String value);
+  @NotNull ScoreComponent value(final @Nullable String value);
 
   /**
    * A score component builder.
@@ -122,7 +122,7 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder name(final @NonNull String name);
+    @NotNull Builder name(final @NotNull String name);
 
     /**
      * Sets the score objective.
@@ -132,7 +132,7 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder objective(final @NonNull String objective);
+    @NotNull Builder objective(final @NotNull String objective);
 
     /**
      * Sets the value.
@@ -144,6 +144,6 @@ public interface ScoreComponent extends BuildableComponent<ScoreComponent, Score
      */
     @Deprecated
     @Contract("_ -> this")
-    @NonNull Builder value(final @Nullable String value);
+    @NotNull Builder value(final @Nullable String value);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
@@ -28,8 +28,8 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -39,7 +39,7 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
   @Deprecated
   private final @Nullable String value;
 
-  ScoreComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final @NonNull String name, final @NonNull String objective, final @Nullable String value) {
+  ScoreComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String name, final @NotNull String objective, final @Nullable String value) {
     super(children, style);
     this.name = name;
     this.objective = objective;
@@ -47,23 +47,23 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
   }
 
   @Override
-  public @NonNull String name() {
+  public @NotNull String name() {
     return this.name;
   }
 
   @Override
-  public @NonNull ScoreComponent name(final @NonNull String name) {
+  public @NotNull ScoreComponent name(final @NotNull String name) {
     if (Objects.equals(this.name, name)) return this;
     return new ScoreComponentImpl(this.children, this.style, requireNonNull(name, "name"), this.objective, this.value);
   }
 
   @Override
-  public @NonNull String objective() {
+  public @NotNull String objective() {
     return this.objective;
   }
 
   @Override
-  public @NonNull ScoreComponent objective(final @NonNull String objective) {
+  public @NotNull ScoreComponent objective(final @NotNull String objective) {
     if (Objects.equals(this.objective, objective)) return this;
     return new ScoreComponentImpl(this.children, this.style, this.name, requireNonNull(objective, "objective"), this.value);
   }
@@ -76,18 +76,18 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
 
   @Override
   @Deprecated
-  public @NonNull ScoreComponent value(final @Nullable String value) {
+  public @NotNull ScoreComponent value(final @Nullable String value) {
     if (Objects.equals(this.value, value)) return this;
     return new ScoreComponentImpl(this.children, this.style, this.name, this.objective, value);
   }
 
   @Override
-  public @NonNull ScoreComponent children(final @NonNull List<? extends ComponentLike> children) {
+  public @NotNull ScoreComponent children(final @NotNull List<? extends ComponentLike> children) {
     return new ScoreComponentImpl(children, this.style, this.name, this.objective, this.value);
   }
 
   @Override
-  public @NonNull ScoreComponent style(final @NonNull Style style) {
+  public @NotNull ScoreComponent style(final @NotNull Style style) {
     return new ScoreComponentImpl(this.children, style, this.name, this.objective, this.value);
   }
 
@@ -113,7 +113,7 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("name", this.name),
@@ -125,7 +125,7 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
   }
 
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -138,7 +138,7 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
     }
 
     @SuppressWarnings("deprecation")
-    BuilderImpl(final @NonNull ScoreComponent component) {
+    BuilderImpl(final @NotNull ScoreComponent component) {
       super(component);
       this.name = component.name();
       this.objective = component.objective();
@@ -146,26 +146,26 @@ final class ScoreComponentImpl extends AbstractComponent implements ScoreCompone
     }
 
     @Override
-    public @NonNull Builder name(final @NonNull String name) {
+    public @NotNull Builder name(final @NotNull String name) {
       this.name = name;
       return this;
     }
 
     @Override
-    public @NonNull Builder objective(final @NonNull String objective) {
+    public @NotNull Builder objective(final @NotNull String objective) {
       this.objective = objective;
       return this;
     }
 
     @Override
     @Deprecated
-    public @NonNull Builder value(final @Nullable String value) {
+    public @NotNull Builder value(final @Nullable String value) {
       this.value = value;
       return this;
     }
 
     @Override
-    public @NonNull ScoreComponent build() {
+    public @NotNull ScoreComponent build() {
       if (this.name == null) throw new IllegalStateException("name must be set");
       if (this.objective == null) throw new IllegalStateException("objective must be set");
       return new ScoreComponentImpl(this.children, this.buildStyle(), this.name, this.objective, this.value);

--- a/api/src/main/java/net/kyori/adventure/text/SelectorComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/SelectorComponent.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.text;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A component that can display the name of entities found with a given selector.
@@ -48,7 +48,7 @@ public interface SelectorComponent extends BuildableComponent<SelectorComponent,
    * @return the selector pattern
    * @since 4.0.0
    */
-  @NonNull String pattern();
+  @NotNull String pattern();
 
   /**
    * Sets the selector pattern.
@@ -58,7 +58,7 @@ public interface SelectorComponent extends BuildableComponent<SelectorComponent,
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull SelectorComponent pattern(final @NonNull String pattern);
+  @NotNull SelectorComponent pattern(final @NotNull String pattern);
 
   /**
    * A selector component builder.
@@ -74,6 +74,6 @@ public interface SelectorComponent extends BuildableComponent<SelectorComponent,
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder pattern(final @NonNull String pattern);
+    @NotNull Builder pattern(final @NotNull String pattern);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/SelectorComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/SelectorComponentImpl.java
@@ -28,37 +28,37 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 final class SelectorComponentImpl extends AbstractComponent implements SelectorComponent {
   private final String pattern;
 
-  SelectorComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final @NonNull String pattern) {
+  SelectorComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String pattern) {
     super(children, style);
     this.pattern = pattern;
   }
 
   @Override
-  public @NonNull String pattern() {
+  public @NotNull String pattern() {
     return this.pattern;
   }
 
   @Override
-  public @NonNull SelectorComponent pattern(final @NonNull String pattern) {
+  public @NotNull SelectorComponent pattern(final @NotNull String pattern) {
     if (Objects.equals(this.pattern, pattern)) return this;
     return new SelectorComponentImpl(this.children, this.style, requireNonNull(pattern, "pattern"));
   }
 
   @Override
-  public @NonNull SelectorComponent children(final @NonNull List<? extends ComponentLike> children) {
+  public @NotNull SelectorComponent children(final @NotNull List<? extends ComponentLike> children) {
     return new SelectorComponentImpl(children, this.style, this.pattern);
   }
 
   @Override
-  public @NonNull SelectorComponent style(final @NonNull Style style) {
+  public @NotNull SelectorComponent style(final @NotNull Style style) {
     return new SelectorComponentImpl(this.children, style, this.pattern);
   }
 
@@ -79,7 +79,7 @@ final class SelectorComponentImpl extends AbstractComponent implements SelectorC
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("pattern", this.pattern)
@@ -89,7 +89,7 @@ final class SelectorComponentImpl extends AbstractComponent implements SelectorC
   }
 
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -99,19 +99,19 @@ final class SelectorComponentImpl extends AbstractComponent implements SelectorC
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull SelectorComponent component) {
+    BuilderImpl(final @NotNull SelectorComponent component) {
       super(component);
       this.pattern = component.pattern();
     }
 
     @Override
-    public @NonNull Builder pattern(final @NonNull String pattern) {
+    public @NotNull Builder pattern(final @NotNull String pattern) {
       this.pattern = pattern;
       return this;
     }
 
     @Override
-    public @NonNull SelectorComponent build() {
+    public @NotNull SelectorComponent build() {
       if (this.pattern == null) throw new IllegalStateException("pattern must be set");
       return new SelectorComponentImpl(this.children, this.buildStyle(), this.pattern);
     }

--- a/api/src/main/java/net/kyori/adventure/text/StorageNBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/StorageNBTComponent.java
@@ -24,8 +24,8 @@
 package net.kyori.adventure.text;
 
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Given a {@link Key}, this component reads the NBT of the associated command storage and displays that information.
@@ -49,7 +49,7 @@ public interface StorageNBTComponent extends NBTComponent<StorageNBTComponent, S
    * @return the NBT storage
    * @since 4.0.0
    */
-  @NonNull Key storage();
+  @NotNull Key storage();
 
   /**
    * Sets the NBT storage.
@@ -59,7 +59,7 @@ public interface StorageNBTComponent extends NBTComponent<StorageNBTComponent, S
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull StorageNBTComponent storage(final @NonNull Key storage);
+  @NotNull StorageNBTComponent storage(final @NotNull Key storage);
 
   /**
    * A command storage NBT component builder.
@@ -75,6 +75,6 @@ public interface StorageNBTComponent extends NBTComponent<StorageNBTComponent, S
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder storage(final @NonNull Key storage);
+    @NotNull Builder storage(final @NotNull Key storage);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/StorageNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/StorageNBTComponentImpl.java
@@ -29,48 +29,47 @@ import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class StorageNBTComponentImpl extends NBTComponentImpl<StorageNBTComponent, StorageNBTComponent.Builder> implements StorageNBTComponent {
   private final Key storage;
 
-  StorageNBTComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final String nbtPath, final boolean interpret, final Key storage) {
+  StorageNBTComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final String nbtPath, final boolean interpret, final Key storage) {
     super(children, style, nbtPath, interpret);
     this.storage = storage;
   }
 
   @Override
-  public @NonNull StorageNBTComponent nbtPath(final @NonNull String nbtPath) {
+  public @NotNull StorageNBTComponent nbtPath(final @NotNull String nbtPath) {
     if (Objects.equals(this.nbtPath, nbtPath)) return this;
     return new StorageNBTComponentImpl(this.children, this.style, nbtPath, this.interpret, this.storage);
   }
 
   @Override
-  public @NonNull StorageNBTComponent interpret(final boolean interpret) {
+  public @NotNull StorageNBTComponent interpret(final boolean interpret) {
     if (this.interpret == interpret) return this;
     return new StorageNBTComponentImpl(this.children, this.style, this.nbtPath, interpret, this.storage);
   }
 
   @Override
-  public @NonNull Key storage() {
+  public @NotNull Key storage() {
     return this.storage;
   }
 
   @Override
-  public @NonNull StorageNBTComponent storage(final @NonNull Key storage) {
+  public @NotNull StorageNBTComponent storage(final @NotNull Key storage) {
     if (Objects.equals(this.storage, storage)) return this;
     return new StorageNBTComponentImpl(this.children, this.style, this.nbtPath, this.interpret, storage);
   }
 
   @Override
-  public @NonNull StorageNBTComponent children(final @NonNull List<? extends ComponentLike> children) {
+  public @NotNull StorageNBTComponent children(final @NotNull List<? extends ComponentLike> children) {
     return new StorageNBTComponentImpl(children, this.style, this.nbtPath, this.interpret, this.storage);
   }
 
   @Override
-  public @NonNull StorageNBTComponent style(final @NonNull Style style) {
+  public @NotNull StorageNBTComponent style(final @NotNull Style style) {
     return new StorageNBTComponentImpl(this.children, style, this.nbtPath, this.interpret, this.storage);
   }
 
@@ -91,7 +90,7 @@ final class StorageNBTComponentImpl extends NBTComponentImpl<StorageNBTComponent
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("storage", this.storage)
@@ -101,29 +100,29 @@ final class StorageNBTComponentImpl extends NBTComponentImpl<StorageNBTComponent
   }
 
   @Override
-  public StorageNBTComponent.@NonNull Builder toBuilder() {
+  public StorageNBTComponent.@NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
   static class BuilderImpl extends NBTComponentImpl.BuilderImpl<StorageNBTComponent, StorageNBTComponent.Builder> implements StorageNBTComponent.Builder {
-    private @MonotonicNonNull Key storage;
+    private @Nullable Key storage;
 
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull StorageNBTComponent component) {
+    BuilderImpl(final @NotNull StorageNBTComponent component) {
       super(component);
       this.storage = component.storage();
     }
 
     @Override
-    public StorageNBTComponent.@NonNull Builder storage(final @NonNull Key storage) {
+    public StorageNBTComponent.@NotNull Builder storage(final @NotNull Key storage) {
       this.storage = storage;
       return this;
     }
 
     @Override
-    public @NonNull StorageNBTComponent build() {
+    public @NotNull StorageNBTComponent build() {
       if (this.nbtPath == null) throw new IllegalStateException("nbt path must be set");
       if (this.storage == null) throw new IllegalStateException("storage must be set");
       return new StorageNBTComponentImpl(this.children, this.buildStyle(), this.nbtPath, this.interpret, this.storage);

--- a/api/src/main/java/net/kyori/adventure/text/TextComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponent.java
@@ -25,8 +25,8 @@ package net.kyori.adventure.text;
 
 import java.util.Arrays;
 import net.kyori.adventure.text.format.Style;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A component that displays a string.
@@ -47,7 +47,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @return a text component
    * @since 4.0.0
    */
-  static @NonNull TextComponent ofChildren(final @NonNull ComponentLike@NonNull... components) {
+  static @NotNull TextComponent ofChildren(final @NotNull ComponentLike@NotNull... components) {
     if (components.length == 0) return Component.empty();
     return new TextComponentImpl(Arrays.asList(components), Style.empty(), "");
   }
@@ -58,7 +58,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @return the plain text content
    * @since 4.0.0
    */
-  @NonNull String content();
+  @NotNull String content();
 
   /**
    * Sets the plain text content.
@@ -68,7 +68,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull TextComponent content(final @NonNull String content);
+  @NotNull TextComponent content(final @NotNull String content);
 
   /**
    * A text component builder.
@@ -82,7 +82,7 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
      * @return the plain text content
      * @since 4.0.0
      */
-    @NonNull String content();
+    @NotNull String content();
 
     /**
      * Sets the plain text content.
@@ -92,6 +92,6 @@ public interface TextComponent extends BuildableComponent<TextComponent, TextCom
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder content(final @NonNull String content);
+    @NotNull Builder content(final @NotNull String content);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -30,8 +30,8 @@ import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.util.Nag;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import static java.util.Objects.requireNonNull;
@@ -45,13 +45,13 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   static final TextComponent NEWLINE = createDirect("\n");
   static final TextComponent SPACE = createDirect(" ");
 
-  private static @NonNull TextComponent createDirect(final @NonNull String content) {
+  private static @NotNull TextComponent createDirect(final @NotNull String content) {
     return new TextComponentImpl(Collections.emptyList(), Style.empty(), content);
   }
 
   private final String content;
 
-  TextComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final @NonNull String content) {
+  TextComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String content) {
     super(children, style);
     this.content = content;
 
@@ -72,23 +72,23 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   }
 
   @Override
-  public @NonNull String content() {
+  public @NotNull String content() {
     return this.content;
   }
 
   @Override
-  public @NonNull TextComponent content(final @NonNull String content) {
+  public @NotNull TextComponent content(final @NotNull String content) {
     if (Objects.equals(this.content, content)) return this;
     return new TextComponentImpl(this.children, this.style, requireNonNull(content, "content"));
   }
 
   @Override
-  public @NonNull TextComponent children(final @NonNull List<? extends ComponentLike> children) {
+  public @NotNull TextComponent children(final @NotNull List<? extends ComponentLike> children) {
     return new TextComponentImpl(children, this.style, this.content);
   }
 
   @Override
-  public @NonNull TextComponent style(final @NonNull Style style) {
+  public @NotNull TextComponent style(final @NotNull Style style) {
     return new TextComponentImpl(this.children, style, this.content);
   }
 
@@ -109,7 +109,7 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("content", this.content)
@@ -119,7 +119,7 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   }
 
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -134,24 +134,24 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull TextComponent component) {
+    BuilderImpl(final @NotNull TextComponent component) {
       super(component);
       this.content = component.content();
     }
 
     @Override
-    public @NonNull Builder content(final @NonNull String content) {
+    public @NotNull Builder content(final @NotNull String content) {
       this.content = requireNonNull(content, "content");
       return this;
     }
 
     @Override
-    public @NonNull String content() {
+    public @NotNull String content() {
       return this.content;
     }
 
     @Override
-    public @NonNull TextComponent build() {
+    public @NotNull TextComponent build() {
       if (this.isEmpty()) {
         return Component.empty();
       }

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
@@ -30,10 +30,10 @@ import java.util.regex.Pattern;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.intellij.lang.annotations.RegExp;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +52,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
    * @return a new builder
    * @since 4.2.0
    */
-  static @NonNull Builder builder() {
+  static @NotNull Builder builder() {
     return new TextReplacementConfigImpl.Builder();
   }
 
@@ -62,7 +62,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
    * @return the match pattern
    * @since 4.2.0
    */
-  @NonNull Pattern matchPattern();
+  @NotNull Pattern matchPattern();
 
   /**
    * A builder for replacement configurations.
@@ -98,7 +98,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder match(final @NonNull @RegExp String pattern) {
+    default @NotNull Builder match(final @NotNull @RegExp String pattern) {
       return this.match(Pattern.compile(pattern));
     }
 
@@ -110,7 +110,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    @NonNull Builder match(final @NonNull Pattern pattern);
+    @NotNull Builder match(final @NotNull Pattern pattern);
 
     /*
      * ---------------------------
@@ -124,7 +124,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @return this builder
      * @since 4.2.0
      */
-    default @NonNull Builder once() {
+    default @NotNull Builder once() {
       return this.times(1);
     }
 
@@ -136,7 +136,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder times(final int times) {
+    default @NotNull Builder times(final int times) {
       return this.condition((index, replaced) -> replaced < times ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
     }
 
@@ -149,7 +149,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder condition(final @NonNull IntFunction2<PatternReplacementResult> condition) {
+    default @NotNull Builder condition(final @NotNull IntFunction2<PatternReplacementResult> condition) {
       return this.condition((result, matchCount, replaced) -> condition.apply(matchCount, replaced));
     }
 
@@ -162,7 +162,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.8.0
      */
     @Contract("_ -> this")
-    @NonNull Builder condition(final @NonNull Condition condition);
+    @NotNull Builder condition(final @NotNull Condition condition);
 
     /*
      * -------------------------
@@ -178,7 +178,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder replacement(final @NonNull String replacement) {
+    default @NotNull Builder replacement(final @NotNull String replacement) {
       requireNonNull(replacement, "replacement");
       return this.replacement(builder -> builder.content(replacement));
     }
@@ -191,7 +191,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder replacement(final @Nullable ComponentLike replacement) {
+    default @NotNull Builder replacement(final @Nullable ComponentLike replacement) {
       final @Nullable Component baked = replacement == null ? null : replacement.asComponent();
       return this.replacement((result, input) -> baked);
     }
@@ -204,7 +204,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder replacement(final @NonNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
+    default @NotNull Builder replacement(final @NotNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
       requireNonNull(replacement, "replacement");
       return this.replacement((result, input) -> replacement.apply(input));
 
@@ -218,7 +218,7 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    @NonNull Builder replacement(final @NonNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement);
+    @NotNull Builder replacement(final @NotNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement);
   }
 
   /**
@@ -237,6 +237,6 @@ public interface TextReplacementConfig extends Buildable<TextReplacementConfig, 
      * @return whether a certain match should
      * @since 4.8.0
      */
-    @NonNull PatternReplacementResult shouldReplace(final @NonNull MatchResult result, final int matchCount, final int replaced);
+    @NotNull PatternReplacementResult shouldReplace(final @NotNull MatchResult result, final int matchCount, final int replaced);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
@@ -29,9 +29,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -47,7 +46,7 @@ final class TextReplacementConfigImpl implements TextReplacementConfig {
   }
 
   @Override
-  public @NonNull Pattern matchPattern() {
+  public @NotNull Pattern matchPattern() {
     return this.matchPattern;
   }
 
@@ -56,12 +55,12 @@ final class TextReplacementConfigImpl implements TextReplacementConfig {
   }
 
   @Override
-  public TextReplacementConfig.@NonNull Builder toBuilder() {
+  public TextReplacementConfig.@NotNull Builder toBuilder() {
     return new Builder(this);
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("matchPattern", this.matchPattern),
       ExaminableProperty.of("replacement", this.replacement),
@@ -75,8 +74,8 @@ final class TextReplacementConfigImpl implements TextReplacementConfig {
   }
 
   static final class Builder implements TextReplacementConfig.Builder {
-    @MonotonicNonNull Pattern matchPattern;
-    @MonotonicNonNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement;
+    @Nullable Pattern matchPattern;
+    @Nullable BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement;
     TextReplacementConfig.Condition continuer = (matchResult, index, replacement) -> PatternReplacementResult.REPLACE;
 
     Builder() {
@@ -89,25 +88,25 @@ final class TextReplacementConfigImpl implements TextReplacementConfig {
     }
 
     @Override
-    public @NonNull Builder match(final @NonNull Pattern pattern) {
+    public @NotNull Builder match(final @NotNull Pattern pattern) {
       this.matchPattern = requireNonNull(pattern, "pattern");
       return this;
     }
 
     @Override
-    public @NonNull Builder condition(final TextReplacementConfig.@NonNull Condition condition) {
+    public @NotNull Builder condition(final TextReplacementConfig.@NotNull Condition condition) {
       this.continuer = requireNonNull(condition, "continuation");
       return this;
     }
 
     @Override
-    public @NonNull Builder replacement(final @NonNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement) {
+    public @NotNull Builder replacement(final @NotNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement) {
       this.replacement = requireNonNull(replacement, "replacement");
       return this;
     }
 
     @Override
-    public @NonNull TextReplacementConfig build() {
+    public @NotNull TextReplacementConfig build() {
       if (this.matchPattern == null) throw new IllegalStateException("A pattern must be provided to match against");
       if (this.replacement == null) throw new IllegalStateException("A replacement action must be provided");
       return new TextReplacementConfigImpl(this);

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
@@ -31,8 +31,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.renderer.ComponentRenderer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A renderer performing a replacement on every {@link TextComponent} element of a component tree.
@@ -44,7 +44,7 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
   }
 
   @Override
-  public @NonNull Component render(final @NonNull Component component, final @NonNull State state) {
+  public @NotNull Component render(final @NotNull Component component, final @NotNull State state) {
     if (!state.running) return component;
     final boolean prevFirstMatch = state.firstMatch;
     state.firstMatch = true;
@@ -194,7 +194,7 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
     int replaceCount = 0;
     boolean firstMatch = true;
 
-    State(final @NonNull Pattern pattern, final @NonNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement, final TextReplacementConfig.@NonNull Condition continuer) {
+    State(final @NotNull Pattern pattern, final @NotNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement, final TextReplacementConfig.@NotNull Condition continuer) {
       this.pattern = pattern;
       this.replacement = replacement;
       this.continuer = continuer;

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -30,8 +30,8 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.translation.Translatable;
 import net.kyori.adventure.translation.TranslationRegistry;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A component that can display translated text.
@@ -65,7 +65,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @return the translation key
    * @since 4.0.0
    */
-  @NonNull String key();
+  @NotNull String key();
 
   /**
    * Sets the translation key.
@@ -75,7 +75,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @since 4.8.0
    */
   @Contract(pure = true)
-  default @NonNull TranslatableComponent key(final @NonNull Translatable translatable) {
+  default @NotNull TranslatableComponent key(final @NotNull Translatable translatable) {
     return this.key(Objects.requireNonNull(translatable, "translatable").translationKey());
   }
 
@@ -87,7 +87,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull TranslatableComponent key(final @NonNull String key);
+  @NotNull TranslatableComponent key(final @NotNull String key);
 
   /**
    * Gets the unmodifiable list of translation arguments.
@@ -95,7 +95,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @return the unmodifiable list of translation arguments
    * @since 4.0.0
    */
-  @NonNull List<Component> args();
+  @NotNull List<Component> args();
 
   /**
    * Sets the translation arguments for this component.
@@ -105,7 +105,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull TranslatableComponent args(final @NonNull ComponentLike@NonNull... args);
+  @NotNull TranslatableComponent args(final @NotNull ComponentLike@NotNull... args);
 
   /**
    * Sets the translation arguments for this component.
@@ -115,7 +115,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NonNull TranslatableComponent args(final @NonNull List<? extends ComponentLike> args);
+  @NotNull TranslatableComponent args(final @NotNull List<? extends ComponentLike> args);
 
   /**
    * A text component builder.
@@ -131,7 +131,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      * @since 4.8.0
      */
     @Contract(pure = true)
-    default @NonNull Builder key(final @NonNull Translatable translatable) {
+    default @NotNull Builder key(final @NotNull Translatable translatable) {
       return this.key(Objects.requireNonNull(translatable, "translatable").translationKey());
     }
 
@@ -143,7 +143,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder key(final @NonNull String key);
+    @NotNull Builder key(final @NotNull String key);
 
     /**
      * Sets the translation args.
@@ -153,7 +153,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder args(final @NonNull ComponentBuilder<?, ?> arg);
+    @NotNull Builder args(final @NotNull ComponentBuilder<?, ?> arg);
 
     /**
      * Sets the translation args.
@@ -164,7 +164,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      */
     @Contract("_ -> this")
     @SuppressWarnings("checkstyle:GenericWhitespace")
-    @NonNull Builder args(final @NonNull ComponentBuilder<?, ?>@NonNull... args);
+    @NotNull Builder args(final @NotNull ComponentBuilder<?, ?>@NotNull... args);
 
     /**
      * Sets the translation args.
@@ -174,7 +174,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder args(final @NonNull Component arg);
+    @NotNull Builder args(final @NotNull Component arg);
 
     /**
      * Sets the translation args.
@@ -184,7 +184,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder args(final @NonNull ComponentLike@NonNull... args);
+    @NotNull Builder args(final @NotNull ComponentLike@NotNull... args);
 
     /**
      * Sets the translation args.
@@ -194,6 +194,6 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder args(final @NonNull List<? extends ComponentLike> args);
+    @NotNull Builder args(final @NotNull List<? extends ComponentLike> args);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
@@ -31,8 +31,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -40,11 +40,11 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   private final String key;
   private final List<Component> args;
 
-  TranslatableComponentImpl(final @NonNull List<Component> children, final @NonNull Style style, final @NonNull String key, final @NonNull ComponentLike@NonNull[] args) {
+  TranslatableComponentImpl(final @NotNull List<Component> children, final @NotNull Style style, final @NotNull String key, final @NotNull ComponentLike@NotNull[] args) {
     this(children, style, key, Arrays.asList(args));
   }
 
-  TranslatableComponentImpl(final @NonNull List<? extends ComponentLike> children, final @NonNull Style style, final @NonNull String key, final @NonNull List<? extends ComponentLike> args) {
+  TranslatableComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String key, final @NotNull List<? extends ComponentLike> args) {
     super(children, style);
     this.key = requireNonNull(key, "key");
     // Since translation arguments can be indexed, empty components are also included.
@@ -52,38 +52,38 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   }
 
   @Override
-  public @NonNull String key() {
+  public @NotNull String key() {
     return this.key;
   }
 
   @Override
-  public @NonNull TranslatableComponent key(final @NonNull String key) {
+  public @NotNull TranslatableComponent key(final @NotNull String key) {
     if (Objects.equals(this.key, key)) return this;
     return new TranslatableComponentImpl(this.children, this.style, requireNonNull(key, "key"), this.args);
   }
 
   @Override
-  public @NonNull List<Component> args() {
+  public @NotNull List<Component> args() {
     return this.args;
   }
 
   @Override
-  public @NonNull TranslatableComponent args(final @NonNull ComponentLike@NonNull... args) {
+  public @NotNull TranslatableComponent args(final @NotNull ComponentLike@NotNull... args) {
     return new TranslatableComponentImpl(this.children, this.style, this.key, args);
   }
 
   @Override
-  public @NonNull TranslatableComponent args(final @NonNull List<? extends ComponentLike> args) {
+  public @NotNull TranslatableComponent args(final @NotNull List<? extends ComponentLike> args) {
     return new TranslatableComponentImpl(this.children, this.style, this.key, args);
   }
 
   @Override
-  public @NonNull TranslatableComponent children(final @NonNull List<? extends ComponentLike> children) {
+  public @NotNull TranslatableComponent children(final @NotNull List<? extends ComponentLike> children) {
     return new TranslatableComponentImpl(children, this.style, this.key, this.args);
   }
 
   @Override
-  public @NonNull TranslatableComponent style(final @NonNull Style style) {
+  public @NotNull TranslatableComponent style(final @NotNull Style style) {
     return new TranslatableComponentImpl(this.children, style, this.key, this.args);
   }
 
@@ -105,7 +105,7 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   }
 
   @Override
-  protected @NonNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
+  protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("key", this.key),
@@ -116,7 +116,7 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   }
 
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -127,49 +127,49 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull TranslatableComponent component) {
+    BuilderImpl(final @NotNull TranslatableComponent component) {
       super(component);
       this.key = component.key();
       this.args = component.args();
     }
 
     @Override
-    public @NonNull Builder key(final @NonNull String key) {
+    public @NotNull Builder key(final @NotNull String key) {
       this.key = key;
       return this;
     }
 
     @Override
-    public @NonNull Builder args(final @NonNull ComponentBuilder<?, ?> arg) {
+    public @NotNull Builder args(final @NotNull ComponentBuilder<?, ?> arg) {
       return this.args(Collections.singletonList(arg.build()));
     }
 
     @Override
     @SuppressWarnings("checkstyle:GenericWhitespace")
-    public @NonNull Builder args(final @NonNull ComponentBuilder<?, ?>@NonNull... args) {
+    public @NotNull Builder args(final @NotNull ComponentBuilder<?, ?>@NotNull... args) {
       if (args.length == 0) return this.args(Collections.emptyList());
       return this.args(Stream.of(args).map(ComponentBuilder::build).collect(Collectors.toList()));
     }
 
     @Override
-    public @NonNull Builder args(final @NonNull Component arg) {
+    public @NotNull Builder args(final @NotNull Component arg) {
       return this.args(Collections.singletonList(arg));
     }
 
     @Override
-    public @NonNull Builder args(final @NonNull ComponentLike@NonNull... args) {
+    public @NotNull Builder args(final @NotNull ComponentLike@NotNull... args) {
       if (args.length == 0) return this.args(Collections.emptyList());
       return this.args(Arrays.asList(args));
     }
 
     @Override
-    public @NonNull Builder args(final @NonNull List<? extends ComponentLike> args) {
+    public @NotNull Builder args(final @NotNull List<? extends ComponentLike> args) {
       this.args = ComponentLike.asComponents(args);
       return this;
     }
 
     @Override
-    public @NonNull TranslatableComponentImpl build() {
+    public @NotNull TranslatableComponentImpl build() {
       if (this.key == null) throw new IllegalStateException("key must be set");
       return new TranslatableComponentImpl(this.children, this.buildStyle(), this.key, this.args);
     }

--- a/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
@@ -32,8 +32,8 @@ import net.kyori.adventure.util.Index;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +52,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @since 4.0.0
    */
-  public static @NonNull ClickEvent openUrl(final @NonNull String url) {
+  public static @NotNull ClickEvent openUrl(final @NotNull String url) {
     return new ClickEvent(Action.OPEN_URL, url);
   }
 
@@ -63,7 +63,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @since 4.0.0
    */
-  public static @NonNull ClickEvent openUrl(final @NonNull URL url) {
+  public static @NotNull ClickEvent openUrl(final @NotNull URL url) {
     return openUrl(url.toExternalForm());
   }
 
@@ -76,7 +76,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @since 4.0.0
    */
-  public static @NonNull ClickEvent openFile(final @NonNull String file) {
+  public static @NotNull ClickEvent openFile(final @NotNull String file) {
     return new ClickEvent(Action.OPEN_FILE, file);
   }
 
@@ -87,7 +87,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @since 4.0.0
    */
-  public static @NonNull ClickEvent runCommand(final @NonNull String command) {
+  public static @NotNull ClickEvent runCommand(final @NotNull String command) {
     return new ClickEvent(Action.RUN_COMMAND, command);
   }
 
@@ -98,7 +98,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @since 4.0.0
    */
-  public static @NonNull ClickEvent suggestCommand(final @NonNull String command) {
+  public static @NotNull ClickEvent suggestCommand(final @NotNull String command) {
     return new ClickEvent(Action.SUGGEST_COMMAND, command);
   }
 
@@ -109,7 +109,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @since 4.0.0
    */
-  public static @NonNull ClickEvent changePage(final @NonNull String page) {
+  public static @NotNull ClickEvent changePage(final @NotNull String page) {
     return new ClickEvent(Action.CHANGE_PAGE, page);
   }
 
@@ -120,7 +120,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @since 4.0.0
    */
-  public static @NonNull ClickEvent changePage(final int page) {
+  public static @NotNull ClickEvent changePage(final int page) {
     return changePage(String.valueOf(page));
   }
 
@@ -132,7 +132,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @since 4.0.0
    * @sinceMinecraft 1.15
    */
-  public static @NonNull ClickEvent copyToClipboard(final @NonNull String text) {
+  public static @NotNull ClickEvent copyToClipboard(final @NotNull String text) {
     return new ClickEvent(Action.COPY_TO_CLIPBOARD, text);
   }
 
@@ -144,14 +144,14 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @since 4.0.0
    */
-  public static @NonNull ClickEvent clickEvent(final @NonNull Action action, final @NonNull String value) {
+  public static @NotNull ClickEvent clickEvent(final @NotNull Action action, final @NotNull String value) {
     return new ClickEvent(action, value);
   }
 
   private final Action action;
   private final String value;
 
-  private ClickEvent(final @NonNull Action action, final @NonNull String value) {
+  private ClickEvent(final @NotNull Action action, final @NotNull String value) {
     this.action = requireNonNull(action, "action");
     this.value = requireNonNull(value, "value");
   }
@@ -162,7 +162,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return the click event action
    * @since 4.0.0
    */
-  public @NonNull Action action() {
+  public @NotNull Action action() {
     return this.action;
   }
 
@@ -172,12 +172,12 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return the click event value
    * @since 4.0.0
    */
-  public @NonNull String value() {
+  public @NotNull String value() {
     return this.value;
   }
 
   @Override
-  public void styleApply(final Style.@NonNull Builder style) {
+  public void styleApply(final Style.@NotNull Builder style) {
     style.clickEvent(this);
   }
 
@@ -197,7 +197,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("action", this.action),
       ExaminableProperty.of("value", this.value)
@@ -269,7 +269,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
      */
     private final boolean readable;
 
-    Action(final @NonNull String name, final boolean readable) {
+    Action(final @NotNull String name, final boolean readable) {
       this.name = name;
       this.readable = readable;
     }
@@ -286,7 +286,7 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
     }
 
     @Override
-    public @NonNull String toString() {
+    public @NotNull String toString() {
       return this.name;
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -39,9 +39,9 @@ import net.kyori.adventure.util.Index;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 import static java.util.Objects.requireNonNull;
 
@@ -62,7 +62,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.2.0
    */
-  public static @NonNull HoverEvent<Component> showText(final @NonNull ComponentLike text) {
+  public static @NotNull HoverEvent<Component> showText(final @NotNull ComponentLike text) {
     return showText(text.asComponent());
   }
 
@@ -73,7 +73,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.0.0
    */
-  public static @NonNull HoverEvent<Component> showText(final @NonNull Component text) {
+  public static @NotNull HoverEvent<Component> showText(final @NotNull Component text) {
     return new HoverEvent<>(Action.SHOW_TEXT, text);
   }
 
@@ -85,7 +85,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.0.0
    */
-  public static @NonNull HoverEvent<ShowItem> showItem(final @NonNull Key item, final @NonNegative int count) {
+  public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
     return showItem(item, count, null);
   }
 
@@ -97,7 +97,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.6.0
    */
-  public static @NonNull HoverEvent<ShowItem> showItem(final @NonNull Keyed item, final @NonNegative int count) {
+  public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
     return showItem(item, count, null);
   }
 
@@ -110,7 +110,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.0.0
    */
-  public static @NonNull HoverEvent<ShowItem> showItem(final @NonNull Key item, final @NonNegative int count, final @Nullable BinaryTagHolder nbt) {
+  public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
     return showItem(ShowItem.of(item, count, nbt));
   }
 
@@ -123,7 +123,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.6.0
    */
-  public static @NonNull HoverEvent<ShowItem> showItem(final @NonNull Keyed item, final @NonNegative int count, final @Nullable BinaryTagHolder nbt) {
+  public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
     return showItem(ShowItem.of(item, count, nbt));
   }
 
@@ -134,7 +134,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.0.0
    */
-  public static @NonNull HoverEvent<ShowItem> showItem(final @NonNull ShowItem item) {
+  public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull ShowItem item) {
     return new HoverEvent<>(Action.SHOW_ITEM, item);
   }
 
@@ -148,7 +148,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a {@code ShowEntity}
    * @since 4.0.0
    */
-  public static @NonNull HoverEvent<ShowEntity> showEntity(final @NonNull Key type, final @NonNull UUID id) {
+  public static @NotNull HoverEvent<ShowEntity> showEntity(final @NotNull Key type, final @NotNull UUID id) {
     return showEntity(type, id, null);
   }
 
@@ -162,7 +162,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a {@code ShowEntity}
    * @since 4.6.0
    */
-  public static @NonNull HoverEvent<ShowEntity> showEntity(final @NonNull Keyed type, final @NonNull UUID id) {
+  public static @NotNull HoverEvent<ShowEntity> showEntity(final @NotNull Keyed type, final @NotNull UUID id) {
     return showEntity(type, id, null);
   }
 
@@ -177,7 +177,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a {@code ShowEntity}
    * @since 4.0.0
    */
-  public static @NonNull HoverEvent<ShowEntity> showEntity(final @NonNull Key type, final @NonNull UUID id, final @Nullable Component name) {
+  public static @NotNull HoverEvent<ShowEntity> showEntity(final @NotNull Key type, final @NotNull UUID id, final @Nullable Component name) {
     return showEntity(ShowEntity.of(type, id, name));
   }
 
@@ -192,7 +192,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a {@code ShowEntity}
    * @since 4.6.0
    */
-  public static @NonNull HoverEvent<ShowEntity> showEntity(final @NonNull Keyed type, final @NonNull UUID id, final @Nullable Component name) {
+  public static @NotNull HoverEvent<ShowEntity> showEntity(final @NotNull Keyed type, final @NotNull UUID id, final @Nullable Component name) {
     return showEntity(ShowEntity.of(type, id, name));
   }
 
@@ -205,7 +205,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.0.0
    */
-  public static @NonNull HoverEvent<ShowEntity> showEntity(final @NonNull ShowEntity entity) {
+  public static @NotNull HoverEvent<ShowEntity> showEntity(final @NotNull ShowEntity entity) {
     return new HoverEvent<>(Action.SHOW_ENTITY, entity);
   }
 
@@ -218,14 +218,14 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a click event
    * @since 4.0.0
    */
-  public static <V> @NonNull HoverEvent<V> hoverEvent(final @NonNull Action<V> action, final @NonNull V value) {
+  public static <V> @NotNull HoverEvent<V> hoverEvent(final @NotNull Action<V> action, final @NotNull V value) {
     return new HoverEvent<>(action, value);
   }
 
   private final Action<V> action;
   private final V value;
 
-  private HoverEvent(final @NonNull Action<V> action, final @NonNull V value) {
+  private HoverEvent(final @NotNull Action<V> action, final @NotNull V value) {
     this.action = requireNonNull(action, "action");
     this.value = requireNonNull(value, "value");
   }
@@ -236,7 +236,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return the hover event action
    * @since 4.0.0
    */
-  public @NonNull Action<V> action() {
+  public @NotNull Action<V> action() {
     return this.action;
   }
 
@@ -246,7 +246,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return the hover event value
    * @since 4.0.0
    */
-  public @NonNull V value() {
+  public @NotNull V value() {
     return this.value;
   }
 
@@ -257,7 +257,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.0.0
    */
-  public @NonNull HoverEvent<V> value(final @NonNull V value) {
+  public @NotNull HoverEvent<V> value(final @NotNull V value) {
     return new HoverEvent<>(this.action, value);
   }
 
@@ -270,7 +270,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.0.0
    */
-  public <C> @NonNull HoverEvent<V> withRenderedValue(final @NonNull ComponentRenderer<C> renderer, final @NonNull C context) {
+  public <C> @NotNull HoverEvent<V> withRenderedValue(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context) {
     final V oldValue = this.value;
     final V newValue = this.action.renderer.render(renderer, context, oldValue);
     if (newValue != oldValue) return new HoverEvent<>(this.action, newValue);
@@ -278,18 +278,18 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
   }
 
   @Override
-  public @NonNull HoverEvent<V> asHoverEvent() {
+  public @NotNull HoverEvent<V> asHoverEvent() {
     return this; // i already am a hover event! hehehehe
   }
 
   @Override
-  public @NonNull HoverEvent<V> asHoverEvent(final @NonNull UnaryOperator<V> op) {
+  public @NotNull HoverEvent<V> asHoverEvent(final @NotNull UnaryOperator<V> op) {
     if (op == UnaryOperator.<V>identity()) return this; // nothing to do, can return ourself
     return new HoverEvent<>(this.action, op.apply(this.value));
   }
 
   @Override
-  public void styleApply(final Style.@NonNull Builder style) {
+  public void styleApply(final Style.@NotNull Builder style) {
     style.hoverEvent(this);
   }
 
@@ -309,7 +309,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("action", this.action),
       ExaminableProperty.of("value", this.value)
@@ -339,7 +339,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      * @since 4.0.0
      */
-    public static @NonNull ShowItem of(final @NonNull Key item, final @NonNegative int count) {
+    public static @NotNull ShowItem of(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
       return of(item, count, null);
     }
 
@@ -351,7 +351,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      * @since 4.6.0
      */
-    public static @NonNull ShowItem of(final @NonNull Keyed item, final @NonNegative int count) {
+    public static @NotNull ShowItem of(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
       return of(item, count, null);
     }
 
@@ -364,7 +364,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      * @since 4.0.0
      */
-    public static @NonNull ShowItem of(final @NonNull Key item, final @NonNegative int count, final @Nullable BinaryTagHolder nbt) {
+    public static @NotNull ShowItem of(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
       return new ShowItem(requireNonNull(item, "item"), count, nbt);
     }
 
@@ -377,11 +377,11 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      * @since 4.6.0
      */
-    public static @NonNull ShowItem of(final @NonNull Keyed item, final @NonNegative int count, final @Nullable BinaryTagHolder nbt) {
+    public static @NotNull ShowItem of(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
       return new ShowItem(requireNonNull(item, "item").key(), count, nbt);
     }
 
-    private ShowItem(final @NonNull Key item, final @NonNegative int count, final @Nullable BinaryTagHolder nbt) {
+    private ShowItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
       this.item = item;
       this.count = count;
       this.nbt = nbt;
@@ -393,7 +393,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return the item
      * @since 4.0.0
      */
-    public @NonNull Key item() {
+    public @NotNull Key item() {
       return this.item;
     }
 
@@ -404,7 +404,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      * @since 4.0.0
      */
-    public @NonNull ShowItem item(final @NonNull Key item) {
+    public @NotNull ShowItem item(final @NotNull Key item) {
       if (requireNonNull(item, "item").equals(this.item)) return this;
       return new ShowItem(item, this.count, this.nbt);
     }
@@ -415,7 +415,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return the count
      * @since 4.0.0
      */
-    public @NonNegative int count() {
+    public @Range(from = 0, to = Integer.MAX_VALUE) int count() {
       return this.count;
     }
 
@@ -426,7 +426,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      * @since 4.0.0
      */
-    public @NonNull ShowItem count(final @NonNegative int count) {
+    public @NotNull ShowItem count(final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
       if (count == this.count) return this;
       return new ShowItem(this.item, count, this.nbt);
     }
@@ -448,7 +448,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowItem}
      * @since 4.0.0
      */
-    public @NonNull ShowItem nbt(final @Nullable BinaryTagHolder nbt) {
+    public @NotNull ShowItem nbt(final @Nullable BinaryTagHolder nbt) {
       if (Objects.equals(nbt, this.nbt)) return this;
       return new ShowItem(this.item, this.count, nbt);
     }
@@ -470,7 +470,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     }
 
     @Override
-    public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("item", this.item),
         ExaminableProperty.of("count", this.count),
@@ -502,7 +502,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      * @since 4.0.0
      */
-    public static @NonNull ShowEntity of(final @NonNull Key type, final @NonNull UUID id) {
+    public static @NotNull ShowEntity of(final @NotNull Key type, final @NotNull UUID id) {
       return of(type, id, null);
     }
 
@@ -514,7 +514,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      * @since 4.6.0
      */
-    public static @NonNull ShowEntity of(final @NonNull Keyed type, final @NonNull UUID id) {
+    public static @NotNull ShowEntity of(final @NotNull Keyed type, final @NotNull UUID id) {
       return of(type, id, null);
     }
 
@@ -527,7 +527,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      * @since 4.0.0
      */
-    public static @NonNull ShowEntity of(final @NonNull Key type, final @NonNull UUID id, final @Nullable Component name) {
+    public static @NotNull ShowEntity of(final @NotNull Key type, final @NotNull UUID id, final @Nullable Component name) {
       return new ShowEntity(requireNonNull(type, "type"), requireNonNull(id, "id"), name);
     }
 
@@ -540,11 +540,11 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      * @since 4.6.0
      */
-    public static @NonNull ShowEntity of(final @NonNull Keyed type, final @NonNull UUID id, final @Nullable Component name) {
+    public static @NotNull ShowEntity of(final @NotNull Keyed type, final @NotNull UUID id, final @Nullable Component name) {
       return new ShowEntity(requireNonNull(type, "type").key(), requireNonNull(id, "id"), name);
     }
 
-    private ShowEntity(final @NonNull Key type, final @NonNull UUID id, final @Nullable Component name) {
+    private ShowEntity(final @NotNull Key type, final @NotNull UUID id, final @Nullable Component name) {
       this.type = type;
       this.id = id;
       this.name = name;
@@ -556,7 +556,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return the type
      * @since 4.0.0
      */
-    public @NonNull Key type() {
+    public @NotNull Key type() {
       return this.type;
     }
 
@@ -567,7 +567,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      * @since 4.0.0
      */
-    public @NonNull ShowEntity type(final @NonNull Key type) {
+    public @NotNull ShowEntity type(final @NotNull Key type) {
       if (requireNonNull(type, "type").equals(this.type)) return this;
       return new ShowEntity(type, this.id, this.name);
     }
@@ -579,7 +579,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      * @since 4.6.0
      */
-    public @NonNull ShowEntity type(final @NonNull Keyed type) {
+    public @NotNull ShowEntity type(final @NotNull Keyed type) {
       return this.type(requireNonNull(type, "type").key());
     }
 
@@ -589,7 +589,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return the id
      * @since 4.0.0
      */
-    public @NonNull UUID id() {
+    public @NotNull UUID id() {
       return this.id;
     }
 
@@ -600,7 +600,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      * @since 4.0.0
      */
-    public @NonNull ShowEntity id(final @NonNull UUID id) {
+    public @NotNull ShowEntity id(final @NotNull UUID id) {
       if (requireNonNull(id).equals(this.id)) return this;
       return new ShowEntity(this.type, id, this.name);
     }
@@ -622,7 +622,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return a {@code ShowEntity}
      * @since 4.0.0
      */
-    public @NonNull ShowEntity name(final @Nullable Component name) {
+    public @NotNull ShowEntity name(final @Nullable Component name) {
       if (Objects.equals(name, this.name)) return this;
       return new ShowEntity(this.type, this.id, name);
     }
@@ -644,7 +644,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     }
 
     @Override
-    public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("type", this.type),
         ExaminableProperty.of("id", this.id),
@@ -671,7 +671,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      */
     public static final Action<Component> SHOW_TEXT = new Action<>("show_text", Component.class, true, new Renderer<Component>() {
       @Override
-      public <C> @NonNull Component render(final @NonNull ComponentRenderer<C> renderer, final @NonNull C context, final @NonNull Component value) {
+      public <C> @NotNull Component render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull Component value) {
         return renderer.render(value, context);
       }
     });
@@ -682,7 +682,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      */
     public static final Action<ShowItem> SHOW_ITEM = new Action<>("show_item", ShowItem.class, true, new Renderer<ShowItem>() {
       @Override
-      public <C> @NonNull ShowItem render(final @NonNull ComponentRenderer<C> renderer, final @NonNull C context, final @NonNull ShowItem value) {
+      public <C> @NotNull ShowItem render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull ShowItem value) {
         return value;
       }
     });
@@ -693,7 +693,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      */
     public static final Action<ShowEntity> SHOW_ENTITY = new Action<>("show_entity", ShowEntity.class, true, new Renderer<ShowEntity>() {
       @Override
-      public <C> @NonNull ShowEntity render(final @NonNull ComponentRenderer<C> renderer, final @NonNull C context, final @NonNull ShowEntity value) {
+      public <C> @NotNull ShowEntity render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull ShowEntity value) {
         if (value.name == null) return value;
         return value.name(renderer.render(value.name, context));
       }
@@ -728,7 +728,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return the value type
      * @since 4.0.0
      */
-    public @NonNull Class<V> type() {
+    public @NotNull Class<V> type() {
       return this.type;
     }
 
@@ -744,13 +744,13 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     }
 
     @Override
-    public @NonNull String toString() {
+    public @NotNull String toString() {
       return this.name;
     }
 
     @FunctionalInterface
     interface Renderer<V> {
-      <C> @NonNull V render(final @NonNull ComponentRenderer<C> renderer, final @NonNull C context, final @NonNull V value);
+      <C> @NotNull V render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull V value);
     }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEventSource.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEventSource.java
@@ -24,8 +24,8 @@
 package net.kyori.adventure.text.event;
 
 import java.util.function.UnaryOperator;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Something that can provide a {@link HoverEvent}.
@@ -52,7 +52,7 @@ public interface HoverEventSource<V> {
    * @return a hover event
    * @since 4.0.0
    */
-  default @NonNull HoverEvent<V> asHoverEvent() {
+  default @NotNull HoverEvent<V> asHoverEvent() {
     return this.asHoverEvent(UnaryOperator.identity());
   }
 
@@ -66,5 +66,5 @@ public interface HoverEventSource<V> {
    * @return a hover event
    * @since 4.0.0
    */
-  @NonNull HoverEvent<V> asHoverEvent(final @NonNull UnaryOperator<V> op);
+  @NotNull HoverEvent<V> asHoverEvent(final @NotNull UnaryOperator<V> op);
 }

--- a/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattener.java
+++ b/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattener.java
@@ -28,8 +28,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Buildable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A 'flattener' to convert a component tree to a linear string for display.
@@ -43,7 +43,7 @@ public interface ComponentFlattener extends Buildable<ComponentFlattener, Compon
    * @return a new builder
    * @since 4.7.0
    */
-  static @NonNull Builder builder() {
+  static @NotNull Builder builder() {
     return new ComponentFlattenerImpl.BuilderImpl();
   }
 
@@ -56,7 +56,7 @@ public interface ComponentFlattener extends Buildable<ComponentFlattener, Compon
    * @return a basic flattener
    * @since 4.7.0
    */
-  static @NonNull ComponentFlattener basic() {
+  static @NotNull ComponentFlattener basic() {
     return ComponentFlattenerImpl.BASIC;
   }
 
@@ -68,7 +68,7 @@ public interface ComponentFlattener extends Buildable<ComponentFlattener, Compon
    * @return a text-only flattener
    * @since 4.7.0
    */
-  static @NonNull ComponentFlattener textOnly() {
+  static @NotNull ComponentFlattener textOnly() {
     return ComponentFlattenerImpl.TEXT_ONLY;
   }
 
@@ -79,7 +79,7 @@ public interface ComponentFlattener extends Buildable<ComponentFlattener, Compon
    * @param listener the listener that will receive flattened component state
    * @since 4.7.0
    */
-  void flatten(final @NonNull Component input, final @NonNull FlattenerListener listener);
+  void flatten(final @NotNull Component input, final @NotNull FlattenerListener listener);
 
   /**
    * A builder for a component flattener.
@@ -99,7 +99,7 @@ public interface ComponentFlattener extends Buildable<ComponentFlattener, Compon
      * @see #complexMapper(Class, BiConsumer) for component types that are too complex to be directly rendered to a string
      * @since 4.7.0
      */
-    <T extends Component> @NonNull Builder mapper(final @NonNull Class<T> type, final @NonNull Function<T, String> converter);
+    <T extends Component> @NotNull Builder mapper(final @NotNull Class<T> type, final @NotNull Function<T, String> converter);
 
     /**
      * Register a type of component that needs to be flattened to an intermediate stage.
@@ -110,7 +110,7 @@ public interface ComponentFlattener extends Buildable<ComponentFlattener, Compon
      * @return this builder
      * @since 4.7.0
      */
-    <T extends Component> @NonNull Builder complexMapper(final @NonNull Class<T> type, final @NonNull BiConsumer<T, Consumer<Component>> converter);
+    <T extends Component> @NotNull Builder complexMapper(final @NotNull Class<T> type, final @NotNull BiConsumer<T, Consumer<Component>> converter);
 
     /**
      * Register a handler for unknown component types.
@@ -121,6 +121,6 @@ public interface ComponentFlattener extends Buildable<ComponentFlattener, Compon
      * @return this builder
      * @since 4.7.0
      */
-    @NonNull Builder unknownMapper(final @Nullable Function<Component, String> converter);
+    @NotNull Builder unknownMapper(final @Nullable Function<Component, String> converter);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattenerImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattenerImpl.java
@@ -38,8 +38,8 @@ import net.kyori.adventure.text.SelectorComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.Style;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -71,11 +71,11 @@ final class ComponentFlattenerImpl implements ComponentFlattener {
   }
 
   @Override
-  public void flatten(final @NonNull Component input, final @NonNull FlattenerListener listener) {
+  public void flatten(final @NotNull Component input, final @NotNull FlattenerListener listener) {
     this.flatten0(input, listener, 0);
   }
 
-  private void flatten0(final @NonNull Component input, final @NonNull FlattenerListener listener, final int depth) {
+  private void flatten0(final @NotNull Component input, final @NotNull FlattenerListener listener, final int depth) {
     requireNonNull(input, "input");
     requireNonNull(listener, "listener");
     if (input == Component.empty()) return;
@@ -136,7 +136,7 @@ final class ComponentFlattenerImpl implements ComponentFlattener {
   }
 
   @Override
-  public ComponentFlattener.@NonNull Builder toBuilder() {
+  public ComponentFlattener.@NotNull Builder toBuilder() {
     return new BuilderImpl(this.flatteners, this.complexFlatteners, this.unknownHandler);
   }
 
@@ -165,12 +165,12 @@ final class ComponentFlattenerImpl implements ComponentFlattener {
     }
 
     @Override
-    public @NonNull ComponentFlattener build() {
+    public @NotNull ComponentFlattener build() {
       return new ComponentFlattenerImpl(this.flatteners, this.complexFlatteners, this.unknownHandler);
     }
 
     @Override
-    public <T extends Component> ComponentFlattener.@NonNull Builder mapper(final @NonNull Class<T> type, final @NonNull Function<T, String> converter) {
+    public <T extends Component> ComponentFlattener.@NotNull Builder mapper(final @NotNull Class<T> type, final @NotNull Function<T, String> converter) {
       this.validateNoneInHierarchy(requireNonNull(type, "type"));
       this.flatteners.put(
         type,
@@ -181,7 +181,7 @@ final class ComponentFlattenerImpl implements ComponentFlattener {
     }
 
     @Override
-    public <T extends Component> ComponentFlattener.@NonNull Builder complexMapper(final @NonNull Class<T> type, final @NonNull BiConsumer<T, Consumer<Component>> converter) {
+    public <T extends Component> ComponentFlattener.@NotNull Builder complexMapper(final @NotNull Class<T> type, final @NotNull BiConsumer<T, Consumer<Component>> converter) {
       this.validateNoneInHierarchy(requireNonNull(type, "type"));
       this.complexFlatteners.put(
         type,
@@ -209,7 +209,7 @@ final class ComponentFlattenerImpl implements ComponentFlattener {
     }
 
     @Override
-    public ComponentFlattener.@NonNull Builder unknownMapper(final @Nullable Function<Component, String> converter) {
+    public ComponentFlattener.@NotNull Builder unknownMapper(final @Nullable Function<Component, String> converter) {
       this.unknownHandler = converter;
       return this;
     }

--- a/api/src/main/java/net/kyori/adventure/text/flattener/FlattenerListener.java
+++ b/api/src/main/java/net/kyori/adventure/text/flattener/FlattenerListener.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.text.flattener;
 
 import net.kyori.adventure.text.format.Style;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A listener accepting styled information from flattened components.
@@ -39,7 +39,7 @@ public interface FlattenerListener {
    * @param style the style to push
    * @since 4.7.0
    */
-  default void pushStyle(final @NonNull Style style) {
+  default void pushStyle(final @NotNull Style style) {
   }
 
   /**
@@ -48,7 +48,7 @@ public interface FlattenerListener {
    * @param text the component text
    * @since 4.7.0
    */
-  void component(final @NonNull String text);
+  void component(final @NotNull String text);
 
   /**
    * Pop a pushed style.
@@ -58,6 +58,6 @@ public interface FlattenerListener {
    * @param style the style popped, as passed to {@link #pushStyle(Style)}
    * @since 4.7.0
    */
-  default void popStyle(final @NonNull Style style) {
+  default void popStyle(final @NotNull Style style) {
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/AlwaysMerger.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/AlwaysMerger.java
@@ -26,8 +26,8 @@ package net.kyori.adventure.text.format;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class AlwaysMerger implements Merger {
   static final AlwaysMerger INSTANCE = new AlwaysMerger();
@@ -41,7 +41,7 @@ final class AlwaysMerger implements Merger {
   }
 
   @Override
-  public void mergeDecoration(final StyleImpl.BuilderImpl target, final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state) {
+  public void mergeDecoration(final StyleImpl.BuilderImpl target, final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     target.decoration(decoration, state);
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/format/IfAbsentOnTargetMerger.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/IfAbsentOnTargetMerger.java
@@ -26,8 +26,8 @@ package net.kyori.adventure.text.format;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class IfAbsentOnTargetMerger implements Merger {
   static final IfAbsentOnTargetMerger INSTANCE = new IfAbsentOnTargetMerger();
@@ -43,7 +43,7 @@ final class IfAbsentOnTargetMerger implements Merger {
   }
 
   @Override
-  public void mergeDecoration(final StyleImpl.BuilderImpl target, final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state) {
+  public void mergeDecoration(final StyleImpl.BuilderImpl target, final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     target.decorationIfAbsent(decoration, state);
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/format/Merger.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Merger.java
@@ -27,13 +27,13 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.StyleImpl.BuilderImpl;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 interface Merger {
   void mergeColor(final BuilderImpl target, final @Nullable TextColor color);
 
-  void mergeDecoration(final BuilderImpl target, final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state);
+  void mergeDecoration(final BuilderImpl target, final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
   void mergeClickEvent(final BuilderImpl target, final @Nullable ClickEvent event);
 

--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -30,8 +30,8 @@ import java.util.stream.Stream;
 import net.kyori.adventure.util.HSVLike;
 import net.kyori.adventure.util.Index;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -197,7 +197,7 @@ public final class NamedTextColor implements TextColor {
    * @return nearest named colour. will always return a value
    * @since 4.0.0
    */
-  public static @NonNull NamedTextColor nearestTo(final @NonNull TextColor any) {
+  public static @NotNull NamedTextColor nearestTo(final @NotNull TextColor any) {
     if (any instanceof NamedTextColor) {
       return (NamedTextColor) any;
     }
@@ -228,7 +228,7 @@ public final class NamedTextColor implements TextColor {
    * @param other colour to compare to
    * @return distance metric
    */
-  private static float distance(final @NonNull HSVLike self, final @NonNull HSVLike other) {
+  private static float distance(final @NotNull HSVLike self, final @NotNull HSVLike other) {
     // weight hue more heavily than saturation and brightness. kind of magic numbers, but is fine for our use case of downsampling to a set of colors
     final float hueDistance = 3 * Math.min(Math.abs(self.h() - other.h()), 1f - Math.abs(self.h() - other.h()));
     final float saturationDiff = self.s() - other.s();
@@ -252,17 +252,17 @@ public final class NamedTextColor implements TextColor {
   }
 
   @Override
-  public @NonNull HSVLike asHSV() {
+  public @NotNull HSVLike asHSV() {
     return this.hsv;
   }
 
   @Override
-  public @NonNull String toString() {
+  public @NotNull String toString() {
     return this.name;
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(ExaminableProperty.of("name", this.name)),
       TextColor.super.examinableProperties()

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -36,10 +36,10 @@ import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.adventure.util.MonkeyBars;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 /**
@@ -74,7 +74,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return empty style
    * @since 4.0.0
    */
-  static @NonNull Style empty() {
+  static @NotNull Style empty() {
     return StyleImpl.EMPTY;
   }
 
@@ -84,7 +84,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a builder
    * @since 4.0.0
    */
-  static @NonNull Builder style() {
+  static @NotNull Builder style() {
     return new StyleImpl.BuilderImpl();
   }
 
@@ -95,7 +95,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  static @NonNull Style style(final @NonNull Consumer<Builder> consumer) {
+  static @NotNull Style style(final @NotNull Consumer<Builder> consumer) {
     return Buildable.configureAndBuild(style(), consumer);
   }
 
@@ -106,7 +106,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  static @NonNull Style style(final @Nullable TextColor color) {
+  static @NotNull Style style(final @Nullable TextColor color) {
     if (color == null) return empty();
     return new StyleImpl(null, color, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, null, null, null);
   }
@@ -118,7 +118,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  static @NonNull Style style(final @NonNull TextDecoration decoration) {
+  static @NotNull Style style(final @NotNull TextDecoration decoration) {
     return style().decoration(decoration, true).build();
   }
 
@@ -130,7 +130,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  static @NonNull Style style(final @Nullable TextColor color, final TextDecoration@NonNull... decorations) {
+  static @NotNull Style style(final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     final Builder builder = style();
     builder.color(color);
     StyleImpl.decorate(builder, decorations);
@@ -145,7 +145,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  static @NonNull Style style(final @Nullable TextColor color, final Set<TextDecoration> decorations) {
+  static @NotNull Style style(final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     final Builder builder = style();
     builder.color(color);
     if (!decorations.isEmpty()) {
@@ -163,7 +163,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  static @NonNull Style style(final StyleBuilderApplicable@NonNull... applicables) {
+  static @NotNull Style style(final StyleBuilderApplicable@NotNull... applicables) {
     if (applicables.length == 0) return empty();
     final Builder builder = style();
     for (int i = 0, length = applicables.length; i < length; i++) {
@@ -179,7 +179,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  static @NonNull Style style(final @NonNull Iterable<? extends StyleBuilderApplicable> applicables) {
+  static @NotNull Style style(final @NotNull Iterable<? extends StyleBuilderApplicable> applicables) {
     final Builder builder = style();
     for (final StyleBuilderApplicable applicable : applicables) {
       applicable.styleApply(builder);
@@ -196,7 +196,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a new style
    * @since 4.0.0
    */
-  default @NonNull Style edit(final @NonNull Consumer<Builder> consumer) {
+  default @NotNull Style edit(final @NotNull Consumer<Builder> consumer) {
     return this.edit(consumer, Merge.Strategy.ALWAYS);
   }
 
@@ -208,7 +208,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a new style
    * @since 4.0.0
    */
-  default @NonNull Style edit(final @NonNull Consumer<Builder> consumer, final Merge.@NonNull Strategy strategy) {
+  default @NotNull Style edit(final @NotNull Consumer<Builder> consumer, final Merge.@NotNull Strategy strategy) {
     return style(style -> {
       if (strategy == Merge.Strategy.ALWAYS) {
         style.merge(this, strategy);
@@ -238,7 +238,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @since 4.0.0
    * @sinceMinecraft 1.16
    */
-  @NonNull Style font(final @Nullable Key font);
+  @NotNull Style font(final @Nullable Key font);
 
   /**
    * Gets the color.
@@ -255,7 +255,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  @NonNull Style color(final @Nullable TextColor color);
+  @NotNull Style color(final @Nullable TextColor color);
 
   /**
    * Sets the color if there isn't one set already.
@@ -264,7 +264,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return this builder
    * @since 4.0.0
    */
-  @NonNull Style colorIfAbsent(final @Nullable TextColor color);
+  @NotNull Style colorIfAbsent(final @Nullable TextColor color);
 
   /**
    * Tests if this style has a decoration.
@@ -274,7 +274,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    *     style does not have the decoration
    * @since 4.0.0
    */
-  default boolean hasDecoration(final @NonNull TextDecoration decoration) {
+  default boolean hasDecoration(final @NotNull TextDecoration decoration) {
     return this.decoration(decoration) == TextDecoration.State.TRUE;
   }
 
@@ -287,7 +287,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    *     and {@link TextDecoration.State#NOT_SET} if not set
    * @since 4.0.0
    */
-  TextDecoration.@NonNull State decoration(final @NonNull TextDecoration decoration);
+  TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration);
 
   /**
    * Sets the state of {@code decoration} to {@link TextDecoration.State#TRUE} on this style.
@@ -296,7 +296,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style decorate(final @NonNull TextDecoration decoration) {
+  default @NotNull Style decorate(final @NotNull TextDecoration decoration) {
     return this.decoration(decoration, TextDecoration.State.TRUE);
   }
 
@@ -309,7 +309,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style decoration(final @NonNull TextDecoration decoration, final boolean flag) {
+  default @NotNull Style decoration(final @NotNull TextDecoration decoration, final boolean flag) {
     return this.decoration(decoration, TextDecoration.State.byBoolean(flag));
   }
 
@@ -324,7 +324,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  @NonNull Style decoration(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state);
+  @NotNull Style decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
   /**
    * Gets a map of decorations this style has.
@@ -332,7 +332,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a set of decorations this style has
    * @since 4.0.0
    */
-  @Unmodifiable @NonNull Map<TextDecoration, TextDecoration.State> decorations();
+  @Unmodifiable @NotNull Map<TextDecoration, TextDecoration.State> decorations();
 
   /**
    * Sets decorations for this style using the specified {@code decorations} map.
@@ -343,7 +343,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  @NonNull Style decorations(final @NonNull Map<TextDecoration, TextDecoration.State> decorations);
+  @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations);
 
   /**
    * Gets the click event.
@@ -360,7 +360,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  @NonNull Style clickEvent(final @Nullable ClickEvent event);
+  @NotNull Style clickEvent(final @Nullable ClickEvent event);
 
   /**
    * Gets the hover event.
@@ -377,7 +377,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  @NonNull Style hoverEvent(final @Nullable HoverEventSource<?> source);
+  @NotNull Style hoverEvent(final @Nullable HoverEventSource<?> source);
 
   /**
    * Gets the string to be inserted when this style is shift-clicked.
@@ -394,7 +394,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  @NonNull Style insertion(final @Nullable String insertion);
+  @NotNull Style insertion(final @Nullable String insertion);
 
   /**
    * Merges from another style into this style.
@@ -403,7 +403,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style merge(final @NonNull Style that) {
+  default @NotNull Style merge(final @NotNull Style that) {
     return this.merge(that, Merge.all());
   }
 
@@ -415,7 +415,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy) {
+  default @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy) {
     return this.merge(that, strategy, Merge.all());
   }
 
@@ -427,7 +427,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style merge(final @NonNull Style that, final @NonNull Merge merge) {
+  default @NotNull Style merge(final @NotNull Style that, final @NotNull Merge merge) {
     return this.merge(that, Collections.singleton(merge));
   }
 
@@ -440,7 +440,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy, final @NonNull Merge merge) {
+  default @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Merge merge) {
     return this.merge(that, strategy, Collections.singleton(merge));
   }
 
@@ -452,7 +452,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style merge(final @NonNull Style that, final @NonNull Merge@NonNull... merges) {
+  default @NotNull Style merge(final @NotNull Style that, final @NotNull Merge@NotNull... merges) {
     return this.merge(that, Merge.of(merges));
   }
 
@@ -465,7 +465,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy, final @NonNull Merge@NonNull... merges) {
+  default @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Merge@NotNull... merges) {
     return this.merge(that, strategy, Merge.of(merges));
   }
 
@@ -477,7 +477,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  default @NonNull Style merge(final @NonNull Style that, final @NonNull Set<Merge> merges) {
+  default @NotNull Style merge(final @NotNull Style that, final @NotNull Set<Merge> merges) {
     return this.merge(that, Merge.Strategy.ALWAYS, merges);
   }
 
@@ -490,7 +490,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a style
    * @since 4.0.0
    */
-  @NonNull Style merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy, final @NonNull Set<Merge> merges);
+  @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges);
 
   /**
    * Tests if this style is empty.
@@ -507,7 +507,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @return a builder
    */
   @Override
-  @NonNull Builder toBuilder();
+  @NotNull Builder toBuilder();
 
   /**
    * A merge choice.
@@ -555,7 +555,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @return a merge set
      * @since 4.0.0
      */
-    public static @Unmodifiable @NonNull Set<Merge> all() {
+    public static @Unmodifiable @NotNull Set<Merge> all() {
       return ALL;
     }
 
@@ -565,7 +565,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @return a merge set
      * @since 4.0.0
      */
-    public static @Unmodifiable @NonNull Set<Merge> colorAndDecorations() {
+    public static @Unmodifiable @NotNull Set<Merge> colorAndDecorations() {
       return COLOR_AND_DECORATIONS;
     }
 
@@ -576,11 +576,11 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @return a merge set
      * @since 4.0.0
      */
-    public static @Unmodifiable @NonNull Set<Merge> of(final Merge@NonNull... merges) {
+    public static @Unmodifiable @NotNull Set<Merge> of(final Merge@NotNull... merges) {
       return MonkeyBars.enumSet(Merge.class, merges);
     }
 
-    static boolean hasAll(final @NonNull Set<Merge> merges) {
+    static boolean hasAll(final @NotNull Set<Merge> merges) {
       return merges.size() == ALL.size();
     }
 
@@ -626,7 +626,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @sinceMinecraft 1.16
      */
     @Contract("_ -> this")
-    @NonNull Builder font(final @Nullable Key font);
+    @NotNull Builder font(final @Nullable Key font);
 
     /**
      * Sets the color.
@@ -636,7 +636,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder color(final @Nullable TextColor color);
+    @NotNull Builder color(final @Nullable TextColor color);
 
     /**
      * Sets the color if there isn't one set already.
@@ -646,7 +646,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder colorIfAbsent(final @Nullable TextColor color);
+    @NotNull Builder colorIfAbsent(final @Nullable TextColor color);
 
     /**
      * Sets {@code decoration} to {@link TextDecoration.State#TRUE}.
@@ -656,7 +656,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder decorate(final @NonNull TextDecoration decoration) {
+    default @NotNull Builder decorate(final @NotNull TextDecoration decoration) {
       return this.decoration(decoration, TextDecoration.State.TRUE);
     }
 
@@ -668,7 +668,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder decorate(final @NonNull TextDecoration@NonNull... decorations) {
+    default @NotNull Builder decorate(final @NotNull TextDecoration@NotNull... decorations) {
       for (int i = 0, length = decorations.length; i < length; i++) {
         this.decorate(decorations[i]);
       }
@@ -685,7 +685,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_, _ -> this")
-    default @NonNull Builder decoration(final @NonNull TextDecoration decoration, final boolean flag) {
+    default @NotNull Builder decoration(final @NotNull TextDecoration decoration, final boolean flag) {
       return this.decoration(decoration, TextDecoration.State.byBoolean(flag));
     }
 
@@ -701,7 +701,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_, _ -> this")
-    @NonNull Builder decoration(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state);
+    @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
     /**
      * Sets the click event.
@@ -711,7 +711,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder clickEvent(final @Nullable ClickEvent event);
+    @NotNull Builder clickEvent(final @Nullable ClickEvent event);
 
     /**
      * Sets the hover event.
@@ -721,7 +721,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder hoverEvent(final @Nullable HoverEventSource<?> source);
+    @NotNull Builder hoverEvent(final @Nullable HoverEventSource<?> source);
 
     /**
      * Sets the string to be inserted.
@@ -731,7 +731,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NonNull Builder insertion(final @Nullable String insertion);
+    @NotNull Builder insertion(final @Nullable String insertion);
 
     /**
      * Merges from another style into this style.
@@ -741,7 +741,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder merge(final @NonNull Style that) {
+    default @NotNull Builder merge(final @NotNull Style that) {
       return this.merge(that, Merge.all());
     }
 
@@ -754,7 +754,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_, _ -> this")
-    default @NonNull Builder merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy) {
+    default @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy) {
       return this.merge(that, strategy, Merge.all());
     }
 
@@ -767,7 +767,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_, _ -> this")
-    default @NonNull Builder merge(final @NonNull Style that, final @NonNull Merge@NonNull... merges) {
+    default @NotNull Builder merge(final @NotNull Style that, final @NotNull Merge@NotNull... merges) {
       if (merges.length == 0) return this;
       return this.merge(that, Merge.of(merges));
     }
@@ -782,7 +782,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NonNull Builder merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy, final @NonNull Merge@NonNull... merges) {
+    default @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Merge@NotNull... merges) {
       if (merges.length == 0) return this;
       return this.merge(that, strategy, Merge.of(merges));
     }
@@ -796,7 +796,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_, _ -> this")
-    default @NonNull Builder merge(final @NonNull Style that, final @NonNull Set<Merge> merges) {
+    default @NotNull Builder merge(final @NotNull Style that, final @NotNull Set<Merge> merges) {
       return this.merge(that, Merge.Strategy.ALWAYS, merges);
     }
 
@@ -810,7 +810,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    @NonNull Builder merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy, final @NonNull Set<Merge> merges);
+    @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges);
 
     /**
      * Applies {@code applicable} to this builder.
@@ -820,7 +820,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    default @NonNull Builder apply(final @NonNull StyleBuilderApplicable applicable) {
+    default @NotNull Builder apply(final @NotNull StyleBuilderApplicable applicable) {
       applicable.styleApply(this);
       return this;
     }
@@ -831,6 +831,6 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      * @return the style
      */
     @Override
-    @NonNull Style build();
+    @NotNull Style build();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleBuilderApplicable.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleBuilderApplicable.java
@@ -25,8 +25,8 @@ package net.kyori.adventure.text.format;
 
 import net.kyori.adventure.text.ComponentBuilder;
 import net.kyori.adventure.text.ComponentBuilderApplicable;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can be applied to a {@link Style}.
@@ -42,10 +42,10 @@ public interface StyleBuilderApplicable extends ComponentBuilderApplicable {
    * @since 4.0.0
    */
   @Contract(mutates = "param")
-  void styleApply(final Style.@NonNull Builder style);
+  void styleApply(final Style.@NotNull Builder style);
 
   @Override
-  default void componentBuilderApply(final @NonNull ComponentBuilder<?, ?> component) {
+  default void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component) {
     component.style(this::styleApply);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -34,8 +34,8 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -90,7 +90,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull Style font(final @Nullable Key font) {
+  public @NotNull Style font(final @Nullable Key font) {
     if (Objects.equals(this.font, font)) return this;
     return new StyleImpl(font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
   }
@@ -101,13 +101,13 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull Style color(final @Nullable TextColor color) {
+  public @NotNull Style color(final @Nullable TextColor color) {
     if (Objects.equals(this.color, color)) return this;
     return new StyleImpl(this.font, color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
-  public @NonNull Style colorIfAbsent(final @Nullable TextColor color) {
+  public @NotNull Style colorIfAbsent(final @Nullable TextColor color) {
     if (this.color == null) {
       return this.color(color);
     }
@@ -115,7 +115,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public TextDecoration.@NonNull State decoration(final @NonNull TextDecoration decoration) {
+  public TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
     if (decoration == TextDecoration.BOLD) {
       return this.bold;
     } else if (decoration == TextDecoration.ITALIC) {
@@ -131,7 +131,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull Style decoration(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state) {
+  public @NotNull Style decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     requireNonNull(state, "state");
     if (decoration == TextDecoration.BOLD) {
       return new StyleImpl(this.font, this.color, this.obfuscated, state, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
@@ -148,7 +148,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull Map<TextDecoration, TextDecoration.State> decorations() {
+  public @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
     final Map<TextDecoration, TextDecoration.State> decorations = new EnumMap<>(TextDecoration.class);
     for (int i = 0, length = DECORATIONS.length; i < length; i++) {
       final TextDecoration decoration = DECORATIONS[i];
@@ -159,7 +159,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull Style decorations(final @NonNull Map<TextDecoration, TextDecoration.State> decorations) {
+  public @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
     final TextDecoration.State obfuscated = decorations.getOrDefault(TextDecoration.OBFUSCATED, this.obfuscated);
     final TextDecoration.State bold = decorations.getOrDefault(TextDecoration.BOLD, this.bold);
     final TextDecoration.State strikethrough = decorations.getOrDefault(TextDecoration.STRIKETHROUGH, this.strikethrough);
@@ -174,7 +174,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull Style clickEvent(final @Nullable ClickEvent event) {
+  public @NotNull Style clickEvent(final @Nullable ClickEvent event) {
     return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, event, this.hoverEvent, this.insertion);
   }
 
@@ -184,7 +184,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull Style hoverEvent(final @Nullable HoverEventSource<?> source) {
+  public @NotNull Style hoverEvent(final @Nullable HoverEventSource<?> source) {
     return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, HoverEventSource.unbox(source), this.insertion);
   }
 
@@ -194,13 +194,13 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull Style insertion(final @Nullable String insertion) {
+  public @NotNull Style insertion(final @Nullable String insertion) {
     if (Objects.equals(this.insertion, insertion)) return this;
     return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, insertion);
   }
 
   @Override
-  public @NonNull Style merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy, final @NonNull Set<Merge> merges) {
+  public @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges) {
     if (that.isEmpty() || strategy == Merge.Strategy.NEVER || merges.isEmpty()) {
       // nothing to merge
       return this;
@@ -228,12 +228,12 @@ final class StyleImpl implements Style {
    * @return a builder
    */
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("color", this.color),
       ExaminableProperty.of("obfuscated", this.obfuscated),
@@ -249,7 +249,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NonNull String toString() {
+  public @NotNull String toString() {
     return this.examine(StringExaminer.simpleEscaping());
   }
 
@@ -300,7 +300,7 @@ final class StyleImpl implements Style {
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NonNull StyleImpl style) {
+    BuilderImpl(final @NotNull StyleImpl style) {
       this.color = style.color;
       this.obfuscated = style.obfuscated;
       this.bold = style.bold;
@@ -314,19 +314,19 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NonNull Builder font(final @Nullable Key font) {
+    public @NotNull Builder font(final @Nullable Key font) {
       this.font = font;
       return this;
     }
 
     @Override
-    public @NonNull Builder color(final @Nullable TextColor color) {
+    public @NotNull Builder color(final @Nullable TextColor color) {
       this.color = color;
       return this;
     }
 
     @Override
-    public @NonNull Builder colorIfAbsent(final @Nullable TextColor color) {
+    public @NotNull Builder colorIfAbsent(final @Nullable TextColor color) {
       if (this.color == null) {
         this.color = color;
       }
@@ -334,12 +334,12 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NonNull Builder decorate(final @NonNull TextDecoration decoration) {
+    public @NotNull Builder decorate(final @NotNull TextDecoration decoration) {
       return this.decoration(decoration, TextDecoration.State.TRUE);
     }
 
     @Override
-    public @NonNull Builder decorate(final @NonNull TextDecoration@NonNull... decorations) {
+    public @NotNull Builder decorate(final @NotNull TextDecoration@NotNull... decorations) {
       for (int i = 0, length = decorations.length; i < length; i++) {
         this.decorate(decorations[i]);
       }
@@ -347,7 +347,7 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NonNull Builder decoration(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state) {
+    public @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
       if (decoration == TextDecoration.BOLD) {
         this.bold = state;
@@ -368,7 +368,7 @@ final class StyleImpl implements Style {
       throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
     }
 
-    @NonNull Builder decorationIfAbsent(final @NonNull TextDecoration decoration, final TextDecoration.@NonNull State state) {
+    @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
       if (decoration == TextDecoration.BOLD && this.bold == TextDecoration.State.NOT_SET) {
         this.bold = state;
@@ -390,25 +390,25 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NonNull Builder clickEvent(final @Nullable ClickEvent event) {
+    public @NotNull Builder clickEvent(final @Nullable ClickEvent event) {
       this.clickEvent = event;
       return this;
     }
 
     @Override
-    public @NonNull Builder hoverEvent(final @Nullable HoverEventSource<?> source) {
+    public @NotNull Builder hoverEvent(final @Nullable HoverEventSource<?> source) {
       this.hoverEvent = HoverEventSource.unbox(source);
       return this;
     }
 
     @Override
-    public @NonNull Builder insertion(final @Nullable String insertion) {
+    public @NotNull Builder insertion(final @Nullable String insertion) {
       this.insertion = insertion;
       return this;
     }
 
     @Override
-    public @NonNull Builder merge(final @NonNull Style that, final Merge.@NonNull Strategy strategy, final @NonNull Set<Merge> merges) {
+    public @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges) {
       if (strategy == Merge.Strategy.NEVER || that.isEmpty() || merges.isEmpty()) {
         // nothing to merge
         return this;
@@ -462,7 +462,7 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NonNull StyleImpl build() {
+    public @NotNull StyleImpl build() {
       if (this.isEmpty()) {
         return EMPTY;
       }

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -28,9 +28,9 @@ import net.kyori.adventure.util.HSVLike;
 import net.kyori.adventure.util.RGBLike;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.common.value.qual.IntRange;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 /**
  * A color which may be applied to a {@link Style}.
@@ -51,7 +51,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @NonNull TextColor color(final int value) {
+  static @NotNull TextColor color(final int value) {
     final int truncatedValue = value & 0xffffff;
     final NamedTextColor named = NamedTextColor.ofExact(truncatedValue);
     return named != null ? named : new TextColorImpl(truncatedValue);
@@ -64,7 +64,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @NonNull TextColor color(final @NonNull RGBLike rgb) {
+  static @NotNull TextColor color(final @NotNull RGBLike rgb) {
     return color(rgb.red(), rgb.green(), rgb.blue());
   }
 
@@ -76,7 +76,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @see <a href="https://en.wikipedia.org/wiki/HSL_and_HSV">https://en.wikipedia.org/wiki/HSL_and_HSV</a>
    * @since 4.6.0
    */
-  static @NonNull TextColor color(final @NonNull HSVLike hsv) {
+  static @NotNull TextColor color(final @NotNull HSVLike hsv) {
     final float s = hsv.s();
     final float v = hsv.v();
     if (s == 0) {
@@ -115,7 +115,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @NonNull TextColor color(final @IntRange(from = 0x0, to = 0xff) int r, final @IntRange(from = 0x0, to = 0xff) int g, final @IntRange(from = 0x0, to = 0xff) int b) {
+  static @NotNull TextColor color(final @Range(from = 0x0, to = 0xff) int r, final @Range(from = 0x0, to = 0xff) int g, final @Range(from = 0x0, to = 0xff) int b) {
     return color((r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff));
   }
 
@@ -128,7 +128,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @NonNull TextColor color(final float r, final float g, final float b) {
+  static @NotNull TextColor color(final float r, final float g, final float b) {
     return color((int) (r * 0xff), (int) (g * 0xff), (int) (b * 0xff));
   }
 
@@ -139,7 +139,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @Nullable TextColor fromHexString(final @NonNull String string) {
+  static @Nullable TextColor fromHexString(final @NotNull String string) {
     if (string.startsWith("#")) {
       try {
         final int hex = Integer.parseInt(string.substring(1), 16);
@@ -158,7 +158,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @Nullable TextColor fromCSSHexString(final @NonNull String string) {
+  static @Nullable TextColor fromCSSHexString(final @NotNull String string) {
     if (string.startsWith("#")) {
       final String hexString = string.substring(1);
       if (hexString.length() != 3 && hexString.length() != 6) {
@@ -197,7 +197,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a hex string
    * @since 4.0.0
    */
-  default @NonNull String asHexString() {
+  default @NotNull String asHexString() {
     return String.format("#%06x", this.value());
   }
 
@@ -208,7 +208,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @since 4.0.0
    */
   @Override
-  default @IntRange(from = 0x0, to = 0xff) int red() {
+  default @Range(from = 0x0, to = 0xff) int red() {
     return (this.value() >> 16) & 0xff;
   }
 
@@ -219,7 +219,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @since 4.0.0
    */
   @Override
-  default @IntRange(from = 0x0, to = 0xff) int green() {
+  default @Range(from = 0x0, to = 0xff) int green() {
     return (this.value() >> 8) & 0xff;
   }
 
@@ -230,12 +230,12 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @since 4.0.0
    */
   @Override
-  default @IntRange(from = 0x0, to = 0xff) int blue() {
+  default @Range(from = 0x0, to = 0xff) int blue() {
     return this.value() & 0xff;
   }
 
   @Override
-  default void styleApply(final Style.@NonNull Builder style) {
+  default void styleApply(final Style.@NotNull Builder style) {
     style.color(this);
   }
 
@@ -245,7 +245,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
   }
 
   @Override
-  default @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.asHexString()));
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.text.format;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.Nullable;
 
 @Debug.Renderer(text = "asHexString()")
 final class TextColorImpl implements TextColor {

--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
@@ -25,8 +25,8 @@ package net.kyori.adventure.text.format;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Index;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An enumeration of decorations which may be applied to a {@link Component}.
@@ -78,12 +78,12 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
   }
 
   @Override
-  public void styleApply(final Style.@NonNull Builder style) {
+  public void styleApply(final Style.@NotNull Builder style) {
     style.decorate(this);
   }
 
   @Override
-  public @NonNull String toString() {
+  public @NotNull String toString() {
     return this.name;
   }
 
@@ -130,7 +130,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
      * @return the state
      * @since 4.0.0
      */
-    public static @NonNull State byBoolean(final boolean flag) {
+    public static @NotNull State byBoolean(final boolean flag) {
       return flag ? TRUE : FALSE;
     }
 
@@ -141,7 +141,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
      * @return the state
      * @since 4.0.0
      */
-    public static @NonNull State byBoolean(final @Nullable Boolean flag) {
+    public static @NotNull State byBoolean(final @Nullable Boolean flag) {
       return flag == null ? NOT_SET : byBoolean(flag.booleanValue());
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/renderer/AbstractComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/AbstractComponentRenderer.java
@@ -33,7 +33,7 @@ import net.kyori.adventure.text.SelectorComponent;
 import net.kyori.adventure.text.StorageNBTComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An abstract implementation of a component renderer.
@@ -43,7 +43,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<C> {
   @Override
-  public @NonNull Component render(final @NonNull Component component, final @NonNull C context) {
+  public @NotNull Component render(final @NotNull Component component, final @NotNull C context) {
     if (component instanceof TextComponent) {
       return this.renderText((TextComponent) component, context);
     } else if (component instanceof TranslatableComponent) {
@@ -73,7 +73,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NonNull Component renderBlockNbt(final @NonNull BlockNBTComponent component, final @NonNull C context);
+  protected abstract @NotNull Component renderBlockNbt(final @NotNull BlockNBTComponent component, final @NotNull C context);
 
   /**
    * Renders an entity NBT component.
@@ -82,7 +82,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NonNull Component renderEntityNbt(final @NonNull EntityNBTComponent component, final @NonNull C context);
+  protected abstract @NotNull Component renderEntityNbt(final @NotNull EntityNBTComponent component, final @NotNull C context);
 
   /**
    * Renders a storage NBT component.
@@ -91,7 +91,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NonNull Component renderStorageNbt(final @NonNull StorageNBTComponent component, final @NonNull C context);
+  protected abstract @NotNull Component renderStorageNbt(final @NotNull StorageNBTComponent component, final @NotNull C context);
 
   /**
    * Renders a keybind component.
@@ -100,7 +100,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NonNull Component renderKeybind(final @NonNull KeybindComponent component, final @NonNull C context);
+  protected abstract @NotNull Component renderKeybind(final @NotNull KeybindComponent component, final @NotNull C context);
 
   /**
    * Renders a score component.
@@ -109,7 +109,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NonNull Component renderScore(final @NonNull ScoreComponent component, final @NonNull C context);
+  protected abstract @NotNull Component renderScore(final @NotNull ScoreComponent component, final @NotNull C context);
 
   /**
    * Renders a selector component.
@@ -118,7 +118,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NonNull Component renderSelector(final @NonNull SelectorComponent component, final @NonNull C context);
+  protected abstract @NotNull Component renderSelector(final @NotNull SelectorComponent component, final @NotNull C context);
 
   /**
    * Renders a text component.
@@ -127,7 +127,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NonNull Component renderText(final @NonNull TextComponent component, final @NonNull C context);
+  protected abstract @NotNull Component renderText(final @NotNull TextComponent component, final @NotNull C context);
 
   /**
    * Renders a translatable component.
@@ -136,5 +136,5 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NonNull Component renderTranslatable(final @NonNull TranslatableComponent component, final @NonNull C context);
+  protected abstract @NotNull Component renderTranslatable(final @NotNull TranslatableComponent component, final @NotNull C context);
 }

--- a/api/src/main/java/net/kyori/adventure/text/renderer/ComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/ComponentRenderer.java
@@ -25,7 +25,7 @@ package net.kyori.adventure.text.renderer;
 
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A component renderer.
@@ -42,7 +42,7 @@ public interface ComponentRenderer<C> {
    * @return the rendered component
    * @since 4.0.0
    */
-  @NonNull Component render(final @NonNull Component component, final @NonNull C context);
+  @NotNull Component render(final @NotNull Component component, final @NotNull C context);
 
   /**
    * Return a {@link ComponentRenderer} that takes a different context type.

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -45,8 +45,8 @@ import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.translation.Translator;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -66,11 +66,11 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
    * @return the renderer
    * @since 4.0.0
    */
-  public static @NonNull TranslatableComponentRenderer<Locale> usingTranslationSource(final @NonNull Translator source) {
+  public static @NotNull TranslatableComponentRenderer<Locale> usingTranslationSource(final @NotNull Translator source) {
     requireNonNull(source, "source");
     return new TranslatableComponentRenderer<Locale>() {
       @Override
-      protected @Nullable MessageFormat translate(final @NonNull String key, final @NonNull Locale context) {
+      protected @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale context) {
         return source.translate(key, context);
       }
     };
@@ -83,24 +83,24 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
    * @param context a context
    * @return a message format or {@code null} to skip translation
    */
-  protected abstract @Nullable MessageFormat translate(final @NonNull String key, final @NonNull C context);
+  protected abstract @Nullable MessageFormat translate(final @NotNull String key, final @NotNull C context);
 
   @Override
-  protected @NonNull Component renderBlockNbt(final @NonNull BlockNBTComponent component, final @NonNull C context) {
+  protected @NotNull Component renderBlockNbt(final @NotNull BlockNBTComponent component, final @NotNull C context) {
     final BlockNBTComponent.Builder builder = nbt(Component.blockNBT(), component)
       .pos(component.pos());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
-  protected @NonNull Component renderEntityNbt(final @NonNull EntityNBTComponent component, final @NonNull C context) {
+  protected @NotNull Component renderEntityNbt(final @NotNull EntityNBTComponent component, final @NotNull C context) {
     final EntityNBTComponent.Builder builder = nbt(Component.entityNBT(), component)
       .selector(component.selector());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
-  protected @NonNull Component renderStorageNbt(final @NonNull StorageNBTComponent component, final @NonNull C context) {
+  protected @NotNull Component renderStorageNbt(final @NotNull StorageNBTComponent component, final @NotNull C context) {
     final StorageNBTComponent.Builder builder = nbt(Component.storageNBT(), component)
       .storage(component.storage());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
@@ -113,14 +113,14 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   }
 
   @Override
-  protected @NonNull Component renderKeybind(final @NonNull KeybindComponent component, final @NonNull C context) {
+  protected @NotNull Component renderKeybind(final @NotNull KeybindComponent component, final @NotNull C context) {
     final KeybindComponent.Builder builder = Component.keybind().keybind(component.keybind());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
   @SuppressWarnings("deprecation")
-  protected @NonNull Component renderScore(final @NonNull ScoreComponent component, final @NonNull C context) {
+  protected @NotNull Component renderScore(final @NotNull ScoreComponent component, final @NotNull C context) {
     final ScoreComponent.Builder builder = Component.score()
       .name(component.name())
       .objective(component.objective())
@@ -129,19 +129,19 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   }
 
   @Override
-  protected @NonNull Component renderSelector(final @NonNull SelectorComponent component, final @NonNull C context) {
+  protected @NotNull Component renderSelector(final @NotNull SelectorComponent component, final @NotNull C context) {
     final SelectorComponent.Builder builder = Component.selector().pattern(component.pattern());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
-  protected @NonNull Component renderText(final @NonNull TextComponent component, final @NonNull C context) {
+  protected @NotNull Component renderText(final @NotNull TextComponent component, final @NotNull C context) {
     final TextComponent.Builder builder = Component.text().content(component.content());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
-  protected @NonNull Component renderTranslatable(final @NonNull TranslatableComponent component, final @NonNull C context) {
+  protected @NotNull Component renderTranslatable(final @NotNull TranslatableComponent component, final @NotNull C context) {
     final @Nullable MessageFormat format = this.translate(component.key(), context);
     if (format == null) {
       // we don't have a translation for this component, but the arguments or children

--- a/api/src/main/java/net/kyori/adventure/text/serializer/ComponentSerializer.java
+++ b/api/src/main/java/net/kyori/adventure/text/serializer/ComponentSerializer.java
@@ -24,11 +24,10 @@
 package net.kyori.adventure.text.serializer;
 
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A {@link Component} serializer and deserializer.
@@ -46,7 +45,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @return the component
    * @since 4.0.0
    */
-  @NonNull O deserialize(final @NonNull R input);
+  @NotNull O deserialize(final @NotNull R input);
 
   /**
    * Deserialize a component from input of type {@code R}.
@@ -61,7 +60,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
   @ApiStatus.ScheduledForRemoval
   @Contract(value = "!null -> !null; null -> null", pure = true)
   @Deprecated
-  default @PolyNull O deseializeOrNull(final @PolyNull R input) {
+  default @Nullable O deseializeOrNull(final @Nullable R input) {
     return this.deserializeOrNull(input);
   }
 
@@ -75,7 +74,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @since 4.8.0
    */
   @Contract(value = "!null -> !null; null -> null", pure = true)
-  default @PolyNull O deserializeOrNull(final @PolyNull R input) {
+  default @Nullable O deserializeOrNull(final @Nullable R input) {
     return this.deserializeOr(input, null);
   }
 
@@ -90,7 +89,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @since 4.7.0
    */
   @Contract(value = "!null, _ -> !null; null, _ -> param2", pure = true)
-  default @PolyNull O deserializeOr(final @Nullable R input, final @PolyNull O fallback) {
+  default @Nullable O deserializeOr(final @Nullable R input, final @Nullable O fallback) {
     if (input == null) return fallback;
 
     return this.deserialize(input);
@@ -103,7 +102,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @return the output
    * @since 4.0.0
    */
-  @NonNull R serialize(final @NonNull I component);
+  @NotNull R serialize(final @NotNull I component);
 
   /**
    * Serializes a component into an output of type {@code R}.
@@ -115,7 +114,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @since 4.7.0
    */
   @Contract(value = "!null -> !null; null -> null", pure = true)
-  default @PolyNull R serializeOrNull(final @PolyNull I component) {
+  default @Nullable R serializeOrNull(final @Nullable I component) {
     return this.serializeOr(component, null);
   }
 
@@ -130,7 +129,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @since 4.7.0
    */
   @Contract(value = "!null, _ -> !null; null, _ -> param2", pure = true)
-  default @PolyNull R serializeOr(final @Nullable I component, final @PolyNull R fallback) {
+  default @Nullable R serializeOr(final @Nullable I component, final @Nullable R fallback) {
     if (component == null) return fallback;
 
     return this.serialize(component);

--- a/api/src/main/java/net/kyori/adventure/title/Title.java
+++ b/api/src/main/java/net/kyori/adventure/title/Title.java
@@ -27,9 +27,9 @@ import java.time.Duration;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Ticks;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents an in-game title, which can be displayed across the centre of the screen.
@@ -54,7 +54,7 @@ public interface Title extends Examinable {
    * @return the title
    * @since 4.0.0
    */
-  static @NonNull Title title(final @NonNull Component title, final @NonNull Component subtitle) {
+  static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle) {
     return title(title, subtitle, DEFAULT_TIMES);
   }
 
@@ -67,7 +67,7 @@ public interface Title extends Examinable {
    * @return the title
    * @since 4.0.0
    */
-  static @NonNull Title title(final @NonNull Component title, final @NonNull Component subtitle, final @Nullable Times times) {
+  static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle, final @Nullable Times times) {
     return new TitleImpl(title, subtitle, times);
   }
 
@@ -77,7 +77,7 @@ public interface Title extends Examinable {
    * @return the title
    * @since 4.0.0
    */
-  @NonNull Component title();
+  @NotNull Component title();
 
   /**
    * Gets the subtitle.
@@ -85,7 +85,7 @@ public interface Title extends Examinable {
    * @return the subtitle
    * @since 4.0.0
    */
-  @NonNull Component subtitle();
+  @NotNull Component subtitle();
 
   /**
    * Gets the times.
@@ -110,7 +110,7 @@ public interface Title extends Examinable {
      * @return times
      * @since 4.0.0
      */
-    static @NonNull Times of(final @NonNull Duration fadeIn, final @NonNull Duration stay, final @NonNull Duration fadeOut) {
+    static @NotNull Times of(final @NotNull Duration fadeIn, final @NotNull Duration stay, final @NotNull Duration fadeOut) {
       return new TitleImpl.TimesImpl(fadeIn, stay, fadeOut);
     }
 
@@ -120,7 +120,7 @@ public interface Title extends Examinable {
      * @return the time the title will fade-in
      * @since 4.0.0
      */
-    @NonNull Duration fadeIn();
+    @NotNull Duration fadeIn();
 
     /**
      * Gets the time the title will stay.
@@ -128,7 +128,7 @@ public interface Title extends Examinable {
      * @return the time the title will stay
      * @since 4.0.0
      */
-    @NonNull Duration stay();
+    @NotNull Duration stay();
 
     /**
      * Gets the time the title will fade-out.
@@ -136,6 +136,6 @@ public interface Title extends Examinable {
      * @return the time the title will fade-out
      * @since 4.0.0
      */
-    @NonNull Duration fadeOut();
+    @NotNull Duration fadeOut();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/title/TitleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/title/TitleImpl.java
@@ -29,27 +29,27 @@ import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class TitleImpl implements Title {
   private final Component title;
   private final Component subtitle;
   private final @Nullable Times times;
 
-  TitleImpl(final @NonNull Component title, final @NonNull Component subtitle, final @Nullable Times times) {
+  TitleImpl(final @NotNull Component title, final @NotNull Component subtitle, final @Nullable Times times) {
     this.title = title;
     this.subtitle = subtitle;
     this.times = times;
   }
 
   @Override
-  public @NonNull Component title() {
+  public @NotNull Component title() {
     return this.title;
   }
 
   @Override
-  public @NonNull Component subtitle() {
+  public @NotNull Component subtitle() {
     return this.subtitle;
   }
 
@@ -77,7 +77,7 @@ final class TitleImpl implements Title {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("title", this.title),
       ExaminableProperty.of("subtitle", this.subtitle),
@@ -102,17 +102,17 @@ final class TitleImpl implements Title {
     }
 
     @Override
-    public @NonNull Duration fadeIn() {
+    public @NotNull Duration fadeIn() {
       return this.fadeIn;
     }
 
     @Override
-    public @NonNull Duration stay() {
+    public @NotNull Duration stay() {
       return this.stay;
     }
 
     @Override
-    public @NonNull Duration fadeOut() {
+    public @NotNull Duration fadeOut() {
       return this.fadeOut;
     }
 
@@ -135,7 +135,7 @@ final class TitleImpl implements Title {
     }
 
     @Override
-    public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("fadeIn", this.fadeIn),
         ExaminableProperty.of("stay", this.stay),

--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslator.java
@@ -29,7 +29,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A global source of translations. The global source is the default source used by adventure platforms
@@ -47,7 +47,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return the source
    * @since 4.0.0
    */
-  static @NonNull GlobalTranslator get() {
+  static @NotNull GlobalTranslator get() {
     return GlobalTranslatorImpl.INSTANCE;
   }
 
@@ -57,7 +57,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return a renderer
    * @since 4.0.0
    */
-  static @NonNull TranslatableComponentRenderer<Locale> renderer() {
+  static @NotNull TranslatableComponentRenderer<Locale> renderer() {
     return GlobalTranslatorImpl.INSTANCE.renderer;
   }
 
@@ -69,7 +69,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return the rendered component
    * @since 4.0.0
    */
-  static @NonNull Component render(final @NonNull Component component, final @NonNull Locale locale) {
+  static @NotNull Component render(final @NotNull Component component, final @NotNull Locale locale) {
     return renderer().render(component, locale);
   }
 
@@ -79,7 +79,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return the sources
    * @since 4.0.0
    */
-  @NonNull Iterable<? extends Translator> sources();
+  @NotNull Iterable<? extends Translator> sources();
 
   /**
    * Adds a translation source.
@@ -91,7 +91,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @throws IllegalArgumentException if source is {@link GlobalTranslator}
    * @since 4.0.0
    */
-  boolean addSource(final @NonNull Translator source);
+  boolean addSource(final @NotNull Translator source);
 
   /**
    * Removes a translation source.
@@ -100,5 +100,5 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return {@code true} if unregistered, {@code false} otherwise
    * @since 4.0.0
    */
-  boolean removeSource(final @NonNull Translator source);
+  boolean removeSource(final @NotNull Translator source);
 }

--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
@@ -32,8 +32,8 @@ import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -47,30 +47,30 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
   }
 
   @Override
-  public @NonNull Key name() {
+  public @NotNull Key name() {
     return NAME;
   }
 
   @Override
-  public @NonNull Iterable<? extends Translator> sources() {
+  public @NotNull Iterable<? extends Translator> sources() {
     return Collections.unmodifiableSet(this.sources);
   }
 
   @Override
-  public boolean addSource(final @NonNull Translator source) {
+  public boolean addSource(final @NotNull Translator source) {
     requireNonNull(source, "source");
     if (source == this) throw new IllegalArgumentException("GlobalTranslationSource");
     return this.sources.add(source);
   }
 
   @Override
-  public boolean removeSource(final @NonNull Translator source) {
+  public boolean removeSource(final @NotNull Translator source) {
     requireNonNull(source, "source");
     return this.sources.remove(source);
   }
 
   @Override
-  public @Nullable MessageFormat translate(final @NonNull String key, final @NonNull Locale locale) {
+  public @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
     requireNonNull(key, "key");
     requireNonNull(locale, "locale");
     for (final Translator source : this.sources) {
@@ -81,7 +81,7 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("sources", this.sources));
   }
 }

--- a/api/src/main/java/net/kyori/adventure/translation/Translatable.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translatable.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.translation;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that has a translation key.
@@ -37,5 +37,5 @@ public interface Translatable {
    * @return the translation key
    * @since 4.8.0
    */
-  @NonNull String translationKey();
+  @NotNull String translationKey();
 }

--- a/api/src/main/java/net/kyori/adventure/translation/TranslationRegistry.java
+++ b/api/src/main/java/net/kyori/adventure/translation/TranslationRegistry.java
@@ -40,8 +40,8 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.util.UTF8ResourceBundleControl;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -67,7 +67,7 @@ public interface TranslationRegistry extends Translator {
    * @return a translation registry
    * @since 4.0.0
    */
-  static @NonNull TranslationRegistry create(final Key name) {
+  static @NotNull TranslationRegistry create(final Key name) {
     return new TranslationRegistryImpl(requireNonNull(name, "name"));
   }
 
@@ -78,7 +78,7 @@ public interface TranslationRegistry extends Translator {
    * @return whether the registry contains a value for the translation key
    * @since 4.7.0
    */
-  boolean contains(final @NonNull String key);
+  boolean contains(final @NotNull String key);
 
   /**
    * Gets a message format from a key and locale.
@@ -91,7 +91,7 @@ public interface TranslationRegistry extends Translator {
    * @since 4.0.0
    */
   @Override
-  @Nullable MessageFormat translate(final @NonNull String key, final @NonNull Locale locale);
+  @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale);
 
   /**
    * Sets the default locale used by this registry.
@@ -99,7 +99,7 @@ public interface TranslationRegistry extends Translator {
    * @param locale the locale to use a default
    * @since 4.0.0
    */
-  void defaultLocale(final @NonNull Locale locale);
+  void defaultLocale(final @NotNull Locale locale);
 
   /**
    * Registers a translation.
@@ -115,7 +115,7 @@ public interface TranslationRegistry extends Translator {
    * @throws IllegalArgumentException if the translation key is already exists
    * @since 4.0.0
    */
-  void register(final @NonNull String key, final @NonNull Locale locale, final @NonNull MessageFormat format);
+  void register(final @NotNull String key, final @NotNull Locale locale, final @NotNull MessageFormat format);
 
   /**
    * Registers a map of translations.
@@ -136,7 +136,7 @@ public interface TranslationRegistry extends Translator {
    * @see #register(String, Locale, MessageFormat)
    * @since 4.0.0
    */
-  default void registerAll(final @NonNull Locale locale, final @NonNull Map<String, MessageFormat> formats) {
+  default void registerAll(final @NotNull Locale locale, final @NotNull Map<String, MessageFormat> formats) {
     this.registerAll(locale, formats.keySet(), formats::get);
   }
 
@@ -150,7 +150,7 @@ public interface TranslationRegistry extends Translator {
    * @see #registerAll(Locale, ResourceBundle, boolean)
    * @since 4.0.0
    */
-  default void registerAll(final @NonNull Locale locale, final @NonNull Path path, final boolean escapeSingleQuotes) {
+  default void registerAll(final @NotNull Locale locale, final @NotNull Path path, final boolean escapeSingleQuotes) {
     try(final BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
       this.registerAll(locale, new PropertyResourceBundle(reader), escapeSingleQuotes);
     } catch(final IOException e) {
@@ -175,7 +175,7 @@ public interface TranslationRegistry extends Translator {
    * @see UTF8ResourceBundleControl
    * @since 4.0.0
    */
-  default void registerAll(final @NonNull Locale locale, final @NonNull ResourceBundle bundle, final boolean escapeSingleQuotes) {
+  default void registerAll(final @NotNull Locale locale, final @NotNull ResourceBundle bundle, final boolean escapeSingleQuotes) {
     this.registerAll(locale, bundle.keySet(), key -> {
       final String format = bundle.getString(key);
       return new MessageFormat(
@@ -196,7 +196,7 @@ public interface TranslationRegistry extends Translator {
    * @throws IllegalArgumentException if a translation key is already exists
    * @since 4.0.0
    */
-  default void registerAll(final @NonNull Locale locale, final @NonNull Set<String> keys, final Function<String, MessageFormat> function) {
+  default void registerAll(final @NotNull Locale locale, final @NotNull Set<String> keys, final Function<String, MessageFormat> function) {
     List<IllegalArgumentException> errors = null;
     for (final String key : keys) {
       try {
@@ -224,5 +224,5 @@ public interface TranslationRegistry extends Translator {
    * @param key a translation key
    * @since 4.0.0
    */
-  void unregister(final @NonNull String key);
+  void unregister(final @NotNull String key);
 }

--- a/api/src/main/java/net/kyori/adventure/translation/TranslationRegistryImpl.java
+++ b/api/src/main/java/net/kyori/adventure/translation/TranslationRegistryImpl.java
@@ -33,8 +33,8 @@ import net.kyori.adventure.key.Key;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,39 +48,39 @@ final class TranslationRegistryImpl implements Examinable, TranslationRegistry {
   }
 
   @Override
-  public void register(final @NonNull String key, final @NonNull Locale locale, final @NonNull MessageFormat format) {
+  public void register(final @NotNull String key, final @NotNull Locale locale, final @NotNull MessageFormat format) {
     this.translations.computeIfAbsent(key, Translation::new).register(locale, format);
   }
 
   @Override
-  public void unregister(final @NonNull String key) {
+  public void unregister(final @NotNull String key) {
     this.translations.remove(key);
   }
 
   @Override
-  public @NonNull Key name() {
+  public @NotNull Key name() {
     return this.name;
   }
 
   @Override
-  public boolean contains(final @NonNull String key) {
+  public boolean contains(final @NotNull String key) {
     return this.translations.containsKey(key);
   }
 
   @Override
-  public @Nullable MessageFormat translate(final @NonNull String key, final @NonNull Locale locale) {
+  public @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
     final Translation translation = this.translations.get(key);
     if (translation == null) return null;
     return translation.translate(locale);
   }
 
   @Override
-  public void defaultLocale(final @NonNull Locale defaultLocale) {
+  public void defaultLocale(final @NotNull Locale defaultLocale) {
     this.defaultLocale = requireNonNull(defaultLocale, "defaultLocale");
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("translations", this.translations));
   }
 
@@ -110,18 +110,18 @@ final class TranslationRegistryImpl implements Examinable, TranslationRegistry {
     private final String key;
     private final Map<Locale, MessageFormat> formats;
 
-    Translation(final @NonNull String key) {
+    Translation(final @NotNull String key) {
       this.key = requireNonNull(key, "translation key");
       this.formats = new ConcurrentHashMap<>();
     }
 
-    void register(final @NonNull Locale locale, final @NonNull MessageFormat format) {
+    void register(final @NotNull Locale locale, final @NotNull MessageFormat format) {
       if (this.formats.putIfAbsent(requireNonNull(locale, "locale"), requireNonNull(format, "message format")) != null) {
         throw new IllegalArgumentException(String.format("Translation already exists: %s for %s", this.key, locale));
       }
     }
 
-    @Nullable MessageFormat translate(final @NonNull Locale locale) {
+    @Nullable MessageFormat translate(final @NotNull Locale locale) {
       MessageFormat format = this.formats.get(requireNonNull(locale, "locale"));
       if (format == null) {
         format = this.formats.get(new Locale(locale.getLanguage())); // try without country
@@ -136,7 +136,7 @@ final class TranslationRegistryImpl implements Examinable, TranslationRegistry {
     }
 
     @Override
-    public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("key", this.key),
         ExaminableProperty.of("formats", this.formats)

--- a/api/src/main/java/net/kyori/adventure/translation/Translator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translator.java
@@ -27,8 +27,8 @@ import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A message format translator.
@@ -50,7 +50,7 @@ public interface Translator {
    * @return a locale
    * @since 4.0.0
    */
-  static @Nullable Locale parseLocale(final @NonNull String string) {
+  static @Nullable Locale parseLocale(final @NotNull String string) {
     final String[] segments = string.split("_", 3); // language_country_variant
     final int length = segments.length;
     if (length == 1) {
@@ -71,7 +71,7 @@ public interface Translator {
    * @return an identifier for this translation source
    * @since 4.0.0
    */
-  @NonNull Key name();
+  @NotNull Key name();
 
   /**
    * Gets a message format from a key and locale.
@@ -81,5 +81,5 @@ public interface Translator {
    * @return a message format or {@code null} to skip translation
    * @since 4.0.0
    */
-  @Nullable MessageFormat translate(final @NonNull String key, final @NonNull Locale locale);
+  @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale);
 }

--- a/api/src/main/java/net/kyori/adventure/util/Buildable.java
+++ b/api/src/main/java/net/kyori/adventure/util/Buildable.java
@@ -24,9 +24,9 @@
 package net.kyori.adventure.util;
 
 import java.util.function.Consumer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Something that can be built.
@@ -47,7 +47,7 @@ public interface Buildable<R, B extends Buildable.Builder<R>> {
    * @since 4.0.0
    */
   @Contract(mutates = "param1")
-  static <R extends Buildable<R, B>, B extends Builder<R>> @NonNull R configureAndBuild(final @NonNull B builder, final @Nullable Consumer<? super B> consumer) {
+  static <R extends Buildable<R, B>, B extends Builder<R>> @NotNull R configureAndBuild(final @NotNull B builder, final @Nullable Consumer<? super B> consumer) {
     if (consumer != null) consumer.accept(builder);
     return builder.build();
   }
@@ -59,7 +59,7 @@ public interface Buildable<R, B extends Buildable.Builder<R>> {
    * @since 4.0.0
    */
   @Contract(value = "-> new", pure = true)
-  @NonNull B toBuilder();
+  @NotNull B toBuilder();
 
   /**
    * A builder.
@@ -75,6 +75,6 @@ public interface Buildable<R, B extends Buildable.Builder<R>> {
      * @since 4.0.0
      */
     @Contract(value = "-> new", pure = true)
-    @NonNull R build();
+    @NotNull R build();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/Codec.java
+++ b/api/src/main/java/net/kyori/adventure/util/Codec.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A combination encoder and decoder.
@@ -46,15 +46,15 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
    * @return a codec
    * @since 4.0.0
    */
-  static <D, E, DX extends Throwable, EX extends Throwable> @NonNull Codec<D, E, DX, EX> of(final @NonNull Decoder<D, E, DX> decoder, final @NonNull Encoder<D, E, EX> encoder) {
+  static <D, E, DX extends Throwable, EX extends Throwable> @NotNull Codec<D, E, DX, EX> of(final @NotNull Decoder<D, E, DX> decoder, final @NotNull Encoder<D, E, EX> encoder) {
     return new Codec<D, E, DX, EX>() {
       @Override
-      public @NonNull D decode(final @NonNull E encoded) throws DX {
+      public @NotNull D decode(final @NotNull E encoded) throws DX {
         return decoder.decode(encoded);
       }
 
       @Override
-      public @NonNull E encode(final @NonNull D decoded) throws EX {
+      public @NotNull E encode(final @NotNull D decoded) throws EX {
         return encoder.encode(decoded);
       }
     };
@@ -68,7 +68,7 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
    * @throws DX if an exception is encountered while decoding
    * @since 4.0.0
    */
-  @NonNull D decode(final @NonNull E encoded) throws DX;
+  @NotNull D decode(final @NotNull E encoded) throws DX;
 
   /**
    * A decoder.
@@ -87,7 +87,7 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
      * @throws X if an exception is encountered while decoding
      * @since 4.0.0
      */
-    @NonNull D decode(final @NonNull E encoded) throws X;
+    @NotNull D decode(final @NotNull E encoded) throws X;
   }
 
   /**
@@ -98,7 +98,7 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
    * @throws EX if an exception is encountered while encoding
    * @since 4.0.0
    */
-  @NonNull E encode(final @NonNull D decoded) throws EX;
+  @NotNull E encode(final @NotNull D decoded) throws EX;
 
   /**
    * An encoder.
@@ -117,6 +117,6 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
      * @throws X if an exception is encountered while encoding
      * @since 4.0.0
      */
-    @NonNull E encode(final @NonNull D decoded) throws X;
+    @NotNull E encode(final @NotNull D decoded) throws X;
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/ComponentMessageThrowable.java
+++ b/api/src/main/java/net/kyori/adventure/util/ComponentMessageThrowable.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.util;
 
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An extension interface for {@link Throwable}s to provide a {@link Component}-based message.

--- a/api/src/main/java/net/kyori/adventure/util/HSVLike.java
+++ b/api/src/main/java/net/kyori/adventure/util/HSVLike.java
@@ -26,8 +26,8 @@ package net.kyori.adventure.util;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.common.value.qual.IntRange;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
 
 /**
  * Something that can provide hue, saturation, and value color components.
@@ -46,7 +46,7 @@ public interface HSVLike extends Examinable {
    * @return a new HSVLike
    * @since 4.6.0
    */
-  static @NonNull HSVLike of(final float h, final float s, final float v) {
+  static @NotNull HSVLike of(final float h, final float s, final float v) {
     return new HSVLikeImpl(h, s, v);
   }
 
@@ -59,7 +59,7 @@ public interface HSVLike extends Examinable {
    * @return a new HSVLike
    * @since 4.6.0
    */
-  static @NonNull HSVLike fromRGB(@IntRange(from = 0x0, to = 0xff) final int red, @IntRange(from = 0x0, to = 0xff) final int green, @IntRange(from = 0x0, to = 0xff) final int blue) {
+  static @NotNull HSVLike fromRGB(@Range(from = 0x0, to = 0xff) final int red, @Range(from = 0x0, to = 0xff) final int green, @Range(from = 0x0, to = 0xff) final int blue) {
     final float r = red / 255.0f;
     final float g = green / 255.0f;
     final float b = blue / 255.0f;
@@ -120,7 +120,7 @@ public interface HSVLike extends Examinable {
   float v();
 
   @Override
-  default @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("h", this.h()),
       ExaminableProperty.of("s", this.s()),

--- a/api/src/main/java/net/kyori/adventure/util/HSVLikeImpl.java
+++ b/api/src/main/java/net/kyori/adventure/util/HSVLikeImpl.java
@@ -25,7 +25,7 @@ package net.kyori.adventure.util;
 
 import java.util.Objects;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 final class HSVLikeImpl implements HSVLike {
   private final float h;

--- a/api/src/main/java/net/kyori/adventure/util/Index.java
+++ b/api/src/main/java/net/kyori/adventure/util/Index.java
@@ -32,8 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A bi-directional map in which keys and values must be unique.
@@ -61,7 +61,7 @@ public final class Index<K, V> {
    * @return the key map
    * @since 4.0.0
    */
-  public static <K, V extends Enum<V>> @NonNull Index<K, V> create(final Class<V> type, final @NonNull Function<? super V, ? extends K> keyFunction) {
+  public static <K, V extends Enum<V>> @NotNull Index<K, V> create(final Class<V> type, final @NotNull Function<? super V, ? extends K> keyFunction) {
     return create(type, keyFunction, type.getEnumConstants());
   }
 
@@ -78,7 +78,7 @@ public final class Index<K, V> {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <K, V extends Enum<V>> @NonNull Index<K, V> create(final Class<V> type, final @NonNull Function<? super V, ? extends K> keyFunction, final @NonNull V@NonNull... values) {
+  public static <K, V extends Enum<V>> @NotNull Index<K, V> create(final Class<V> type, final @NotNull Function<? super V, ? extends K> keyFunction, final @NotNull V@NotNull... values) {
     return create(values, length -> new EnumMap<>(type), keyFunction);
   }
 
@@ -94,7 +94,7 @@ public final class Index<K, V> {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <K, V> @NonNull Index<K, V> create(final @NonNull Function<? super V, ? extends K> keyFunction, final @NonNull V@NonNull... values) {
+  public static <K, V> @NotNull Index<K, V> create(final @NotNull Function<? super V, ? extends K> keyFunction, final @NotNull V@NotNull... values) {
     return create(values, HashMap::new, keyFunction);
   }
 
@@ -108,15 +108,15 @@ public final class Index<K, V> {
    * @return the key map
    * @since 4.0.0
    */
-  public static <K, V> @NonNull Index<K, V> create(final @NonNull Function<? super V, ? extends K> keyFunction, final @NonNull List<V> constants) {
+  public static <K, V> @NotNull Index<K, V> create(final @NotNull Function<? super V, ? extends K> keyFunction, final @NotNull List<V> constants) {
     return create(constants, HashMap::new, keyFunction);
   }
 
-  private static <K, V> @NonNull Index<K, V> create(final V[] values, final IntFunction<Map<V, K>> valueToKeyFactory, final @NonNull Function<? super V, ? extends K> keyFunction) {
+  private static <K, V> @NotNull Index<K, V> create(final V[] values, final IntFunction<Map<V, K>> valueToKeyFactory, final @NotNull Function<? super V, ? extends K> keyFunction) {
     return create(Arrays.asList(values), valueToKeyFactory, keyFunction);
   }
 
-  private static <K, V> @NonNull Index<K, V> create(final List<V> values, final IntFunction<Map<V, K>> valueToKeyFactory, final @NonNull Function<? super V, ? extends K> keyFunction) {
+  private static <K, V> @NotNull Index<K, V> create(final List<V> values, final IntFunction<Map<V, K>> valueToKeyFactory, final @NotNull Function<? super V, ? extends K> keyFunction) {
     final int length = values.size();
     final Map<K, V> keyToValue = new HashMap<>(length);
     final Map<V, K> valueToKey = valueToKeyFactory.apply(length); // to support using EnumMap instead of HashMap when possible
@@ -139,7 +139,7 @@ public final class Index<K, V> {
    * @return the keys
    * @since 4.0.0
    */
-  public @NonNull Set<K> keys() {
+  public @NotNull Set<K> keys() {
     return Collections.unmodifiableSet(this.keyToValue.keySet());
   }
 
@@ -150,7 +150,7 @@ public final class Index<K, V> {
    * @return the key
    * @since 4.0.0
    */
-  public @Nullable K key(final @NonNull V value) {
+  public @Nullable K key(final @NotNull V value) {
     return this.valueToKey.get(value);
   }
 
@@ -160,7 +160,7 @@ public final class Index<K, V> {
    * @return the keys
    * @since 4.0.0
    */
-  public @NonNull Set<V> values() {
+  public @NotNull Set<V> values() {
     return Collections.unmodifiableSet(this.valueToKey.keySet());
   }
 
@@ -171,7 +171,7 @@ public final class Index<K, V> {
    * @return the value
    * @since 4.0.0
    */
-  public @Nullable V value(final @NonNull K key) {
+  public @Nullable V value(final @NotNull K key) {
     return this.keyToValue.get(key);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/Listenable.java
+++ b/api/src/main/java/net/kyori/adventure/util/Listenable.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.util;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that has listeners.
@@ -43,7 +43,7 @@ public abstract class Listenable<L> {
    * @param consumer the consumer
    * @since 4.0.0
    */
-  protected final void forEachListener(final @NonNull Consumer<L> consumer) {
+  protected final void forEachListener(final @NotNull Consumer<L> consumer) {
     for (final L listener : this.listeners) {
       consumer.accept(listener);
     }
@@ -55,7 +55,7 @@ public abstract class Listenable<L> {
    * @param listener the listener
    * @since 4.0.0
    */
-  protected final void addListener0(final @NonNull L listener) {
+  protected final void addListener0(final @NotNull L listener) {
     this.listeners.add(listener);
   }
 
@@ -65,7 +65,7 @@ public abstract class Listenable<L> {
    * @param listener the listener
    * @since 4.0.0
    */
-  protected final void removeListener0(final @NonNull L listener) {
+  protected final void removeListener0(final @NotNull L listener) {
     this.listeners.remove(listener);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/MonkeyBars.java
+++ b/api/src/main/java/net/kyori/adventure/util/MonkeyBars.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * {@link Collection} related utilities.
@@ -51,7 +51,7 @@ public final class MonkeyBars {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <E extends Enum<E>> @NonNull Set<E> enumSet(final Class<E> type, final E@NonNull... constants) {
+  public static <E extends Enum<E>> @NotNull Set<E> enumSet(final Class<E> type, final E@NotNull... constants) {
     final Set<E> set = EnumSet.noneOf(type);
     Collections.addAll(set, constants);
     return Collections.unmodifiableSet(set);
@@ -68,7 +68,7 @@ public final class MonkeyBars {
    * @return a list
    * @since 4.8.0
    */
-  public static <T> @NonNull List<T> addOne(final @NonNull List<T> oldList, final T newElement) {
+  public static <T> @NotNull List<T> addOne(final @NotNull List<T> oldList, final T newElement) {
     if (oldList.isEmpty()) return Collections.singletonList(newElement);
     final List<T> newList = new ArrayList<>(oldList.size() + 1);
     newList.addAll(oldList);

--- a/api/src/main/java/net/kyori/adventure/util/Nag.java
+++ b/api/src/main/java/net/kyori/adventure/util/Nag.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A nag.
@@ -37,7 +37,7 @@ public abstract class Nag extends RuntimeException {
    * @param nag the nag
    * @since 4.7.0
    */
-  public static void print(final @NonNull Nag nag) {
+  public static void print(final @NotNull Nag nag) {
     nag.printStackTrace();
   }
 

--- a/api/src/main/java/net/kyori/adventure/util/RGBLike.java
+++ b/api/src/main/java/net/kyori/adventure/util/RGBLike.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.common.value.qual.IntRange;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
 
 /**
  * Something that can provide red, green, and blue colour components.
@@ -38,7 +38,7 @@ public interface RGBLike {
    * @return the red component
    * @since 4.0.0
    */
-  @IntRange(from = 0x0, to = 0xff) int red();
+  @Range(from = 0x0, to = 0xff) int red();
 
   /**
    * Gets the green component.
@@ -46,7 +46,7 @@ public interface RGBLike {
    * @return the green component
    * @since 4.0.0
    */
-  @IntRange(from = 0x0, to = 0xff) int green();
+  @Range(from = 0x0, to = 0xff) int green();
 
   /**
    * Gets the blue component.
@@ -54,7 +54,7 @@ public interface RGBLike {
    * @return the blue component
    * @since 4.0.0
    */
-  @IntRange(from = 0x0, to = 0xff) int blue();
+  @Range(from = 0x0, to = 0xff) int blue();
 
   /**
    * Converts the color represented by this RGBLike to the HSV color space.
@@ -62,7 +62,7 @@ public interface RGBLike {
    * @return an HSVLike representing this RGBLike in the HSV color space
    * @since 4.6.0
    */
-  default @NonNull HSVLike asHSV() {
+  default @NotNull HSVLike asHSV() {
     return HSVLike.fromRGB(this.red(), this.green(), this.blue());
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/Services.java
+++ b/api/src/main/java/net/kyori/adventure/util/Services.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.util;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Tools for working with {@link ServiceLoader}s.
@@ -48,7 +48,7 @@ public final class Services {
    * @return a service, or {@link Optional#empty()}
    * @since 4.8.0
    */
-  public static <P> @NonNull Optional<P> service(final @NonNull Class<P> type) {
+  public static <P> @NotNull Optional<P> service(final @NotNull Class<P> type) {
     final ServiceLoader<P> loader = Services0.loader(type);
     final Iterator<P> it = loader.iterator();
     while (it.hasNext()) {

--- a/api/src/main/java/net/kyori/adventure/util/ShadyPines.java
+++ b/api/src/main/java/net/kyori/adventure/util/ShadyPines.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.util;
 
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Various utilities.
@@ -48,7 +48,7 @@ public final class ShadyPines {
   @Deprecated
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <E extends Enum<E>> @NonNull Set<E> enumSet(final Class<E> type, final E@NonNull... constants) {
+  public static <E extends Enum<E>> @NotNull Set<E> enumSet(final Class<E> type, final E@NotNull... constants) {
     return MonkeyBars.enumSet(type, constants);
   }
 

--- a/api/src/main/java/net/kyori/adventure/util/Ticks.java
+++ b/api/src/main/java/net/kyori/adventure/util/Ticks.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.util;
 
 import java.time.Duration;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Standard game tick utilities.
@@ -53,7 +53,7 @@ public interface Ticks {
    * @return a duration
    * @since 4.0.0
    */
-  static @NonNull Duration duration(final long ticks) {
+  static @NotNull Duration duration(final long ticks) {
     return Duration.ofMillis(ticks * SINGLE_TICK_DURATION_MS);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/TriState.java
+++ b/api/src/main/java/net/kyori/adventure/util/TriState.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Similar to a {@code boolean} but with three states.
@@ -58,7 +58,7 @@ public enum TriState {
    * @return a tri-state
    * @since 4.8.0
    */
-  public static @NonNull TriState byBoolean(final boolean value) {
+  public static @NotNull TriState byBoolean(final boolean value) {
     return value ? TRUE : FALSE;
   }
 
@@ -69,7 +69,7 @@ public enum TriState {
    * @return a tri-state
    * @since 4.8.0
    */
-  public static @NonNull TriState byBoolean(final @Nullable Boolean value) {
+  public static @NotNull TriState byBoolean(final @Nullable Boolean value) {
     return value == null ? NOT_SET : byBoolean(value.booleanValue());
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/UTF8ResourceBundleControl.java
+++ b/api/src/main/java/net/kyori/adventure/util/UTF8ResourceBundleControl.java
@@ -35,7 +35,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A {@link ResourceBundle.Control} that enforces UTF-8 string encoding.
@@ -53,7 +53,7 @@ public final class UTF8ResourceBundleControl extends ResourceBundle.Control {
    * @return a resource bundle control
    * @since 4.0.0
    */
-  public static ResourceBundle.@NonNull Control get() {
+  public static ResourceBundle.@NotNull Control get() {
     return INSTANCE;
   }
 

--- a/api/src/test/java/net/kyori/adventure/bossbar/BossBarTest.java
+++ b/api/src/test/java/net/kyori/adventure/bossbar/BossBarTest.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -45,27 +45,27 @@ public class BossBarTest {
   private final AtomicInteger flags = new AtomicInteger();
   private final BossBar.Listener listener = new BossBar.Listener() {
     @Override
-    public void bossBarNameChanged(final @NonNull BossBar bar, final @NonNull Component oldName, final @NonNull Component newName) {
+    public void bossBarNameChanged(final @NotNull BossBar bar, final @NotNull Component oldName, final @NotNull Component newName) {
       BossBarTest.this.name.incrementAndGet();
     }
 
     @Override
-    public void bossBarProgressChanged(final @NonNull BossBar bar, final float oldProgress, final float newProgress) {
+    public void bossBarProgressChanged(final @NotNull BossBar bar, final float oldProgress, final float newProgress) {
       BossBarTest.this.progress.incrementAndGet();
     }
 
     @Override
-    public void bossBarColorChanged(final @NonNull BossBar bar, final BossBar.@NonNull Color oldColor, final BossBar.@NonNull Color newColor) {
+    public void bossBarColorChanged(final @NotNull BossBar bar, final BossBar.@NotNull Color oldColor, final BossBar.@NotNull Color newColor) {
       BossBarTest.this.color.incrementAndGet();
     }
 
     @Override
-    public void bossBarOverlayChanged(final @NonNull BossBar bar, final BossBar.@NonNull Overlay oldOverlay, final BossBar.@NonNull Overlay newOverlay) {
+    public void bossBarOverlayChanged(final @NotNull BossBar bar, final BossBar.@NotNull Overlay oldOverlay, final BossBar.@NotNull Overlay newOverlay) {
       BossBarTest.this.overlay.incrementAndGet();
     }
 
     @Override
-    public void bossBarFlagsChanged(final @NonNull BossBar bar, final @NonNull Set<BossBar.Flag> oldFlags, final @NonNull Set<BossBar.Flag> newFlags) {
+    public void bossBarFlagsChanged(final @NotNull BossBar bar, final @NotNull Set<BossBar.Flag> oldFlags, final @NotNull Set<BossBar.Flag> newFlags) {
       BossBarTest.this.flags.incrementAndGet();
     }
   };
@@ -229,7 +229,7 @@ public class BossBarTest {
     final AtomicReference<Set<BossBar.Flag>> flagsRemoved = new AtomicReference<>(Collections.emptySet());
 
     @Override
-    public void bossBarFlagsChanged(final @NonNull BossBar bar, final @NonNull Set<BossBar.Flag> flagsAdded, final @NonNull Set<BossBar.Flag> flagsRemoved) {
+    public void bossBarFlagsChanged(final @NotNull BossBar bar, final @NotNull Set<BossBar.Flag> flagsAdded, final @NotNull Set<BossBar.Flag> flagsRemoved) {
       this.flagsAdded.set(flagsAdded);
       this.flagsRemoved.set(flagsRemoved);
     }

--- a/api/src/test/java/net/kyori/adventure/text/flattener/ComponentFlattenerTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/flattener/ComponentFlattenerTest.java
@@ -34,7 +34,7 @@ import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -51,18 +51,18 @@ class ComponentFlattenerTest {
     final List<String> strings = new ArrayList<>();
 
     @Override
-    public void pushStyle(final @NonNull Style style) {
+    public void pushStyle(final @NotNull Style style) {
       this.pushCount++;
       this.pushedStyles.add(style);
     }
 
     @Override
-    public void component(final @NonNull String text) {
+    public void component(final @NotNull String text) {
       this.strings.add(text);
     }
 
     @Override
-    public void popStyle(final @NonNull Style style) {
+    public void popStyle(final @NotNull Style style) {
       this.popCount++;
     }
 

--- a/api/src/test/java/net/kyori/adventure/text/format/TextColorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/TextColorTest.java
@@ -25,7 +25,7 @@ package net.kyori.adventure.text.format;
 
 import com.google.common.testing.EqualsTester;
 import net.kyori.adventure.util.RGBLike;
-import org.checkerframework.common.value.qual.IntRange;
+import org.jetbrains.annotations.Range;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,17 +41,17 @@ class TextColorTest {
   void testFromRGBLike() {
     assertEquals(TextColor.color(0xaa00aa), TextColor.color(new RGBLike() {
       @Override
-      public @IntRange(from = 0x0, to = 0xff) int red() {
+      public @Range(from = 0x0, to = 0xff) int red() {
         return 0xaa;
       }
 
       @Override
-      public @IntRange(from = 0x0, to = 0xff) int green() {
+      public @Range(from = 0x0, to = 0xff) int green() {
         return 0x00;
       }
 
       @Override
-      public @IntRange(from = 0x0, to = 0xff) int blue() {
+      public @Range(from = 0x0, to = 0xff) int blue() {
         return 0xaa;
       }
     }));

--- a/api/src/test/java/net/kyori/adventure/translation/GlobalTranslatorTest.java
+++ b/api/src/test/java/net/kyori/adventure/translation/GlobalTranslatorTest.java
@@ -28,8 +28,8 @@ import java.util.Locale;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -82,12 +82,12 @@ class GlobalTranslatorTest {
     static final DummyTranslator INSTANCE = new DummyTranslator();
 
     @Override
-    public @NonNull Key name() {
+    public @NotNull Key name() {
       return Key.key("adventure", "test_dummy");
     }
 
     @Override
-    public @Nullable MessageFormat translate(final @NonNull String key, final @NonNull Locale locale) {
+    public @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
       return (key.equals("testDummy") && locale.equals(Locale.US))
         ? new MessageFormat("Hello {0}!")
         : null;

--- a/api/src/test/java/net/kyori/adventure/util/ComponentMessageThrowableTest.java
+++ b/api/src/test/java/net/kyori/adventure/util/ComponentMessageThrowableTest.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.util;
 
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/api/src/test/java/net/kyori/adventure/util/HSVLikeTest.java
+++ b/api/src/test/java/net/kyori/adventure/util/HSVLikeTest.java
@@ -28,7 +28,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -48,7 +48,7 @@ class HSVLikeTest {
     NamedTextColor.NAMES.values().forEach(HSVLikeTest::assertRgbToHsvConversionRoughlyMatchesJavaAwtColor);
   }
 
-  private static void assertRgbToHsvConversionRoughlyMatchesJavaAwtColor(final @NonNull RGBLike rgb) {
+  private static void assertRgbToHsvConversionRoughlyMatchesJavaAwtColor(final @NotNull RGBLike rgb) {
     final HSVLike hsv = rgb.asHSV();
     assertArrayEquals(
       roundFloats(Color.RGBtoHSB(rgb.red(), rgb.green(), rgb.blue(), null)),
@@ -57,7 +57,7 @@ class HSVLikeTest {
     );
   }
 
-  private static float[] roundFloats(final float @NonNull [] floats) {
+  private static float[] roundFloats(final float @NotNull [] floats) {
     final float[] result = new float[floats.length];
     for (int i = 0; i < floats.length; i++) {
       result[i] = BigDecimal.valueOf(floats[i]).setScale(7, RoundingMode.UP).floatValue();

--- a/key/build.gradle.kts
+++ b/key/build.gradle.kts
@@ -11,7 +11,6 @@ configurations {
 dependencies {
   api("net.kyori:examination-api:1.1.0")
   api("net.kyori:examination-string:1.1.0")
-  compileOnlyApi("org.checkerframework:checker-qual:3.13.0")
   compileOnlyApi("org.jetbrains:annotations:21.0.1")
   testImplementation("com.google.guava:guava:23.0")
 }

--- a/key/src/main/java/net/kyori/adventure/key/InvalidKeyException.java
+++ b/key/src/main/java/net/kyori/adventure/key/InvalidKeyException.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.key;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This exception is thrown when an invalid namespace and/or value has been detected while creating a {@link Key}.
@@ -36,7 +36,7 @@ public final class InvalidKeyException extends RuntimeException {
   private final String keyNamespace;
   private final String keyValue;
 
-  InvalidKeyException(final @NonNull String keyNamespace, final @NonNull String keyValue, final @Nullable String message) {
+  InvalidKeyException(final @NotNull String keyNamespace, final @NotNull String keyValue, final @Nullable String message) {
     super(message);
     this.keyNamespace = keyNamespace;
     this.keyValue = keyValue;
@@ -48,7 +48,7 @@ public final class InvalidKeyException extends RuntimeException {
    * @return a key
    * @since 4.0.0
    */
-  public final @NonNull String keyNamespace() {
+  public final @NotNull String keyNamespace() {
     return this.keyNamespace;
   }
 
@@ -58,7 +58,7 @@ public final class InvalidKeyException extends RuntimeException {
    * @return a key
    * @since 4.0.0
    */
-  public final @NonNull String keyValue() {
+  public final @NotNull String keyValue() {
     return this.keyValue;
   }
 }

--- a/key/src/main/java/net/kyori/adventure/key/Key.java
+++ b/key/src/main/java/net/kyori/adventure/key/Key.java
@@ -26,8 +26,8 @@ package net.kyori.adventure.key;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.intellij.lang.annotations.Pattern;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An identifying object used to fetch and/or store unique objects.
@@ -76,7 +76,7 @@ public interface Key extends Comparable<Key>, Examinable {
    * @throws InvalidKeyException if the namespace or value contains an invalid character
    * @since 4.0.0
    */
-  static @NonNull Key key(final @NonNull @Pattern("(" + KeyImpl.NAMESPACE_PATTERN + ":)?" + KeyImpl.VALUE_PATTERN) String string) {
+  static @NotNull Key key(final @NotNull @Pattern("(" + KeyImpl.NAMESPACE_PATTERN + ":)?" + KeyImpl.VALUE_PATTERN) String string) {
     return key(string, ':');
   }
 
@@ -96,7 +96,7 @@ public interface Key extends Comparable<Key>, Examinable {
    * @since 4.0.0
    */
   @SuppressWarnings("PatternValidation") // impossible to validate since the character is variable
-  static @NonNull Key key(final @NonNull String string, final char character) {
+  static @NotNull Key key(final @NotNull String string, final char character) {
     final int index = string.indexOf(character);
     final String namespace = index >= 1 ? string.substring(0, index) : MINECRAFT_NAMESPACE;
     final String value = index >= 0 ? string.substring(index + 1) : string;
@@ -112,7 +112,7 @@ public interface Key extends Comparable<Key>, Examinable {
    * @throws InvalidKeyException if the namespace or value contains an invalid character
    * @since 4.4.0
    */
-  static @NonNull Key key(final @NonNull Namespaced namespaced, final @NonNull @Pattern(KeyImpl.VALUE_PATTERN) String value) {
+  static @NotNull Key key(final @NotNull Namespaced namespaced, final @NotNull @Pattern(KeyImpl.VALUE_PATTERN) String value) {
     return key(namespaced.namespace(), value);
   }
 
@@ -125,7 +125,7 @@ public interface Key extends Comparable<Key>, Examinable {
    * @throws InvalidKeyException if the namespace or value contains an invalid character
    * @since 4.0.0
    */
-  static @NonNull Key key(final @NonNull @Pattern(KeyImpl.NAMESPACE_PATTERN) String namespace, final @NonNull @Pattern(KeyImpl.VALUE_PATTERN) String value) {
+  static @NotNull Key key(final @NotNull @Pattern(KeyImpl.NAMESPACE_PATTERN) String namespace, final @NotNull @Pattern(KeyImpl.VALUE_PATTERN) String value) {
     return new KeyImpl(namespace, value);
   }
 
@@ -135,7 +135,7 @@ public interface Key extends Comparable<Key>, Examinable {
    * @return the namespace
    * @since 4.0.0
    */
-  @NonNull String namespace();
+  @NotNull String namespace();
 
   /**
    * Gets the value.
@@ -143,7 +143,7 @@ public interface Key extends Comparable<Key>, Examinable {
    * @return the value
    * @since 4.0.0
    */
-  @NonNull String value();
+  @NotNull String value();
 
   /**
    * Returns the string representation of this key.
@@ -151,10 +151,10 @@ public interface Key extends Comparable<Key>, Examinable {
    * @return the string representation
    * @since 4.0.0
    */
-  @NonNull String asString();
+  @NotNull String asString();
 
   @Override
-  default @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("namespace", this.namespace()),
       ExaminableProperty.of("value", this.value())
@@ -162,7 +162,7 @@ public interface Key extends Comparable<Key>, Examinable {
   }
 
   @Override
-  default int compareTo(final @NonNull Key that) {
+  default int compareTo(final @NotNull Key that) {
     final int value = this.value().compareTo(that.value());
     if (value != 0) {
       return KeyImpl.clampCompare(value);

--- a/key/src/main/java/net/kyori/adventure/key/KeyImpl.java
+++ b/key/src/main/java/net/kyori/adventure/key/KeyImpl.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 import java.util.function.IntPredicate;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import static java.util.Objects.requireNonNull;
@@ -41,7 +41,7 @@ final class KeyImpl implements Key {
   private final String namespace;
   private final String value;
 
-  KeyImpl(final @NonNull String namespace, final @NonNull String value) {
+  KeyImpl(final @NotNull String namespace, final @NotNull String value) {
     if (!namespaceValid(namespace)) throw new InvalidKeyException(namespace, value, String.format("Non [a-z0-9_.-] character in namespace of Key[%s]", asString(namespace, value)));
     if (!valueValid(value)) throw new InvalidKeyException(namespace, value, String.format("Non [a-z0-9/._-] character in value of Key[%s]", asString(namespace, value)));
     this.namespace = requireNonNull(namespace, "namespace");
@@ -49,7 +49,7 @@ final class KeyImpl implements Key {
   }
 
   @VisibleForTesting
-  static boolean namespaceValid(final @NonNull String namespace) {
+  static boolean namespaceValid(final @NotNull String namespace) {
     for (int i = 0, length = namespace.length(); i < length; i++) {
       if (!NAMESPACE_PREDICATE.test(namespace.charAt(i))) {
         return false;
@@ -59,7 +59,7 @@ final class KeyImpl implements Key {
   }
 
   @VisibleForTesting
-  static boolean valueValid(final @NonNull String value) {
+  static boolean valueValid(final @NotNull String value) {
     for (int i = 0, length = value.length(); i < length; i++) {
       if (!VALUE_PREDICATE.test(value.charAt(i))) {
         return false;
@@ -69,31 +69,31 @@ final class KeyImpl implements Key {
   }
 
   @Override
-  public @NonNull String namespace() {
+  public @NotNull String namespace() {
     return this.namespace;
   }
 
   @Override
-  public @NonNull String value() {
+  public @NotNull String value() {
     return this.value;
   }
 
   @Override
-  public @NonNull String asString() {
+  public @NotNull String asString() {
     return asString(this.namespace, this.value);
   }
 
-  private static @NonNull String asString(final @NonNull String namespace, final @NonNull String value) {
+  private static @NotNull String asString(final @NotNull String namespace, final @NotNull String value) {
     return namespace + ':' + value;
   }
 
   @Override
-  public @NonNull String toString() {
+  public @NotNull String toString() {
     return this.asString();
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("namespace", this.namespace),
       ExaminableProperty.of("value", this.value)
@@ -116,7 +116,7 @@ final class KeyImpl implements Key {
   }
 
   @Override
-  public int compareTo(final @NonNull Key that) {
+  public int compareTo(final @NotNull Key that) {
     return Key.super.compareTo(that);
   }
 

--- a/key/src/main/java/net/kyori/adventure/key/Keyed.java
+++ b/key/src/main/java/net/kyori/adventure/key/Keyed.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.key;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that has an associated {@link Key}.
@@ -37,5 +37,5 @@ public interface Keyed {
    * @return the key
    * @since 4.0.0
    */
-  @NonNull Key key();
+  @NotNull Key key();
 }

--- a/key/src/main/java/net/kyori/adventure/key/KeyedValue.java
+++ b/key/src/main/java/net/kyori/adventure/key/KeyedValue.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.key;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,7 +43,7 @@ public interface KeyedValue<T> extends Keyed {
    * @return the keyed
    * @since 4.0.0
    */
-  static <T> @NonNull KeyedValue<T> of(final @NonNull Key key, final @NonNull T value) {
+  static <T> @NotNull KeyedValue<T> of(final @NotNull Key key, final @NotNull T value) {
     return new KeyedValueImpl<>(key, requireNonNull(value, "value"));
   }
 
@@ -53,5 +53,5 @@ public interface KeyedValue<T> extends Keyed {
    * @return the value
    * @since 4.0.0
    */
-  @NonNull T value();
+  @NotNull T value();
 }

--- a/key/src/main/java/net/kyori/adventure/key/KeyedValueImpl.java
+++ b/key/src/main/java/net/kyori/adventure/key/KeyedValueImpl.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class KeyedValueImpl<T> implements Examinable, KeyedValue<T> {
   private final Key key;
@@ -40,12 +40,12 @@ final class KeyedValueImpl<T> implements Examinable, KeyedValue<T> {
   }
 
   @Override
-  public @NonNull Key key() {
+  public @NotNull Key key() {
     return this.key;
   }
 
   @Override
-  public @NonNull T value() {
+  public @NotNull T value() {
     return this.value;
   }
 
@@ -65,7 +65,7 @@ final class KeyedValueImpl<T> implements Examinable, KeyedValue<T> {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("key", this.key),
       ExaminableProperty.of("value", this.value)

--- a/key/src/main/java/net/kyori/adventure/key/Namespaced.java
+++ b/key/src/main/java/net/kyori/adventure/key/Namespaced.java
@@ -23,8 +23,8 @@
  */
 package net.kyori.adventure.key;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.intellij.lang.annotations.Pattern;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that has a namespace.
@@ -38,5 +38,5 @@ public interface Namespaced {
    * @return the namespace
    * @since 4.4.0
    */
-  @NonNull @Pattern(KeyImpl.NAMESPACE_PATTERN) String namespace();
+  @NotNull @Pattern(KeyImpl.NAMESPACE_PATTERN) String namespace();
 }

--- a/nbt/build.gradle.kts
+++ b/nbt/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 dependencies {
   api("net.kyori:examination-api:1.1.0")
   api("net.kyori:examination-string:1.1.0")
-  compileOnlyApi("org.checkerframework:checker-qual:3.13.0")
   compileOnlyApi("org.jetbrains:annotations:21.0.1")
 }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/AbstractBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/AbstractBinaryTag.java
@@ -24,11 +24,11 @@
 package net.kyori.adventure.nbt;
 
 import net.kyori.examination.string.StringExaminer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 abstract class AbstractBinaryTag implements BinaryTag {
   @Override
-  public final @NonNull String examinableName() {
+  public final @NotNull String examinableName() {
     return this.type().toString();
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ArrayBinaryTag.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An array binary tag.
@@ -32,5 +32,5 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public interface ArrayBinaryTag extends BinaryTag {
   @Override
-  @NonNull BinaryTagType<? extends ArrayBinaryTag> type();
+  @NotNull BinaryTagType<? extends ArrayBinaryTag> type();
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTag.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.nbt;
 
 import net.kyori.examination.Examinable;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A binary tag.
@@ -38,10 +38,10 @@ public interface BinaryTag extends BinaryTagLike, Examinable {
    * @return the tag type
    * @since 4.0.0
    */
-  @NonNull BinaryTagType<? extends BinaryTag> type();
+  @NotNull BinaryTagType<? extends BinaryTag> type();
 
   @Override
-  default @NonNull BinaryTag asBinaryTag() {
+  default @NotNull BinaryTag asBinaryTag() {
     return this;
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
@@ -34,7 +34,7 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.InflaterInputStream;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Serialization operations for binary tags.
@@ -57,7 +57,7 @@ public final class BinaryTagIO {
    * @return binary tag reader
    * @since 4.4.0
    */
-  public static @NonNull Reader unlimitedReader() {
+  public static @NotNull Reader unlimitedReader() {
     return BinaryTagReaderImpl.UNLIMITED;
   }
 
@@ -69,7 +69,7 @@ public final class BinaryTagIO {
    * @return binary tag reader
    * @since 4.4.0
    */
-  public static @NonNull Reader reader() {
+  public static @NotNull Reader reader() {
     return BinaryTagReaderImpl.DEFAULT_LIMIT;
   }
 
@@ -81,7 +81,7 @@ public final class BinaryTagIO {
    * @return binary tag reader
    * @since 4.4.0
    */
-  public static @NonNull Reader reader(final long sizeLimitBytes) {
+  public static @NotNull Reader reader(final long sizeLimitBytes) {
     if (sizeLimitBytes <= 0) {
       throw new IllegalArgumentException("The size limit must be greater than zero");
     }
@@ -94,7 +94,7 @@ public final class BinaryTagIO {
    * @return binary tag writer
    * @since 4.4.0
    */
-  public static @NonNull Writer writer() {
+  public static @NotNull Writer writer() {
     return BinaryTagWriterImpl.INSTANCE;
   }
 
@@ -108,7 +108,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static @NonNull CompoundBinaryTag readPath(final @NonNull Path path) throws IOException {
+  public static @NotNull CompoundBinaryTag readPath(final @NotNull Path path) throws IOException {
     return reader().read(path);
   }
 
@@ -122,7 +122,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static @NonNull CompoundBinaryTag readInputStream(final @NonNull InputStream input) throws IOException {
+  public static @NotNull CompoundBinaryTag readInputStream(final @NotNull InputStream input) throws IOException {
     return reader().read(input);
   }
 
@@ -136,7 +136,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static @NonNull CompoundBinaryTag readCompressedPath(final @NonNull Path path) throws IOException {
+  public static @NotNull CompoundBinaryTag readCompressedPath(final @NotNull Path path) throws IOException {
     return reader().read(path, Compression.GZIP);
   }
 
@@ -150,7 +150,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static @NonNull CompoundBinaryTag readCompressedInputStream(final @NonNull InputStream input) throws IOException {
+  public static @NotNull CompoundBinaryTag readCompressedInputStream(final @NotNull InputStream input) throws IOException {
     return reader().read(input, Compression.GZIP);
   }
 
@@ -164,7 +164,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static @NonNull CompoundBinaryTag readDataInput(final @NonNull DataInput input) throws IOException {
+  public static @NotNull CompoundBinaryTag readDataInput(final @NotNull DataInput input) throws IOException {
     return reader().read(input);
   }
 
@@ -178,7 +178,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static void writePath(final @NonNull CompoundBinaryTag tag, final @NonNull Path path) throws IOException {
+  public static void writePath(final @NotNull CompoundBinaryTag tag, final @NotNull Path path) throws IOException {
     writer().write(tag, path);
   }
 
@@ -192,7 +192,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static void writeOutputStream(final @NonNull CompoundBinaryTag tag, final @NonNull OutputStream output) throws IOException {
+  public static void writeOutputStream(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output) throws IOException {
     writer().write(tag, output);
   }
 
@@ -206,7 +206,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static void writeCompressedPath(final @NonNull CompoundBinaryTag tag, final @NonNull Path path) throws IOException {
+  public static void writeCompressedPath(final @NotNull CompoundBinaryTag tag, final @NotNull Path path) throws IOException {
     writer().write(tag, path, Compression.GZIP);
   }
 
@@ -220,7 +220,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static void writeCompressedOutputStream(final @NonNull CompoundBinaryTag tag, final @NonNull OutputStream output) throws IOException {
+  public static void writeCompressedOutputStream(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output) throws IOException {
     writer().write(tag, output, Compression.GZIP);
   }
 
@@ -234,7 +234,7 @@ public final class BinaryTagIO {
    * @since 4.0.0
    */
   @Deprecated
-  public static void writeDataOutput(final @NonNull CompoundBinaryTag tag, final @NonNull DataOutput output) throws IOException {
+  public static void writeDataOutput(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException {
     writer().write(tag, output);
   }
 
@@ -254,7 +254,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default @NonNull CompoundBinaryTag read(final @NonNull Path path) throws IOException {
+    default @NotNull CompoundBinaryTag read(final @NotNull Path path) throws IOException {
       return this.read(path, Compression.NONE);
     }
 
@@ -267,7 +267,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    @NonNull CompoundBinaryTag read(final @NonNull Path path, final @NonNull Compression compression) throws IOException;
+    @NotNull CompoundBinaryTag read(final @NotNull Path path, final @NotNull Compression compression) throws IOException;
 
     /**
      * Reads a binary tag from {@code input}.
@@ -279,7 +279,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default @NonNull CompoundBinaryTag read(final @NonNull InputStream input) throws IOException {
+    default @NotNull CompoundBinaryTag read(final @NotNull InputStream input) throws IOException {
       return this.read(input, Compression.NONE);
     }
 
@@ -292,7 +292,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    @NonNull CompoundBinaryTag read(final @NonNull InputStream input, final @NonNull Compression compression) throws IOException;
+    @NotNull CompoundBinaryTag read(final @NotNull InputStream input, final @NotNull Compression compression) throws IOException;
 
     /**
      * Reads a binary tag from {@code input}.
@@ -302,7 +302,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    @NonNull CompoundBinaryTag read(final @NonNull DataInput input) throws IOException;
+    @NotNull CompoundBinaryTag read(final @NotNull DataInput input) throws IOException;
 
     /**
      * Reads a binary tag, with a name, from {@code path}.
@@ -314,7 +314,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default Map.@NonNull Entry<String, CompoundBinaryTag> readNamed(final @NonNull Path path) throws IOException {
+    default Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull Path path) throws IOException {
       return this.readNamed(path, Compression.NONE);
     }
 
@@ -327,7 +327,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    Map.@NonNull Entry<String, CompoundBinaryTag> readNamed(final @NonNull Path path, final @NonNull Compression compression) throws IOException;
+    Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull Path path, final @NotNull Compression compression) throws IOException;
 
     /**
      * Reads a binary tag, with a name, from {@code input}.
@@ -339,7 +339,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default Map.@NonNull Entry<String, CompoundBinaryTag> readNamed(final @NonNull InputStream input) throws IOException {
+    default Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull InputStream input) throws IOException {
       return this.readNamed(input, Compression.NONE);
     }
 
@@ -352,7 +352,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    Map.@NonNull Entry<String, CompoundBinaryTag> readNamed(final @NonNull InputStream input, final @NonNull Compression compression) throws IOException;
+    Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull InputStream input, final @NotNull Compression compression) throws IOException;
 
     /**
      * Reads a binary tag, with a name, from {@code input}.
@@ -362,7 +362,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    Map.@NonNull Entry<String, CompoundBinaryTag> readNamed(final @NonNull DataInput input) throws IOException;
+    Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull DataInput input) throws IOException;
   }
 
   /**
@@ -380,7 +380,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default void write(final @NonNull CompoundBinaryTag tag, final @NonNull Path path) throws IOException {
+    default void write(final @NotNull CompoundBinaryTag tag, final @NotNull Path path) throws IOException {
       this.write(tag, path, Compression.NONE);
     }
 
@@ -392,7 +392,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void write(final @NonNull CompoundBinaryTag tag, final @NonNull Path path, final @NonNull Compression compression) throws IOException;
+    void write(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final @NotNull Compression compression) throws IOException;
 
     /**
      * Writes a binary tag to {@code output}.
@@ -403,7 +403,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default void write(final @NonNull CompoundBinaryTag tag, final @NonNull OutputStream output) throws IOException {
+    default void write(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output) throws IOException {
       this.write(tag, output, Compression.NONE);
     }
 
@@ -415,7 +415,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void write(final @NonNull CompoundBinaryTag tag, final @NonNull OutputStream output, final @NonNull Compression compression) throws IOException;
+    void write(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final @NotNull Compression compression) throws IOException;
 
     /**
      * Writes a binary tag to {@code output}.
@@ -424,7 +424,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void write(final @NonNull CompoundBinaryTag tag, final @NonNull DataOutput output) throws IOException;
+    void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException;
 
     /**
      * Writes a binary tag, with a name, to {@code path}.
@@ -435,7 +435,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default void writeNamed(final Map.@NonNull Entry<String, CompoundBinaryTag> tag, final @NonNull Path path) throws IOException {
+    default void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull Path path) throws IOException {
       this.writeNamed(tag, path, Compression.NONE);
     }
 
@@ -447,7 +447,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void writeNamed(final Map.@NonNull Entry<String, CompoundBinaryTag> tag, final @NonNull Path path, final @NonNull Compression compression) throws IOException;
+    void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull Path path, final @NotNull Compression compression) throws IOException;
 
     /**
      * Writes a binary tag, with a name, to {@code output}.
@@ -458,7 +458,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default void writeNamed(final Map.@NonNull Entry<String, CompoundBinaryTag> tag, final @NonNull OutputStream output) throws IOException {
+    default void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull OutputStream output) throws IOException {
       this.writeNamed(tag, output, Compression.NONE);
     }
 
@@ -470,7 +470,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void writeNamed(final Map.@NonNull Entry<String, CompoundBinaryTag> tag, final @NonNull OutputStream output, final @NonNull Compression compression) throws IOException;
+    void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull OutputStream output, final @NotNull Compression compression) throws IOException;
 
     /**
      * Writes a binary tag, with a name, to {@code output}.
@@ -479,7 +479,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void writeNamed(final Map.@NonNull Entry<String, CompoundBinaryTag> tag, final @NonNull DataOutput output) throws IOException;
+    void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull DataOutput output) throws IOException;
   }
 
   /**
@@ -495,12 +495,12 @@ public final class BinaryTagIO {
      */
     public static final Compression NONE = new Compression() {
       @Override
-      @NonNull InputStream decompress(final @NonNull InputStream is) {
+      @NotNull InputStream decompress(final @NotNull InputStream is) {
         return is;
       }
 
       @Override
-      @NonNull OutputStream compress(final @NonNull OutputStream os) {
+      @NotNull OutputStream compress(final @NotNull OutputStream os) {
         return os;
       }
 
@@ -516,12 +516,12 @@ public final class BinaryTagIO {
      */
     public static final Compression GZIP = new Compression() {
       @Override
-      @NonNull InputStream decompress(final @NonNull InputStream is) throws IOException {
+      @NotNull InputStream decompress(final @NotNull InputStream is) throws IOException {
         return new GZIPInputStream(is);
       }
 
       @Override
-      @NonNull OutputStream compress(final @NonNull OutputStream os) throws IOException {
+      @NotNull OutputStream compress(final @NotNull OutputStream os) throws IOException {
         return new GZIPOutputStream(os);
       }
 
@@ -537,12 +537,12 @@ public final class BinaryTagIO {
      */
     public static final Compression ZLIB = new Compression() {
       @Override
-      @NonNull InputStream decompress(final @NonNull InputStream is) {
+      @NotNull InputStream decompress(final @NotNull InputStream is) {
         return new InflaterInputStream(is);
       }
 
       @Override
-      @NonNull OutputStream compress(final @NonNull OutputStream os) {
+      @NotNull OutputStream compress(final @NotNull OutputStream os) {
         return new DeflaterOutputStream(os);
       }
 
@@ -552,8 +552,8 @@ public final class BinaryTagIO {
       }
     };
 
-    abstract @NonNull InputStream decompress(final @NonNull InputStream is) throws IOException;
+    abstract @NotNull InputStream decompress(final @NotNull InputStream is) throws IOException;
 
-    abstract @NonNull OutputStream compress(final @NonNull OutputStream os) throws IOException;
+    abstract @NotNull OutputStream compress(final @NotNull OutputStream os) throws IOException;
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagLike.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagLike.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can be represented as a binary tag.
@@ -37,5 +37,5 @@ public interface BinaryTagLike {
    * @return a binary tag
    * @since 4.4.0
    */
-  @NonNull BinaryTag asBinaryTag();
+  @NotNull BinaryTag asBinaryTag();
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
@@ -32,7 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import static net.kyori.adventure.nbt.IOStreamUtil.closeShield;
 
@@ -47,21 +47,21 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
   }
 
   @Override
-  public @NonNull CompoundBinaryTag read(final @NonNull Path path, final BinaryTagIO.@NonNull Compression compression) throws IOException {
+  public @NotNull CompoundBinaryTag read(final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
     try(final InputStream is = Files.newInputStream(path)) {
       return this.read(is, compression);
     }
   }
 
   @Override
-  public @NonNull CompoundBinaryTag read(final @NonNull InputStream input, final BinaryTagIO.@NonNull Compression compression) throws IOException {
+  public @NotNull CompoundBinaryTag read(final @NotNull InputStream input, final BinaryTagIO.@NotNull Compression compression) throws IOException {
     try(final DataInputStream dis = new DataInputStream(new BufferedInputStream(compression.decompress(closeShield(input))))) {
       return this.read((DataInput) dis);
     }
   }
 
   @Override
-  public @NonNull CompoundBinaryTag read(@NonNull DataInput input) throws IOException {
+  public @NotNull CompoundBinaryTag read(@NotNull DataInput input) throws IOException {
     if (!(input instanceof TrackingDataInput)) {
       input = new TrackingDataInput(input, this.maxBytes);
     }
@@ -73,21 +73,21 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
   }
 
   @Override
-  public Map.@NonNull Entry<String, CompoundBinaryTag> readNamed(final @NonNull Path path, final BinaryTagIO.@NonNull Compression compression) throws IOException {
+  public Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
     try(final InputStream is = Files.newInputStream(path)) {
       return this.readNamed(is, compression);
     }
   }
 
   @Override
-  public Map.@NonNull Entry<String, CompoundBinaryTag> readNamed(final @NonNull InputStream input, final BinaryTagIO.@NonNull Compression compression) throws IOException {
+  public Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull InputStream input, final BinaryTagIO.@NotNull Compression compression) throws IOException {
     try(final DataInputStream dis = new DataInputStream(new BufferedInputStream(compression.decompress(closeShield(input))))) {
       return this.readNamed((DataInput) dis);
     }
   }
 
   @Override
-  public Map.@NonNull Entry<String, CompoundBinaryTag> readNamed(final @NonNull DataInput input) throws IOException {
+  public Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull DataInput input) throws IOException {
     final BinaryTagType<? extends BinaryTag> type = BinaryTagType.of(input.readByte());
     requireCompound(type);
     final String name = input.readUTF();

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagType.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagType.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary tag type.
@@ -59,7 +59,7 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @throws IOException if an exception was encountered while reading
    * @since 4.0.0
    */
-  public abstract @NonNull T read(final @NonNull DataInput input) throws IOException;
+  public abstract @NotNull T read(final @NotNull DataInput input) throws IOException;
 
   /**
    * Writes a tag.
@@ -69,14 +69,14 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @throws IOException if an exception was encountered while writing
    * @since 4.0.0
    */
-  public abstract void write(final @NonNull T tag, final @NonNull DataOutput output) throws IOException;
+  public abstract void write(final @NotNull T tag, final @NotNull DataOutput output) throws IOException;
 
   @SuppressWarnings("unchecked") // HACK: generics suck
   static <T extends BinaryTag> void write(final BinaryTagType<? extends BinaryTag> type, final T tag, final DataOutput output) throws IOException {
     ((BinaryTagType<T>) type).write(tag, output);
   }
 
-  static @NonNull BinaryTagType<? extends BinaryTag> of(final byte id) {
+  static @NotNull BinaryTagType<? extends BinaryTag> of(final byte id) {
     for (int i = 0; i < TYPES.size(); i++) {
       final BinaryTagType<? extends BinaryTag> type = TYPES.get(i);
       if (type.id() == id) {
@@ -86,11 +86,11 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
     throw new IllegalArgumentException(String.valueOf(id));
   }
 
-  static <T extends BinaryTag> @NonNull BinaryTagType<T> register(final Class<T> type, final byte id, final Reader<T> reader, final @Nullable Writer<T> writer) {
+  static <T extends BinaryTag> @NotNull BinaryTagType<T> register(final Class<T> type, final byte id, final Reader<T> reader, final @Nullable Writer<T> writer) {
     return register(new Impl<>(type, id, reader, writer));
   }
 
-  static <T extends NumberBinaryTag> @NonNull BinaryTagType<T> registerNumeric(final Class<T> type, final byte id, final Reader<T> reader, final Writer<T> writer) {
+  static <T extends NumberBinaryTag> @NotNull BinaryTagType<T> registerNumeric(final Class<T> type, final byte id, final Reader<T> reader, final Writer<T> writer) {
     return register(new Impl.Numeric<>(type, id, reader, writer));
   }
 
@@ -105,7 +105,7 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @param <T> the tag type
    */
   interface Reader<T extends BinaryTag> {
-    @NonNull T read(final @NonNull DataInput input) throws IOException;
+    @NotNull T read(final @NotNull DataInput input) throws IOException;
   }
 
   /**
@@ -114,7 +114,7 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @param <T> the tag type
    */
   interface Writer<T extends BinaryTag> {
-    void write(final @NonNull T tag, final @NonNull DataOutput output) throws IOException;
+    void write(final @NotNull T tag, final @NotNull DataOutput output) throws IOException;
   }
 
   @Override
@@ -136,12 +136,12 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
     }
 
     @Override
-    public final @NonNull T read(final @NonNull DataInput input) throws IOException {
+    public final @NotNull T read(final @NotNull DataInput input) throws IOException {
       return this.reader.read(input);
     }
 
     @Override
-    public final void write(final @NonNull T tag, final @NonNull DataOutput output) throws IOException {
+    public final void write(final @NotNull T tag, final @NotNull DataOutput output) throws IOException {
       if (this.writer != null) this.writer.write(tag, output);
     }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
@@ -31,7 +31,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import static net.kyori.adventure.nbt.IOStreamUtil.closeShield;
 
@@ -39,42 +39,42 @@ final class BinaryTagWriterImpl implements BinaryTagIO.Writer {
   static final BinaryTagIO.Writer INSTANCE = new BinaryTagWriterImpl();
 
   @Override
-  public void write(final @NonNull CompoundBinaryTag tag, final @NonNull Path path, final BinaryTagIO.@NonNull Compression compression) throws IOException {
+  public void write(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
     try(final OutputStream os = Files.newOutputStream(path)) {
       this.write(tag, os, compression);
     }
   }
 
   @Override
-  public void write(final @NonNull CompoundBinaryTag tag, final @NonNull OutputStream output, final BinaryTagIO.@NonNull Compression compression) throws IOException {
+  public void write(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final BinaryTagIO.@NotNull Compression compression) throws IOException {
     try(final DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(compression.compress(closeShield(output))))) {
       this.write(tag, (DataOutput) dos);
     }
   }
 
   @Override
-  public void write(final @NonNull CompoundBinaryTag tag, final @NonNull DataOutput output) throws IOException {
+  public void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException {
     output.writeByte(BinaryTagTypes.COMPOUND.id());
     output.writeUTF(""); // write empty name
     BinaryTagTypes.COMPOUND.write(tag, output);
   }
 
   @Override
-  public void writeNamed(final Map.@NonNull Entry<String, CompoundBinaryTag> tag, final @NonNull Path path, final BinaryTagIO.@NonNull Compression compression) throws IOException {
+  public void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
     try(final OutputStream os = Files.newOutputStream(path)) {
       this.writeNamed(tag, os, compression);
     }
   }
 
   @Override
-  public void writeNamed(final Map.@NonNull Entry<String, CompoundBinaryTag> tag, final @NonNull OutputStream output, final BinaryTagIO.@NonNull Compression compression) throws IOException {
+  public void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull OutputStream output, final BinaryTagIO.@NotNull Compression compression) throws IOException {
     try(final DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(compression.compress(closeShield(output))))) {
       this.writeNamed(tag, (DataOutput) dos);
     }
   }
 
   @Override
-  public void writeNamed(final Map.@NonNull Entry<String, CompoundBinaryTag> tag, final @NonNull DataOutput output) throws IOException {
+  public void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull DataOutput output) throws IOException {
     output.writeByte(BinaryTagTypes.COMPOUND.id());
     output.writeUTF(tag.getKey());
     BinaryTagTypes.COMPOUND.write(tag.getValue(), output);

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTag.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A binary tag holding a {@code byte}-array value.
@@ -38,12 +38,12 @@ public interface ByteArrayBinaryTag extends ArrayBinaryTag, Iterable<Byte> {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull ByteArrayBinaryTag of(final byte@NonNull... value) {
+  static @NotNull ByteArrayBinaryTag of(final byte@NotNull... value) {
     return new ByteArrayBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<ByteArrayBinaryTag> type() {
+  default @NotNull BinaryTagType<ByteArrayBinaryTag> type() {
     return BinaryTagTypes.BYTE_ARRAY;
   }
 
@@ -55,7 +55,7 @@ public interface ByteArrayBinaryTag extends ArrayBinaryTag, Iterable<Byte> {
    * @return the value
    * @since 4.0.0
    */
-  byte@NonNull[] value();
+  byte@NotNull[] value();
 
   /**
    * Get the size of the array.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
@@ -27,9 +27,9 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Debug.Renderer(text = "\"byte[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class ByteArrayBinaryTagImpl extends ArrayBinaryTagImpl implements ByteArrayBinaryTag {
@@ -40,7 +40,7 @@ final class ByteArrayBinaryTagImpl extends ArrayBinaryTagImpl implements ByteArr
   }
 
   @Override
-  public byte@NonNull[] value() {
+  public byte@NotNull[] value() {
     return Arrays.copyOf(this.value, this.value.length);
   }
 
@@ -74,7 +74,7 @@ final class ByteArrayBinaryTagImpl extends ArrayBinaryTagImpl implements ByteArr
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteBinaryTag.java
@@ -25,9 +25,9 @@ package net.kyori.adventure.nbt;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary tag holding a {@code byte} value.
@@ -56,7 +56,7 @@ public interface ByteBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull ByteBinaryTag of(final byte value) {
+  static @NotNull ByteBinaryTag of(final byte value) {
     if (value == 0) {
       return ZERO;
     } else if (value == 1) {
@@ -67,7 +67,7 @@ public interface ByteBinaryTag extends NumberBinaryTag {
   }
 
   @Override
-  default @NonNull BinaryTagType<ByteBinaryTag> type() {
+  default @NotNull BinaryTagType<ByteBinaryTag> type() {
     return BinaryTagTypes.BYTE;
   }
 
@@ -137,7 +137,7 @@ final class ByteBinaryTagImpl extends AbstractBinaryTag implements ByteBinaryTag
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -26,8 +26,8 @@ package net.kyori.adventure.nbt;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Binary tag holding a mapping of string keys to {@link BinaryTag} values.
@@ -41,7 +41,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return an empty tag
    * @since 4.0.0
    */
-  static @NonNull CompoundBinaryTag empty() {
+  static @NotNull CompoundBinaryTag empty() {
     return CompoundBinaryTagImpl.EMPTY;
   }
 
@@ -53,7 +53,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a compound tag
    * @since 4.4.0
    */
-  static @NonNull CompoundBinaryTag from(final @NonNull Map<String, ? extends BinaryTag> tags) {
+  static @NotNull CompoundBinaryTag from(final @NotNull Map<String, ? extends BinaryTag> tags) {
     if (tags.isEmpty()) return empty();
     return new CompoundBinaryTagImpl(new HashMap<>(tags)); // explicitly copy
   }
@@ -64,12 +64,12 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a new builder
    * @since 4.0.0
    */
-  static @NonNull Builder builder() {
+  static @NotNull Builder builder() {
     return new CompoundTagBuilder();
   }
 
   @Override
-  default @NonNull BinaryTagType<CompoundBinaryTag> type() {
+  default @NotNull BinaryTagType<CompoundBinaryTag> type() {
     return BinaryTagTypes.COMPOUND;
   }
 
@@ -79,7 +79,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return the keys
    * @since 4.0.0
    */
-  @NonNull Set<String> keySet();
+  @NotNull Set<String> keySet();
 
   /**
    * Gets a tag.
@@ -100,7 +100,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default boolean getBoolean(final @NonNull String key) {
+  default boolean getBoolean(final @NotNull String key) {
     return this.getBoolean(key, false);
   }
 
@@ -115,7 +115,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default boolean getBoolean(final @NonNull String key, final boolean defaultValue) {
+  default boolean getBoolean(final @NotNull String key, final boolean defaultValue) {
     // != 0 might look weird, but it is what vanilla does
     return this.getByte(key) != 0 || defaultValue;
   }
@@ -128,7 +128,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default byte getByte(final @NonNull String key) {
+  default byte getByte(final @NotNull String key) {
     return this.getByte(key, (byte) 0);
   }
 
@@ -141,7 +141,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  byte getByte(final @NonNull String key, final byte defaultValue);
+  byte getByte(final @NotNull String key, final byte defaultValue);
 
   /**
    * Gets a short.
@@ -151,7 +151,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default short getShort(final @NonNull String key) {
+  default short getShort(final @NotNull String key) {
     return this.getShort(key, (short) 0);
   }
 
@@ -164,7 +164,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  short getShort(final @NonNull String key, final short defaultValue);
+  short getShort(final @NotNull String key, final short defaultValue);
 
   /**
    * Gets an int.
@@ -174,7 +174,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default int getInt(final @NonNull String key) {
+  default int getInt(final @NotNull String key) {
     return this.getInt(key, 0);
   }
 
@@ -187,7 +187,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  int getInt(final @NonNull String key, final int defaultValue);
+  int getInt(final @NotNull String key, final int defaultValue);
 
   /**
    * Gets a long.
@@ -197,7 +197,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default long getLong(final @NonNull String key) {
+  default long getLong(final @NotNull String key) {
     return this.getLong(key, 0L);
   }
 
@@ -210,7 +210,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  long getLong(final @NonNull String key, final long defaultValue);
+  long getLong(final @NotNull String key, final long defaultValue);
 
   /**
    * Gets a float.
@@ -220,7 +220,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default float getFloat(final @NonNull String key) {
+  default float getFloat(final @NotNull String key) {
     return this.getFloat(key, 0f);
   }
 
@@ -233,7 +233,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  float getFloat(final @NonNull String key, final float defaultValue);
+  float getFloat(final @NotNull String key, final float defaultValue);
 
   /**
    * Gets a double.
@@ -243,7 +243,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default double getDouble(final @NonNull String key) {
+  default double getDouble(final @NotNull String key) {
     return this.getDouble(key, 0d);
   }
 
@@ -256,7 +256,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  double getDouble(final @NonNull String key, final double defaultValue);
+  double getDouble(final @NotNull String key, final double defaultValue);
 
   /**
    * Gets an array of bytes.
@@ -266,7 +266,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  byte@NonNull[] getByteArray(final @NonNull String key);
+  byte@NotNull[] getByteArray(final @NotNull String key);
 
   /**
    * Gets an array of bytes.
@@ -276,7 +276,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return the array of bytes, or {@code defaultValue}
    * @since 4.0.0
    */
-  byte@NonNull[] getByteArray(final @NonNull String key, final byte@NonNull[] defaultValue);
+  byte@NotNull[] getByteArray(final @NotNull String key, final byte@NotNull[] defaultValue);
 
   /**
    * Gets a string.
@@ -286,7 +286,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default @NonNull String getString(final @NonNull String key) {
+  default @NotNull String getString(final @NotNull String key) {
     return this.getString(key, "");
   }
 
@@ -299,7 +299,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  @NonNull String getString(final @NonNull String key, final @NonNull String defaultValue);
+  @NotNull String getString(final @NotNull String key, final @NotNull String defaultValue);
 
   /**
    * Gets a list.
@@ -309,7 +309,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default @NonNull ListBinaryTag getList(final @NonNull String key) {
+  default @NotNull ListBinaryTag getList(final @NotNull String key) {
     return this.getList(key, ListBinaryTag.empty());
   }
 
@@ -322,7 +322,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  @NonNull ListBinaryTag getList(final @NonNull String key, final @NonNull ListBinaryTag defaultValue);
+  @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull ListBinaryTag defaultValue);
 
   /**
    * Gets a list, ensuring that the type is the same as {@code type}.
@@ -334,7 +334,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     does not match {@code expectedType}
    * @since 4.0.0
    */
-  default @NonNull ListBinaryTag getList(final @NonNull String key, final @NonNull BinaryTagType<? extends BinaryTag> expectedType) {
+  default @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull BinaryTagType<? extends BinaryTag> expectedType) {
     return this.getList(key, expectedType, ListBinaryTag.empty());
   }
 
@@ -349,7 +349,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     does not match {@code expectedType}
    * @since 4.0.0
    */
-  @NonNull ListBinaryTag getList(final @NonNull String key, final @NonNull BinaryTagType<? extends BinaryTag> expectedType, final @NonNull ListBinaryTag defaultValue);
+  @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull BinaryTagType<? extends BinaryTag> expectedType, final @NotNull ListBinaryTag defaultValue);
 
   /**
    * Gets a compound.
@@ -359,7 +359,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default @NonNull CompoundBinaryTag getCompound(final @NonNull String key) {
+  default @NotNull CompoundBinaryTag getCompound(final @NotNull String key) {
     return this.getCompound(key, empty());
   }
 
@@ -372,7 +372,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  @NonNull CompoundBinaryTag getCompound(final @NonNull String key, final @NonNull CompoundBinaryTag defaultValue);
+  @NotNull CompoundBinaryTag getCompound(final @NotNull String key, final @NotNull CompoundBinaryTag defaultValue);
 
   /**
    * Gets an array of ints.
@@ -382,7 +382,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  int@NonNull[] getIntArray(final @NonNull String key);
+  int@NotNull[] getIntArray(final @NotNull String key);
 
   /**
    * Gets an array of ints.
@@ -392,7 +392,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return the array of ints, or {@code defaultValue}
    * @since 4.0.0
    */
-  int@NonNull[] getIntArray(final @NonNull String key, final int@NonNull[] defaultValue);
+  int@NotNull[] getIntArray(final @NotNull String key, final int@NotNull[] defaultValue);
 
   /**
    * Gets an array of longs.
@@ -402,7 +402,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  long@NonNull[] getLongArray(final @NonNull String key);
+  long@NotNull[] getLongArray(final @NotNull String key);
 
   /**
    * Gets an array of longs.
@@ -412,7 +412,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return the array of longs, or {@code defaultValue}
    * @since 4.0.0
    */
-  long@NonNull[] getLongArray(final @NonNull String key, final long@NonNull[] defaultValue);
+  long@NotNull[] getLongArray(final @NotNull String key, final long@NotNull[] defaultValue);
 
   /**
    * A compound tag builder.
@@ -426,6 +426,6 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
      * @return a compound tag
      * @since 4.0.0
      */
-    @NonNull CompoundBinaryTag build();
+    @NotNull CompoundBinaryTag build();
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -31,9 +31,9 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,13 +48,13 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
     this.hashCode = tags.hashCode();
   }
 
-  public boolean contains(final @NonNull String key, final @NonNull BinaryTagType<?> type) {
+  public boolean contains(final @NotNull String key, final @NotNull BinaryTagType<?> type) {
     final @Nullable BinaryTag tag = this.tags.get(key);
     return tag != null && type.test(tag.type());
   }
 
   @Override
-  public @NonNull Set<String> keySet() {
+  public @NotNull Set<String> keySet() {
     return Collections.unmodifiableSet(this.tags.keySet());
   }
 
@@ -64,12 +64,12 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NonNull CompoundBinaryTag put(final @NonNull String key, final @NonNull BinaryTag tag) {
+  public @NotNull CompoundBinaryTag put(final @NotNull String key, final @NotNull BinaryTag tag) {
     return this.edit(map -> map.put(key, tag));
   }
 
   @Override
-  public @NonNull CompoundBinaryTag put(final @NonNull CompoundBinaryTag tag) {
+  public @NotNull CompoundBinaryTag put(final @NotNull CompoundBinaryTag tag) {
     return this.edit(map -> {
       for (final String key : tag.keySet()) {
         map.put(key, tag.get(key));
@@ -78,12 +78,12 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NonNull CompoundBinaryTag put(final @NonNull Map<String, ? extends BinaryTag> tags) {
+  public @NotNull CompoundBinaryTag put(final @NotNull Map<String, ? extends BinaryTag> tags) {
     return this.edit(map -> map.putAll(tags));
   }
 
   @Override
-  public @NonNull CompoundBinaryTag remove(final @NonNull String key, final @Nullable Consumer<? super BinaryTag> removed) {
+  public @NotNull CompoundBinaryTag remove(final @NotNull String key, final @Nullable Consumer<? super BinaryTag> removed) {
     if (!this.tags.containsKey(key)) {
       return this;
     }
@@ -96,7 +96,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public byte getByte(final @NonNull String key, final byte defaultValue) {
+  public byte getByte(final @NotNull String key, final byte defaultValue) {
     if (this.contains(key, BinaryTagTypes.BYTE)) {
       return ((NumberBinaryTag) this.tags.get(key)).byteValue();
     }
@@ -104,7 +104,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public short getShort(final @NonNull String key, final short defaultValue) {
+  public short getShort(final @NotNull String key, final short defaultValue) {
     if (this.contains(key, BinaryTagTypes.SHORT)) {
       return ((NumberBinaryTag) this.tags.get(key)).shortValue();
     }
@@ -112,7 +112,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public int getInt(final @NonNull String key, final int defaultValue) {
+  public int getInt(final @NotNull String key, final int defaultValue) {
     if (this.contains(key, BinaryTagTypes.INT)) {
       return ((NumberBinaryTag) this.tags.get(key)).intValue();
     }
@@ -120,7 +120,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public long getLong(final @NonNull String key, final long defaultValue) {
+  public long getLong(final @NotNull String key, final long defaultValue) {
     if (this.contains(key, BinaryTagTypes.LONG)) {
       return ((NumberBinaryTag) this.tags.get(key)).longValue();
     }
@@ -128,7 +128,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public float getFloat(final @NonNull String key, final float defaultValue) {
+  public float getFloat(final @NotNull String key, final float defaultValue) {
     if (this.contains(key, BinaryTagTypes.FLOAT)) {
       return ((NumberBinaryTag) this.tags.get(key)).floatValue();
     }
@@ -136,7 +136,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public double getDouble(final @NonNull String key, final double defaultValue) {
+  public double getDouble(final @NotNull String key, final double defaultValue) {
     if (this.contains(key, BinaryTagTypes.DOUBLE)) {
       return ((NumberBinaryTag) this.tags.get(key)).doubleValue();
     }
@@ -144,7 +144,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public byte@NonNull[] getByteArray(final @NonNull String key) {
+  public byte@NotNull[] getByteArray(final @NotNull String key) {
     if (this.contains(key, BinaryTagTypes.BYTE_ARRAY)) {
       return ((ByteArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -152,7 +152,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public byte@NonNull[] getByteArray(final @NonNull String key, final byte@NonNull[] defaultValue) {
+  public byte@NotNull[] getByteArray(final @NotNull String key, final byte@NotNull[] defaultValue) {
     if (this.contains(key, BinaryTagTypes.BYTE_ARRAY)) {
       return ((ByteArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -160,7 +160,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NonNull String getString(final @NonNull String key, final @NonNull String defaultValue) {
+  public @NotNull String getString(final @NotNull String key, final @NotNull String defaultValue) {
     if (this.contains(key, BinaryTagTypes.STRING)) {
       return ((StringBinaryTag) this.tags.get(key)).value();
     }
@@ -168,7 +168,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NonNull ListBinaryTag getList(final @NonNull String key, final @NonNull ListBinaryTag defaultValue) {
+  public @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull ListBinaryTag defaultValue) {
     if (this.contains(key, BinaryTagTypes.LIST)) {
       return (ListBinaryTag) this.tags.get(key);
     }
@@ -176,7 +176,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NonNull ListBinaryTag getList(final @NonNull String key, final @NonNull BinaryTagType<? extends BinaryTag> expectedType, final @NonNull ListBinaryTag defaultValue) {
+  public @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull BinaryTagType<? extends BinaryTag> expectedType, final @NotNull ListBinaryTag defaultValue) {
     if (this.contains(key, BinaryTagTypes.LIST)) {
       final ListBinaryTag tag = (ListBinaryTag) this.tags.get(key);
       if (expectedType.test(tag.elementType())) {
@@ -187,7 +187,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NonNull CompoundBinaryTag getCompound(final @NonNull String key, final @NonNull CompoundBinaryTag defaultValue) {
+  public @NotNull CompoundBinaryTag getCompound(final @NotNull String key, final @NotNull CompoundBinaryTag defaultValue) {
     if (this.contains(key, BinaryTagTypes.COMPOUND)) {
       return (CompoundBinaryTag) this.tags.get(key);
     }
@@ -195,7 +195,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public int@NonNull[] getIntArray(final @NonNull String key) {
+  public int@NotNull[] getIntArray(final @NotNull String key) {
     if (this.contains(key, BinaryTagTypes.INT_ARRAY)) {
       return ((IntArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -203,7 +203,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public int@NonNull[] getIntArray(final @NonNull String key, final int@NonNull[] defaultValue) {
+  public int@NotNull[] getIntArray(final @NotNull String key, final int@NotNull[] defaultValue) {
     if (this.contains(key, BinaryTagTypes.INT_ARRAY)) {
       return ((IntArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -211,7 +211,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public long@NonNull[] getLongArray(final @NonNull String key) {
+  public long@NotNull[] getLongArray(final @NotNull String key) {
     if (this.contains(key, BinaryTagTypes.LONG_ARRAY)) {
       return ((LongArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -219,7 +219,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public long@NonNull[] getLongArray(final @NonNull String key, final long@NonNull[] defaultValue) {
+  public long@NotNull[] getLongArray(final @NotNull String key, final long@NotNull[] defaultValue) {
     if (this.contains(key, BinaryTagTypes.LONG_ARRAY)) {
       return ((LongArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -243,18 +243,18 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("tags", this.tags));
   }
 
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public @NonNull Iterator<Map.Entry<String, ? extends BinaryTag>> iterator() {
+  public @NotNull Iterator<Map.Entry<String, ? extends BinaryTag>> iterator() {
     return (Iterator) this.tags.entrySet().iterator();
   }
 
   @Override
-  public void forEach(final @NonNull Consumer<? super Map.Entry<String, ? extends BinaryTag>> action) {
+  public void forEach(final @NotNull Consumer<? super Map.Entry<String, ? extends BinaryTag>> action) {
     this.tags.entrySet().forEach(requireNonNull(action, "action"));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
@@ -26,12 +26,11 @@ package net.kyori.adventure.nbt;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
-  private @MonotonicNonNull Map<String, BinaryTag> tags;
+  private @Nullable Map<String, BinaryTag> tags;
 
   private Map<String, BinaryTag> tags() {
     if (this.tags == null) {
@@ -41,13 +40,13 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   }
 
   @Override
-  public CompoundBinaryTag.@NonNull Builder put(final @NonNull String key, final @NonNull BinaryTag tag) {
+  public CompoundBinaryTag.@NotNull Builder put(final @NotNull String key, final @NotNull BinaryTag tag) {
     this.tags().put(key, tag);
     return this;
   }
 
   @Override
-  public CompoundBinaryTag.@NonNull Builder put(final @NonNull CompoundBinaryTag tag) {
+  public CompoundBinaryTag.@NotNull Builder put(final @NotNull CompoundBinaryTag tag) {
     final Map<String, BinaryTag> tags = this.tags();
     for (final String key : tag.keySet()) {
       tags.put(key, tag.get(key));
@@ -56,13 +55,13 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   }
 
   @Override
-  public CompoundBinaryTag.@NonNull Builder put(final @NonNull Map<String, ? extends BinaryTag> tags) {
+  public CompoundBinaryTag.@NotNull Builder put(final @NotNull Map<String, ? extends BinaryTag> tags) {
     this.tags().putAll(tags);
     return this;
   }
 
   @Override
-  public CompoundBinaryTag.@NonNull Builder remove(final @NonNull String key, final @Nullable Consumer<? super BinaryTag> removed) {
+  public CompoundBinaryTag.@NotNull Builder remove(final @NotNull String key, final @Nullable Consumer<? super BinaryTag> removed) {
     if (this.tags != null) {
       final BinaryTag tag = this.tags.remove(key);
       if (removed != null) {
@@ -73,7 +72,7 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   }
 
   @Override
-  public @NonNull CompoundBinaryTag build() {
+  public @NotNull CompoundBinaryTag build() {
     if (this.tags == null) return CompoundBinaryTag.empty();
     return new CompoundBinaryTagImpl(new HashMap<>(this.tags));
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagSetter.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagSetter.java
@@ -25,8 +25,8 @@ package net.kyori.adventure.nbt;
 
 import java.util.Map;
 import java.util.function.Consumer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Common methods between {@link CompoundBinaryTag} and {@link CompoundBinaryTag.Builder}.
@@ -43,7 +43,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  @NonNull R put(final @NonNull String key, final @NonNull BinaryTag tag);
+  @NotNull R put(final @NotNull String key, final @NotNull BinaryTag tag);
 
   /**
    * Inserts the tags in {@code tag}, overwriting any that are in {@code this}.
@@ -52,7 +52,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.6.0
    */
-  @NonNull R put(final @NonNull CompoundBinaryTag tag);
+  @NotNull R put(final @NotNull CompoundBinaryTag tag);
 
   /**
    * Inserts some tags.
@@ -61,7 +61,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.4.0
    */
-  @NonNull R put(final @NonNull Map<String, ? extends BinaryTag> tags);
+  @NotNull R put(final @NotNull Map<String, ? extends BinaryTag> tags);
 
   /**
    * Removes a tag.
@@ -70,7 +70,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.4.0
    */
-  default @NonNull R remove(final @NonNull String key) {
+  default @NotNull R remove(final @NotNull String key) {
     return this.remove(key, null);
   }
 
@@ -82,7 +82,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.4.0
    */
-  @NonNull R remove(final @NonNull String key, final @Nullable Consumer<? super BinaryTag> removed);
+  @NotNull R remove(final @NotNull String key, final @Nullable Consumer<? super BinaryTag> removed);
 
   /**
    * Inserts a boolean.
@@ -94,7 +94,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putBoolean(final @NonNull String key, final boolean value) {
+  default @NotNull R putBoolean(final @NotNull String key, final boolean value) {
     return this.put(key, value ? ByteBinaryTag.ONE : ByteBinaryTag.ZERO);
   }
 
@@ -106,7 +106,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putByte(final @NonNull String key, final byte value) {
+  default @NotNull R putByte(final @NotNull String key, final byte value) {
     return this.put(key, ByteBinaryTag.of(value));
   }
 
@@ -118,7 +118,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putShort(final @NonNull String key, final short value) {
+  default @NotNull R putShort(final @NotNull String key, final short value) {
     return this.put(key, ShortBinaryTag.of(value));
   }
 
@@ -130,7 +130,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putInt(final @NonNull String key, final int value) {
+  default @NotNull R putInt(final @NotNull String key, final int value) {
     return this.put(key, IntBinaryTag.of(value));
   }
 
@@ -142,7 +142,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putLong(final @NonNull String key, final long value) {
+  default @NotNull R putLong(final @NotNull String key, final long value) {
     return this.put(key, LongBinaryTag.of(value));
   }
 
@@ -154,7 +154,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putFloat(final @NonNull String key, final float value) {
+  default @NotNull R putFloat(final @NotNull String key, final float value) {
     return this.put(key, FloatBinaryTag.of(value));
   }
 
@@ -166,7 +166,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putDouble(final @NonNull String key, final double value) {
+  default @NotNull R putDouble(final @NotNull String key, final double value) {
     return this.put(key, DoubleBinaryTag.of(value));
   }
 
@@ -178,7 +178,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putByteArray(final @NonNull String key, final byte@NonNull[] value) {
+  default @NotNull R putByteArray(final @NotNull String key, final byte@NotNull[] value) {
     return this.put(key, ByteArrayBinaryTag.of(value));
   }
 
@@ -190,7 +190,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putString(final @NonNull String key, final @NonNull String value) {
+  default @NotNull R putString(final @NotNull String key, final @NotNull String value) {
     return this.put(key, StringBinaryTag.of(value));
   }
 
@@ -202,7 +202,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putIntArray(final @NonNull String key, final int@NonNull[] value) {
+  default @NotNull R putIntArray(final @NotNull String key, final int@NotNull[] value) {
     return this.put(key, IntArrayBinaryTag.of(value));
   }
 
@@ -214,7 +214,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NonNull R putLongArray(final @NonNull String key, final long@NonNull[] value) {
+  default @NotNull R putLongArray(final @NotNull String key, final long@NotNull[] value) {
     return this.put(key, LongArrayBinaryTag.of(value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/DoubleBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/DoubleBinaryTag.java
@@ -25,9 +25,9 @@ package net.kyori.adventure.nbt;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary tag holding a {@code double} value.
@@ -42,12 +42,12 @@ public interface DoubleBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull DoubleBinaryTag of(final double value) {
+  static @NotNull DoubleBinaryTag of(final double value) {
     return new DoubleBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<DoubleBinaryTag> type() {
+  default @NotNull BinaryTagType<DoubleBinaryTag> type() {
     return BinaryTagTypes.DOUBLE;
   }
 
@@ -117,7 +117,7 @@ final class DoubleBinaryTagImpl extends AbstractBinaryTag implements DoubleBinar
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/EndBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/EndBinaryTag.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An end tag.
@@ -37,12 +37,12 @@ public interface EndBinaryTag extends BinaryTag {
    * @return the end tag
    * @since 4.0.0
    */
-  static @NonNull EndBinaryTag get() {
+  static @NotNull EndBinaryTag get() {
     return EndBinaryTagImpl.INSTANCE;
   }
 
   @Override
-  default @NonNull BinaryTagType<EndBinaryTag> type() {
+  default @NotNull BinaryTagType<EndBinaryTag> type() {
     return BinaryTagTypes.END;
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTag.java
@@ -25,9 +25,9 @@ package net.kyori.adventure.nbt;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary tag holding a {@code float} value.
@@ -42,12 +42,12 @@ public interface FloatBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull FloatBinaryTag of(final float value) {
+  static @NotNull FloatBinaryTag of(final float value) {
     return new FloatBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<FloatBinaryTag> type() {
+  default @NotNull BinaryTagType<FloatBinaryTag> type() {
     return BinaryTagTypes.FLOAT;
   }
 
@@ -117,7 +117,7 @@ final class FloatBinaryTagImpl extends AbstractBinaryTag implements FloatBinaryT
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTag.java
@@ -27,7 +27,7 @@ import java.util.PrimitiveIterator;
 import java.util.Spliterator;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A binary tag holding an {@code int}-array value.
@@ -42,12 +42,12 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull IntArrayBinaryTag of(final int@NonNull... value) {
+  static @NotNull IntArrayBinaryTag of(final int@NotNull... value) {
     return new IntArrayBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<IntArrayBinaryTag> type() {
+  default @NotNull BinaryTagType<IntArrayBinaryTag> type() {
     return BinaryTagTypes.INT_ARRAY;
   }
 
@@ -59,7 +59,7 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @return the value
    * @since 4.0.0
    */
-  int@NonNull[] value();
+  int@NotNull[] value();
 
   /**
    * Get the length of the array.
@@ -87,10 +87,10 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @since 4.2.0
    */
   @Override
-  PrimitiveIterator.@NonNull OfInt iterator();
+  PrimitiveIterator.@NotNull OfInt iterator();
 
   @Override
-  Spliterator.@NonNull OfInt spliterator();
+  Spliterator.@NotNull OfInt spliterator();
 
   /**
    * Create a stream whose elements are the elements of this array tag.
@@ -98,7 +98,7 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @return a new stream
    * @since 4.2.0
    */
-  @NonNull IntStream stream();
+  @NotNull IntStream stream();
 
   /**
    * Perform an action for every int in the backing array.
@@ -106,5 +106,5 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @param action the action to perform
    * @since 4.2.0
    */
-  void forEachInt(final @NonNull IntConsumer action);
+  void forEachInt(final @NotNull IntConsumer action);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
@@ -31,9 +31,9 @@ import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Debug.Renderer(text = "\"int[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArrayBinaryTag {
@@ -44,7 +44,7 @@ final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArray
   }
 
   @Override
-  public int@NonNull[] value() {
+  public int@NotNull[] value() {
     return Arrays.copyOf(this.value, this.value.length);
   }
 
@@ -60,7 +60,7 @@ final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArray
   }
 
   @Override
-  public PrimitiveIterator.@NonNull OfInt iterator() {
+  public PrimitiveIterator.@NotNull OfInt iterator() {
     return new PrimitiveIterator.OfInt() {
       private int index;
 
@@ -80,17 +80,17 @@ final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArray
   }
 
   @Override
-  public Spliterator.@NonNull OfInt spliterator() {
+  public Spliterator.@NotNull OfInt spliterator() {
     return Arrays.spliterator(this.value);
   }
 
   @Override
-  public @NonNull IntStream stream() {
+  public @NotNull IntStream stream() {
     return Arrays.stream(this.value);
   }
 
   @Override
-  public void forEachInt(final @NonNull IntConsumer action) {
+  public void forEachInt(final @NotNull IntConsumer action) {
     for (int i = 0, length = this.value.length; i < length; i++) {
       action.accept(this.value[i]);
     }
@@ -115,7 +115,7 @@ final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArray
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntBinaryTag.java
@@ -25,9 +25,9 @@ package net.kyori.adventure.nbt;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary tag holding an {@code int} value.
@@ -42,12 +42,12 @@ public interface IntBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull IntBinaryTag of(final int value) {
+  static @NotNull IntBinaryTag of(final int value) {
     return new IntBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<IntBinaryTag> type() {
+  default @NotNull BinaryTagType<IntBinaryTag> type() {
     return BinaryTagTypes.INT;
   }
 
@@ -117,7 +117,7 @@ final class IntBinaryTagImpl extends AbstractBinaryTag implements IntBinaryTag {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
@@ -26,9 +26,9 @@ package net.kyori.adventure.nbt;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 /**
  * A list of zero or more values of a single tag type.
@@ -42,7 +42,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return an empty tag
    * @since 4.0.0
    */
-  static @NonNull ListBinaryTag empty() {
+  static @NotNull ListBinaryTag empty() {
     return ListBinaryTagImpl.EMPTY;
   }
 
@@ -55,7 +55,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IllegalArgumentException if {@code tags} has different tag types within
    * @since 4.4.0
    */
-  static @NonNull ListBinaryTag from(final @NonNull Iterable<? extends BinaryTag> tags) {
+  static @NotNull ListBinaryTag from(final @NotNull Iterable<? extends BinaryTag> tags) {
     return builder().add(tags).build();
   }
 
@@ -65,7 +65,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a new builder
    * @since 4.0.0
    */
-  static @NonNull Builder<BinaryTag> builder() {
+  static @NotNull Builder<BinaryTag> builder() {
     return new ListTagBuilder<>();
   }
 
@@ -78,7 +78,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IllegalArgumentException if {@code type} is {@link BinaryTagTypes#END}
    * @since 4.0.0
    */
-  static <T extends BinaryTag> @NonNull Builder<T> builder(final @NonNull BinaryTagType<T> type) {
+  static <T extends BinaryTag> @NotNull Builder<T> builder(final @NotNull BinaryTagType<T> type) {
     if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);
     return new ListTagBuilder<>(type);
   }
@@ -94,14 +94,14 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IllegalArgumentException if {@code type} is {@link BinaryTagTypes#END}
    * @since 4.0.0
    */
-  static @NonNull ListBinaryTag of(final @NonNull BinaryTagType<? extends BinaryTag> type, final @NonNull List<BinaryTag> tags) {
+  static @NotNull ListBinaryTag of(final @NotNull BinaryTagType<? extends BinaryTag> type, final @NotNull List<BinaryTag> tags) {
     if (tags.isEmpty()) return empty();
     if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);
     return new ListBinaryTagImpl(type, tags);
   }
 
   @Override
-  default @NonNull BinaryTagType<ListBinaryTag> type() {
+  default @NotNull BinaryTagType<ListBinaryTag> type() {
     return BinaryTagTypes.LIST;
   }
 
@@ -113,7 +113,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @deprecated since 4.4.0, use {@link #elementType()} instead
    */
   @Deprecated
-  default @NonNull BinaryTagType<? extends BinaryTag> listType() {
+  default @NotNull BinaryTagType<? extends BinaryTag> listType() {
     return this.elementType();
   }
 
@@ -123,7 +123,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the type
    * @since 4.4.0
    */
-  @NonNull BinaryTagType<? extends BinaryTag> elementType();
+  @NotNull BinaryTagType<? extends BinaryTag> elementType();
 
   /**
    * Gets the size.
@@ -141,7 +141,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IndexOutOfBoundsException if the index is out of range
    * @since 4.0.0
    */
-  @NonNull BinaryTag get(final @NonNegative int index);
+  @NotNull BinaryTag get(final @Range(from = 0, to = Integer.MAX_VALUE) int index);
 
   /**
    * Sets the tag at index {@code index} to {@code tag}, optionally providing {@code removedConsumer} with the tag previously at index {@code index}.
@@ -152,7 +152,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a list tag
    * @since 4.0.0
    */
-  @NonNull ListBinaryTag set(final int index, final @NonNull BinaryTag tag, final @Nullable Consumer<? super BinaryTag> removed);
+  @NotNull ListBinaryTag set(final int index, final @NotNull BinaryTag tag, final @Nullable Consumer<? super BinaryTag> removed);
 
   /**
    * Removes the tag at index {@code index}, optionally providing {@code removedConsumer} with the tag previously at index {@code index}.
@@ -162,7 +162,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a list tag
    * @since 4.0.0
    */
-  @NonNull ListBinaryTag remove(final int index, final @Nullable Consumer<? super BinaryTag> removed);
+  @NotNull ListBinaryTag remove(final int index, final @Nullable Consumer<? super BinaryTag> removed);
 
   /**
    * Gets a byte.
@@ -171,7 +171,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the byte value, or {@code 0}
    * @since 4.0.0
    */
-  default byte getByte(final @NonNegative int index) {
+  default byte getByte(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getByte(index, (byte) 0);
   }
 
@@ -183,7 +183,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the byte value, or {@code defaultValue}
    * @since 4.0.0
    */
-  default byte getByte(final @NonNegative int index, final byte defaultValue) {
+  default byte getByte(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final byte defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type().numeric()) {
       return ((NumberBinaryTag) tag).byteValue();
@@ -198,7 +198,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the short value, or {@code 0}
    * @since 4.0.0
    */
-  default short getShort(final @NonNegative int index) {
+  default short getShort(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getShort(index, (short) 0);
   }
 
@@ -210,7 +210,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the short value, or {@code defaultValue}
    * @since 4.0.0
    */
-  default short getShort(final @NonNegative int index, final short defaultValue) {
+  default short getShort(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final short defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type().numeric()) {
       return ((NumberBinaryTag) tag).shortValue();
@@ -225,7 +225,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the int value, or {@code 0}
    * @since 4.0.0
    */
-  default int getInt(final @NonNegative int index) {
+  default int getInt(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getInt(index, 0);
   }
 
@@ -237,7 +237,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the int value, or {@code defaultValue}
    * @since 4.0.0
    */
-  default int getInt(final @NonNegative int index, final int defaultValue) {
+  default int getInt(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final int defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type().numeric()) {
       return ((NumberBinaryTag) tag).intValue();
@@ -252,7 +252,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the long value, or {@code 0}
    * @since 4.0.0
    */
-  default long getLong(final @NonNegative int index) {
+  default long getLong(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getLong(index, 0L);
   }
 
@@ -264,7 +264,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the long value, or {@code defaultValue}
    * @since 4.0.0
    */
-  default long getLong(final @NonNegative int index, final long defaultValue) {
+  default long getLong(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final long defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type().numeric()) {
       return ((NumberBinaryTag) tag).longValue();
@@ -279,7 +279,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the float value, or {@code 0}
    * @since 4.0.0
    */
-  default float getFloat(final @NonNegative int index) {
+  default float getFloat(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getFloat(index, 0f);
   }
 
@@ -291,7 +291,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the float value, or {@code defaultValue}
    * @since 4.0.0
    */
-  default float getFloat(final @NonNegative int index, final float defaultValue) {
+  default float getFloat(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final float defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type().numeric()) {
       return ((NumberBinaryTag) tag).floatValue();
@@ -306,7 +306,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the double value, or {@code 0}
    * @since 4.0.0
    */
-  default double getDouble(final @NonNegative int index) {
+  default double getDouble(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getDouble(index, 0d);
   }
 
@@ -318,7 +318,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the double value, or {@code defaultValue}
    * @since 4.0.0
    */
-  default double getDouble(final @NonNegative int index, final double defaultValue) {
+  default double getDouble(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final double defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type().numeric()) {
       return ((NumberBinaryTag) tag).doubleValue();
@@ -333,7 +333,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of bytes, or a zero-length array
    * @since 4.0.0
    */
-  default byte@NonNull[] getByteArray(final @NonNegative int index) {
+  default byte@NotNull[] getByteArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.BYTE_ARRAY) {
       return ((ByteArrayBinaryTag) tag).value();
@@ -349,7 +349,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of bytes, or {@code defaultValue}
    * @since 4.0.0
    */
-  default byte@NonNull[] getByteArray(final @NonNegative int index, final byte@NonNull[] defaultValue) {
+  default byte@NotNull[] getByteArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final byte@NotNull[] defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.BYTE_ARRAY) {
       return ((ByteArrayBinaryTag) tag).value();
@@ -364,7 +364,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the string value, or {@code ""}
    * @since 4.0.0
    */
-  default @NonNull String getString(final @NonNegative int index) {
+  default @NotNull String getString(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getString(index, "");
   }
 
@@ -376,7 +376,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the string value, or {@code defaultValue}
    * @since 4.0.0
    */
-  default @NonNull String getString(final @NonNegative int index, final @NonNull String defaultValue) {
+  default @NotNull String getString(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @NotNull String defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.STRING) {
       return ((StringBinaryTag) tag).value();
@@ -391,7 +391,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the list, or an empty list if the tag at index {@code index} is not a list tag
    * @since 4.4.0
    */
-  default @NonNull ListBinaryTag getList(final @NonNegative int index) {
+  default @NotNull ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getList(index, null, ListBinaryTag.empty());
   }
 
@@ -403,7 +403,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the list, or an empty list if the tag at index {@code index} is not a list tag, or if the list tag's element type is not {@code elementType}
    * @since 4.4.0
    */
-  default @NonNull ListBinaryTag getList(final @NonNegative int index, final @Nullable BinaryTagType<?> elementType) {
+  default @NotNull ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable BinaryTagType<?> elementType) {
     return this.getList(index, elementType, ListBinaryTag.empty());
   }
 
@@ -415,7 +415,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the list, or {@code defaultValue} if the tag at index {@code index} is not a list tag
    * @since 4.4.0
    */
-  default @NonNull ListBinaryTag getList(final @NonNegative int index, final @NonNull ListBinaryTag defaultValue) {
+  default @NotNull ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @NotNull ListBinaryTag defaultValue) {
     return this.getList(index, null, defaultValue);
   }
 
@@ -430,7 +430,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the list, or {@code defaultValue} if the tag at index {@code index} is not a list tag, or if the list tag's element type is not {@code elementType}
    * @since 4.4.0
    */
-  default @NonNull ListBinaryTag getList(final @NonNegative int index, final @Nullable BinaryTagType<?> elementType, final @NonNull ListBinaryTag defaultValue) {
+  default @NotNull ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable BinaryTagType<?> elementType, final @NotNull ListBinaryTag defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.LIST) {
       final ListBinaryTag list = (ListBinaryTag) tag;
@@ -448,7 +448,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the compound, or a new compound
    * @since 4.0.0
    */
-  default @NonNull CompoundBinaryTag getCompound(final @NonNegative int index) {
+  default @NotNull CompoundBinaryTag getCompound(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getCompound(index, CompoundBinaryTag.empty());
   }
 
@@ -460,7 +460,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the compound, or {@code defaultValue}
    * @since 4.0.0
    */
-  default @NonNull CompoundBinaryTag getCompound(final @NonNegative int index, final @NonNull CompoundBinaryTag defaultValue) {
+  default @NotNull CompoundBinaryTag getCompound(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @NotNull CompoundBinaryTag defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.COMPOUND) {
       return (CompoundBinaryTag) tag;
@@ -475,7 +475,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of ints, or a zero-length array
    * @since 4.0.0
    */
-  default int@NonNull[] getIntArray(final @NonNegative int index) {
+  default int@NotNull[] getIntArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.INT_ARRAY) {
       return ((IntArrayBinaryTag) tag).value();
@@ -491,7 +491,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of ints, or {@code defaultValue}
    * @since 4.0.0
    */
-  default int@NonNull[] getIntArray(final @NonNegative int index, final int@NonNull[] defaultValue) {
+  default int@NotNull[] getIntArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final int@NotNull[] defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.INT_ARRAY) {
       return ((IntArrayBinaryTag) tag).value();
@@ -506,7 +506,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of longs, or a zero-length array
    * @since 4.0.0
    */
-  default long@NonNull[] getLongArray(final @NonNegative int index) {
+  default long@NotNull[] getLongArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.LONG_ARRAY) {
       return ((LongArrayBinaryTag) tag).value();
@@ -522,7 +522,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of longs, or {@code defaultValue}
    * @since 4.0.0
    */
-  default long@NonNull[] getLongArray(final @NonNegative int index, final long@NonNull[] defaultValue) {
+  default long@NotNull[] getLongArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final long@NotNull[] defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.LONG_ARRAY) {
       return ((LongArrayBinaryTag) tag).value();
@@ -536,7 +536,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a new stream
    * @since 4.2.0
    */
-  @NonNull Stream<BinaryTag> stream();
+  @NotNull Stream<BinaryTag> stream();
 
   /**
    * A list tag builder.
@@ -551,6 +551,6 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
      * @return a list tag
      * @since 4.0.0
      */
-    @NonNull ListBinaryTag build();
+    @NotNull ListBinaryTag build();
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -33,10 +33,10 @@ import java.util.Spliterators;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.index.qual.NonNegative;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 @Debug.Renderer(text = "\"ListBinaryTag[type=\" + this.type.toString() + \"]\"", childrenArray = "this.tags.toArray()", hasChildren = "!this.tags.isEmpty()")
 final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag {
@@ -52,7 +52,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NonNull BinaryTagType<? extends BinaryTag> elementType() {
+  public @NotNull BinaryTagType<? extends BinaryTag> elementType() {
     return this.elementType;
   }
 
@@ -62,12 +62,12 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NonNull BinaryTag get(@NonNegative final int index) {
+  public @NotNull BinaryTag get(@Range(from = 0, to = Integer.MAX_VALUE) final int index) {
     return this.tags.get(index);
   }
 
   @Override
-  public @NonNull ListBinaryTag set(final int index, final @NonNull BinaryTag newTag, final @Nullable Consumer<? super BinaryTag> removed) {
+  public @NotNull ListBinaryTag set(final int index, final @NotNull BinaryTag newTag, final @Nullable Consumer<? super BinaryTag> removed) {
     return this.edit(tags -> {
       final BinaryTag oldTag = tags.set(index, newTag);
       if (removed != null) {
@@ -77,7 +77,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NonNull ListBinaryTag remove(final int index, final @Nullable Consumer<? super BinaryTag> removed) {
+  public @NotNull ListBinaryTag remove(final int index, final @Nullable Consumer<? super BinaryTag> removed) {
     return this.edit(tags -> {
       final BinaryTag oldTag = tags.remove(index);
       if (removed != null) {
@@ -87,7 +87,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NonNull ListBinaryTag add(final BinaryTag tag) {
+  public @NotNull ListBinaryTag add(final BinaryTag tag) {
     noAddEnd(tag);
     if (this.elementType != BinaryTagTypes.END) {
       mustBeSameType(tag, this.elementType);
@@ -96,7 +96,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NonNull ListBinaryTag add(final Iterable<? extends BinaryTag> tagsToAdd) {
+  public @NotNull ListBinaryTag add(final Iterable<? extends BinaryTag> tagsToAdd) {
     if (tagsToAdd instanceof Collection<?> && ((Collection<?>) tagsToAdd).isEmpty()) {
       return this;
     }
@@ -147,7 +147,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NonNull Stream<BinaryTag> stream() {
+  public @NotNull Stream<BinaryTag> stream() {
     return this.tags.stream();
   }
 
@@ -193,7 +193,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("tags", this.tags),
       ExaminableProperty.of("type", this.elementType)

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
@@ -25,11 +25,11 @@ package net.kyori.adventure.nbt;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder<T> {
-  private @MonotonicNonNull List<BinaryTag> tags;
+  private @Nullable List<BinaryTag> tags;
   private BinaryTagType<? extends BinaryTag> elementType;
 
   ListTagBuilder() {
@@ -41,7 +41,7 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   }
 
   @Override
-  public ListBinaryTag.@NonNull Builder<T> add(final BinaryTag tag) {
+  public ListBinaryTag.@NotNull Builder<T> add(final BinaryTag tag) {
     ListBinaryTagImpl.noAddEnd(tag);
     // set the type if it has not yet been set
     if (this.elementType == BinaryTagTypes.END) {
@@ -57,7 +57,7 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   }
 
   @Override
-  public ListBinaryTag.@NonNull Builder<T> add(final Iterable<? extends T> tagsToAdd) {
+  public ListBinaryTag.@NotNull Builder<T> add(final Iterable<? extends T> tagsToAdd) {
     for (final T tag : tagsToAdd) {
       this.add(tag);
     }
@@ -65,7 +65,7 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   }
 
   @Override
-  public @NonNull ListBinaryTag build() {
+  public @NotNull ListBinaryTag build() {
     if (this.tags == null) return ListBinaryTag.empty();
     return new ListBinaryTagImpl(this.elementType, new ArrayList<>(this.tags));
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListTagSetter.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListTagSetter.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Common methods between {@link ListBinaryTag} and {@link ListBinaryTag.Builder}.
@@ -40,7 +40,7 @@ public interface ListTagSetter<R, T extends BinaryTag> {
    * @return a list tag
    * @since 4.0.0
    */
-  @NonNull R add(final T tag);
+  @NotNull R add(final T tag);
 
   /**
    * Adds multiple tags.
@@ -49,5 +49,5 @@ public interface ListTagSetter<R, T extends BinaryTag> {
    * @return a list tag
    * @since 4.4.0
    */
-  @NonNull R add(final Iterable<? extends T> tags);
+  @NotNull R add(final Iterable<? extends T> tags);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTag.java
@@ -27,7 +27,7 @@ import java.util.PrimitiveIterator;
 import java.util.Spliterator;
 import java.util.function.LongConsumer;
 import java.util.stream.LongStream;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A binary tag holding a {@code long}-array value.
@@ -42,12 +42,12 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull LongArrayBinaryTag of(final long@NonNull... value) {
+  static @NotNull LongArrayBinaryTag of(final long@NotNull... value) {
     return new LongArrayBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<LongArrayBinaryTag> type() {
+  default @NotNull BinaryTagType<LongArrayBinaryTag> type() {
     return BinaryTagTypes.LONG_ARRAY;
   }
 
@@ -59,7 +59,7 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @return the value
    * @since 4.0.0
    */
-  long@NonNull[] value();
+  long@NotNull[] value();
 
   /**
    * Gets the length of the array.
@@ -87,10 +87,10 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @since 4.2.0
    */
   @Override
-  PrimitiveIterator.@NonNull OfLong iterator();
+  PrimitiveIterator.@NotNull OfLong iterator();
 
   @Override
-  Spliterator.@NonNull OfLong spliterator();
+  Spliterator.@NotNull OfLong spliterator();
 
   /**
    * Create a stream whose elements are the elements of this array tag.
@@ -98,7 +98,7 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @return a new stream
    * @since 4.2.0
    */
-  @NonNull LongStream stream();
+  @NotNull LongStream stream();
 
   /**
    * Perform an action for every long in the backing array.
@@ -106,5 +106,5 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @param action the action to perform
    * @since 4.2.0
    */
-  void forEachLong(final @NonNull LongConsumer action);
+  void forEachLong(final @NotNull LongConsumer action);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
@@ -31,9 +31,9 @@ import java.util.function.LongConsumer;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Debug.Renderer(text = "\"long[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArrayBinaryTag {
@@ -44,7 +44,7 @@ final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArr
   }
 
   @Override
-  public long@NonNull[] value() {
+  public long@NotNull[] value() {
     return Arrays.copyOf(this.value, this.value.length);
   }
   
@@ -60,7 +60,7 @@ final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArr
   }
 
   @Override
-  public PrimitiveIterator.@NonNull OfLong iterator() {
+  public PrimitiveIterator.@NotNull OfLong iterator() {
     return new PrimitiveIterator.OfLong() {
       private int index;
 
@@ -80,17 +80,17 @@ final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArr
   }
 
   @Override
-  public Spliterator.@NonNull OfLong spliterator() {
+  public Spliterator.@NotNull OfLong spliterator() {
     return Arrays.spliterator(this.value);
   }
 
   @Override
-  public @NonNull LongStream stream() {
+  public @NotNull LongStream stream() {
     return Arrays.stream(this.value);
   }
 
   @Override
-  public void forEachLong(final @NonNull LongConsumer action) {
+  public void forEachLong(final @NotNull LongConsumer action) {
     for (int i = 0, length = this.value.length; i < length; i++) {
       action.accept(this.value[i]);
     }
@@ -115,7 +115,7 @@ final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArr
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongBinaryTag.java
@@ -25,9 +25,9 @@ package net.kyori.adventure.nbt;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary tag holding a {@code long} value.
@@ -42,12 +42,12 @@ public interface LongBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull LongBinaryTag of(final long value) {
+  static @NotNull LongBinaryTag of(final long value) {
     return new LongBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<LongBinaryTag> type() {
+  default @NotNull BinaryTagType<LongBinaryTag> type() {
     return BinaryTagTypes.LONG;
   }
 
@@ -117,7 +117,7 @@ final class LongBinaryTagImpl extends AbstractBinaryTag implements LongBinaryTag
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/NumberBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/NumberBinaryTag.java
@@ -23,7 +23,7 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A numeric binary tag.
@@ -32,7 +32,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public interface NumberBinaryTag extends BinaryTag {
   @Override
-  @NonNull BinaryTagType<? extends NumberBinaryTag> type();
+  @NotNull BinaryTagType<? extends NumberBinaryTag> type();
 
   /**
    * Gets the value as a {@code byte}.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ShortBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ShortBinaryTag.java
@@ -25,9 +25,9 @@ package net.kyori.adventure.nbt;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary tag holding a {@code short} value.
@@ -42,12 +42,12 @@ public interface ShortBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull ShortBinaryTag of(final short value) {
+  static @NotNull ShortBinaryTag of(final short value) {
     return new ShortBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<ShortBinaryTag> type() {
+  default @NotNull BinaryTagType<ShortBinaryTag> type() {
     return BinaryTagTypes.SHORT;
   }
 
@@ -117,7 +117,7 @@ final class ShortBinaryTagImpl extends AbstractBinaryTag implements ShortBinaryT
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/StringBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/StringBinaryTag.java
@@ -25,9 +25,9 @@ package net.kyori.adventure.nbt;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A binary tag holding a {@link String} value.
@@ -42,12 +42,12 @@ public interface StringBinaryTag extends BinaryTag {
    * @return a binary tag
    * @since 4.0.0
    */
-  static @NonNull StringBinaryTag of(final @NonNull String value) {
+  static @NotNull StringBinaryTag of(final @NotNull String value) {
     return new StringBinaryTagImpl(value);
   }
 
   @Override
-  default @NonNull BinaryTagType<StringBinaryTag> type() {
+  default @NotNull BinaryTagType<StringBinaryTag> type() {
     return BinaryTagTypes.STRING;
   }
 
@@ -57,7 +57,7 @@ public interface StringBinaryTag extends BinaryTag {
    * @return the value
    * @since 4.0.0
    */
-  @NonNull String value();
+  @NotNull String value();
 }
 
 @Debug.Renderer(text = "\"\\\"\" + this.value + \"\\\"\"", hasChildren = "false")
@@ -69,7 +69,7 @@ final class StringBinaryTagImpl extends AbstractBinaryTag implements StringBinar
   }
 
   @Override
-  public @NonNull String value() {
+  public @NotNull String value() {
     return this.value;
   }
 
@@ -87,7 +87,7 @@ final class StringBinaryTagImpl extends AbstractBinaryTag implements StringBinar
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringIO.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringIO.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.nbt;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A holder for string tag format options.
@@ -42,7 +42,7 @@ public final class TagStringIO {
    * @return the basic instance
    * @since 4.0.0
    */
-  public static @NonNull TagStringIO get() {
+  public static @NotNull TagStringIO get() {
     return INSTANCE;
   }
 
@@ -52,7 +52,7 @@ public final class TagStringIO {
    * @return a builder
    * @since 4.0.0
    */
-  public static @NonNull Builder builder() {
+  public static @NotNull Builder builder() {
     return new Builder();
   }
 
@@ -60,7 +60,7 @@ public final class TagStringIO {
   private final boolean emitLegacy;
   private final String indent;
 
-  private TagStringIO(final @NonNull Builder builder) {
+  private TagStringIO(final @NotNull Builder builder) {
     this.acceptLegacy = builder.acceptLegacy;
     this.emitLegacy = builder.emitLegacy;
     this.indent = builder.indent;
@@ -148,7 +148,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.0.0
      */
-    public @NonNull Builder indent(final int spaces) {
+    public @NotNull Builder indent(final int spaces) {
       if (spaces == 0) {
         this.indent = "";
       } else if ((this.indent.length() > 0 && this.indent.charAt(0) != ' ') || spaces != this.indent.length()) {
@@ -168,7 +168,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.0.0
      */
-    public @NonNull Builder indentTab(final int tabs) {
+    public @NotNull Builder indentTab(final int tabs) {
       if (tabs == 0) {
         this.indent = "";
       } else if ((this.indent.length() > 0 && this.indent.charAt(0) != '\t') || tabs != this.indent.length()) {
@@ -191,7 +191,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.0.0
      */
-    public @NonNull Builder acceptLegacy(final boolean legacy) {
+    public @NotNull Builder acceptLegacy(final boolean legacy) {
       this.acceptLegacy = legacy;
       return this;
     }
@@ -203,7 +203,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.0.0
      */
-    public @NonNull Builder emitLegacy(final boolean legacy) {
+    public @NotNull Builder emitLegacy(final boolean legacy) {
       this.emitLegacy = legacy;
       return this;
     }
@@ -214,7 +214,7 @@ public final class TagStringIO {
      * @return new IO configuration
      * @since 4.0.0
      */
-    public @NonNull TagStringIO build() {
+    public @NotNull TagStringIO build() {
       return new TagStringIO(this);
     }
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TrackingDataInput.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TrackingDataInput.java
@@ -25,8 +25,8 @@ package net.kyori.adventure.nbt;
 
 import java.io.DataInput;
 import java.io.IOException;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class TrackingDataInput implements DataInput, BinaryTagScope {
   private static final int MAX_DEPTH = 512;
@@ -90,13 +90,13 @@ final class TrackingDataInput implements DataInput, BinaryTagScope {
   }
 
   @Override
-  public void readFully(final byte@NonNull[] array) throws IOException {
+  public void readFully(final byte@NotNull[] array) throws IOException {
     this.counter += array.length;
     this.input.readFully(array);
   }
 
   @Override
-  public void readFully(final byte@NonNull[] array, final int off, final int len) throws IOException {
+  public void readFully(final byte@NotNull[] array, final int off, final int len) throws IOException {
     this.counter += len;
     this.input.readFully(array, off, len);
   }
@@ -176,7 +176,7 @@ final class TrackingDataInput implements DataInput, BinaryTagScope {
   }
 
   @Override
-  public @NonNull String readUTF() throws IOException {
+  public @NotNull String readUTF() throws IOException {
     final String result = this.input.readUTF();
     this.counter += (result.length() * 2L) + 2; // not entirely accurate, but the closest we can get without doing implementation details
     return result;

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/BlockNBTPosSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/BlockNBTPosSerializer.java
@@ -28,7 +28,7 @@ import java.util.function.Predicate;
 import net.kyori.adventure.text.BlockNBTComponent;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class BlockNBTPosSerializer extends ScalarSerializer<BlockNBTComponent.Pos> {
@@ -39,7 +39,7 @@ final class BlockNBTPosSerializer extends ScalarSerializer<BlockNBTComponent.Pos
   }
 
   @Override
-  public BlockNBTComponent.Pos deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+  public BlockNBTComponent.Pos deserialize(final @NotNull TypeToken<?> type, final @NotNull Object obj) throws ObjectMappingException {
     try {
       return BlockNBTComponent.Pos.fromString(obj.toString());
     } catch(final IllegalArgumentException ex) {
@@ -48,7 +48,7 @@ final class BlockNBTPosSerializer extends ScalarSerializer<BlockNBTComponent.Pos
   }
 
   @Override
-  public Object serialize(final BlockNBTComponent.@NonNull Pos item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final BlockNBTComponent.@NotNull Pos item, final @NotNull Predicate<Class<?>> typeSupported) {
     return item.asString();
   }
 }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/BookTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/BookTypeSerializer.java
@@ -30,8 +30,8 @@ import net.kyori.adventure.text.Component;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class BookTypeSerializer implements TypeSerializer<Book> {
@@ -45,7 +45,7 @@ final class BookTypeSerializer implements TypeSerializer<Book> {
   }
 
   @Override
-  public Book deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public Book deserialize(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     final Component title = value.getNode(TITLE).getValue(ComponentTypeSerializer.TYPE);
     final Component author = value.getNode(AUTHOR).getValue(ComponentTypeSerializer.TYPE);
     final List<Component> pages = value.getNode(PAGES).getValue(ComponentTypeSerializer.LIST_TYPE);
@@ -56,7 +56,7 @@ final class BookTypeSerializer implements TypeSerializer<Book> {
   }
 
   @Override
-  public void serialize(final @NonNull TypeToken<?> type, final @Nullable Book obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public void serialize(final @NotNull TypeToken<?> type, final @Nullable Book obj, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (obj == null) {
       value.setValue(null);
       return;

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
@@ -44,8 +44,8 @@ import net.kyori.adventure.text.serializer.ComponentSerializer;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class ComponentTypeSerializer implements TypeSerializer<Component> {
@@ -77,11 +77,11 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   }
 
   @Override
-  public @NonNull Component deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public @NotNull Component deserialize(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     return this.deserialize0(type, value);
   }
 
-  private @NonNull BuildableComponent<?, ?> deserialize0(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  private @NotNull BuildableComponent<?, ?> deserialize0(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     // Try to read as a string
     if (!value.isList() && !value.isMap()) {
       final String str = value.getString();
@@ -184,7 +184,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   }
 
   @Override
-  public void serialize(final @NonNull TypeToken<?> type, final @Nullable Component src, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public void serialize(final @NotNull TypeToken<?> type, final @Nullable Component src, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     value.setValue(null);
     if (src == null) {
       return;

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializer.java
@@ -28,7 +28,7 @@ import net.kyori.adventure.text.serializer.ComponentSerializer;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A serializer that will output to Configurate {@link ConfigurationNode}s.
@@ -49,7 +49,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return the shared default instance
    * @since 4.0.0
    */
-  static @NonNull ConfigurateComponentSerializer configurate() {
+  static @NotNull ConfigurateComponentSerializer configurate() {
     return ConfigurateComponentSerializerImpl.INSTANCE;
   }
 
@@ -59,7 +59,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return a new builder
    * @since 4.0.0
    */
-  static @NonNull Builder builder() {
+  static @NotNull Builder builder() {
     return new ConfigurateComponentSerializerImpl.Builder();
   }
 
@@ -72,7 +72,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return input collection
    * @since 4.0.0
    */
-  @NonNull TypeSerializerCollection addSerializersTo(final @NonNull TypeSerializerCollection collection);
+  @NotNull TypeSerializerCollection addSerializersTo(final @NotNull TypeSerializerCollection collection);
 
   /**
    * A builder for a configurate serializer instance.
@@ -91,7 +91,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder scalarSerializer(final @NonNull ComponentSerializer<Component, ?, String> stringSerializer);
+    @NotNull Builder scalarSerializer(final @NotNull ComponentSerializer<Component, ?, String> stringSerializer);
 
     /**
      * If the {@link #scalarSerializer(ComponentSerializer)} is set, output components as serialized strings
@@ -104,7 +104,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder outputStringComponents(final boolean stringComponents);
+    @NotNull Builder outputStringComponents(final boolean stringComponents);
 
     /**
      * Create a new component serializer instance.
@@ -112,6 +112,6 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return new serializer
      * @since 4.0.0
      */
-    @NonNull ConfigurateComponentSerializer build();
+    @NotNull ConfigurateComponentSerializer build();
   }
 }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializerImpl.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ConfigurateComponentSerializerImpl.java
@@ -36,8 +36,8 @@ import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,7 +48,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   private final boolean serializeStringComponents;
   static final ConfigurateComponentSerializer INSTANCE = new Builder().build();
 
-  private ConfigurateComponentSerializerImpl(final @NonNull Builder builder) {
+  private ConfigurateComponentSerializerImpl(final @NotNull Builder builder) {
     this.stringSerializer = builder.stringSerializer;
     this.serializeStringComponents = builder.outputStringComponents;
     this.ownNodeOptions = ConfigurationOptions.defaults()
@@ -57,7 +57,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   }
 
   @Override
-  public @NonNull Component deserialize(final @NonNull ConfigurationNode input) {
+  public @NotNull Component deserialize(final @NotNull ConfigurationNode input) {
     try {
       final @Nullable Component deserialized = input.getValue(ComponentTypeSerializer.TYPE);
       if (deserialized != null) {
@@ -70,7 +70,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   }
 
   @Override
-  public @NonNull ConfigurationNode serialize(final @NonNull Component component) {
+  public @NotNull ConfigurationNode serialize(final @NotNull Component component) {
     final ConfigurationNode base = ConfigurationNode.root(this.ownNodeOptions);
     try {
       base.setValue(ComponentTypeSerializer.TYPE, component);
@@ -82,7 +82,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
 
   @Override
   @SuppressWarnings("serial")
-  public @NonNull TypeSerializerCollection addSerializersTo(final @NonNull TypeSerializerCollection serializers) {
+  public @NotNull TypeSerializerCollection addSerializersTo(final @NotNull TypeSerializerCollection serializers) {
     return serializers
       .register(BookTypeSerializer.TYPE, BookTypeSerializer.INSTANCE)
       .register(TitleSerializer.TYPE, TitleSerializer.INSTANCE)
@@ -112,19 +112,19 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
     }
 
     @Override
-    public ConfigurateComponentSerializer.@NonNull Builder scalarSerializer(final @NonNull ComponentSerializer<Component, ?, String> stringSerializer) {
+    public ConfigurateComponentSerializer.@NotNull Builder scalarSerializer(final @NotNull ComponentSerializer<Component, ?, String> stringSerializer) {
       this.stringSerializer = requireNonNull(stringSerializer, "stringSerializer");
       return this;
     }
 
     @Override
-    public ConfigurateComponentSerializer.@NonNull Builder outputStringComponents(final boolean stringComponents) {
+    public ConfigurateComponentSerializer.@NotNull Builder outputStringComponents(final boolean stringComponents) {
       this.outputStringComponents = stringComponents;
       return this;
     }
 
     @Override
-    public @NonNull ConfigurateComponentSerializer build() {
+    public @NotNull ConfigurateComponentSerializer build() {
       return new ConfigurateComponentSerializerImpl(this);
     }
   }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/DurationSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/DurationSerializer.java
@@ -29,7 +29,7 @@ import java.time.format.DateTimeParseException;
 import java.util.function.Predicate;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A serializer for the JDK {@link Duration} type.
@@ -45,7 +45,7 @@ final class DurationSerializer extends ScalarSerializer<Duration> {
   }
 
   @Override
-  public Duration deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+  public Duration deserialize(final @NotNull TypeToken<?> type, final @NotNull Object obj) throws ObjectMappingException {
     if (obj instanceof CharSequence) {
       String value = obj.toString();
       if (!value.startsWith("P") && !value.startsWith("p")) {
@@ -62,7 +62,7 @@ final class DurationSerializer extends ScalarSerializer<Duration> {
   }
 
   @Override
-  public Object serialize(final @NonNull Duration item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final @NotNull Duration item, final @NotNull Predicate<Class<?>> typeSupported) {
     return item.toString();
   }
 }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowEntitySerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowEntitySerializer.java
@@ -31,8 +31,8 @@ import net.kyori.adventure.text.event.HoverEvent;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEvent.ShowEntity> {
@@ -48,7 +48,7 @@ final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEvent.
   }
 
   @Override
-  public HoverEvent.ShowEntity deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public HoverEvent.ShowEntity deserialize(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     final Key typeId = value.getNode(ENTITY_TYPE).getValue(KeySerializer.INSTANCE.type());
     final UUID id = value.getNode(ID).getValue(UUID_TYPE);
     if (typeId == null || id == null) {
@@ -60,7 +60,7 @@ final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEvent.
   }
 
   @Override
-  public void serialize(final @NonNull TypeToken<?> type, final HoverEvent.@Nullable ShowEntity obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public void serialize(final @NotNull TypeToken<?> type, final HoverEvent.@Nullable ShowEntity obj, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (obj == null) {
       value.setValue(null);
       return;

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowItemSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowItemSerializer.java
@@ -30,8 +30,8 @@ import net.kyori.adventure.text.event.HoverEvent;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class HoverEventShowItemSerializer implements TypeSerializer<HoverEvent.ShowItem> {
@@ -46,7 +46,7 @@ final class HoverEventShowItemSerializer implements TypeSerializer<HoverEvent.Sh
   }
 
   @Override
-  public HoverEvent.ShowItem deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public HoverEvent.ShowItem deserialize(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     final Key id = value.getNode(ID).getValue(KeySerializer.INSTANCE.type());
     if (id == null) {
       throw new ObjectMappingException("An id is required to deserialize the show_item hover event");
@@ -58,7 +58,7 @@ final class HoverEventShowItemSerializer implements TypeSerializer<HoverEvent.Sh
   }
 
   @Override
-  public void serialize(final @NonNull TypeToken<?> type, final HoverEvent.@Nullable ShowItem obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public void serialize(final @NotNull TypeToken<?> type, final HoverEvent.@Nullable ShowItem obj, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (obj == null) {
       value.setValue(null);
       return;

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/IndexSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/IndexSerializer.java
@@ -28,19 +28,19 @@ import java.util.function.Predicate;
 import net.kyori.adventure.util.Index;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class IndexSerializer<T> extends ScalarSerializer<T> {
   private final Index<String, T> idx;
 
-  IndexSerializer(final @NonNull TypeToken<T> type, final @NonNull Index<String, T> idx) {
+  IndexSerializer(final @NotNull TypeToken<T> type, final @NotNull Index<String, T> idx) {
     super(type);
     this.idx = idx;
   }
 
   @Override
-  public @NonNull T deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+  public @NotNull T deserialize(final @NotNull TypeToken<?> type, final @NotNull Object obj) throws ObjectMappingException {
     final T value = this.idx.value(obj.toString());
     if (value == null) {
       throw new ObjectMappingException("No value for key '" + obj + "' in index for type " + this.type());
@@ -49,7 +49,7 @@ final class IndexSerializer<T> extends ScalarSerializer<T> {
   }
 
   @Override
-  public Object serialize(final @NonNull T item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final @NotNull T item, final @NotNull Predicate<Class<?>> typeSupported) {
     return this.idx.key(item);
   }
 }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/KeySerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/KeySerializer.java
@@ -30,7 +30,7 @@ import net.kyori.adventure.key.Key;
 import ninja.leaping.configurate.objectmapping.InvalidTypeException;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class KeySerializer extends ScalarSerializer<Key> {
@@ -41,7 +41,7 @@ final class KeySerializer extends ScalarSerializer<Key> {
   }
 
   @Override
-  public @NonNull Key deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+  public @NotNull Key deserialize(final @NotNull TypeToken<?> type, final @NotNull Object obj) throws ObjectMappingException {
     if (!(obj instanceof CharSequence)) {
       throw new InvalidTypeException(type);
     }
@@ -53,7 +53,7 @@ final class KeySerializer extends ScalarSerializer<Key> {
   }
 
   @Override
-  public @NonNull Object serialize(final @NonNull Key item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public @NotNull Object serialize(final @NotNull Key item, final @NotNull Predicate<Class<?>> typeSupported) {
     return item.asString();
   }
 }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/SoundSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/SoundSerializer.java
@@ -29,8 +29,8 @@ import net.kyori.adventure.sound.Sound;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class SoundSerializer implements TypeSerializer<Sound> {
@@ -47,7 +47,7 @@ final class SoundSerializer implements TypeSerializer<Sound> {
   }
 
   @Override
-  public @Nullable Sound deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public @Nullable Sound deserialize(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (value.isEmpty()) {
       return null;
     }
@@ -65,7 +65,7 @@ final class SoundSerializer implements TypeSerializer<Sound> {
   }
 
   @Override
-  public void serialize(final @NonNull TypeToken<?> type, final @Nullable Sound obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public void serialize(final @NotNull TypeToken<?> type, final @Nullable Sound obj, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (obj == null) {
       value.setValue(null);
       return;

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/SoundStopSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/SoundStopSerializer.java
@@ -31,8 +31,8 @@ import net.kyori.adventure.sound.SoundStop;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class SoundStopSerializer implements TypeSerializer<SoundStop> {
@@ -46,7 +46,7 @@ final class SoundStopSerializer implements TypeSerializer<SoundStop> {
   }
 
   @Override
-  public SoundStop deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public SoundStop deserialize(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (value.isEmpty()) {
       return SoundStop.all();
     } else {
@@ -61,7 +61,7 @@ final class SoundStopSerializer implements TypeSerializer<SoundStop> {
   }
 
   @Override
-  public void serialize(final @NonNull TypeToken<?> type, final @Nullable SoundStop obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public void serialize(final @NotNull TypeToken<?> type, final @Nullable SoundStop obj, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     value.getNode(SOUND).setValue(KeySerializer.INSTANCE.type(), obj == null ? null : obj.sound());
     value.getNode(SOURCE).setValue(SoundSerializer.SOURCE_TYPE, obj == null ? null : obj.source());
     if (value.isEmpty()) {

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/StyleSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/StyleSerializer.java
@@ -34,8 +34,8 @@ import net.kyori.adventure.text.format.TextDecoration;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class StyleSerializer implements TypeSerializer<Style> {
@@ -63,7 +63,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
   }
 
   @Override
-  public @NonNull Style deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public @NotNull Style deserialize(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (value.isVirtual()) {
       return Style.empty();
     }
@@ -129,7 +129,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
   }
 
   @Override
-  public void serialize(final @NonNull TypeToken<?> type, @Nullable Style obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public void serialize(final @NotNull TypeToken<?> type, @Nullable Style obj, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (obj == null) {
       obj = Style.empty();
     }
@@ -172,7 +172,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
     }
   }
 
-  private static <T> @NonNull T nonNull(final @Nullable T value, final @NonNull String type) throws ObjectMappingException {
+  private static <T> @NotNull T nonNull(final @Nullable T value, final @NotNull String type) throws ObjectMappingException {
     if (value == null) {
       throw new ObjectMappingException(type + " was null in an unexpected location");
     }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TextColorSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TextColorSerializer.java
@@ -29,7 +29,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.ScalarSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class TextColorSerializer extends ScalarSerializer<TextColor> {
@@ -41,7 +41,7 @@ final class TextColorSerializer extends ScalarSerializer<TextColor> {
   }
 
   @Override
-  public TextColor deserialize(final @NonNull TypeToken<?> type, final @NonNull Object obj) throws ObjectMappingException {
+  public TextColor deserialize(final @NotNull TypeToken<?> type, final @NotNull Object obj) throws ObjectMappingException {
     if (obj instanceof Number) { // numerical values
       return TextColor.color(((Number) obj).intValue());
     } else if (!(obj instanceof CharSequence)) {
@@ -61,7 +61,7 @@ final class TextColorSerializer extends ScalarSerializer<TextColor> {
   }
 
   @Override
-  public Object serialize(final @NonNull TextColor item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final @NotNull TextColor item, final @NotNull Predicate<Class<?>> typeSupported) {
     if (item instanceof NamedTextColor) { // TODO: Downsampling
       return NamedTextColor.NAMES.key((NamedTextColor) item);
     } else {

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TitleSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/TitleSerializer.java
@@ -31,8 +31,8 @@ import net.kyori.adventure.title.Title;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage") // TypeToken
 final class TitleSerializer implements TypeSerializer<Title> {
@@ -51,7 +51,7 @@ final class TitleSerializer implements TypeSerializer<Title> {
   static final String FADE_OUT = "fade-out";
 
   @Override
-  public @Nullable Title deserialize(final @NonNull TypeToken<?> type, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public @Nullable Title deserialize(final @NotNull TypeToken<?> type, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (value.isEmpty()) {
       return null;
     }
@@ -70,7 +70,7 @@ final class TitleSerializer implements TypeSerializer<Title> {
   }
 
   @Override
-  public void serialize(final @NonNull TypeToken<?> type, final @Nullable Title obj, final @NonNull ConfigurationNode value) throws ObjectMappingException {
+  public void serialize(final @NotNull TypeToken<?> type, final @Nullable Title obj, final @NotNull ConfigurationNode value) throws ObjectMappingException {
     if (obj == null) {
       value.setValue(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/BlockNBTPosSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/BlockNBTPosSerializer.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.serializer.configurate4;
 import java.lang.reflect.Type;
 import java.util.function.Predicate;
 import net.kyori.adventure.text.BlockNBTComponent;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -38,7 +38,7 @@ final class BlockNBTPosSerializer extends ScalarSerializer<BlockNBTComponent.Pos
   }
 
   @Override
-  public BlockNBTComponent.Pos deserialize(final @NonNull Type type, final @NonNull Object obj) throws SerializationException {
+  public BlockNBTComponent.Pos deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
     try {
       return BlockNBTComponent.Pos.fromString(obj.toString());
     } catch(final IllegalArgumentException ex) {
@@ -47,7 +47,7 @@ final class BlockNBTPosSerializer extends ScalarSerializer<BlockNBTComponent.Pos
   }
 
   @Override
-  public Object serialize(final BlockNBTComponent.@NonNull Pos item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final BlockNBTComponent.@NotNull Pos item, final @NotNull Predicate<Class<?>> typeSupported) {
     return item.asString();
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/BookTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/BookTypeSerializer.java
@@ -27,8 +27,8 @@ import java.lang.reflect.Type;
 import java.util.List;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -43,7 +43,7 @@ final class BookTypeSerializer implements TypeSerializer<Book> {
   }
 
   @Override
-  public Book deserialize(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  public Book deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     final Component title = value.node(TITLE).get(Component.class);
     final Component author = value.node(AUTHOR).get(Component.class);
     final List<Component> pages = value.node(PAGES).get(ComponentTypeSerializer.LIST_TYPE);
@@ -54,7 +54,7 @@ final class BookTypeSerializer implements TypeSerializer<Book> {
   }
 
   @Override
-  public void serialize(final @NonNull Type type, final @Nullable Book obj, final @NonNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final @NotNull Type type, final @Nullable Book obj, final @NotNull ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
@@ -42,8 +42,8 @@ import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -75,11 +75,11 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   }
 
   @Override
-  public @NonNull Component deserialize(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  public @NotNull Component deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     return this.deserialize0(type, value);
   }
 
-  private @NonNull BuildableComponent<?, ?> deserialize0(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  private @NotNull BuildableComponent<?, ?> deserialize0(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     // Try to read as a string
     if (!value.isList() && !value.isMap()) {
       final String str = value.getString();
@@ -182,7 +182,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   }
 
   @Override
-  public void serialize(final @NonNull Type type, final @Nullable Component src, final @NonNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final @NotNull Type type, final @Nullable Component src, final @NotNull ConfigurationNode value) throws SerializationException {
     value.set(null);
     if (src == null) {
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializer.java
@@ -25,7 +25,7 @@ package net.kyori.adventure.serializer.configurate4;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.TypeSerializer;
 import org.spongepowered.configurate.serialize.TypeSerializerCollection;
@@ -49,7 +49,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return the shared default instance
    * @since 4.2.0
    */
-  static @NonNull ConfigurateComponentSerializer configurate() {
+  static @NotNull ConfigurateComponentSerializer configurate() {
     return ConfigurateComponentSerializerImpl.INSTANCE;
   }
 
@@ -59,7 +59,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return a new builder
    * @since 4.2.0
    */
-  static @NonNull Builder builder() {
+  static @NotNull Builder builder() {
     return new ConfigurateComponentSerializerImpl.Builder();
   }
 
@@ -69,7 +69,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return a collection containing Adventure serializers
    * @since 4.2.0
    */
-  @NonNull TypeSerializerCollection serializers();
+  @NotNull TypeSerializerCollection serializers();
 
   /**
    * A builder for a configurate serializer instance.
@@ -88,7 +88,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return this builder
      * @since 4.2.0
      */
-    @NonNull Builder scalarSerializer(final @NonNull ComponentSerializer<Component, ?, String> stringSerializer);
+    @NotNull Builder scalarSerializer(final @NotNull ComponentSerializer<Component, ?, String> stringSerializer);
 
     /**
      * If the {@link #scalarSerializer(ComponentSerializer)} is set, output components as serialized strings
@@ -101,7 +101,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return this builder
      * @since 4.2.0
      */
-    @NonNull Builder outputStringComponents(final boolean stringComponents);
+    @NotNull Builder outputStringComponents(final boolean stringComponents);
 
     /**
      * Create a new component serializer instance.
@@ -109,6 +109,6 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return new serializer
      * @since 4.2.0
      */
-    @NonNull ConfigurateComponentSerializer build();
+    @NotNull ConfigurateComponentSerializer build();
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializerImpl.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializerImpl.java
@@ -34,8 +34,8 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.title.Title;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.BasicConfigurationNode;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
@@ -52,7 +52,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   private final @Nullable ComponentSerializer<Component, ?, String> stringSerializer;
   private final boolean serializeStringComponents;
 
-  private ConfigurateComponentSerializerImpl(final @NonNull Builder builder) {
+  private ConfigurateComponentSerializerImpl(final @NotNull Builder builder) {
     this.stringSerializer = builder.stringSerializer;
     this.serializeStringComponents = builder.outputStringComponents;
     this.serializers = this.makeSerializers(TypeSerializerCollection.defaults().childBuilder());
@@ -62,7 +62,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   }
 
   @Override
-  public @NonNull Component deserialize(final @NonNull ConfigurationNode input) {
+  public @NotNull Component deserialize(final @NotNull ConfigurationNode input) {
     try {
       final @Nullable Component deserialized = input.get(Component.class);
       if (deserialized != null) {
@@ -75,7 +75,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   }
 
   @Override
-  public @NonNull ConfigurationNode serialize(final @NonNull Component component) {
+  public @NotNull ConfigurationNode serialize(final @NotNull Component component) {
     final ConfigurationNode base = BasicConfigurationNode.root(this.ownNodeOptions);
     try {
       base.set(Component.class, component);
@@ -85,7 +85,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
     return base;
   }
 
-  private @NonNull TypeSerializerCollection makeSerializers(final TypeSerializerCollection.@NonNull Builder serializers) {
+  private @NotNull TypeSerializerCollection makeSerializers(final TypeSerializerCollection.@NotNull Builder serializers) {
     return serializers
       .register(Book.class, BookTypeSerializer.INSTANCE)
       .register(Title.class, TitleSerializer.INSTANCE)
@@ -109,7 +109,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   }
 
   @Override
-  public @NonNull TypeSerializerCollection serializers() {
+  public @NotNull TypeSerializerCollection serializers() {
     return this.serializers;
   }
 
@@ -121,19 +121,19 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
     }
 
     @Override
-    public ConfigurateComponentSerializer.@NonNull Builder scalarSerializer(final @NonNull ComponentSerializer<Component, ?, String> stringSerializer) {
+    public ConfigurateComponentSerializer.@NotNull Builder scalarSerializer(final @NotNull ComponentSerializer<Component, ?, String> stringSerializer) {
       this.stringSerializer = requireNonNull(stringSerializer, "stringSerializer");
       return this;
     }
 
     @Override
-    public ConfigurateComponentSerializer.@NonNull Builder outputStringComponents(final boolean stringComponents) {
+    public ConfigurateComponentSerializer.@NotNull Builder outputStringComponents(final boolean stringComponents) {
       this.outputStringComponents = stringComponents;
       return this;
     }
 
     @Override
-    public @NonNull ConfigurateComponentSerializer build() {
+    public @NotNull ConfigurateComponentSerializer build() {
       return new ConfigurateComponentSerializerImpl(this);
     }
   }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/DurationSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/DurationSerializer.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Type;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.function.Predicate;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -44,7 +44,7 @@ final class DurationSerializer extends ScalarSerializer<Duration> {
   }
 
   @Override
-  public Duration deserialize(final @NonNull Type type, final @NonNull Object obj) throws SerializationException {
+  public Duration deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
     if (obj instanceof CharSequence) {
       String value = obj.toString();
       if (!value.startsWith("P") && !value.startsWith("p")) {
@@ -61,7 +61,7 @@ final class DurationSerializer extends ScalarSerializer<Duration> {
   }
 
   @Override
-  public Object serialize(final @NonNull Duration item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final @NotNull Duration item, final @NotNull Predicate<Class<?>> typeSupported) {
     return item.toString();
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowEntitySerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowEntitySerializer.java
@@ -28,8 +28,8 @@ import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -45,7 +45,7 @@ final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEvent.
   }
 
   @Override
-  public HoverEvent.ShowEntity deserialize(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  public HoverEvent.ShowEntity deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     final Key typeId = value.node(ENTITY_TYPE).get(Key.class);
     final UUID id = value.node(ID).get(UUID.class);
     if (typeId == null || id == null) {
@@ -57,7 +57,7 @@ final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEvent.
   }
 
   @Override
-  public void serialize(final @NonNull Type type, final HoverEvent.@Nullable ShowEntity obj, final @NonNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final @NotNull Type type, final HoverEvent.@Nullable ShowEntity obj, final @NotNull ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowItemSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowItemSerializer.java
@@ -27,8 +27,8 @@ import java.lang.reflect.Type;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -44,7 +44,7 @@ final class HoverEventShowItemSerializer implements TypeSerializer<HoverEvent.Sh
   }
 
   @Override
-  public HoverEvent.ShowItem deserialize(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  public HoverEvent.ShowItem deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     final Key id = value.node(ID).get(Key.class);
     if (id == null) {
       throw new SerializationException("An id is required to deserialize the show_item hover event");
@@ -56,7 +56,7 @@ final class HoverEventShowItemSerializer implements TypeSerializer<HoverEvent.Sh
   }
 
   @Override
-  public void serialize(final @NonNull Type type, final HoverEvent.@Nullable ShowItem obj, final @NonNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final @NotNull Type type, final HoverEvent.@Nullable ShowItem obj, final @NotNull ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/IndexSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/IndexSerializer.java
@@ -27,20 +27,20 @@ import io.leangen.geantyref.TypeToken;
 import java.lang.reflect.Type;
 import java.util.function.Predicate;
 import net.kyori.adventure.util.Index;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
 final class IndexSerializer<T> extends ScalarSerializer<T> {
   private final Index<String, T> idx;
 
-  IndexSerializer(final @NonNull TypeToken<T> type, final @NonNull Index<String, T> idx) {
+  IndexSerializer(final @NotNull TypeToken<T> type, final @NotNull Index<String, T> idx) {
     super(type);
     this.idx = idx;
   }
 
   @Override
-  public @NonNull T deserialize(final @NonNull Type type, final @NonNull Object obj) throws SerializationException {
+  public @NotNull T deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
     final T value = this.idx.value(obj.toString());
     if (value == null) {
       throw new SerializationException("No value for key '" + obj + "' in index for type " + this.type());
@@ -49,7 +49,7 @@ final class IndexSerializer<T> extends ScalarSerializer<T> {
   }
 
   @Override
-  public Object serialize(final @NonNull T item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final @NotNull T item, final @NotNull Predicate<Class<?>> typeSupported) {
     return this.idx.key(item);
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/KeySerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/KeySerializer.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Type;
 import java.util.function.Predicate;
 import net.kyori.adventure.key.InvalidKeyException;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.CoercionFailedException;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -40,7 +40,7 @@ final class KeySerializer extends ScalarSerializer<Key> {
   }
 
   @Override
-  public @NonNull Key deserialize(final @NonNull Type type, final @NonNull Object obj) throws SerializationException {
+  public @NotNull Key deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
     if (!(obj instanceof CharSequence)) {
       throw new CoercionFailedException(obj, "string");
     }
@@ -52,7 +52,7 @@ final class KeySerializer extends ScalarSerializer<Key> {
   }
 
   @Override
-  public @NonNull Object serialize(final @NonNull Key item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public @NotNull Object serialize(final @NotNull Key item, final @NotNull Predicate<Class<?>> typeSupported) {
     return item.asString();
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SoundSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SoundSerializer.java
@@ -26,8 +26,8 @@ package net.kyori.adventure.serializer.configurate4;
 import java.lang.reflect.Type;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -44,7 +44,7 @@ final class SoundSerializer implements TypeSerializer<Sound> {
   }
 
   @Override
-  public @Nullable Sound deserialize(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  public @Nullable Sound deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     if (value.empty()) {
       return null;
     }
@@ -62,7 +62,7 @@ final class SoundSerializer implements TypeSerializer<Sound> {
   }
 
   @Override
-  public void serialize(final @NonNull Type type, final @Nullable Sound obj, final @NonNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final @NotNull Type type, final @Nullable Sound obj, final @NotNull ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SoundStopSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SoundStopSerializer.java
@@ -28,8 +28,8 @@ import java.util.Collections;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -44,7 +44,7 @@ final class SoundStopSerializer implements TypeSerializer<SoundStop> {
   }
 
   @Override
-  public SoundStop deserialize(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  public SoundStop deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     if (value.empty()) {
       return SoundStop.all();
     } else {
@@ -59,7 +59,7 @@ final class SoundStopSerializer implements TypeSerializer<SoundStop> {
   }
 
   @Override
-  public void serialize(final @NonNull Type type, final @Nullable SoundStop obj, final @NonNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final @NotNull Type type, final @Nullable SoundStop obj, final @NotNull ConfigurationNode value) throws SerializationException {
     value.node(SOUND).set(Key.class, obj == null ? null : obj.sound());
     value.node(SOURCE).set(Sound.Source.class, obj == null ? null : obj.source());
     if (value.empty()) {

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/StyleSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/StyleSerializer.java
@@ -32,8 +32,8 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -60,7 +60,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
   }
 
   @Override
-  public @NonNull Style deserialize(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  public @NotNull Style deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     if (value.virtual()) {
       return Style.empty();
     }
@@ -126,7 +126,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
   }
 
   @Override
-  public void serialize(final @NonNull Type type, @Nullable Style obj, final @NonNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final @NotNull Type type, @Nullable Style obj, final @NotNull ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       obj = Style.empty();
     }
@@ -169,7 +169,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
     }
   }
 
-  private static <T> @NonNull T nonNull(final @Nullable T value, final @NonNull String type) throws SerializationException {
+  private static <T> @NotNull T nonNull(final @Nullable T value, final @NotNull String type) throws SerializationException {
     if (value == null) {
       throw new SerializationException(type + " was null in an unexpected location");
     }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TextColorSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TextColorSerializer.java
@@ -27,7 +27,7 @@ import java.lang.reflect.Type;
 import java.util.function.Predicate;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -40,7 +40,7 @@ final class TextColorSerializer extends ScalarSerializer<TextColor> {
   }
 
   @Override
-  public TextColor deserialize(final @NonNull Type type, final @NonNull Object obj) throws SerializationException {
+  public TextColor deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
     if (obj instanceof Number) { // numerical values
       return TextColor.color(((Number) obj).intValue());
     } else if (!(obj instanceof CharSequence)) {
@@ -60,7 +60,7 @@ final class TextColorSerializer extends ScalarSerializer<TextColor> {
   }
 
   @Override
-  public Object serialize(final @NonNull TextColor item, final @NonNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final @NotNull TextColor item, final @NotNull Predicate<Class<?>> typeSupported) {
     if (item instanceof NamedTextColor) { // TODO: Downsampling
       return NamedTextColor.NAMES.key((NamedTextColor) item);
     } else {

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TitleSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TitleSerializer.java
@@ -28,8 +28,8 @@ import java.time.Duration;
 import java.util.Objects;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -49,7 +49,7 @@ final class TitleSerializer implements TypeSerializer<Title> {
   static final String FADE_OUT = "fade-out";
 
   @Override
-  public @Nullable Title deserialize(final @NonNull Type type, final @NonNull ConfigurationNode value) throws SerializationException {
+  public @Nullable Title deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
     if (value.empty()) {
       return null;
     }
@@ -68,7 +68,7 @@ final class TitleSerializer implements TypeSerializer<Title> {
   }
 
   @Override
-  public void serialize(final @NonNull Type type, final @Nullable Title obj, final @NonNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final @NotNull Type type, final @Nullable Title obj, final @NotNull ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializer.java
+++ b/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializer.java
@@ -25,7 +25,7 @@ package net.kyori.adventure.text.serializer.gson.legacyimpl;
 
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.gson.LegacyHoverEventSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A legacy {@link HoverEvent} serializer.
@@ -39,7 +39,7 @@ public interface NBTLegacyHoverEventSerializer extends LegacyHoverEventSerialize
    * @return a legacy {@link HoverEvent} serializer
    * @since 4.3.0
    */
-  static @NonNull LegacyHoverEventSerializer get() {
+  static @NotNull LegacyHoverEventSerializer get() {
     return NBTLegacyHoverEventSerializerImpl.INSTANCE;
   }
 }

--- a/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
+++ b/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
@@ -34,8 +34,8 @@ import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.gson.LegacyHoverEventSerializer;
 import net.kyori.adventure.util.Codec;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSerializer {
   static final NBTLegacyHoverEventSerializerImpl INSTANCE = new NBTLegacyHoverEventSerializerImpl();
@@ -54,7 +54,7 @@ final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSeriali
   }
 
   @Override
-  public HoverEvent.@NonNull ShowItem deserializeShowItem(final @NonNull Component input) throws IOException {
+  public HoverEvent.@NotNull ShowItem deserializeShowItem(final @NotNull Component input) throws IOException {
     assertTextComponent(input);
     final CompoundBinaryTag contents = SNBT_CODEC.decode(((TextComponent) input).content());
     final CompoundBinaryTag tag = contents.getCompound(ITEM_TAG);
@@ -66,7 +66,7 @@ final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSeriali
   }
 
   @Override
-  public HoverEvent.@NonNull ShowEntity deserializeShowEntity(final @NonNull Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
+  public HoverEvent.@NotNull ShowEntity deserializeShowEntity(final @NotNull Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
     assertTextComponent(input);
     final CompoundBinaryTag contents = SNBT_CODEC.decode(((TextComponent) input).content());
     return HoverEvent.ShowEntity.of(
@@ -83,7 +83,7 @@ final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSeriali
   }
 
   @Override
-  public @NonNull Component serializeShowItem(final HoverEvent.@NonNull ShowItem input) throws IOException {
+  public @NotNull Component serializeShowItem(final HoverEvent.@NotNull ShowItem input) throws IOException {
     final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
       .putString(ITEM_TYPE, input.item().asString())
       .putByte(ITEM_COUNT, (byte) input.count());
@@ -95,7 +95,7 @@ final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSeriali
   }
 
   @Override
-  public @NonNull Component serializeShowEntity(final HoverEvent.@NonNull ShowEntity input, final Codec.Encoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
+  public @NotNull Component serializeShowEntity(final HoverEvent.@NotNull ShowEntity input, final Codec.Encoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
     final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
       .putString(ENTITY_ID, input.id().toString())
       .putString(ENTITY_TYPE, input.type().asString());

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
@@ -50,7 +50,7 @@ import net.kyori.adventure.text.StorageNBTComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.Style;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 final class ComponentSerializerImpl implements JsonDeserializer<Component>, JsonSerializer<Component> {
   static final String TEXT = "text";

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -31,9 +31,9 @@ import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A gson component serializer.
@@ -50,7 +50,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return a gson component serializer
    * @since 4.0.0
    */
-  static @NonNull GsonComponentSerializer gson() {
+  static @NotNull GsonComponentSerializer gson() {
     return GsonComponentSerializerImpl.Instances.INSTANCE;
   }
 
@@ -63,7 +63,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return a gson component serializer
    * @since 4.0.0
    */
-  static @NonNull GsonComponentSerializer colorDownsamplingGson() {
+  static @NotNull GsonComponentSerializer colorDownsamplingGson() {
     return GsonComponentSerializerImpl.Instances.LEGACY_INSTANCE;
   }
 
@@ -83,7 +83,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return a gson serializer
    * @since 4.0.0
    */
-  @NonNull Gson serializer();
+  @NotNull Gson serializer();
 
   /**
    * Gets the underlying gson populator.
@@ -91,7 +91,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return a gson populator
    * @since 4.0.0
    */
-  @NonNull UnaryOperator<GsonBuilder> populator();
+  @NotNull UnaryOperator<GsonBuilder> populator();
 
   /**
    * Deserialize a component from input of type {@link JsonElement}.
@@ -100,7 +100,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return the component
    * @since 4.7.0
    */
-  @NonNull Component deserializeFromTree(final @NonNull JsonElement input);
+  @NotNull Component deserializeFromTree(final @NotNull JsonElement input);
 
   /**
    * Deserialize a component to output of type {@link JsonElement}.
@@ -109,7 +109,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
    * @return the json element
    * @since 4.7.0
    */
-  @NonNull JsonElement serializeToTree(final @NonNull Component component);
+  @NotNull JsonElement serializeToTree(final @NotNull Component component);
 
   /**
    * A builder for {@link GsonComponentSerializer}.
@@ -123,7 +123,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder downsampleColors();
+    @NotNull Builder downsampleColors();
 
     /**
      * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
@@ -134,7 +134,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
+    @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
 
     /**
      * Output a legacy hover event {@code value} in addition to the modern {@code contents}.
@@ -145,7 +145,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder emitLegacyHoverEvent();
+    @NotNull Builder emitLegacyHoverEvent();
 
     /**
      * Builds the serializer.
@@ -153,7 +153,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @return the built serializer
      */
     @Override
-    @NonNull GsonComponentSerializer build();
+    @NotNull GsonComponentSerializer build();
   }
 
   /**
@@ -170,7 +170,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @since 4.8.0
      */
     @ApiStatus.Internal
-    @NonNull GsonComponentSerializer gson();
+    @NotNull GsonComponentSerializer gson();
 
     /**
      * Provides a legacy {@link GsonComponentSerializer}.
@@ -179,7 +179,7 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @since 4.8.0
      */
     @ApiStatus.Internal
-    @NonNull GsonComponentSerializer gsonLegacy();
+    @NotNull GsonComponentSerializer gsonLegacy();
 
     /**
      * Completes the building process of {@link Builder}.
@@ -188,6 +188,6 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @since 4.8.0
      */
     @ApiStatus.Internal
-    @NonNull Consumer<Builder> builder();
+    @NotNull Consumer<Builder> builder();
   }
 }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -38,8 +38,8 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.Services;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   private static final Optional<Provider> SERVICE = Services.service(Provider.class);
@@ -87,41 +87,41 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   }
 
   @Override
-  public @NonNull Gson serializer() {
+  public @NotNull Gson serializer() {
     return this.serializer;
   }
 
   @Override
-  public @NonNull UnaryOperator<GsonBuilder> populator() {
+  public @NotNull UnaryOperator<GsonBuilder> populator() {
     return this.populator;
   }
 
   @Override
-  public @NonNull Component deserialize(final @NonNull String string) {
+  public @NotNull Component deserialize(final @NotNull String string) {
     final Component component = this.serializer().fromJson(string, Component.class);
     if (component == null) throw ComponentSerializerImpl.notSureHowToDeserialize(string);
     return component;
   }
 
   @Override
-  public @NonNull String serialize(final @NonNull Component component) {
+  public @NotNull String serialize(final @NotNull Component component) {
     return this.serializer().toJson(component);
   }
 
   @Override
-  public @NonNull Component deserializeFromTree(final @NonNull JsonElement input) {
+  public @NotNull Component deserializeFromTree(final @NotNull JsonElement input) {
     final Component component = this.serializer().fromJson(input, Component.class);
     if (component == null) throw ComponentSerializerImpl.notSureHowToDeserialize(input);
     return component;
   }
 
   @Override
-  public @NonNull JsonElement serializeToTree(final @NonNull Component component) {
+  public @NotNull JsonElement serializeToTree(final @NotNull Component component) {
     return this.serializer().toJsonTree(component);
   }
 
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -142,25 +142,25 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
     }
 
     @Override
-    public @NonNull Builder downsampleColors() {
+    public @NotNull Builder downsampleColors() {
       this.downsampleColor = true;
       return this;
     }
 
     @Override
-    public @NonNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer) {
+    public @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer) {
       this.legacyHoverSerializer = serializer;
       return this;
     }
 
     @Override
-    public @NonNull Builder emitLegacyHoverEvent() {
+    public @NotNull Builder emitLegacyHoverEvent() {
       this.emitLegacyHover = true;
       return this;
     }
 
     @Override
-    public @NonNull GsonComponentSerializer build() {
+    public @NotNull GsonComponentSerializer build() {
       if (this.legacyHoverSerializer == null) {
         return this.downsampleColor ? Instances.LEGACY_INSTANCE : Instances.INSTANCE;
       } else {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/LegacyHoverEventSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/LegacyHoverEventSerializer.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.util.Codec;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Adapter to convert between modern and legacy hover event formats.
@@ -43,7 +43,7 @@ public interface LegacyHoverEventSerializer {
    * @throws IOException if the input is improperly formatted
    * @since 4.0.0
    */
-  HoverEvent.@NonNull ShowItem deserializeShowItem(final @NonNull Component input) throws IOException;
+  HoverEvent.@NotNull ShowItem deserializeShowItem(final @NotNull Component input) throws IOException;
 
   /**
    * Convert a legacy hover event {@code show_entity} value to its modern format.
@@ -54,7 +54,7 @@ public interface LegacyHoverEventSerializer {
    * @throws IOException if the input is improperly formatted
    * @since 4.0.0
    */
-  HoverEvent.@NonNull ShowEntity deserializeShowEntity(final @NonNull Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentDecoder) throws IOException;
+  HoverEvent.@NotNull ShowEntity deserializeShowEntity(final @NotNull Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentDecoder) throws IOException;
 
   /**
    * Convert a modern hover event {@code show_item} value to its legacy format.
@@ -64,7 +64,7 @@ public interface LegacyHoverEventSerializer {
    * @throws IOException if the input is improperly formatted
    * @since 4.0.0
    */
-  @NonNull Component serializeShowItem(final HoverEvent.@NonNull ShowItem input) throws IOException;
+  @NotNull Component serializeShowItem(final HoverEvent.@NotNull ShowItem input) throws IOException;
 
   /**
    * Convert a modern hover event {@code show_entity} value to its legacy format.
@@ -75,5 +75,5 @@ public interface LegacyHoverEventSerializer {
    * @throws IOException if the input is improperly formatted
    * @since 4.0.0
    */
-  @NonNull Component serializeShowEntity(final HoverEvent.@NonNull ShowEntity input, final Codec.Encoder<Component, String, ? extends RuntimeException> componentEncoder) throws IOException;
+  @NotNull Component serializeShowEntity(final HoverEvent.@NotNull ShowEntity input, final Codec.Encoder<Component, String, ? extends RuntimeException> componentEncoder) throws IOException;
 }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowEntitySerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowEntitySerializer.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 final class ShowEntitySerializer implements JsonDeserializer<HoverEvent.ShowEntity>, JsonSerializer<HoverEvent.ShowEntity> {
   static final String TYPE = "type";

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
@@ -34,7 +34,7 @@ import java.lang.reflect.Type;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 final class ShowItemSerializer implements JsonDeserializer<HoverEvent.ShowItem>, JsonSerializer<HoverEvent.ShowItem> {
   static final String ID = "id";

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -48,7 +48,7 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.Codec;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 final class StyleSerializer implements JsonDeserializer<Style>, JsonSerializer<Style> {
   @SuppressWarnings("checkstyle:NoWhitespaceAfter")

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorSerializer.java
@@ -29,8 +29,8 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class TextColorSerializer extends TypeAdapter<TextColor> {
   static final TypeAdapter<TextColor> INSTANCE = new TextColorSerializer(false).nullSafe();
@@ -61,7 +61,7 @@ final class TextColorSerializer extends TypeAdapter<TextColor> {
     return this.downsampleColor ? NamedTextColor.nearestTo(color) : color;
   }
 
-  static @Nullable TextColor fromString(final @NonNull String value) {
+  static @Nullable TextColor fromString(final @NotNull String value) {
     if (value.startsWith("#")) {
       return TextColor.fromHexString(value);
     } else {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorWrapper.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorWrapper.java
@@ -31,7 +31,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /*
  * This is a hack.

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -33,9 +33,9 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A legacy component serializer.
@@ -56,7 +56,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return a component serializer for legacy serialization and deserialization
    * @since 4.0.0
    */
-  static @NonNull LegacyComponentSerializer legacySection() {
+  static @NotNull LegacyComponentSerializer legacySection() {
     return LegacyComponentSerializerImpl.Instances.SECTION;
   }
 
@@ -70,7 +70,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return a component serializer for legacy serialization and deserialization
    * @since 4.0.0
    */
-  static @NonNull LegacyComponentSerializer legacyAmpersand() {
+  static @NotNull LegacyComponentSerializer legacyAmpersand() {
     return LegacyComponentSerializerImpl.Instances.AMPERSAND;
   }
 
@@ -83,7 +83,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return a component serializer for legacy serialization and deserialization
    * @since 4.0.0
    */
-  static @NonNull LegacyComponentSerializer legacy(final char legacyCharacter) {
+  static @NotNull LegacyComponentSerializer legacy(final char legacyCharacter) {
     if (legacyCharacter == SECTION_CHAR) {
       return legacySection();
     } else if (legacyCharacter == AMPERSAND_CHAR) {
@@ -109,7 +109,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return the builder
    * @since 4.0.0
    */
-  static @NonNull Builder builder() {
+  static @NotNull Builder builder() {
     return new LegacyComponentSerializerImpl.BuilderImpl();
   }
 
@@ -141,7 +141,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return the component
    */
   @Override
-  @NonNull TextComponent deserialize(final @NonNull String input);
+  @NotNull TextComponent deserialize(final @NotNull String input);
 
   /**
    * Serializes a component into a legacy {@link String}.
@@ -150,7 +150,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return the string
    */
   @Override
-  @NonNull String serialize(final @NonNull Component component);
+  @NotNull String serialize(final @NotNull Component component);
 
   /**
    * A builder for {@link LegacyComponentSerializer}.
@@ -165,7 +165,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder character(final char legacyCharacter);
+    @NotNull Builder character(final char legacyCharacter);
 
     /**
      * Sets the legacy hex character used by the serializer.
@@ -174,7 +174,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder hexCharacter(final char legacyHexCharacter);
+    @NotNull Builder hexCharacter(final char legacyHexCharacter);
 
     /**
      * Sets that the serializer should extract URLs into {@link ClickEvent}s
@@ -183,7 +183,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder extractUrls();
+    @NotNull Builder extractUrls();
 
     /**
      * Sets that the serializer should extract URLs into {@link ClickEvent}s
@@ -193,7 +193,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.2.0
      */
-    @NonNull Builder extractUrls(final @NonNull Pattern pattern);
+    @NotNull Builder extractUrls(final @NotNull Pattern pattern);
 
     /**
      * Sets that the serializer should extract URLs into {@link ClickEvent}s
@@ -203,7 +203,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder extractUrls(final @Nullable Style style);
+    @NotNull Builder extractUrls(final @Nullable Style style);
 
     /**
      * Sets that the serializer should extract URLs into {@link ClickEvent}s
@@ -213,7 +213,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.2.0
      */
-    @NonNull Builder extractUrls(final @NonNull Pattern pattern, final @Nullable Style style);
+    @NotNull Builder extractUrls(final @NotNull Pattern pattern, final @Nullable Style style);
 
     /**
      * Sets that the serializer should support hex colors.
@@ -223,7 +223,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder hexColors();
+    @NotNull Builder hexColors();
 
     /**
      * Sets that the serializer should use the '&amp;x' repeated code format when serializing hex
@@ -242,7 +242,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NonNull Builder useUnusualXRepeatedCharacterHexFormat();
+    @NotNull Builder useUnusualXRepeatedCharacterHexFormat();
 
     /**
      * Use this component flattener to convert components into plain text.
@@ -253,7 +253,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.7.0
      */
-    @NonNull Builder flattener(final @NonNull ComponentFlattener flattener);
+    @NotNull Builder flattener(final @NotNull ComponentFlattener flattener);
 
     /**
      * Builds the serializer.
@@ -261,7 +261,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return the built serializer
      */
     @Override
-    @NonNull LegacyComponentSerializer build();
+    @NotNull LegacyComponentSerializer build();
   }
 
   /**
@@ -278,7 +278,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @since 4.8.0
      */
     @ApiStatus.Internal
-    @NonNull LegacyComponentSerializer legacyAmpersand();
+    @NotNull LegacyComponentSerializer legacyAmpersand();
 
     /**
      * Provides a {@link LegacyComponentSerializer} using {@link #SECTION_CHAR}.
@@ -287,7 +287,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @since 4.8.0
      */
     @ApiStatus.Internal
-    @NonNull LegacyComponentSerializer legacySection();
+    @NotNull LegacyComponentSerializer legacySection();
 
     /**
      * Completes the building process of {@link Builder}.
@@ -296,6 +296,6 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @since 4.8.0
      */
     @ApiStatus.Internal
-    @NonNull Consumer<Builder> legacy();
+    @NotNull Consumer<Builder> legacy();
   }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -46,8 +46,8 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.format.TextFormat;
 import net.kyori.adventure.util.Services;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -238,7 +238,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   }
 
   @Override
-  public @NonNull TextComponent deserialize(final @NonNull String input) {
+  public @NotNull TextComponent deserialize(final @NotNull String input) {
     int next = input.lastIndexOf(this.character, input.length() - 2);
     if (next == -1) {
       return this.extractUrl(Component.text(input));
@@ -301,13 +301,13 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   }
 
   @Override
-  public @NonNull String serialize(final @NonNull Component component) {
+  public @NotNull String serialize(final @NotNull Component component) {
     final Cereal state = new Cereal();
     this.flattener.flatten(component, state);
     return state.toString();
   }
 
-  private static boolean applyFormat(final TextComponent.@NonNull Builder builder, final @NonNull TextFormat format) {
+  private static boolean applyFormat(final TextComponent.@NotNull Builder builder, final @NotNull TextFormat format) {
     if (format instanceof TextColor) {
       builder.colorIfAbsent((TextColor) format);
       return true;
@@ -321,7 +321,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   }
 
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -338,7 +338,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     private int head = -1;
 
     @Override
-    public void pushStyle(final @NonNull Style pushed) {
+    public void pushStyle(final @NotNull Style pushed) {
       final int idx = ++this.head;
       if (idx >= this.styles.length) {
         this.styles = Arrays.copyOf(this.styles, this.styles.length * 2);
@@ -361,7 +361,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public void component(final @NonNull String text) {
+    public void component(final @NotNull String text) {
       if (!text.isEmpty()) {
         if (this.head < 0) throw new IllegalStateException("No style has been pushed!");
 
@@ -371,13 +371,13 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public void popStyle(final @NonNull Style style) {
+    public void popStyle(final @NotNull Style style) {
       if (this.head-- < 0) {
         throw new IllegalStateException("Tried to pop beyond what was pushed!");
       }
     }
 
-    void append(final @NonNull TextFormat format) {
+    void append(final @NotNull TextFormat format) {
       if (this.lastWritten != format) {
         this.sb.append(LegacyComponentSerializerImpl.this.character).append(LegacyComponentSerializerImpl.this.toLegacyCode(format));
       }
@@ -398,7 +398,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         this.decorations = EnumSet.noneOf(TextDecoration.class);
       }
 
-      void set(final @NonNull StyleState that) {
+      void set(final @NotNull StyleState that) {
         this.color = that.color;
         this.decorations.clear();
         this.decorations.addAll(that.decorations);
@@ -409,7 +409,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         this.decorations.clear();
       }
 
-      void apply(final @NonNull Style component) {
+      void apply(final @NotNull Style component) {
         final TextColor color = component.color();
         if (color != null) {
           this.color = color;
@@ -491,7 +491,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
       BUILDER.accept(this); // let service provider touch the builder before anybody else touches it
     }
 
-    BuilderImpl(final @NonNull LegacyComponentSerializerImpl serializer) {
+    BuilderImpl(final @NotNull LegacyComponentSerializerImpl serializer) {
       this();
       this.character = serializer.character;
       this.hexCharacter = serializer.hexCharacter;
@@ -501,34 +501,34 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public @NonNull Builder character(final char legacyCharacter) {
+    public @NotNull Builder character(final char legacyCharacter) {
       this.character = legacyCharacter;
       return this;
     }
 
     @Override
-    public @NonNull Builder hexCharacter(final char legacyHexCharacter) {
+    public @NotNull Builder hexCharacter(final char legacyHexCharacter) {
       this.hexCharacter = legacyHexCharacter;
       return this;
     }
 
     @Override
-    public @NonNull Builder extractUrls() {
+    public @NotNull Builder extractUrls() {
       return this.extractUrls(DEFAULT_URL_PATTERN, null);
     }
 
     @Override
-    public @NonNull Builder extractUrls(final @NonNull Pattern pattern) {
+    public @NotNull Builder extractUrls(final @NotNull Pattern pattern) {
       return this.extractUrls(pattern, null);
     }
 
     @Override
-    public @NonNull Builder extractUrls(final @Nullable Style style) {
+    public @NotNull Builder extractUrls(final @Nullable Style style) {
       return this.extractUrls(DEFAULT_URL_PATTERN, style);
     }
 
     @Override
-    public @NonNull Builder extractUrls(final @NonNull Pattern pattern, final @Nullable Style style) {
+    public @NotNull Builder extractUrls(final @NotNull Pattern pattern, final @Nullable Style style) {
       requireNonNull(pattern, "pattern");
       this.urlReplacementConfig = TextReplacementConfig.builder()
         .match(pattern)
@@ -544,25 +544,25 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public @NonNull Builder hexColors() {
+    public @NotNull Builder hexColors() {
       this.hexColours = true;
       return this;
     }
 
     @Override
-    public @NonNull Builder useUnusualXRepeatedCharacterHexFormat() {
+    public @NotNull Builder useUnusualXRepeatedCharacterHexFormat() {
       this.useTerriblyStupidHexFormat = true; // :(
       return this;
     }
 
     @Override
-    public @NonNull Builder flattener(final @NonNull ComponentFlattener flattener) {
+    public @NotNull Builder flattener(final @NotNull ComponentFlattener flattener) {
       this.flattener = requireNonNull(flattener, "flattener");
       return this;
     }
 
     @Override
-    public @NonNull LegacyComponentSerializer build() {
+    public @NotNull LegacyComponentSerializer build() {
       return new LegacyComponentSerializerImpl(this.character, this.hexCharacter, this.urlReplacementConfig, this.hexColours, this.useTerriblyStupidHexFormat, this.flattener);
     }
   }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java
@@ -30,8 +30,8 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /*
  * This is a hack.
@@ -117,7 +117,7 @@ public final class LegacyFormat implements Examinable {
   }
 
   @Override
-  public @NonNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("color", this.color),
       ExaminableProperty.of("decoration", this.decoration),

--- a/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainComponentSerializer.java
+++ b/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainComponentSerializer.java
@@ -33,8 +33,8 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A plain component serializer.
@@ -55,7 +55,7 @@ public class PlainComponentSerializer implements ComponentSerializer<Component, 
    * @since 4.0.0
    */
   @Deprecated
-  public static @NonNull PlainComponentSerializer plain() {
+  public static @NotNull PlainComponentSerializer plain() {
     return PlainComponentSerializerImpl.INSTANCE;
   }
 
@@ -67,7 +67,7 @@ public class PlainComponentSerializer implements ComponentSerializer<Component, 
    * @since 4.7.0
    */
   @Deprecated
-  public static PlainComponentSerializer.@NonNull Builder builder() {
+  public static PlainComponentSerializer.@NotNull Builder builder() {
     return new PlainComponentSerializerImpl.BuilderImpl();
   }
 
@@ -98,17 +98,17 @@ public class PlainComponentSerializer implements ComponentSerializer<Component, 
   }
 
   @Deprecated
-  PlainComponentSerializer(final @NonNull PlainTextComponentSerializer serializer) {
+  PlainComponentSerializer(final @NotNull PlainTextComponentSerializer serializer) {
     this.serializer = serializer;
   }
 
   @Override
-  public @NonNull TextComponent deserialize(final @NonNull String input) {
+  public @NotNull TextComponent deserialize(final @NotNull String input) {
     return this.serializer.deserialize(input);
   }
 
   @Override
-  public @NonNull String serialize(final @NonNull Component component) {
+  public @NotNull String serialize(final @NotNull Component component) {
     return this.serializer.serialize(component);
   }
 
@@ -121,12 +121,12 @@ public class PlainComponentSerializer implements ComponentSerializer<Component, 
    * @since 4.0.0
    */
   @Deprecated
-  public void serialize(final @NonNull StringBuilder sb, final @NonNull Component component) {
+  public void serialize(final @NotNull StringBuilder sb, final @NotNull Component component) {
     this.serializer.serialize(sb, component);
   }
 
   @Override
-  public PlainComponentSerializer.@NonNull Builder toBuilder() {
+  public PlainComponentSerializer.@NotNull Builder toBuilder() {
     return new PlainComponentSerializerImpl.BuilderImpl(this);
   }
 
@@ -149,6 +149,6 @@ public class PlainComponentSerializer implements ComponentSerializer<Component, 
      * @since 4.7.0
      */
     @Deprecated
-    @NonNull Builder flattener(final @NonNull ComponentFlattener flattener);
+    @NotNull Builder flattener(final @NotNull ComponentFlattener flattener);
   }
 }

--- a/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainComponentSerializerImpl.java
+++ b/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainComponentSerializerImpl.java
@@ -27,8 +27,8 @@ import java.util.function.Function;
 import net.kyori.adventure.text.KeybindComponent;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Deprecated
 final class PlainComponentSerializerImpl {
@@ -66,13 +66,13 @@ final class PlainComponentSerializerImpl {
     }
 
     @Override
-    public PlainComponentSerializer.@NonNull Builder flattener(final @NonNull ComponentFlattener flattener) {
+    public PlainComponentSerializer.@NotNull Builder flattener(final @NotNull ComponentFlattener flattener) {
       this.builder.flattener(flattener);
       return this;
     }
 
     @Override
-    public @NonNull PlainComponentSerializer build() {
+    public @NotNull PlainComponentSerializer build() {
       return new PlainComponentSerializer(this.builder.build());
     }
   }

--- a/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializer.java
+++ b/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializer.java
@@ -31,8 +31,8 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A plain-text component serializer.
@@ -49,7 +49,7 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
    * @return serializer instance
    * @since 4.8.0
    */
-  static @NonNull PlainTextComponentSerializer plainText() {
+  static @NotNull PlainTextComponentSerializer plainText() {
     return PlainTextComponentSerializerImpl.Instances.INSTANCE;
   }
 
@@ -59,17 +59,17 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
    * @return a new plain serializer builder
    * @since 4.8.0
    */
-  static PlainTextComponentSerializer.@NonNull Builder builder() {
+  static PlainTextComponentSerializer.@NotNull Builder builder() {
     return new PlainTextComponentSerializerImpl.BuilderImpl();
   }
 
   @Override
-  default @NonNull TextComponent deserialize(final @NonNull String input) {
+  default @NotNull TextComponent deserialize(final @NotNull String input) {
     return Component.text(input);
   }
 
   @Override
-  default @NonNull String serialize(final @NonNull Component component) {
+  default @NotNull String serialize(final @NotNull Component component) {
     final StringBuilder sb = new StringBuilder();
     this.serialize(sb, component);
     return sb.toString();
@@ -82,7 +82,7 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
    * @param component the component
    * @since 4.8.0
    */
-  void serialize(final @NonNull StringBuilder sb, final @NonNull Component component);
+  void serialize(final @NotNull StringBuilder sb, final @NotNull Component component);
 
   /**
    * A builder for the plain-text component serializer.
@@ -99,7 +99,7 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
      * @return this builder
      * @since 4.8.0
      */
-    @NonNull Builder flattener(final @NonNull ComponentFlattener flattener);
+    @NotNull Builder flattener(final @NotNull ComponentFlattener flattener);
   }
 
   /**
@@ -116,7 +116,7 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
      * @since 4.8.0
      */
     @ApiStatus.Internal
-    @NonNull PlainTextComponentSerializer plainTextSimple();
+    @NotNull PlainTextComponentSerializer plainTextSimple();
 
     /**
      * Completes the building process of {@link Builder}.
@@ -125,6 +125,6 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
      * @since 4.8.0
      */
     @ApiStatus.Internal
-    @NonNull Consumer<Builder> plainText();
+    @NotNull Consumer<Builder> plainText();
   }
 }

--- a/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializerImpl.java
+++ b/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializerImpl.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.util.Services;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -58,12 +58,12 @@ final class PlainTextComponentSerializerImpl implements PlainTextComponentSerial
   }
 
   @Override
-  public void serialize(final @NonNull StringBuilder sb, final @NonNull Component component) {
+  public void serialize(final @NotNull StringBuilder sb, final @NotNull Component component) {
     this.flattener.flatten(requireNonNull(component, "component"), sb::append);
   }
 
   @Override
-  public @NonNull Builder toBuilder() {
+  public @NotNull Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -80,13 +80,13 @@ final class PlainTextComponentSerializerImpl implements PlainTextComponentSerial
     }
 
     @Override
-    public PlainTextComponentSerializer.@NonNull Builder flattener(final @NonNull ComponentFlattener flattener) {
+    public PlainTextComponentSerializer.@NotNull Builder flattener(final @NotNull ComponentFlattener flattener) {
       this.flattener = requireNonNull(flattener, "flattener");
       return this;
     }
 
     @Override
-    public @NonNull PlainTextComponentSerializer build() {
+    public @NotNull PlainTextComponentSerializer build() {
       return new PlainTextComponentSerializerImpl(this.flattener);
     }
   }


### PR DESCRIPTION
Closes #386.

This also removes the compile only dependencies on checker qual, not sure if these should be left until a breaking release or not.

Some points of note:
- Some `@Nullable` annotations were added where they were missing in equals overrides.
- There is no replacement for `@MonotonicNonNull` or `@PolyNull`. Both have been replaced with `@Nullable` annotations with appropriate `@Contract` annotations for poly null methods.