### PR TITLE
api: Add Keybind interface

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -376,7 +376,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind) {
+  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind) {
     return keybind(Objects.requireNonNull(keybind, "keybind").asKeybind(), Style.empty());
   }
 
@@ -402,7 +402,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind, final @NotNull Style style) {
+  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind, final @NotNull Style style) {
     return new KeybindComponentImpl(Collections.emptyList(), style, Objects.requireNonNull(keybind, "keybind").asKeybind());
   }
 
@@ -428,7 +428,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind, final @Nullable TextColor color) {
+  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind, final @Nullable TextColor color) {
     return keybind(Objects.requireNonNull(keybind, "keybind").asKeybind(), Style.style(color));
   }
 
@@ -456,7 +456,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
     return keybind(Objects.requireNonNull(keybind, "keybind").asKeybind(), Style.style(color, decorations));
   }
 
@@ -484,7 +484,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return keybind(Objects.requireNonNull(keybind, "keybind").asKeybind(), Style.style(color, decorations));
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -376,8 +376,8 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind) {
-    return keybind(Objects.requireNonNull(keybind, "keybind").keybind(), Style.empty());
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind) {
+    return keybind(Objects.requireNonNull(keybind, "keybind").asKeybind(), Style.empty());
   }
 
   /**
@@ -402,8 +402,8 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind, final @NotNull Style style) {
-    return new KeybindComponentImpl(Collections.emptyList(), style, Objects.requireNonNull(keybind, "keybind").keybind());
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind, final @NotNull Style style) {
+    return new KeybindComponentImpl(Collections.emptyList(), style, Objects.requireNonNull(keybind, "keybind").asKeybind());
   }
 
   /**
@@ -428,8 +428,8 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind, final @Nullable TextColor color) {
-    return keybind(Objects.requireNonNull(keybind, "keybind").keybind(), Style.style(color));
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind, final @Nullable TextColor color) {
+    return keybind(Objects.requireNonNull(keybind, "keybind").asKeybind(), Style.style(color));
   }
 
   /**
@@ -456,8 +456,8 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
-    return keybind(Objects.requireNonNull(keybind, "keybind").keybind(), Style.style(color, decorations));
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+    return keybind(Objects.requireNonNull(keybind, "keybind").asKeybind(), Style.style(color, decorations));
   }
 
   /**
@@ -484,8 +484,8 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.9.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
-    return keybind(Objects.requireNonNull(keybind, "keybind").keybind(), Style.style(color, decorations));
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+    return keybind(Objects.requireNonNull(keybind, "keybind").asKeybind(), Style.style(color, decorations));
   }
 
   /*

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -369,6 +369,18 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a keybind component with a keybind.
+   *
+   * @param keybind the keybind
+   * @return the keybind component
+   * @since 4.9.0
+   */
+  @Contract(value = "_ -> new", pure = true)
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind) {
+    return keybind(Objects.requireNonNull(keybind, "keybind").keybind(), Style.empty());
+  }
+
+  /**
    * Creates a keybind component with a keybind and styling.
    *
    * @param keybind the keybind
@@ -382,6 +394,19 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a keybind component with a keybind and styling.
+   *
+   * @param keybind the keybind
+   * @param style the style
+   * @return the keybind component
+   * @since 4.9.0
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind, final @NotNull Style style) {
+    return new KeybindComponentImpl(Collections.emptyList(), style, Objects.requireNonNull(keybind, "keybind").keybind());
+  }
+
+  /**
    * Creates a keybind component with a keybind, and optional color.
    *
    * @param keybind the keybind
@@ -392,6 +417,19 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @Nullable TextColor color) {
     return keybind(keybind, Style.style(color));
+  }
+
+  /**
+   * Creates a keybind component with a keybind, and optional color.
+   *
+   * @param keybind the keybind
+   * @param color the color
+   * @return the keybind component
+   * @since 4.9.0
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind, final @Nullable TextColor color) {
+    return keybind(Objects.requireNonNull(keybind, "keybind").keybind(), Style.style(color));
   }
 
   /**
@@ -415,11 +453,39 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param color the color
    * @param decorations the decorations
    * @return the keybind component
+   * @since 4.9.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+    return keybind(Objects.requireNonNull(keybind, "keybind").keybind(), Style.style(color, decorations));
+  }
+
+  /**
+   * Creates a keybind component with a keybind, and optional color and decorations.
+   *
+   * @param keybind the keybind
+   * @param color the color
+   * @param decorations the decorations
+   * @return the keybind component
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
     return keybind(keybind, Style.style(color, decorations));
+  }
+
+  /**
+   * Creates a keybind component with a keybind, and optional color and decorations.
+   *
+   * @param keybind the keybind
+   * @param color the color
+   * @param decorations the decorations
+   * @return the keybind component
+   * @since 4.9.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.Keybind keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+    return keybind(Objects.requireNonNull(keybind, "keybind").keybind(), Style.style(color, decorations));
   }
 
   /*

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text;
 
+import java.util.Objects;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -58,6 +59,33 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
   @NotNull KeybindComponent keybind(final @NotNull String keybind);
 
   /**
+   * Sets the keybind.
+   *
+   * @param keybind the keybind
+   * @return a copy of this component
+   * @since 4.9.0
+   */
+  @Contract(pure = true)
+  default @NotNull KeybindComponent keybind(final @NotNull Keybind keybind) {
+    return this.keybind(Objects.requireNonNull(keybind, "keybind").keybind());
+  }
+
+  /**
+   * An object with a keybind.
+   *
+   * @since 4.9.0
+   */
+  interface Keybind {
+    /**
+     * Gets the string keybind identifier.
+     *
+     * @return the keybind identifier
+     * @since 4.9.0
+     */
+    @NotNull String keybind();
+  }
+
+  /**
    * A keybind component builder.
    *
    * @since 4.0.0
@@ -72,5 +100,17 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
      */
     @Contract("_ -> this")
     @NotNull Builder keybind(final @NotNull String keybind);
