### PR TITLE
api: ClickEvent setters and ClickEventSource

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collector;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.ClickEventSource;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.text.format.Style;
@@ -1838,6 +1839,18 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(pure = true)
   default @NotNull Component clickEvent(final @Nullable ClickEvent event) {
     return this.style(this.style().clickEvent(event));
+  }
+
+  /**
+   * Sets the click event of this component from a source.
+   *
+   * @param source the click event source
+   * @return a component
+   * @since 4.9.0
+   */
+  @Contract(pure = true)
+  default @NotNull Component clickEventFromSource(final @NotNull ClickEventSource source) {
+    return this.clickEvent(Objects.requireNonNull(source, "source").asClickEvent());
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
@@ -24,11 +24,13 @@
 package net.kyori.adventure.text;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.ClickEventSource;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
@@ -296,6 +298,18 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    */
   @Contract("_ -> this")
   @NotNull B clickEvent(final @Nullable ClickEvent event);
+
+  /**
+   * Sets the click event of this component.
+   *
+   * @param source the click event source
+   * @return this builder
+   * @since 4.9.0
+   */
+  @Contract("_ -> this")
+  default @NotNull B clickEventFromSource(final @NotNull ClickEventSource source) {
+    return this.clickEvent(Objects.requireNonNull(source, "source").asClickEvent());
+  }
 
   /**
    * Sets the hover event of this component.

--- a/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.event;
 
 import java.net.URL;
 import java.util.Objects;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
@@ -32,6 +33,7 @@ import net.kyori.adventure.util.Index;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,7 +46,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 4.0.0
  */
-public final class ClickEvent implements Examinable, StyleBuilderApplicable {
+public final class ClickEvent implements ClickEventSource, Examinable, StyleBuilderApplicable {
   /**
    * Creates a click event that opens a url.
    *
@@ -167,6 +169,19 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
   }
 
   /**
+   * Sets the click event action.
+   *
+   * @param action the click event action
+   * @return a copy of this click event with the provided action
+   * @since 4.9.0
+   */
+  @Contract(pure = true)
+  public @NotNull ClickEvent action(final @NotNull Action action) {
+    if (Objects.requireNonNull(action, "action") == this.action) return this;
+    return new ClickEvent(action, this.value);
+  }
+
+  /**
    * Gets the click event value.
    *
    * @return the click event value
@@ -174,6 +189,24 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    */
   public @NotNull String value() {
     return this.value;
+  }
+
+  /**
+   * Sets the click event value.
+   *
+   * @param value the click event value
+   * @return a copy of this click event with the provided value
+   * @since 4.9.0
+   */
+  @Contract(pure = true)
+  public @NotNull ClickEvent value(final @NotNull String value) {
+    if (Objects.requireNonNull(value, "value").equals(this.value)) return this;
+    return new ClickEvent(this.action, value);
+  }
+
+  @Override
+  public @NotNull ClickEvent asClickEvent(final @NotNull UnaryOperator<ClickEvent> op) {
+    return Objects.requireNonNull(op, "op").apply(this);
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/event/ClickEventSource.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickEventSource.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.event;
+
+import java.util.function.UnaryOperator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Something that provides a {@link ClickEvent}.
+ *
+ * @since 4.9.0
+ */
+public interface ClickEventSource {
+  /**
+   * Fetches a {@link ClickEvent} from a {@code ClickEventSource}.
+   *
+   * @param source the click event source
+   * @return a click event, or {@code null}
+   * @since 4.9.0
+   */
+  static @Nullable ClickEvent unbox(final @Nullable ClickEventSource source) {
+    return source != null ? source.asClickEvent() : null;
+  }
+
+  /**
+   * Represent this object as a click event.
+   *
+   * @return a click event
+   * @since 4.9.0
+   */
+  default @NotNull ClickEvent asClickEvent() {
+    return this.asClickEvent(UnaryOperator.identity());
+  }
+
+  /**
+   * Creates a click event derived from this object with a specific action.
+   *
+   * @param action the click event action
+   * @return a click event
+   * @since 4.9.0
+   */
+  default @NotNull ClickEvent asClickEvent(final ClickEvent.@NotNull Action action) {
+    return this.asClickEvent(clickEvent -> clickEvent.action(action));
+  }
+
+  /**
+   * Creates a click event derived from this object.
+   *
+   * <p>The click event will be passed through the provided callback to allow
+   * transforming the event.</p>
+   *
+   * @param op transformation on value
+   * @return a click event
+   * @since 4.9.0
+   */
+  @NotNull ClickEvent asClickEvent(final @NotNull UnaryOperator<ClickEvent> op);
+}

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -25,12 +25,14 @@ package net.kyori.adventure.text.format;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.ClickEventSource;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.util.Buildable;
@@ -361,6 +363,17 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
    * @since 4.0.0
    */
   @NotNull Style clickEvent(final @Nullable ClickEvent event);
+
+  /**
+   * Sets the click event.
+   *
+   * @param source the click event source
+   * @return a style
+   * @since 4.9.0
+   */
+  default @NotNull Style clickEventFromSource(final @NotNull ClickEventSource source) {
+    return this.clickEvent(Objects.requireNonNull(source, "source").asClickEvent());
+  }
 
   /**
    * Gets the hover event.
@@ -712,6 +725,8 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable {
      */
     @Contract("_ -> this")
     @NotNull Builder clickEvent(final @Nullable ClickEvent event);
+
+
 
     /**
      * Sets the hover event.


### PR DESCRIPTION
This PR adds a `ClickEventSource` class in addition to setters for `ClickEvent` properties. In order to prevent the annoyance of forcing people to change `component.clickEvent(null)` to `component.clickEvent((ClickEvent) null)` to prevent unwanted errors the method for setting a click event from a source is named `clickEventFromSource`. This could be replaced to use just `ClickEventSource` methods in 5.0.0 if we fancy a small, but technically breaking, change.

The `ClickEventSource` class provides a method to set the action of the resulting click event. This will resolve the common use case of, for example, obtaining a command as a click event but with a different method (run vs. suggest).