### PR TITLE
build: Apply contract-validator to ensure contract annotations are syntactically valid

### DIFF
--- a/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 }
 
 dependencies {
+  annotationProcessor("ca.stellardrift:contract-validator:1.0.0") // https://github.com/zml2008/contract-validator
   api(platform(project(":adventure-bom")))
   checkstyle("ca.stellardrift:stylecheck:0.1")
   testImplementation("com.google.guava:guava-testlib:30.1.1-jre")


### PR DESCRIPTION
This doesn't verify that the contracts say the right thing, but it does ensure that they are well-formed and applicable to the method's argument types.

See https://github.com/zml2008/contract-validator for the project used