### PR TITLE
Make Gradle automatically copy JD to the appropriate location for JD repo

### DIFF
--- a/build-logic/src/main/kotlin/CopyJavadoc.kt
+++ b/build-logic/src/main/kotlin/CopyJavadoc.kt
@@ -1,0 +1,71 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import java.io.File
+import javax.inject.Inject
+
+private const val ADVENTURE_PREFIX = "adventure-"
+
+/**
+ * Copy project javadoc into the `adventure-javadoc` directory tree
+ */
+abstract class CopyJavadoc : DefaultTask() {
+  @get:Input
+  abstract val projectName: Property<String>
+
+  @get:Input
+  abstract val projectVersion: Property<String>
+
+  @get:InputFiles
+  abstract val javadocFiles: ConfigurableFileCollection
+
+  @get:Internal
+  abstract val rootDir: DirectoryProperty
+
+  @get:Internal
+  @get:Option(option="output", description="The root of the adventure-javadocs repository")
+  abstract val output: Property<String>
+
+  @get:OutputDirectory
+  abstract val outputDir: DirectoryProperty
+
+  @get:Inject
+  protected abstract val fsOps: FileSystemOperations
+
+  init {
+    // relative to project root, <output>/<projectName>/<projectVersion>
+    outputDir.set(rootDir.dir(output).flatMap { it.dir(this.projectName.map(this::filterProjectName)).flatMap { it.dir(this.projectVersion) } })
+  }
+
+  @TaskAction
+  fun doTransfer() {
+    val dest = outputDir.get().asFile // rootDir.get().asFile.resolve(this.output.get())
+      // .resolve(this.filterProjectName(this.projectName.get()))
+      //.resolve(this.projectVersion.get())
+
+    dest.deleteRecursively()
+    dest.mkdirs()
+
+    fsOps.copy {
+      from(javadocFiles)
+      into(dest)
+    }
+  }
+
+  private fun filterProjectName(name: String): String {
+    return if (name.startsWith(ADVENTURE_PREFIX)) {
+      name.substring(ADVENTURE_PREFIX.length, name.length)
+    } else {
+      name
+    }
+  }
+}

--- a/build-logic/src/main/kotlin/CopyJavadoc.kt
+++ b/build-logic/src/main/kotlin/CopyJavadoc.kt
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.options.Option
 import java.io.File
 import javax.inject.Inject
 
