### PR TITLE
api: Merge style of full match when replaced

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
@@ -30,6 +30,7 @@ import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.renderer.ComponentRenderer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -76,6 +77,10 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
               .style(component.style()));
 
             modified = replacement == null ? Component.empty() : replacement.asComponent();
+
+            // merge style of the match into this component to prevent unexpected loss of style
+            modified = modified.style(modified.style().merge(component.style(), Style.Merge.Strategy.IF_ABSENT_ON_TARGET));
+
             if (children == null) { // Prepare children
               children = new ArrayList<>(oldChildrenSize + modified.children().size());
               children.addAll(modified.children());

--- a/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
@@ -246,4 +246,16 @@ class TextReplacementRendererTest {
       .build();
     assertEquals(expected, replaced);
   }
+
+  // https://github.com/KyoriPowered/adventure/issues/387
+  @Test
+  void testFullMatchReplaceWithStyle() {
+    final Component base = Component.text("hello", NamedTextColor.RED);
+
+    final Component replaced = base.replaceText(c -> c.matchLiteral("hello")
+      .replacement(Component.text("world").decorate(TextDecoration.BOLD)));
+
+    final Component expected = Component.text("world", NamedTextColor.RED, TextDecoration.BOLD);
+    assertEquals(expected, replaced);
+  }
 }


### PR DESCRIPTION
This PR fixes #387.

When a full match has been found, the replacement is collected and then the style of the original match is merged into this style using the `IF_ABSENT_ON_TARGET` strategy. This will replicate the behaviour of when a partial match is found as the style will inherit from the parent.