### PR TITLE
api: Add Pointer query to Single

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -182,6 +182,16 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
+    default <T> @PolyNull T getOrDefault(final @NonNull Pointer<T> pointer, final @PolyNull T defaultValue) {
+      return this.audience().getOrDefault(pointer, defaultValue);
+    }
+
+    @Override
+    default <T> @PolyNull T getOrDefaultFrom(final @NonNull Pointer<T> pointer, final @NonNull Supplier<? extends T> defaultValue) {
+      return this.audience().getOrDefaultFrom(pointer, defaultValue);
+    }
+
+    @Override
     default void sendMessage(final @NonNull Identified source, final @NonNull Component message, final @NonNull MessageType type) {
       this.audience().sendMessage(source, message, type);
     }


### PR DESCRIPTION
Hello! I may be misunderstanding this interface, but I believe Single should be inheriting the `Pointered` methods from its `audience()`, rather than its super class.

Basically, `Single#getOrDefault` is currently inherited from ForwardingAudience which always returns the default rather than redirecting the query to `this.audience()`. This fixes that.