### PR TITLE
Clean up StyleImpl

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
@@ -108,7 +109,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    */
   static @NotNull Style style(final @Nullable TextColor color) {
     if (color == null) return empty();
-    return new StyleImpl(null, color, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, null, null, null);
+    return new StyleImpl(null, color, Stream.of(TextDecoration.values()).map(decoration -> TextDecoration.State.NOT_SET).toArray(TextDecoration.State[]::new), null, null, null);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -190,7 +190,7 @@ final class StyleImpl implements Style {
    */
   @Override
   public @NotNull Builder toBuilder() {
-    return new BuilderImpl(new StyleImpl(this.font, this.color, this.decorationStates.clone(), this.clickEvent, this.hoverEvent, this.insertion));
+    return new BuilderImpl(this);
   }
 
   @Override
@@ -249,7 +249,7 @@ final class StyleImpl implements Style {
 
     BuilderImpl(final @NotNull StyleImpl style) {
       this.color = style.color;
-      this.decorationStates = style.decorationStates;
+      this.decorationStates = style.decorationStates.clone();
       this.clickEvent = style.clickEvent;
       this.hoverEvent = style.hoverEvent;
       this.insertion = style.insertion;

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -198,6 +198,7 @@ final class StyleImpl implements Style {
     return Stream.concat(Stream.of(DECORATIONS).map(decoration -> ExaminableProperty.of(requireNonNull(TextDecoration.NAMES.key(decoration)), this.decoration(decoration))),
       Stream.of(ExaminableProperty.of("color", this.color),
         ExaminableProperty.of("clickEvent", this.clickEvent),
+        ExaminableProperty.of("hoverEvent", this.hoverEvent),
         ExaminableProperty.of("insertion", this.insertion),
         ExaminableProperty.of("font", this.font)));
   }

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -23,10 +23,12 @@
  */
 package net.kyori.adventure.text.format;
 
-import java.util.EnumMap;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -40,15 +42,11 @@ import org.jetbrains.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 final class StyleImpl implements Style {
-  static final StyleImpl EMPTY = new StyleImpl(null, null, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, null, null, null);
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
+  static final StyleImpl EMPTY = new StyleImpl(null, null, Stream.of(DECORATIONS).map(decoration -> TextDecoration.State.NOT_SET).toArray(TextDecoration.State[]::new), null, null, null);
   private final @Nullable Key font;
   private final @Nullable TextColor color;
-  private final TextDecoration.State obfuscated;
-  private final TextDecoration.State bold;
-  private final TextDecoration.State strikethrough;
-  private final TextDecoration.State underlined;
-  private final TextDecoration.State italic;
+  private final @NotNull TextDecoration.State[] decorationStates;
   private final @Nullable ClickEvent clickEvent;
   private final @Nullable HoverEvent<?> hoverEvent;
   private final @Nullable String insertion;
@@ -63,22 +61,14 @@ final class StyleImpl implements Style {
   StyleImpl(
     final @Nullable Key font,
     final @Nullable TextColor color,
-    final TextDecoration.State obfuscated,
-    final TextDecoration.State bold,
-    final TextDecoration.State strikethrough,
-    final TextDecoration.State underlined,
-    final TextDecoration.State italic,
+    final @NotNull TextDecoration.State[] decorationStates,
     final @Nullable ClickEvent clickEvent,
     final @Nullable HoverEvent<?> hoverEvent,
     final @Nullable String insertion
   ) {
     this.font = font;
     this.color = color;
-    this.obfuscated = obfuscated;
-    this.bold = bold;
-    this.strikethrough = strikethrough;
-    this.underlined = underlined;
-    this.italic = italic;
+    this.decorationStates = decorationStates;
     this.clickEvent = clickEvent;
     this.hoverEvent = hoverEvent;
     this.insertion = insertion;
@@ -92,7 +82,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style font(final @Nullable Key font) {
     if (Objects.equals(this.font, font)) return this;
-    return new StyleImpl(font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
+    return new StyleImpl(font, this.color, this.decorationStates, this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -103,7 +93,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style color(final @Nullable TextColor color) {
     if (Objects.equals(this.color, color)) return this;
-    return new StyleImpl(this.font, color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
+    return new StyleImpl(this.font, color, this.decorationStates, this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -116,56 +106,27 @@ final class StyleImpl implements Style {
 
   @Override
   public TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
-    if (decoration == TextDecoration.BOLD) {
-      return this.bold;
-    } else if (decoration == TextDecoration.ITALIC) {
-      return this.italic;
-    } else if (decoration == TextDecoration.UNDERLINED) {
-      return this.underlined;
-    } else if (decoration == TextDecoration.STRIKETHROUGH) {
-      return this.strikethrough;
-    } else if (decoration == TextDecoration.OBFUSCATED) {
-      return this.obfuscated;
-    }
-    throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+    return this.decorationStates[decoration.ordinal()];
   }
 
   @Override
   public @NotNull Style decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     requireNonNull(state, "state");
-    if (decoration == TextDecoration.BOLD) {
-      return new StyleImpl(this.font, this.color, this.obfuscated, state, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
-    } else if (decoration == TextDecoration.ITALIC) {
-      return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, state, this.clickEvent, this.hoverEvent, this.insertion);
-    } else if (decoration == TextDecoration.UNDERLINED) {
-      return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, state, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
-    } else if (decoration == TextDecoration.STRIKETHROUGH) {
-      return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, state, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
-    } else if (decoration == TextDecoration.OBFUSCATED) {
-      return new StyleImpl(this.font, this.color, state, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
-    }
-    throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+    if (this.decoration(decoration) == state) return this;
+    final TextDecoration.State[] newDecorationStates = this.decorationStates.clone();
+    newDecorationStates[decoration.ordinal()] = state;
+    return new StyleImpl(this.font, this.color, newDecorationStates, this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
   public @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
-    final Map<TextDecoration, TextDecoration.State> decorations = new EnumMap<>(TextDecoration.class);
-    for (int i = 0, length = DECORATIONS.length; i < length; i++) {
-      final TextDecoration decoration = DECORATIONS[i];
-      final TextDecoration.State value = this.decoration(decoration);
-      decorations.put(decoration, value);
-    }
-    return decorations;
+    return Stream.of(DECORATIONS).collect(Collectors.toMap(Function.identity(), this::decoration));
   }
 
   @Override
   public @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
-    final TextDecoration.State obfuscated = decorations.getOrDefault(TextDecoration.OBFUSCATED, this.obfuscated);
-    final TextDecoration.State bold = decorations.getOrDefault(TextDecoration.BOLD, this.bold);
-    final TextDecoration.State strikethrough = decorations.getOrDefault(TextDecoration.STRIKETHROUGH, this.strikethrough);
-    final TextDecoration.State underlined = decorations.getOrDefault(TextDecoration.UNDERLINED, this.underlined);
-    final TextDecoration.State italic = decorations.getOrDefault(TextDecoration.ITALIC, this.italic);
-    return new StyleImpl(this.font, this.color, obfuscated, bold, strikethrough, underlined, italic, this.clickEvent, this.hoverEvent, this.insertion);
+    if (decorations.entrySet().stream().allMatch(entry -> this.decoration(entry.getKey()) == entry.getValue())) return this;
+    return new StyleImpl(this.font, this.color, Stream.of(DECORATIONS).map(unmappedDecoration -> decorations.getOrDefault(unmappedDecoration, this.decoration(unmappedDecoration))).toArray(TextDecoration.State[]::new), this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -175,7 +136,7 @@ final class StyleImpl implements Style {
 
   @Override
   public @NotNull Style clickEvent(final @Nullable ClickEvent event) {
-    return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, event, this.hoverEvent, this.insertion);
+    return new StyleImpl(this.font, this.color, this.decorationStates, event, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -185,7 +146,7 @@ final class StyleImpl implements Style {
 
   @Override
   public @NotNull Style hoverEvent(final @Nullable HoverEventSource<?> source) {
-    return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, HoverEventSource.unbox(source), this.insertion);
+    return new StyleImpl(this.font, this.color, this.decorationStates, this.clickEvent, HoverEventSource.unbox(source), this.insertion);
   }
 
   @Override
@@ -196,7 +157,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style insertion(final @Nullable String insertion) {
     if (Objects.equals(this.insertion, insertion)) return this;
-    return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, insertion);
+    return new StyleImpl(this.font, this.color, this.decorationStates, this.clickEvent, this.hoverEvent, insertion);
   }
 
   @Override
@@ -229,23 +190,16 @@ final class StyleImpl implements Style {
    */
   @Override
   public @NotNull Builder toBuilder() {
-    return new BuilderImpl(this);
+    return new BuilderImpl(new StyleImpl(this.font, this.color, this.decorationStates.clone(), this.clickEvent, this.hoverEvent, this.insertion));
   }
 
   @Override
   public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
-    return Stream.of(
-      ExaminableProperty.of("color", this.color),
-      ExaminableProperty.of("obfuscated", this.obfuscated),
-      ExaminableProperty.of("bold", this.bold),
-      ExaminableProperty.of("strikethrough", this.strikethrough),
-      ExaminableProperty.of("underlined", this.underlined),
-      ExaminableProperty.of("italic", this.italic),
-      ExaminableProperty.of("clickEvent", this.clickEvent),
-      ExaminableProperty.of("hoverEvent", this.hoverEvent),
-      ExaminableProperty.of("insertion", this.insertion),
-      ExaminableProperty.of("font", this.font)
-    );
+    return Stream.concat(Stream.of(DECORATIONS).map(decoration -> ExaminableProperty.of(requireNonNull(TextDecoration.NAMES.key(decoration)), this.decoration(decoration))),
+      Stream.of(ExaminableProperty.of("color", this.color),
+        ExaminableProperty.of("clickEvent", this.clickEvent),
+        ExaminableProperty.of("insertion", this.insertion),
+        ExaminableProperty.of("font", this.font)));
   }
 
   @Override
@@ -259,11 +213,7 @@ final class StyleImpl implements Style {
     if (!(other instanceof StyleImpl)) return false;
     final StyleImpl that = (StyleImpl) other;
     return Objects.equals(this.color, that.color)
-      && this.obfuscated == that.obfuscated
-      && this.bold == that.bold
-      && this.strikethrough == that.strikethrough
-      && this.underlined == that.underlined
-      && this.italic == that.italic
+      && Arrays.equals(this.decorationStates, that.decorationStates)
       && Objects.equals(this.clickEvent, that.clickEvent)
       && Objects.equals(this.hoverEvent, that.hoverEvent)
       && Objects.equals(this.insertion, that.insertion)
@@ -273,11 +223,10 @@ final class StyleImpl implements Style {
   @Override
   public int hashCode() {
     int result = Objects.hashCode(this.color);
-    result = (31 * result) + this.obfuscated.hashCode();
-    result = (31 * result) + this.bold.hashCode();
-    result = (31 * result) + this.strikethrough.hashCode();
-    result = (31 * result) + this.underlined.hashCode();
-    result = (31 * result) + this.italic.hashCode();
+    for (int i = 0, length = DECORATIONS.length; i < length; i++) {
+      final TextDecoration decoration = DECORATIONS[i];
+      result = (31 * result) + this.decoration(decoration).hashCode();
+    }
     result = (31 * result) + Objects.hashCode(this.clickEvent);
     result = (31 * result) + Objects.hashCode(this.hoverEvent);
     result = (31 * result) + Objects.hashCode(this.insertion);
@@ -288,25 +237,18 @@ final class StyleImpl implements Style {
   static final class BuilderImpl implements Builder {
     @Nullable Key font;
     @Nullable TextColor color;
-    TextDecoration.State obfuscated = TextDecoration.State.NOT_SET;
-    TextDecoration.State bold = TextDecoration.State.NOT_SET;
-    TextDecoration.State strikethrough = TextDecoration.State.NOT_SET;
-    TextDecoration.State underlined = TextDecoration.State.NOT_SET;
-    TextDecoration.State italic = TextDecoration.State.NOT_SET;
+    @NotNull TextDecoration.State[] decorationStates;
     @Nullable ClickEvent clickEvent;
     @Nullable HoverEvent<?> hoverEvent;
     @Nullable String insertion;
 
     BuilderImpl() {
+      this.decorationStates = StyleImpl.EMPTY.decorationStates.clone();
     }
 
     BuilderImpl(final @NotNull StyleImpl style) {
       this.color = style.color;
-      this.obfuscated = style.obfuscated;
-      this.bold = style.bold;
-      this.strikethrough = style.strikethrough;
-      this.underlined = style.underlined;
-      this.italic = style.italic;
+      this.decorationStates = style.decorationStates;
       this.clickEvent = style.clickEvent;
       this.hoverEvent = style.hoverEvent;
       this.insertion = style.insertion;
@@ -349,55 +291,17 @@ final class StyleImpl implements Style {
     @Override
     public @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
-      if (decoration == TextDecoration.BOLD) {
-        this.bold = state;
-        return this;
-      } else if (decoration == TextDecoration.ITALIC) {
-        this.italic = state;
-        return this;
-      } else if (decoration == TextDecoration.UNDERLINED) {
-        this.underlined = state;
-        return this;
-      } else if (decoration == TextDecoration.STRIKETHROUGH) {
-        this.strikethrough = state;
-        return this;
-      } else if (decoration == TextDecoration.OBFUSCATED) {
-        this.obfuscated = state;
-        return this;
-      }
-      throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+      this.decorationStates[decoration.ordinal()] = state;
+      return this;
     }
 
     // todo(kashike): promote to public api?
     @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
-      if (decoration == TextDecoration.BOLD) {
-        if (this.bold == TextDecoration.State.NOT_SET) {
-          this.bold = state;
-        }
-        return this;
-      } else if (decoration == TextDecoration.ITALIC) {
-        if (this.italic == TextDecoration.State.NOT_SET) {
-          this.italic = state;
-        }
-        return this;
-      } else if (decoration == TextDecoration.UNDERLINED) {
-        if (this.underlined == TextDecoration.State.NOT_SET) {
-          this.underlined = state;
-        }
-        return this;
-      } else if (decoration == TextDecoration.STRIKETHROUGH) {
-        if (this.strikethrough == TextDecoration.State.NOT_SET) {
-          this.strikethrough = state;
-        }
-        return this;
-      } else if (decoration == TextDecoration.OBFUSCATED) {
-        if (this.obfuscated == TextDecoration.State.NOT_SET) {
-          this.obfuscated = state;
-        }
-        return this;
+      if (this.decorationStates[decoration.ordinal()] == TextDecoration.State.NOT_SET) {
+        this.decoration(decoration, state);
       }
-      throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+      return this;
     }
 
     @Override
@@ -477,16 +381,12 @@ final class StyleImpl implements Style {
       if (this.isEmpty()) {
         return EMPTY;
       }
-      return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
+      return new StyleImpl(this.font, this.color, this.decorationStates.clone(), this.clickEvent, this.hoverEvent, this.insertion);
     }
 
     private boolean isEmpty() {
       return this.color == null
-        && this.obfuscated == TextDecoration.State.NOT_SET
-        && this.bold == TextDecoration.State.NOT_SET
-        && this.strikethrough == TextDecoration.State.NOT_SET
-        && this.underlined == TextDecoration.State.NOT_SET
-        && this.italic == TextDecoration.State.NOT_SET
+        && Arrays.equals(this.decorationStates, StyleImpl.EMPTY.decorationStates)
         && this.clickEvent == null
         && this.hoverEvent == null
         && this.insertion == null


### PR DESCRIPTION
This closes #392 by replacing the hard-coded `TextDecoration` values in `StyleImpl` and `StyleImpl.BuilderImpl` with `TextDecoration.State[]`s. The index of each `State` is the same as the ordinal of the `TextDecoration` it represents.