+
+    /**
+     * Sets the keybind.
+     *
+     * @param keybind the keybind
+     * @return this builder
+     * @since 4.9.0
+     */
+    @Contract(pure = true)
+    default @NotNull Builder keybind(final @NotNull Keybind keybind) {
+      return this.keybind(Objects.requireNonNull(keybind, "keybind").keybind());
+    }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
@@ -66,23 +66,23 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
    * @since 4.9.0
    */
   @Contract(pure = true)
-  default @NotNull KeybindComponent keybind(final @NotNull Keybind keybind) {
-    return this.keybind(Objects.requireNonNull(keybind, "keybind").keybind());
+  default @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind) {
+    return this.keybind(Objects.requireNonNull(keybind, "keybind").asKeybind());
   }
 
   /**
-   * An object with a keybind.
+   * Something that can provide a keybind identifier.
    *
    * @since 4.9.0
    */
-  interface Keybind {
+  interface KeybindLike {
     /**
-     * Gets the string keybind identifier.
+     * Gets the keybind identifier.
      *
      * @return the keybind identifier
      * @since 4.9.0
      */
-    @NotNull String keybind();
+    @NotNull String asKeybind();
   }
 
   /**
@@ -109,8 +109,8 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
      * @since 4.9.0
      */
     @Contract(pure = true)
-    default @NotNull Builder keybind(final @NotNull Keybind keybind) {
-      return this.keybind(Objects.requireNonNull(keybind, "keybind").keybind());
+    default @NotNull Builder keybind(final @NotNull KeybindComponent.KeybindLike keybind) {
+      return this.keybind(Objects.requireNonNull(keybind, "keybind").asKeybind());
     }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
@@ -66,7 +66,7 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
    * @since 4.9.0
    */
   @Contract(pure = true)
-  default @NotNull KeybindComponent keybind(final @NotNull KeybindComponent.KeybindLike keybind) {
+  default @NotNull KeybindComponent keybind(final @NotNull KeybindLike keybind) {
     return this.keybind(Objects.requireNonNull(keybind, "keybind").asKeybind());
   }
 
@@ -109,7 +109,7 @@ public interface KeybindComponent extends BuildableComponent<KeybindComponent, K
      * @since 4.9.0
      */
     @Contract(pure = true)
-    default @NotNull Builder keybind(final @NotNull KeybindComponent.KeybindLike keybind) {
+    default @NotNull Builder keybind(final @NotNull KeybindLike keybind) {
       return this.keybind(Objects.requireNonNull(keybind, "keybind").asKeybind());
     }
   }


### PR DESCRIPTION
Similar to the `Translatable` interface, this PR adds a `Keybind` interface for implementations with enums/whatever that represent keybinds.