-private const val ADVENTURE_PREFIX = "adventure-"
+internal const val ADVENTURE_PREFIX = "adventure-"
 
 /**
  * Copy project javadoc into the `adventure-javadoc` directory tree
@@ -43,14 +43,12 @@ abstract class CopyJavadoc : DefaultTask() {
 
   init {
     // relative to project root, <output>/<projectName>/<projectVersion>
-    outputDir.set(rootDir.dir(output).flatMap { it.dir(this.projectName.map(this::filterProjectName)).flatMap { it.dir(this.projectVersion) } })
+    outputDir.set(rootDir.dir(output).flatMap { it.dir(this.projectName).flatMap { it.dir(this.projectVersion) } })
   }
 
   @TaskAction
   fun doTransfer() {
-    val dest = outputDir.get().asFile // rootDir.get().asFile.resolve(this.output.get())
-      // .resolve(this.filterProjectName(this.projectName.get()))
-      //.resolve(this.projectVersion.get())
+    val dest = outputDir.get().asFile
 
     dest.deleteRecursively()
     dest.mkdirs()
@@ -58,14 +56,6 @@ abstract class CopyJavadoc : DefaultTask() {
     fsOps.copy {
       from(javadocFiles)
       into(dest)
-    }
-  }
-
-  private fun filterProjectName(name: String): String {
-    return if (name.startsWith(ADVENTURE_PREFIX)) {
-      name.substring(ADVENTURE_PREFIX.length, name.length)
-    } else {
-      name
     }
   }
 }

--- a/build-logic/src/main/kotlin/CopyJavadoc.kt
+++ b/build-logic/src/main/kotlin/CopyJavadoc.kt
@@ -1,16 +1,37 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
-import java.io.File
 import javax.inject.Inject
 
 internal const val ADVENTURE_PREFIX = "adventure-"

--- a/build-logic/src/main/kotlin/JavadocPackaging.kt
+++ b/build-logic/src/main/kotlin/JavadocPackaging.kt
@@ -1,9 +1,32 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 import org.gradle.api.Named
 import org.gradle.api.attributes.Attribute
 
 interface JavadocPackaging : Named {
   companion object {
-    val ATTRIBUTE = Attribute.of("net.kyori.javadoc.packaging", JavadocPackaging::class.java)
+    val ATTRIBUTE: Attribute<JavadocPackaging> = Attribute.of("net.kyori.javadoc.packaging", JavadocPackaging::class.java)
 
     const val ARCHIVE = "archive"
     const val DIRECTORY = "directory"

--- a/build-logic/src/main/kotlin/JavadocPackaging.kt
+++ b/build-logic/src/main/kotlin/JavadocPackaging.kt
@@ -1,0 +1,11 @@
+import org.gradle.api.Named
+import org.gradle.api.attributes.Attribute
+
+interface JavadocPackaging : Named {
+  companion object {
+    val ATTRIBUTE = Attribute.of("net.kyori.javadoc.packaging", JavadocPackaging::class.java)
+
+    const val ARCHIVE = "archive"
+    const val DIRECTORY = "directory"
+  }
+}

--- a/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
@@ -73,10 +73,10 @@ dependencies {
 }
 
 fun filterProjectName(name: String): String {
-  return if (name.startsWith(ADVENTURE_PREFIX)) {
-    name.substring(ADVENTURE_PREFIX.length, name.length)
+  if (name.startsWith(ADVENTURE_PREFIX)) {
+    return name.substring(ADVENTURE_PREFIX.length, name.length)
   } else {
-    name
+    return name
   }
 }
 

--- a/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
@@ -40,4 +40,11 @@ tasks {
     val options = options as? StandardJavadocDocletOptions ?: return@javadoc
     options.tags("sinceMinecraft:a:Since Minecraft:")
   }
+
+  register("copyJavadoc", CopyJavadoc::class) {
+    projectName.set(provider { project.name })
+    projectVersion.set(provider { project.version.toString() })
+    javadocFiles.from(javadoc)
+    rootDir.set(project.rootDir)
+  }
 }

--- a/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
@@ -13,8 +13,41 @@ testlogger {
   showPassed = false
 }
 
-configurations.testCompileClasspath {
-  exclude(group = "junit") // brought in by google's libs
+configurations {
+  testCompileClasspath {
+    exclude(group = "junit") // brought in by google's libs
+  }
+
+  // Register unpacked Javadoc as an artifact for cross-linking
+  javadocElements {
+    outgoing {
+      variants {
+        create("files") {
+          artifact(tasks.javadoc.map { it.destinationDir!! }) {
+            builtBy(tasks.javadoc)
+          }
+          attributes {
+            attribute(JavadocPackaging.ATTRIBUTE, objects.named(JavadocPackaging.DIRECTORY))
+          }
+        }
+      }
+    }
+  }
+}
+
+// Resolve JD for cross-linking between modules
+val offlineLinkedJavadoc = configurations.register("offlineLinkedJavadoc") {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+
+  attributes {
+    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+    attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.JAVADOC))
+    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+    attribute(JavadocPackaging.ATTRIBUTE, objects.named(JavadocPackaging.DIRECTORY))
+  }
+  extendsFrom(configurations.runtimeElements.get())
 }
 
 repositories {
@@ -23,6 +56,10 @@ repositories {
 }
 
 dependencies {
+  attributesSchema {
+    attribute(JavadocPackaging.ATTRIBUTE)
+  }
+
   annotationProcessor("ca.stellardrift:contract-validator:1.0.0") // https://github.com/zml2008/contract-validator
   api(platform(project(":adventure-bom")))
   checkstyle("ca.stellardrift:stylecheck:0.1")
@@ -35,14 +72,47 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
 }
 
+fun filterProjectName(name: String): String {
+  return if (name.startsWith(ADVENTURE_PREFIX)) {
+    name.substring(ADVENTURE_PREFIX.length, name.length)
+  } else {
+    name
+  }
+}
+
 tasks {
+  // link to modules in project
+  val jdLinks = offlineLinkedJavadoc.get().incoming
+    .artifactView {
+      componentFilter { it is ProjectComponentIdentifier } // only in-project
+      isLenient = true // ignore artifacts with no javadoc elements variant
+    }
+  val version = project.version
   javadoc {
+    inputs.property("project.version", version)
+    inputs.files(jdLinks.files)
+      .ignoreEmptyDirectories()
+      .withPropertyName("jdLinks")
+
     val options = options as? StandardJavadocDocletOptions ?: return@javadoc
     options.tags("sinceMinecraft:a:Since Minecraft:")
+
+    doFirst {
+      jdLinks.artifacts.forEach {
+        val file = it.file
+        val projectName = (it.id.componentIdentifier as ProjectComponentIdentifier).projectName
+        if (!file.isDirectory) {
+          logger.warn("Failed to link to Javadoc in $file (for $projectName) because it was not a directory")
+        }
+
+        // This matches the file structure in adventure-javadocs
+        options.linksOffline("../../${filterProjectName(projectName)}/$version", file.absolutePath)
+      }
+    }
   }
 
   register("copyJavadoc", CopyJavadoc::class) {
-    projectName.set(provider { project.name })
+    projectName.set(provider { filterProjectName(project.name) })
     projectVersion.set(provider { project.version.toString() })
     javadocFiles.from(javadoc)
     rootDir.set(project.rootDir)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.configureondemand=true
 org.gradle.parallel=true
+
+javadocPublishRoot=https://jd.adventure.kyori.net/


### PR DESCRIPTION
This automates one of the release steps.

I've also set up JD linking so we can cross-link between projects. The links will point to the final locations at `https://jd.adventure.kyori.net`, but this URL is a gradle property that can be overridden to point to other publishing locations.

When releasing, run `./gradlew copyJavadoc --output ../adventure-javadocs` to copy JD to the appropriate location.