### PR TITLE
Added Moshi component serializer

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
       "text-serializer-gson",
       "text-serializer-gson-legacy-impl",
       "text-serializer-json",
+      "text-serializer-json-legacy-impl",
       "text-serializer-legacy",
       "text-serializer-plain"
     ).forEach {

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
       "serializer-configurate4",
       "text-serializer-gson",
       "text-serializer-gson-legacy-impl",
+      "text-serializer-json",
       "text-serializer-legacy",
       "text-serializer-plain"
     ).forEach {

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
       "text-serializer-json",
       "text-serializer-json-legacy-impl",
       "text-serializer-legacy",
+      "text-serializer-moshi",
       "text-serializer-plain"
     ).forEach {
       api(project(":adventure-$it"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ sequenceOf(
   "text-serializer-gson",
   "text-serializer-gson-legacy-impl",
   "text-serializer-json",
+  "text-serializer-json-legacy-impl",
   "text-serializer-legacy",
   "text-serializer-plain"
 ).forEach {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ sequenceOf(
   "text-serializer-json",
   "text-serializer-json-legacy-impl",
   "text-serializer-legacy",
+  "text-serializer-moshi",
   "text-serializer-plain"
 ).forEach {
   include("adventure-$it")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ sequenceOf(
   "serializer-configurate4",
   "text-serializer-gson",
   "text-serializer-gson-legacy-impl",
+  "text-serializer-json",
   "text-serializer-legacy",
   "text-serializer-plain"
 ).forEach {

--- a/text-serializer-gson-legacy-impl/build.gradle.kts
+++ b/text-serializer-gson-legacy-impl/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   api(project(":adventure-api"))
   api(project(":adventure-text-serializer-gson"))
+  api(project(":adventure-text-serializer-json-legacy-impl"))
   api(project(":adventure-nbt"))
 }
 

--- a/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializer.java
+++ b/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializer.java
@@ -25,13 +25,17 @@ package net.kyori.adventure.text.serializer.gson.legacyimpl;
 
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.gson.LegacyHoverEventSerializer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A legacy {@link HoverEvent} serializer.
  *
  * @since 4.3.0
+ * @deprecated For removal since 4.9.0, use {@link net.kyori.adventure.text.serializer.json.legacyimpl.NBTLegacyHoverEventSerializer} instead.
  */
+@Deprecated
+@ApiStatus.ScheduledForRemoval
 public interface NBTLegacyHoverEventSerializer extends LegacyHoverEventSerializer {
   /**
    * Gets the legacy {@link HoverEvent} serializer.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -126,6 +126,27 @@ public interface GsonComponentSerializer extends JsonComponentSerializer {
    */
   interface Builder extends JsonComponentSerializer.Builder {
     /**
+     * Sets that the serializer should downsample hex colors to named colors.
+     *
+     * @return this builder
+     * @since 4.0.0
+     */
+    @Override
+    @NotNull Builder downsampleColors();
+
+    /**
+     * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
+     * If the serializer is {@code null}, then only {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}
+     * legacy hover events can be deserialized.
+     *
+     * @param serializer serializer
+     * @return this builder
+     * @since 4.9.0
+     */
+    @Override
+    @NotNull Builder legacyHoverEventSerializer(final @Nullable net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer serializer);
+
+    /**
      * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
      * If the serializer is {@code null}, then only {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}
      * legacy hover events can be deserialized.
@@ -138,6 +159,18 @@ public interface GsonComponentSerializer extends JsonComponentSerializer {
     @Deprecated
     @ApiStatus.ScheduledForRemoval
     @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
+
+    /**
+     * Output a legacy hover event {@code value} in addition to the modern {@code contents}.
+     *
+     * <p>A {@link #legacyHoverEventSerializer(net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer) legacy hover serializer} must also be set
+     * to serialize any hover events beyond those with action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}</p>
+     *
+     * @return this builder
+     * @since 4.0.0
+     */
+    @Override
+    @NotNull Builder emitLegacyHoverEvent();
 
     /**
      * Builds the serializer.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -29,8 +29,7 @@ import com.google.gson.JsonElement;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.ComponentSerializer;
-import net.kyori.adventure.util.Buildable;
+import net.kyori.adventure.text.serializer.json.JsonComponentSerializer;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @since 4.0.0
  */
-public interface GsonComponentSerializer extends ComponentSerializer<Component, Component, String>, Buildable<GsonComponentSerializer, GsonComponentSerializer.Builder> {
+public interface GsonComponentSerializer extends JsonComponentSerializer {
   /**
    * Gets a component serializer for gson serialization and deserialization.
    *
@@ -112,19 +111,20 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
   @NotNull JsonElement serializeToTree(final @NotNull Component component);
 
   /**
+   * Creates a new {@link Builder} from this {@link GsonComponentSerializer}.
+   *
+   * @return a new {@link Builder}
+   * @since 4.9.0
+   */
+  @Override
+  @NotNull GsonComponentSerializer.Builder toBuilder();
+
+  /**
    * A builder for {@link GsonComponentSerializer}.
    *
    * @since 4.0.0
    */
-  interface Builder extends Buildable.Builder<GsonComponentSerializer> {
-    /**
-     * Sets that the serializer should downsample hex colors to named colors.
-     *
-     * @return this builder
-     * @since 4.0.0
-     */
-    @NotNull Builder downsampleColors();
-
+  interface Builder extends JsonComponentSerializer.Builder {
     /**
      * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
      * If the serializer is {@code null}, then only {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}
@@ -133,19 +133,11 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @param serializer serializer
      * @return this builder
      * @since 4.0.0
+     * @deprecated For removal, use {@link JsonComponentSerializer.Builder#legacyHoverEventSerializer(net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer)}
      */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval
     @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
-
-    /**
-     * Output a legacy hover event {@code value} in addition to the modern {@code contents}.
-     *
-     * <p>A {@link #legacyHoverEventSerializer(LegacyHoverEventSerializer) legacy hover serializer} must also be set
-     * to serialize any hover events beyond those with action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}</p>
-     *
-     * @return this builder
-     * @since 4.0.0
-     */
-    @NotNull Builder emitLegacyHoverEvent();
 
     /**
      * Builds the serializer.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -37,6 +37,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
 import net.kyori.adventure.util.Services;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -149,6 +150,12 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
 
     @Override
     public @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer) {
+      this.legacyHoverSerializer = serializer;
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder legacyHoverEventSerializer(final net.kyori.adventure.text.serializer.gson.@Nullable LegacyHoverEventSerializer serializer) {
       this.legacyHoverSerializer = serializer;
       return this;
     }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -47,6 +47,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
 import net.kyori.adventure.util.Codec;
 import org.jetbrains.annotations.Nullable;
 

--- a/text-serializer-json-legacy-impl/build.gradle.kts
+++ b/text-serializer-json-legacy-impl/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+  id("adventure.common-conventions")
+}
+
+dependencies {
+  api(project(":adventure-api"))
+  api(project(":adventure-text-serializer-json"))
+  api(project(":adventure-nbt"))
+}
+
+applyJarMetadata("net.kyori.adventure.text.serializer.json.legacyimpl")

--- a/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializer.java
+++ b/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializer.java
@@ -21,8 +21,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package net.kyori.adventure.text.serializer.json.legacyimpl;
+
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
+import org.jetbrains.annotations.NotNull;
+
 /**
- * Gson legacy hover event serialization and deserialization.
+ * A legacy {@link HoverEvent} serializer.
+ *
+ * @since 4.9.0
  */
-@Deprecated
-package net.kyori.adventure.text.serializer.gson.legacyimpl;
+public interface NBTLegacyHoverEventSerializer extends LegacyHoverEventSerializer {
+  /**
+   * Gets the legacy {@link HoverEvent} serializer.
+   *
+   * @return a legacy {@link HoverEvent} serializer
+   * @since 4.9.0
+   */
+  static @NotNull LegacyHoverEventSerializer get() {
+    return NBTLegacyHoverEventSerializerImpl.INSTANCE;
+  }
+}

--- a/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
+++ b/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.json.legacyimpl;
+
+import java.io.IOException;
+import java.util.UUID;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.TagStringIO;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
+import net.kyori.adventure.util.Codec;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSerializer {
+  static final NBTLegacyHoverEventSerializerImpl INSTANCE = new NBTLegacyHoverEventSerializerImpl();
+  private static final TagStringIO SNBT_IO = TagStringIO.get();
+  private static final Codec<CompoundBinaryTag, String, IOException, IOException> SNBT_CODEC = Codec.of(SNBT_IO::asCompound, SNBT_IO::asString);
+
+  static final String ITEM_TYPE = "id";
+  static final String ITEM_COUNT = "Count";
+  static final String ITEM_TAG = "tag";
+
+  static final String ENTITY_NAME = "name";
+  static final String ENTITY_TYPE = "type";
+  static final String ENTITY_ID = "id";
+
+  private NBTLegacyHoverEventSerializerImpl() {
+  }
+
+  @Override
+  public HoverEvent.@NotNull ShowItem deserializeShowItem(final @NotNull Component input) throws IOException {
+    assertTextComponent(input);
+    final CompoundBinaryTag contents = SNBT_CODEC.decode(((TextComponent) input).content());
+    final CompoundBinaryTag tag = contents.getCompound(ITEM_TAG);
+    return HoverEvent.ShowItem.of(
+      Key.key(contents.getString(ITEM_TYPE)),
+      contents.getByte(ITEM_COUNT, (byte) 1),
+      tag == CompoundBinaryTag.empty() ? null : BinaryTagHolder.encode(tag, SNBT_CODEC)
+    );
+  }
+
+  @Override
+  public HoverEvent.@NotNull ShowEntity deserializeShowEntity(final @NotNull Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
+    assertTextComponent(input);
+    final CompoundBinaryTag contents = SNBT_CODEC.decode(((TextComponent) input).content());
+    return HoverEvent.ShowEntity.of(
+      Key.key(contents.getString(ENTITY_TYPE)),
+      UUID.fromString(contents.getString(ENTITY_ID)),
+      componentCodec.decode(contents.getString(ENTITY_NAME))
+    );
+  }
+
+  private static void assertTextComponent(final Component component) {
+    if (!(component instanceof TextComponent) || !component.children().isEmpty()) {
+      throw new IllegalArgumentException("Legacy events must be single Component instances");
+    }
+  }
+
+  @Override
+  public @NotNull Component serializeShowItem(final HoverEvent.@NotNull ShowItem input) throws IOException {
+    final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
+      .putString(ITEM_TYPE, input.item().asString())
+      .putByte(ITEM_COUNT, (byte) input.count());
+    final @Nullable BinaryTagHolder nbt = input.nbt();
+    if (nbt != null) {
+      builder.put(ITEM_TAG, nbt.get(SNBT_CODEC));
+    }
+    return Component.text(SNBT_CODEC.encode(builder.build()));
+  }
+
+  @Override
+  public @NotNull Component serializeShowEntity(final HoverEvent.@NotNull ShowEntity input, final Codec.Encoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
+    final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
+      .putString(ENTITY_ID, input.id().toString())
+      .putString(ENTITY_TYPE, input.type().asString());
+    final @Nullable Component name = input.name();
+    if (name != null) {
+      builder.putString(ENTITY_NAME, componentCodec.encode(name));
+    }
+    return Component.text(SNBT_CODEC.encode(builder.build()));
+  }
+}

--- a/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/package-info.java
+++ b/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/package-info.java
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 /**
- * Gson legacy hover event serialization and deserialization.
+ * JSON legacy hover event serialization and deserialization.
  */
-@Deprecated
-package net.kyori.adventure.text.serializer.gson.legacyimpl;
+package net.kyori.adventure.text.serializer.json.legacyimpl;

--- a/text-serializer-json/build.gradle.kts
+++ b/text-serializer-json/build.gradle.kts
@@ -6,4 +6,4 @@ dependencies {
   api(project(":adventure-api"))
 }
 
-applyJarMetadata("net.kyori.adventure.text.serializer.gson")
+applyJarMetadata("net.kyori.adventure.text.serializer.json")

--- a/text-serializer-json/build.gradle.kts
+++ b/text-serializer-json/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
 
 dependencies {
   api(project(":adventure-api"))
-  api(project(":adventure-text-serializer-json"))
-  api("com.google.code.gson:gson:2.8.0")
-  testImplementation(project(":adventure-nbt"))
 }
 
 applyJarMetadata("net.kyori.adventure.text.serializer.gson")

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/Instances.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/Instances.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.json;
+
+import java.util.Optional;
+import net.kyori.adventure.util.Services;
+
+final class Instances {
+  private static final Optional<JsonComponentSerializer.Provider> PROVIDER = Services.service(JsonComponentSerializer.Provider.class);
+
+  static final Optional<JsonComponentSerializer> INSTANCE = PROVIDER.map(JsonComponentSerializer.Provider::json);
+  static final Optional<JsonComponentSerializer> LEGACY_INSTANCE = PROVIDER.map(JsonComponentSerializer.Provider::jsonLegacy);
+
+  static Optional<JsonComponentSerializer.Builder> builder() {
+    return PROVIDER.map(JsonComponentSerializer.Provider::builder);
+  }
+
+  private Instances() {
+  }
+}

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JsonComponentSerializer.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JsonComponentSerializer.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.json;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.ComponentSerializer;
+import net.kyori.adventure.util.Buildable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A generic JSON component serializer.
+ *
+ * <p>Use {@link Builder#downsampleColors()} to support platforms
+ * that do not understand hex colors that were introduced in Minecraft 1.16.</p>
+ *
+ * @since 4.9.0
+ */
+public interface JsonComponentSerializer extends ComponentSerializer<Component, Component, String>, Buildable<JsonComponentSerializer, JsonComponentSerializer.Builder> {
+  /**
+   * Gets a component serializer for JSON serialization and deserialization.
+   *
+   * @return a JSON component serializer
+   * @since 4.9.0
+   */
+  static @NotNull JsonComponentSerializer json() {
+    return Instances.INSTANCE.orElseThrow(() -> new IllegalStateException("A provider for JsonComponentSerializer was not found!"));
+  }
+
+  /**
+   * Gets a component serializer for JSON serialization and deserialization.
+   *
+   * <p>Hex colors are coerced to the nearest named color, and legacy hover events are
+   * emitted for action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}.</p>
+   *
+   * @return a JSON component serializer
+   * @since 4.9.0
+   */
+  static @NotNull JsonComponentSerializer colorDownsamplingJson() {
+    return Instances.LEGACY_INSTANCE.orElseThrow(() -> new IllegalStateException("A provider for JsonComponentSerializer was not found!"));
+  }
+
+  /**
+   * Creates a new {@link JsonComponentSerializer.Builder}.
+   *
+   * @return a builder
+   * @since 4.9.0
+   */
+  static Builder builder() {
+    return Instances.builder().orElseThrow(() -> new IllegalStateException("A provider for JsonComponentSerializer was not found!"));
+  }
+
+  /**
+   * A builder for {@link JsonComponentSerializer}.
+   *
+   * @since 4.9.0
+   */
+  interface Builder extends Buildable.Builder<JsonComponentSerializer> {
+    /**
+     * Sets that the serializer should downsample hex colors to named colors.
+     *
+     * @return this builder
+     * @since 4.9.0
+     */
+    @NotNull Builder downsampleColors();
+
+    /**
+     * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
+     * If the serializer is {@code null}, then only {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}
+     * legacy hover events can be deserialized.
+     *
+     * @param serializer serializer
+     * @return this builder
+     * @since 4.9.0
+     */
+    @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
+
+    /**
+     * Output a legacy hover event {@code value} in addition to the modern {@code contents}.
+     *
+     * <p>A {@link #legacyHoverEventSerializer(LegacyHoverEventSerializer) legacy hover serializer} must also be set
+     * to serialize any hover events beyond those with action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}</p>
+     *
+     * @return this builder
+     * @since 4.9.0
+     */
+    @NotNull Builder emitLegacyHoverEvent();
+
+    /**
+     * Builds the serializer.
+     *
+     * @return the built serializer
+     */
+    @Override
+    @NotNull JsonComponentSerializer build();
+  }
+
+  /**
+   * A {@link JsonComponentSerializer} service provider.
+   *
+   * @since 4.9.0
+   */
+  @ApiStatus.Internal
+  interface Provider {
+    /**
+     * Provides a standard {@link JsonComponentSerializer}.
+     *
+     * @return a {@link JsonComponentSerializer}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull JsonComponentSerializer json();
+
+    /**
+     * Provides a legacy {@link JsonComponentSerializer}.
+     *
+     * @return a {@link JsonComponentSerializer}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull JsonComponentSerializer jsonLegacy();
+
+    /**
+     * Provides a new {@link Builder}.
+     *
+     * @return a {@link Builder}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull Builder builder();
+  }
+}

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/LegacyHoverEventSerializer.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/LegacyHoverEventSerializer.java
@@ -21,24 +21,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package net.kyori.adventure.text.serializer.gson;
+package net.kyori.adventure.text.serializer.json;
 
 import java.io.IOException;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.util.Codec;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Adapter to convert between modern and legacy hover event formats.
  *
  * @since 4.0.0
- * @deprecated For removal, use {@link net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer}
  */
-@Deprecated
-@ApiStatus.ScheduledForRemoval
-public interface LegacyHoverEventSerializer extends net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer {
+public interface LegacyHoverEventSerializer {
   /**
    * Convert a legacy hover event {@code show_item} value to its modern format.
    *

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/package-info.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Common abstraction between JSON serializer implementations to allow platforms to choose which serializer
+ * they wish to provide.
+ */
+package net.kyori.adventure.text.serializer.json;

--- a/text-serializer-moshi/build.gradle.kts
+++ b/text-serializer-moshi/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  id("adventure.common-conventions")
+  id("me.champeau.jmh")
+}
+
+dependencies {
+  api(project(":adventure-api"))
+  api(project(":adventure-text-serializer-json"))
+  api("com.squareup.moshi:moshi:1.12.0")
+  testImplementation(project(":adventure-nbt"))
+}
+
+applyJarMetadata("net.kyori.adventure.text.serializer.moshi")

--- a/text-serializer-moshi/src/jmh/java/net/kyori/adventure/text/serializer/moshi/ComponentDeserializationBenchmark.java
+++ b/text-serializer-moshi/src/jmh/java/net/kyori/adventure/text/serializer/moshi/ComponentDeserializationBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ComponentDeserializationBenchmark {
+
+  private String simpleComponent;
+  private String componentTreeWithStyle;
+  private String componentTreeWithEvents;
+
+  @Setup(Level.Trial)
+  public void prepare() {
+    this.simpleComponent = MoshiComponentSerializer.moshi().serialize(Component.text("Hello, World!", Style.style(TextDecoration.UNDERLINED)));
+    this.componentTreeWithStyle = MoshiComponentSerializer.moshi().serialize(Component.text()
+      .decorate(TextDecoration.UNDERLINED, TextDecoration.ITALIC)
+      .append(Component.text("Component ", TextColor.color(0x8cfbde)))
+      .append(Component.text("with ", TextColor.color(0x0fff95), TextDecoration.BOLD))
+      .append(Component.text("hex ", TextColor.color(0x06ba63)))
+      .append(Component.text("colors", TextColor.color(0x103900)))
+      .build());
+    this.componentTreeWithEvents = MoshiComponentSerializer.moshi().serialize(Component.text()
+      .decorate(TextDecoration.UNDERLINED, TextDecoration.ITALIC)
+      .append(Component.text("Component ", TextColor.color(0x8cfbde))
+        .clickEvent(ClickEvent.openUrl("https://kyori.net/")))
+      .append(Component.text("with ", TextColor.color(0x0fff95), TextDecoration.BOLD)
+        .hoverEvent(HoverEvent.showItem(Key.key("iron_sword"), 1, BinaryTagHolder.of("{Damage: 30, RepairCost: 4, Enchantments: [{id: 'minecraft:sharpness', lvl: 3s}, {id: 'minecraft:unbreaking', lvl: 1s}]}"))))
+      .append(Component.text("hex ", TextColor.color(0x06ba63))
+        .hoverEvent(HoverEvent.showEntity(Key.key("pig"), UUID.randomUUID(), Component.text("Piggy", NamedTextColor.YELLOW))))
+      .append(Component.text("colors", TextColor.color(0x103900))
+        .hoverEvent(HoverEvent.showText(Component.text("Text hover!"))))
+      .build());
+  }
+
+  @Benchmark
+  public Component simpleComponent() {
+    return MoshiComponentSerializer.moshi().deserialize(this.simpleComponent);
+  }
+
+  @Benchmark
+  public Component componentTreeWithStyle() {
+    return MoshiComponentSerializer.moshi().deserialize(this.componentTreeWithStyle);
+  }
+
+  @Benchmark
+  public Component componentTreeWithEvents() {
+    return MoshiComponentSerializer.moshi().deserialize(this.componentTreeWithEvents);
+  }
+}

--- a/text-serializer-moshi/src/jmh/java/net/kyori/adventure/text/serializer/moshi/ComponentSerializationBenchmark.java
+++ b/text-serializer-moshi/src/jmh/java/net/kyori/adventure/text/serializer/moshi/ComponentSerializationBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ComponentSerializationBenchmark {
+
+  @Benchmark
+  public String simpleComponent() {
+    return MoshiComponentSerializer.moshi().serialize(Component.text("Hello, World!", Style.style(TextDecoration.UNDERLINED)));
+  }
+
+  @Benchmark
+  public String componentTreeWithStyle() {
+    return MoshiComponentSerializer.moshi().serialize(Component.text()
+      .decorate(TextDecoration.UNDERLINED, TextDecoration.ITALIC)
+      .append(Component.text("Component ", TextColor.color(0x8cfbde)))
+      .append(Component.text("with ", TextColor.color(0x0fff95), TextDecoration.BOLD))
+      .append(Component.text("hex ", TextColor.color(0x06ba63)))
+      .append(Component.text("colors", TextColor.color(0x103900)))
+      .build());
+  }
+
+  @Benchmark
+  public String componentTreeWithEvents() {
+    return MoshiComponentSerializer.moshi().serialize(Component.text()
+      .decorate(TextDecoration.UNDERLINED, TextDecoration.ITALIC)
+      .append(Component.text("Component ", TextColor.color(0x8cfbde))
+        .clickEvent(ClickEvent.openUrl("https://kyori.net/")))
+      .append(Component.text("with ", TextColor.color(0x0fff95), TextDecoration.BOLD)
+        .hoverEvent(HoverEvent.showItem(Key.key("iron_sword"), 1, BinaryTagHolder.of("{Damage: 30, RepairCost: 4, Enchantments: [{id: 'minecraft:sharpness', lvl: 3s}, {id: 'minecraft:unbreaking', lvl: 1s}]}"))))
+      .append(Component.text("hex ", TextColor.color(0x06ba63))
+        .hoverEvent(HoverEvent.showEntity(Key.key("pig"), UUID.randomUUID(), Component.text("Piggy", NamedTextColor.YELLOW))))
+      .append(Component.text("colors", TextColor.color(0x103900))
+        .hoverEvent(HoverEvent.showText(Component.text("Text hover!"))))
+      .build());
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/BlockNBTComponentPosAdapter.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/BlockNBTComponentPosAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import java.io.IOException;
+import net.kyori.adventure.text.BlockNBTComponent;
+
+final class BlockNBTComponentPosAdapter extends JsonAdapter<BlockNBTComponent.Pos> {
+  static final JsonAdapter<BlockNBTComponent.Pos> INSTANCE = new BlockNBTComponentPosAdapter().nullSafe();
+
+  private BlockNBTComponentPosAdapter() {
+  }
+
+  @Override
+  public BlockNBTComponent.Pos fromJson(final JsonReader reader) throws IOException {
+    final String string = reader.nextString();
+    try {
+      return BlockNBTComponent.Pos.fromString(string);
+    } catch (final IllegalArgumentException exception) {
+      throw new JsonDataException("Don't know how to turn " + string + " into a Position");
+    }
+  }
+
+  @Override
+  public void toJson(final JsonWriter writer, final BlockNBTComponent.Pos value) throws IOException {
+    writer.value(value.asString());
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/ClickEventActionSerializer.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/ClickEventActionSerializer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import net.kyori.adventure.text.event.ClickEvent;
+
+final class ClickEventActionSerializer {
+  static final JsonAdapter<ClickEvent.Action> INSTANCE = IndexedAdapter.of("click action", ClickEvent.Action.NAMES);
+
+  private ClickEventActionSerializer() {
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/ComponentAdapter.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/ComponentAdapter.java
@@ -1,0 +1,301 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import net.kyori.adventure.text.BlockNBTComponent;
+import net.kyori.adventure.text.BuildableComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentBuilder;
+import net.kyori.adventure.text.EntityNBTComponent;
+import net.kyori.adventure.text.KeybindComponent;
+import net.kyori.adventure.text.NBTComponent;
+import net.kyori.adventure.text.NBTComponentBuilder;
+import net.kyori.adventure.text.ScoreComponent;
+import net.kyori.adventure.text.SelectorComponent;
+import net.kyori.adventure.text.StorageNBTComponent;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.format.Style;
+import org.jetbrains.annotations.Nullable;
+
+final class ComponentAdapter extends JsonAdapter<Component> {
+  static final String TEXT = "text";
+  static final String TRANSLATE = "translate";
+  static final String TRANSLATE_WITH = "with";
+  static final String SCORE = "score";
+  static final String SCORE_NAME = "name";
+  static final String SCORE_OBJECTIVE = "objective";
+  static final String SCORE_VALUE = "value";
+  static final String SELECTOR = "selector";
+  static final String KEYBIND = "keybind";
+  static final String EXTRA = "extra";
+  static final String NBT = "nbt";
+  static final String NBT_INTERPRET = "interpret";
+  static final String NBT_BLOCK = "block";
+  static final String NBT_ENTITY = "entity";
+  static final String NBT_STORAGE = "storage";
+  static final String SEPARATOR = "separator";
+
+  static JsonAdapter<Component> create(final Moshi moshi) {
+    return new ComponentAdapter(moshi).nullSafe().lenient();
+  }
+
+  private final Moshi moshi;
+
+  private ComponentAdapter(final Moshi moshi) {
+    this.moshi = moshi;
+  }
+
+  @Override
+  public Component fromJson(final JsonReader reader) throws IOException {
+    return this.deserialize(reader.readJsonValue());
+  }
+
+  @SuppressWarnings("unchecked")
+  private BuildableComponent<?, ?> deserialize(final Object element) throws JsonDataException {
+    if (element instanceof String || element instanceof Number || element instanceof Boolean) {
+      return Component.text(asString(element));
+    } else if (element instanceof List<?>) {
+      ComponentBuilder<?, ?> parent = null;
+      for (final Object childElement : (List<?>) element) {
+        final BuildableComponent<?, ?> child = this.deserialize(childElement);
+        if (parent == null) {
+          parent = child.toBuilder();
+        } else {
+          parent.append(child);
+        }
+      }
+      if (parent == null) {
+        throw notSureHowToDeserialize(element);
+      }
+      return parent.build();
+    } else if (!(element instanceof Map<?, ?>)) {
+      throw notSureHowToDeserialize(element);
+    }
+
+    final Map<String, Object> object = (Map<String, Object>) element;
+    final ComponentBuilder<?, ?> component;
+    if (object.containsKey(TEXT)) {
+      component = Component.text().content(asString(object.get(TEXT)));
+    } else if (object.containsKey(TRANSLATE)) {
+      final String key = asString(object.get(TRANSLATE));
+      if (!object.containsKey(TRANSLATE_WITH)) {
+        component = Component.translatable().key(key);
+      } else {
+        final List<Object> with = (List<Object>) object.get(TRANSLATE_WITH);
+        final List<Component> args = new ArrayList<>(with.size());
+        for (int i = 0, size = with.size(); i < size; i++) {
+          final Object argElement = with.get(i);
+          args.add(this.deserialize(argElement));
+        }
+        component = Component.translatable().key(key).args(args);
+      }
+    } else if (object.containsKey(SCORE)) {
+      final Map<String, Object> score = (Map<String, Object>) object.get(SCORE);
+      if (!score.containsKey(SCORE_NAME) || !score.containsKey(SCORE_OBJECTIVE)) {
+        throw new JsonDataException("A score component requires a " + SCORE_NAME + " and " + SCORE_OBJECTIVE);
+      }
+      final ScoreComponent.Builder builder = Component.score()
+        .name(asString(score.get(SCORE_NAME)))
+        .objective(asString(score.get(SCORE_OBJECTIVE)));
+      // score components can have a value sometimes, let's grab it
+      if (score.containsKey(SCORE_VALUE)) {
+        component = builder.value(asString(score.get(SCORE_VALUE)));
+      } else {
+        component = builder;
+      }
+    } else if (object.containsKey(SELECTOR)) {
+      final @Nullable Component separator = this.deserializeSeparator(object);
+      component = Component.selector().pattern(asString(object.get(SELECTOR))).separator(separator);
+    } else if (object.containsKey(KEYBIND)) {
+      component = Component.keybind().keybind(asString(object.get(KEYBIND)));
+    } else if (object.containsKey(NBT)) {
+      final String nbt = asString(object.get(NBT));
+      final boolean interpret = object.containsKey(NBT_INTERPRET) && asBoolean(object.get(NBT_INTERPRET));
+      final @Nullable Component separator = this.deserializeSeparator(object);
+      if (object.containsKey(NBT_BLOCK)) {
+        final BlockNBTComponent.Pos pos = this.moshi.adapter(SerializerFactory.BLOCK_NBT_POS_TYPE).fromJsonValue(object.get(NBT_BLOCK));
+        component = nbt(Component.blockNBT(), nbt, interpret, separator).pos(pos);
+      } else if (object.containsKey(NBT_ENTITY)) {
+        component = nbt(Component.entityNBT(), nbt, interpret, separator).selector(asString(object.get(NBT_ENTITY)));
+      } else if (object.containsKey(NBT_STORAGE)) {
+        component = nbt(Component.storageNBT(), nbt, interpret, separator).storage(Objects.requireNonNull(this.moshi.adapter(SerializerFactory.KEY_TYPE).fromJsonValue(object.get(NBT_STORAGE))));
+      } else {
+        throw notSureHowToDeserialize(element);
+      }
+    } else {
+      throw notSureHowToDeserialize(element);
+    }
+
+    if (object.containsKey(EXTRA)) {
+      final List<Object> extra = (List<Object>) object.get(EXTRA);
+      for (int i = 0, size = extra.size(); i < size; i++) {
+        final Object extraElement = extra.get(i);
+        component.append(this.deserialize(extraElement));
+      }
+    }
+
+    final Style style = this.moshi.adapter(SerializerFactory.STYLE_TYPE).fromJsonValue(element);
+    if (!style.isEmpty()) {
+      component.style(style);
+    }
+
+    return component.build();
+  }
+
+  @Override
+  public void toJson(final JsonWriter writer, final Component value) throws IOException {
+    writer.jsonValue(this.serialize(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Object serialize(final Component src) {
+    final Map<String, Object> object = new HashMap<>();
+
+    if (src.hasStyling()) {
+      final Object style = this.moshi.adapter(SerializerFactory.STYLE_TYPE).toJsonValue(src.style());
+      if (style instanceof Map<?, ?>) {
+        for (final Map.Entry<String, Object> entry : ((Map<String, Object>) style).entrySet()) {
+          object.put(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+
+    final List<Component> children = src.children();
+    if (!children.isEmpty()) {
+      final List<Object> extra = new ArrayList<>();
+      for (final Component child : children) {
+        extra.add(this.serialize(child));
+      }
+      object.put(EXTRA, extra);
+    }
+
+    if (src instanceof TextComponent) {
+      object.put(TEXT, ((TextComponent) src).content());
+    } else if (src instanceof TranslatableComponent) {
+      final TranslatableComponent tc = (TranslatableComponent) src;
+      object.put(TRANSLATE, tc.key());
+      if (!tc.args().isEmpty()) {
+        final List<Object> with = new ArrayList<>();
+        for (final Component arg : tc.args()) {
+          with.add(this.serialize(arg));
+        }
+        object.put(TRANSLATE_WITH, with);
+      }
+    } else if (src instanceof ScoreComponent) {
+      final ScoreComponent sc = (ScoreComponent) src;
+      final Map<String, Object> score = new HashMap<>();
+      score.put(SCORE_NAME, sc.name());
+      score.put(SCORE_OBJECTIVE, sc.objective());
+      // score component value is optional
+      @SuppressWarnings("deprecation")
+      final @Nullable String value = sc.value();
+      if (value != null) {
+        score.put(SCORE_VALUE, value);
+      }
+      object.put(SCORE, score);
+    } else if (src instanceof SelectorComponent) {
+      final SelectorComponent sc = (SelectorComponent) src;
+      object.put(SELECTOR, sc.pattern());
+      this.serializeSeparator(object, sc.separator());
+    } else if (src instanceof KeybindComponent) {
+      object.put(KEYBIND, ((KeybindComponent) src).keybind());
+    } else if (src instanceof NBTComponent<?, ?>) {
+      final NBTComponent<?, ?> nc = (NBTComponent<?, ?>) src;
+      object.put(NBT, nc.nbtPath());
+      object.put(NBT_INTERPRET, nc.interpret());
+      if (src instanceof BlockNBTComponent) {
+        final Object position = this.moshi.adapter(SerializerFactory.BLOCK_NBT_POS_TYPE).toJsonValue(((BlockNBTComponent) nc).pos());
+        object.put(NBT_BLOCK, position);
+        this.serializeSeparator(object, nc.separator());
+      } else if (src instanceof EntityNBTComponent) {
+        object.put(NBT_ENTITY, ((EntityNBTComponent) nc).selector());
+      } else if (src instanceof StorageNBTComponent) {
+        object.put(NBT_STORAGE, this.moshi.adapter(SerializerFactory.KEY_TYPE).toJsonValue(((StorageNBTComponent) nc).storage()));
+      } else {
+        throw notSureHowToSerialize(src);
+      }
+    } else {
+      throw notSureHowToSerialize(src);
+    }
+
+    return object;
+  }
+
+  private @Nullable Component deserializeSeparator(final Map<String, Object> json) {
+    if (json.containsKey(SEPARATOR)) {
+      return this.fromJsonValue(json.get(SEPARATOR));
+    }
+    return null;
+  }
+
+  private void serializeSeparator(final Map<String, Object> json, final @Nullable Component separator) {
+    if (separator != null) {
+      json.put(SEPARATOR, this.serialize(separator));
+    }
+  }
+
+  private static <C extends NBTComponent<C, B>, B extends NBTComponentBuilder<C, B>> B nbt(final B builder, final String nbt, final boolean interpret, final @Nullable Component separator) {
+    return builder
+      .nbtPath(nbt)
+      .interpret(interpret)
+      .separator(separator);
+  }
+
+  private static String asString(final Object value) {
+    if (value instanceof Number) {
+      return value.toString();
+    } else if (value instanceof Boolean) {
+      return ((Boolean) value).toString();
+    } else {
+      return (String) value;
+    }
+  }
+
+  private static boolean asBoolean(final Object value) {
+    if (value instanceof Boolean) {
+      return (Boolean) value;
+    }
+    return Boolean.parseBoolean(asString(value));
+  }
+
+  static JsonDataException notSureHowToDeserialize(final Object element) {
+    return new JsonDataException("Don't know how to turn " + element + " into a Component");
+  }
+
+  private static IllegalArgumentException notSureHowToSerialize(final Component component) {
+    return new IllegalArgumentException("Don't know how to serialize " + component + " as a Component");
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/HoverEventActionSerializer.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/HoverEventActionSerializer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import net.kyori.adventure.text.event.HoverEvent;
+
+final class HoverEventActionSerializer {
+  static final JsonAdapter<HoverEvent.Action<?>> INSTANCE = IndexedAdapter.of("hover action", HoverEvent.Action.NAMES);
+
+  private HoverEventActionSerializer() {
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/IndexedAdapter.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/IndexedAdapter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import java.io.IOException;
+import net.kyori.adventure.util.Index;
+
+final class IndexedAdapter<E> extends JsonAdapter<E> {
+
+  public static <E> JsonAdapter<E> of(final String name, final Index<String, E> map) {
+    return new IndexedAdapter<>(name, map);
+  }
+
+  private final String name;
+  private final Index<String, E> map;
+
+  private IndexedAdapter(final String name, final Index<String, E> map) {
+    this.name = name;
+    this.map = map;
+  }
+
+  @Override
+  public E fromJson(final JsonReader reader) throws IOException {
+    final String string = reader.nextString();
+    final E value = this.map.value(string);
+    if (value != null) {
+      return value;
+    } else {
+      throw new JsonDataException("invalid " + this.name + ": " + string);
+    }
+  }
+
+  @Override
+  public void toJson(final JsonWriter writer, final E value) throws IOException {
+    writer.value(this.map.key(value));
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/KeyAdapter.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/KeyAdapter.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import java.io.IOException;
+import net.kyori.adventure.key.Key;
+
+final class KeyAdapter extends JsonAdapter<Key> {
+  static final JsonAdapter<Key> INSTANCE = new KeyAdapter().nullSafe();
+
+  private KeyAdapter() {
+  }
+
+  @Override
+  public Key fromJson(final JsonReader reader) throws IOException {
+    return Key.key(reader.nextString());
+  }
+
+  @Override
+  public void toJson(final JsonWriter writer, final Key value) throws IOException {
+    writer.value(value.asString());
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/MoshiComponentSerializer.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/MoshiComponentSerializer.java
@@ -1,0 +1,159 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.Moshi;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.json.JsonComponentSerializer;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A moshi component serializer.
+ *
+ * <p>Use {@link Builder#downsampleColors()} to support platforms
+ * that do not understand hex colors that were introduced in Minecraft 1.16.</p>
+ *
+ * @since 4.9.0
+ */
+public interface MoshiComponentSerializer extends JsonComponentSerializer {
+  /**
+   * Gets a component serializer for moshi serialization and deserialization.
+   *
+   * @return a moshi component serializer
+   * @since 4.9.0
+   */
+  static @NotNull MoshiComponentSerializer moshi() {
+    return MoshiComponentSerializerImpl.Instances.INSTANCE;
+  }
+
+  /**
+   * Gets a component serializer for moshi serialization and deserialization.
+   *
+   * <p>Hex colors are coerced to the nearest named color, and legacy hover events are
+   * emitted for action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}.</p>
+   *
+   * @return a moshi component serializer
+   * @since 4.9.0
+   */
+  static @NotNull MoshiComponentSerializer colorDownsamplingMoshi() {
+    return MoshiComponentSerializerImpl.Instances.LEGACY_INSTANCE;
+  }
+
+  /**
+   * Creates a new {@link MoshiComponentSerializer.Builder}.
+   *
+   * @return a builder
+   * @since 4.9.0
+   */
+  static Builder builder() {
+    return new MoshiComponentSerializerImpl.BuilderImpl();
+  }
+
+  /**
+   * Gets the underlying moshi serializer.
+   *
+   * @return a moshi serializer
+   * @since 4.9.0
+   */
+  @NotNull Moshi serializer();
+
+  /**
+   * Gets the underlying moshi populator.
+   *
+   * @return a moshi populator
+   * @since 4.9.0
+   */
+  @NotNull UnaryOperator<Moshi.Builder> populator();
+
+  /**
+   * Deserialize a component from input of type {@link Object}.
+   *
+   * @param input the input
+   * @return the component
+   * @since 4.7.0
+   */
+  @NotNull Component deserializeFromTree(final @NotNull Object input);
+
+  /**
+   * Deserialize a component to output of type {@link Object}.
+   *
+   * @param component the component
+   * @return the json element
+   * @since 4.7.0
+   */
+  @NotNull Object serializeToTree(final @NotNull Component component);
+
+  /**
+   * A builder for {@link MoshiComponentSerializer}.
+   *
+   * @since 4.9.0
+   */
+  interface Builder extends JsonComponentSerializer.Builder {
+    /**
+     * Builds the serializer.
+     *
+     * @return the built serializer
+     */
+    @Override
+    @NotNull MoshiComponentSerializer build();
+  }
+
+  /**
+   * A {@link MoshiComponentSerializer} service provider.
+   *
+   * @since 4.9.0
+   */
+  @ApiStatus.Internal
+  interface Provider {
+    /**
+     * Provides a standard {@link MoshiComponentSerializer}.
+     *
+     * @return a {@link MoshiComponentSerializer}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull MoshiComponentSerializer moshi();
+
+    /**
+     * Provides a legacy {@link MoshiComponentSerializer}.
+     *
+     * @return a {@link MoshiComponentSerializer}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull MoshiComponentSerializer moshiLegacy();
+
+    /**
+     * Completes the building process of {@link Builder}.
+     *
+     * @return a {@link Consumer}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull Consumer<Builder> builder();
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/MoshiComponentSerializerImpl.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/MoshiComponentSerializerImpl.java
@@ -1,0 +1,159 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
+import net.kyori.adventure.util.Services;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class MoshiComponentSerializerImpl implements MoshiComponentSerializer {
+  private static final Optional<Provider> SERVICE = Services.service(Provider.class);
+  static final Consumer<Builder> BUILDER = SERVICE
+    .map(Provider::builder)
+    .orElseGet(() -> builder -> {
+      // NOOP
+    });
+
+  // We cannot store these fields in MoshiComponentSerializerImpl directly due to class initialisation issues.
+  static final class Instances {
+    static final MoshiComponentSerializer INSTANCE = SERVICE
+      .map(Provider::moshi)
+      .orElseGet(() -> new MoshiComponentSerializerImpl(false, null, false));
+    static final MoshiComponentSerializer LEGACY_INSTANCE = SERVICE
+      .map(Provider::moshiLegacy)
+      .orElseGet(() -> new MoshiComponentSerializerImpl(true, null, true));
+  }
+
+  private final Moshi serializer;
+  private final UnaryOperator<Moshi.Builder> populator;
+  private final boolean downsampleColor;
+  private final @Nullable LegacyHoverEventSerializer legacyHoverSerializer;
+  private final boolean emitLegacyHover;
+
+  MoshiComponentSerializerImpl(final boolean downsampleColor, final @Nullable LegacyHoverEventSerializer legacyHoverSerializer, final boolean emitLegacyHover) {
+    this.downsampleColor = downsampleColor;
+    this.legacyHoverSerializer = legacyHoverSerializer;
+    this.emitLegacyHover = emitLegacyHover;
+    this.populator = builder -> {
+      builder.add(new SerializerFactory(downsampleColor, legacyHoverSerializer, emitLegacyHover));
+      return builder;
+    };
+    this.serializer = this.populator.apply(new Moshi.Builder()).build();
+  }
+
+  @Override
+  public @NotNull Moshi serializer() {
+    return this.serializer;
+  }
+
+  @Override
+  public @NotNull UnaryOperator<Moshi.Builder> populator() {
+    return this.populator;
+  }
+
+  @Override
+  public @NotNull Component deserialize(final @NotNull String input) {
+    try {
+      final Component component = this.serializer().adapter(SerializerFactory.COMPONENT_TYPE).fromJson(input);
+      if (component == null) throw ComponentAdapter.notSureHowToDeserialize(input);
+      return component;
+    } catch (final IOException exception) {
+      throw ComponentAdapter.notSureHowToDeserialize(input);
+    }
+  }
+
+  @Override
+  public @NotNull String serialize(final @NotNull Component component) {
+    return this.serializer().adapter(SerializerFactory.COMPONENT_TYPE).toJson(component);
+  }
+
+  @Override
+  public @NotNull Component deserializeFromTree(final @NotNull Object input) {
+    final Component component = this.serializer().adapter(SerializerFactory.COMPONENT_TYPE).fromJsonValue(input);
+    if (component == null) throw ComponentAdapter.notSureHowToDeserialize(input);
+    return component;
+  }
+
+  @Override
+  public @NotNull Object serializeToTree(final @NotNull Component component) {
+    return Objects.requireNonNull(this.serializer().adapter(SerializerFactory.COMPONENT_TYPE).toJsonValue(component));
+  }
+
+  @Override
+  public @NotNull MoshiComponentSerializer.Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  static final class BuilderImpl implements Builder {
+    private boolean downsampleColor = false;
+    private @Nullable LegacyHoverEventSerializer legacyHoverSerializer;
+    private boolean emitLegacyHover = false;
+
+    BuilderImpl() {
+      BUILDER.accept(this);
+    }
+
+    BuilderImpl(final MoshiComponentSerializerImpl serializer) {
+      this();
+      this.downsampleColor = serializer.downsampleColor;
+      this.emitLegacyHover = serializer.emitLegacyHover;
+      this.legacyHoverSerializer = serializer.legacyHoverSerializer;
+    }
+
+    @Override
+    public @NotNull Builder downsampleColors() {
+      this.downsampleColor = true;
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer) {
+      this.legacyHoverSerializer = serializer;
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder emitLegacyHoverEvent() {
+      this.emitLegacyHover = true;
+      return this;
+    }
+
+    @Override
+    public @NotNull MoshiComponentSerializer build() {
+      if (this.legacyHoverSerializer == null) {
+        return this.downsampleColor ? Instances.LEGACY_INSTANCE : Instances.INSTANCE;
+      } else {
+        return new MoshiComponentSerializerImpl(this.downsampleColor, this.legacyHoverSerializer, this.emitLegacyHover);
+      }
+    }
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/SerializerFactory.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/SerializerFactory.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.BlockNBTComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class SerializerFactory implements JsonAdapter.Factory {
+  static final Class<Key> KEY_TYPE = Key.class;
+  static final Class<Component> COMPONENT_TYPE = Component.class;
+  static final Class<Style> STYLE_TYPE = Style.class;
+  static final Class<ClickEvent.Action> CLICK_ACTION_TYPE = ClickEvent.Action.class;
+  static final Class<HoverEvent.Action> HOVER_ACTION_TYPE = HoverEvent.Action.class;
+  static final Class<HoverEvent.ShowItem> SHOW_ITEM_TYPE = HoverEvent.ShowItem.class;
+  static final Class<HoverEvent.ShowEntity> SHOW_ENTITY_TYPE = HoverEvent.ShowEntity.class;
+  static final Class<TextColorWrapper> COLOR_WRAPPER_TYPE = TextColorWrapper.class;
+  static final Class<TextColor> COLOR_TYPE = TextColor.class;
+  static final Class<TextDecoration> TEXT_DECORATION_TYPE = TextDecoration.class;
+  static final Class<BlockNBTComponent.Pos> BLOCK_NBT_POS_TYPE = BlockNBTComponent.Pos.class;
+
+  private final boolean downsampleColors;
+  private final LegacyHoverEventSerializer legacyHoverSerializer;
+  private final boolean emitLegacyHover;
+
+  SerializerFactory(final boolean downsampleColors, final @Nullable LegacyHoverEventSerializer legacyHoverSerializer, final boolean emitLegacyHover) {
+    this.downsampleColors = downsampleColors;
+    this.legacyHoverSerializer = legacyHoverSerializer;
+    this.emitLegacyHover = emitLegacyHover;
+  }
+
+  @Override
+  public JsonAdapter<?> create(final @NotNull Type type, final @NotNull Set<? extends Annotation> annotations, final @NotNull Moshi moshi) {
+    if (!(type instanceof Class<?>)) {
+      return null;
+    }
+    final Class<?> clazz = (Class<?>) type;
+    if (COMPONENT_TYPE.isAssignableFrom(clazz)) {
+      return ComponentAdapter.create(moshi);
+    } else if (KEY_TYPE.isAssignableFrom(clazz)) {
+      return KeyAdapter.INSTANCE;
+    } else if (STYLE_TYPE.isAssignableFrom(clazz)) {
+      return StyleAdapter.create(moshi, this.legacyHoverSerializer, this.emitLegacyHover);
+    } else if (CLICK_ACTION_TYPE.isAssignableFrom(clazz)) {
+      return ClickEventActionSerializer.INSTANCE;
+    } else if (HOVER_ACTION_TYPE.isAssignableFrom(clazz)) {
+      return HoverEventActionSerializer.INSTANCE;
+    } else if (SHOW_ITEM_TYPE.isAssignableFrom(clazz)) {
+      return ShowItemAdapter.create(moshi);
+    } else if (SHOW_ENTITY_TYPE.isAssignableFrom(clazz)) {
+      return ShowEntityAdapter.create(moshi);
+    } else if (COLOR_WRAPPER_TYPE.isAssignableFrom(clazz)) {
+      return TextColorWrapper.Serializer.INSTANCE;
+    } else if (COLOR_TYPE.isAssignableFrom(clazz)) {
+      return this.downsampleColors ? TextColorSerializer.DOWNSAMPLE_COLOR : TextColorSerializer.INSTANCE;
+    } else if (TEXT_DECORATION_TYPE.isAssignableFrom(clazz)) {
+      return TextDecorationSerializer.INSTANCE;
+    } else if (BLOCK_NBT_POS_TYPE.isAssignableFrom(clazz)) {
+      return BlockNBTComponentPosAdapter.INSTANCE;
+    } else {
+      return null;
+    }
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/ShowEntityAdapter.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/ShowEntityAdapter.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import java.util.UUID;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
+import org.jetbrains.annotations.Nullable;
+
+final class ShowEntityAdapter extends JsonAdapter<HoverEvent.ShowEntity> {
+  static final String TYPE = "type";
+  static final String ID = "id";
+  static final String NAME = "name";
+  private static final JsonReader.Options OPTIONS = JsonReader.Options.of(TYPE, ID, NAME);
+
+  static JsonAdapter<HoverEvent.ShowEntity> create(final Moshi moshi) {
+    return new ShowEntityAdapter(moshi).nullSafe();
+  }
+
+  private final Moshi moshi;
+
+  private ShowEntityAdapter(final Moshi moshi) {
+    this.moshi = moshi;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public HoverEvent.ShowEntity fromJson(final JsonReader reader) throws IOException {
+    reader.beginObject();
+
+    Key type = null;
+    UUID id = null;
+    @Nullable Component name = null;
+
+    while (reader.hasNext()) {
+      switch (reader.selectName(OPTIONS)) {
+        case 0:
+          type = this.moshi.adapter(SerializerFactory.KEY_TYPE).fromJson(reader);
+          break;
+        case 1:
+          id = UUID.fromString(reader.nextString());
+          break;
+        case 2:
+          name = this.moshi.adapter(SerializerFactory.COMPONENT_TYPE).fromJson(reader);
+          break;
+        default:
+          reader.skipValue();
+          break;
+      }
+    }
+
+    if (type == null || id == null) {
+      throw new JsonDataException("A show entity hover event needs type and id fields to be deserialized");
+    }
+    reader.endObject();
+
+    return HoverEvent.ShowEntity.of(type, id, name);
+  }
+
+  @Override
+  public void toJson(final JsonWriter writer, final HoverEvent.ShowEntity value) throws IOException {
+    writer.beginObject();
+
+    writer.name(TYPE);
+    this.moshi.adapter(SerializerFactory.KEY_TYPE).toJson(writer, value.type());
+
+    writer.name(ID);
+    writer.value(value.id().toString());
+
+    final @Nullable Component name = value.name();
+    if (name != null) {
+      writer.name(NAME);
+      this.moshi.adapter(SerializerFactory.COMPONENT_TYPE).toJson(writer, name);
+    }
+
+    writer.endObject();
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/ShowItemAdapter.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/ShowItemAdapter.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.event.HoverEvent;
+import org.jetbrains.annotations.Nullable;
+
+final class ShowItemAdapter extends JsonAdapter<HoverEvent.ShowItem> {
+  static final String ID = "id";
+  static final String COUNT = "count";
+  static final String TAG = "tag";
+  private static final JsonReader.Options OPTIONS = JsonReader.Options.of(ID, COUNT, TAG);
+
+  static JsonAdapter<HoverEvent.ShowItem> create(final Moshi moshi) {
+    return new ShowItemAdapter(moshi).nullSafe();
+  }
+
+  private final Moshi moshi;
+
+  private ShowItemAdapter(final Moshi moshi) {
+    this.moshi = moshi;
+  }
+
+  @Override
+  public HoverEvent.ShowItem fromJson(final JsonReader reader) throws IOException {
+    reader.beginObject();
+
+    Key key = null;
+    int count = 1;
+    @Nullable BinaryTagHolder nbt = null;
+
+    while (reader.hasNext()) {
+      switch (reader.selectName(OPTIONS)) {
+        case 0:
+          key = this.moshi.adapter(SerializerFactory.KEY_TYPE).fromJson(reader);
+          break;
+        case 1:
+          count = reader.nextInt();
+          break;
+        case 2:
+          final JsonReader.Token token = reader.peek();
+          switch (token) {
+            case STRING:
+            case NUMBER:
+              nbt = BinaryTagHolder.of(reader.nextString());
+              break;
+            case BOOLEAN:
+              nbt = BinaryTagHolder.of(String.valueOf(reader.nextBoolean()));
+              break;
+            case NULL:
+              reader.nextNull();
+              break;
+            default:
+              throw new JsonDataException("Expected " + TAG + " to be a string");
+          }
+          break;
+        default:
+          reader.skipValue();
+          break;
+      }
+    }
+
+    if (key == null) {
+      throw new JsonDataException("Not sure how to deserialize show_item hover event");
+    }
+    reader.endObject();
+
+    return HoverEvent.ShowItem.of(key, count, nbt);
+  }
+
+  @Override
+  public void toJson(final JsonWriter writer, final HoverEvent.ShowItem value) throws IOException {
+    writer.beginObject();
+
+    writer.name(ID);
+    this.moshi.adapter(SerializerFactory.KEY_TYPE).toJson(writer, value.item());
+
+    final int count = value.count();
+    if (count != 1) {
+      writer.name(COUNT);
+      writer.value(count);
+    }
+
+    final @Nullable BinaryTagHolder nbt = value.nbt();
+    if (nbt != null) {
+      writer.name(TAG);
+      writer.value(nbt.string());
+    }
+
+    writer.endObject();
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/StyleAdapter.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/StyleAdapter.java
@@ -1,0 +1,307 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
+import net.kyori.adventure.util.Codec;
+import org.jetbrains.annotations.Nullable;
+
+final class StyleAdapter extends JsonAdapter<Style> {
+  @SuppressWarnings("checkstyle:NoWhitespaceAfter")
+  private static final TextDecoration[] DECORATIONS = {
+    // The order here is important -- Minecraft does string comparisons of some
+    // serialized components so we have to make sure our order matches Vanilla
+    TextDecoration.BOLD,
+    TextDecoration.ITALIC,
+    TextDecoration.UNDERLINED,
+    TextDecoration.STRIKETHROUGH,
+    TextDecoration.OBFUSCATED
+  };
+
+  static {
+    final Set<TextDecoration> knownDecorations = EnumSet.allOf(TextDecoration.class);
+    for (final TextDecoration decoration : DECORATIONS) {
+      knownDecorations.remove(decoration);
+    }
+    if (!knownDecorations.isEmpty()) {
+      throw new IllegalStateException("Moshi serializer is missing some text decorations: " + knownDecorations);
+    }
+  }
+
+  static final String FONT = "font";
+  static final String COLOR = "color";
+  static final String INSERTION = "insertion";
+  static final String CLICK_EVENT = "clickEvent";
+  static final String CLICK_EVENT_ACTION = "action";
+  static final String CLICK_EVENT_VALUE = "value";
+  static final String HOVER_EVENT = "hoverEvent";
+  static final String HOVER_EVENT_ACTION = "action";
+  static final String HOVER_EVENT_CONTENTS = "contents";
+  static final @Deprecated String HOVER_EVENT_VALUE = "value";
+  private static final JsonReader.Options CLICK_EVENT_OPTIONS = JsonReader.Options.of(CLICK_EVENT_ACTION, CLICK_EVENT_VALUE);
+  private static final JsonReader.Options HOVER_EVENT_OPTIONS = JsonReader.Options.of(HOVER_EVENT_ACTION, HOVER_EVENT_CONTENTS, HOVER_EVENT_VALUE);
+
+  static JsonAdapter<Style> create(final Moshi moshi, final @Nullable LegacyHoverEventSerializer legacyHover, final boolean emitLegacyHover) {
+    return new StyleAdapter(moshi, legacyHover, emitLegacyHover).nullSafe();
+  }
+
+  private final Moshi moshi;
+  private final LegacyHoverEventSerializer legacyHover;
+  private final boolean emitLegacyHover;
+
+  private StyleAdapter(final Moshi moshi, final @Nullable LegacyHoverEventSerializer legacyHover, final boolean emitLegacyHover) {
+    this.moshi = moshi;
+    this.legacyHover = legacyHover;
+    this.emitLegacyHover = emitLegacyHover;
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public Style fromJson(final JsonReader reader) throws IOException {
+    reader.beginObject();
+    final Style.Builder style = Style.style();
+
+    while (reader.hasNext()) {
+      final String fieldName = reader.nextName();
+      if (fieldName.equals(FONT)) {
+        style.font(this.moshi.adapter(SerializerFactory.KEY_TYPE).fromJson(reader));
+      } else if (fieldName.equals(COLOR)) {
+        final TextColorWrapper color = this.moshi.adapter(SerializerFactory.COLOR_WRAPPER_TYPE).fromJson(reader);
+        if (color.color != null) {
+          style.color(color.color);
+        } else if (color.decoration != null) {
+          style.decoration(color.decoration, TextDecoration.State.TRUE);
+        }
+      } else if (TextDecoration.NAMES.keys().contains(fieldName)) {
+        style.decoration(TextDecoration.NAMES.value(fieldName), reader.nextBoolean());
+      } else if (fieldName.equals(INSERTION)) {
+        style.insertion(reader.nextString());
+      } else if (fieldName.equals(CLICK_EVENT)) {
+        reader.beginObject();
+        ClickEvent.Action action = null;
+        String value = null;
+        while (reader.hasNext()) {
+          switch (reader.selectName(CLICK_EVENT_OPTIONS)) {
+            case 0:
+              action = this.moshi.adapter(SerializerFactory.CLICK_ACTION_TYPE).fromJson(reader);
+              break;
+            case 1:
+              value = reader.peek() == JsonReader.Token.NULL ? null : reader.nextString();
+              break;
+            default:
+              reader.skipValue();
+              break;
+          }
+        }
+        if (action != null && action.readable() && value != null) {
+          style.clickEvent(ClickEvent.clickEvent(action, value));
+        }
+        reader.endObject();
+      } else if (fieldName.equals(HOVER_EVENT)) {
+        reader.beginObject();
+        HoverEvent.@Nullable Action action = null;
+        @Nullable Object value = null;
+        while (reader.hasNext()) {
+          switch (reader.selectName(HOVER_EVENT_OPTIONS)) {
+            case 0:
+              action = this.moshi.adapter(SerializerFactory.HOVER_ACTION_TYPE).fromJson(reader);
+              break;
+            case 1:
+              if (action != null && action.readable()) {
+                final Class<?> actionType = action.type();
+                if (Component.class.isAssignableFrom(actionType)) {
+                  value = this.moshi.adapter(SerializerFactory.COMPONENT_TYPE).fromJson(reader);
+                } else if (HoverEvent.ShowItem.class.isAssignableFrom(actionType)) {
+                  value = this.moshi.adapter(SerializerFactory.SHOW_ITEM_TYPE).fromJson(reader);
+                } else if (HoverEvent.ShowEntity.class.isAssignableFrom(actionType)) {
+                  value = this.moshi.adapter(SerializerFactory.SHOW_ENTITY_TYPE).fromJson(reader);
+                } else {
+                  value = null;
+                }
+              }
+              break;
+            case 2:
+              if (action != null && action.readable()) {
+                final Component rawValue = this.moshi.adapter(SerializerFactory.COMPONENT_TYPE).fromJson(reader);
+                value = this.legacyHoverEventContents(action, rawValue);
+              }
+              break;
+            default:
+              value = null;
+              break;
+          }
+        }
+
+        if (action != null && value != null) {
+          style.hoverEvent(HoverEvent.hoverEvent(action, value));
+        }
+      } else {
+        reader.skipValue();
+      }
+    }
+
+    reader.endObject();
+    return style.build();
+  }
+
+  @Override
+  public void toJson(final JsonWriter writer, final Style value) throws IOException {
+    writer.beginObject();
+
+    for (int i = 0, length = DECORATIONS.length; i < length; i++) {
+      final TextDecoration decoration = DECORATIONS[i];
+      final TextDecoration.State state = value.decoration(decoration);
+      if (state != TextDecoration.State.NOT_SET) {
+        final String name = TextDecoration.NAMES.key(decoration);
+        assert name != null; // should never be null
+        writer.name(name);
+        writer.value(state == TextDecoration.State.TRUE);
+      }
+    }
+
+    final @Nullable TextColor color = value.color();
+    if (color != null) {
+      writer.name(COLOR);
+      this.moshi.adapter(SerializerFactory.COLOR_TYPE).toJson(writer, color);
+    }
+
+    final @Nullable String insertion = value.insertion();
+    if (insertion != null) {
+      writer.name(INSERTION);
+      writer.value(insertion);
+    }
+
+    final @Nullable ClickEvent clickEvent = value.clickEvent();
+    if (clickEvent != null) {
+      writer.name(CLICK_EVENT);
+      writer.beginObject();
+      writer.name(CLICK_EVENT_ACTION);
+      this.moshi.adapter(SerializerFactory.CLICK_ACTION_TYPE).toJson(writer, clickEvent.action());
+      writer.name(CLICK_EVENT_VALUE);
+      writer.value(clickEvent.value());
+      writer.endObject();
+    }
+
+    final @Nullable HoverEvent hoverEvent = value.hoverEvent();
+    if (hoverEvent != null) {
+      writer.name(HOVER_EVENT);
+      writer.beginObject();
+      writer.name(HOVER_EVENT_ACTION);
+      final HoverEvent.Action<?> action = hoverEvent.action();
+      this.moshi.adapter(SerializerFactory.HOVER_ACTION_TYPE).toJson(writer, action);
+      writer.name(HOVER_EVENT_CONTENTS);
+      if (action == HoverEvent.Action.SHOW_ITEM) {
+        this.moshi.adapter(SerializerFactory.SHOW_ITEM_TYPE).toJson(writer, (HoverEvent.ShowItem) hoverEvent.value());
+      } else if (action == HoverEvent.Action.SHOW_ENTITY) {
+        this.moshi.adapter(SerializerFactory.SHOW_ENTITY_TYPE).toJson(writer, (HoverEvent.ShowEntity) hoverEvent.value());
+      } else if (action == HoverEvent.Action.SHOW_TEXT) {
+        this.moshi.adapter(SerializerFactory.COMPONENT_TYPE).toJson(writer, (Component) hoverEvent.value());
+      } else {
+        throw new JsonDataException("Don't know how to serialize " + hoverEvent.value());
+      }
+      if (this.emitLegacyHover) {
+        writer.name(HOVER_EVENT_VALUE);
+        this.serializeLegacyHoverEvent(hoverEvent, writer);
+      }
+
+      writer.endObject();
+    }
+
+    final @Nullable Key font = value.font();
+    if (font != null) {
+      writer.name(FONT);
+      this.moshi.adapter(SerializerFactory.KEY_TYPE).toJson(writer, font);
+    }
+
+    writer.endObject();
+  }
+
+  private Object legacyHoverEventContents(final HoverEvent.Action<?> action, final Component rawValue) {
+    if (action == HoverEvent.Action.SHOW_TEXT) {
+      return rawValue; // Passthrough -- no serialization needed
+    } else if (this.legacyHover != null) {
+      try {
+        if (action == HoverEvent.Action.SHOW_ENTITY) {
+          return this.legacyHover.deserializeShowEntity(rawValue, this.decoder());
+        } else if (action == HoverEvent.Action.SHOW_ITEM) {
+          return this.legacyHover.deserializeShowItem(rawValue);
+        }
+      } catch (final IOException exception) {
+        throw new JsonDataException(exception);
+      }
+    }
+    // if we can't handle
+    throw new UnsupportedOperationException();
+  }
+
+  private void serializeLegacyHoverEvent(final HoverEvent<?> hoverEvent, final JsonWriter writer) throws IOException {
+    if (hoverEvent.action() == HoverEvent.Action.SHOW_TEXT) { // serialization is the same
+      this.moshi.adapter(SerializerFactory.COMPONENT_TYPE).toJson(writer, (Component) hoverEvent.value());
+    } else if (this.legacyHover != null) { // for data formats that require knowledge of SNBT
+      Component serialized = null;
+      try {
+        if (hoverEvent.action() == HoverEvent.Action.SHOW_ENTITY) {
+          serialized = this.legacyHover.serializeShowEntity((HoverEvent.ShowEntity) hoverEvent.value(), this.moshi.adapter(SerializerFactory.COMPONENT_TYPE)::toJson);
+        } else if (hoverEvent.action() == HoverEvent.Action.SHOW_ITEM) {
+          serialized = this.legacyHover.serializeShowItem((HoverEvent.ShowItem) hoverEvent.value());
+        }
+      } catch (final IOException exception) {
+        throw new JsonDataException(exception);
+      }
+      if (serialized != null) {
+        this.moshi.adapter(SerializerFactory.COMPONENT_TYPE).toJson(writer, serialized);
+      } else {
+        writer.nullValue();
+      }
+    } else {
+      writer.nullValue();
+    }
+  }
+
+  private Codec.Decoder<Component, String, JsonDataException> decoder() {
+    return string -> {
+      try {
+        return Objects.requireNonNull(this.moshi.adapter(SerializerFactory.COMPONENT_TYPE).fromJson(string));
+      } catch (final IOException exception) {
+        throw new JsonDataException(exception);
+      }
+    };
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/TextColorSerializer.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/TextColorSerializer.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import java.io.IOException;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class TextColorSerializer extends JsonAdapter<TextColor> {
+  static final JsonAdapter<TextColor> INSTANCE = new TextColorSerializer(false).nullSafe();
+  static final JsonAdapter<TextColor> DOWNSAMPLE_COLOR = new TextColorSerializer(true).nullSafe();
+
+  private final boolean downsampleColor;
+
+  private TextColorSerializer(final boolean downsampleColor) {
+    this.downsampleColor = downsampleColor;
+  }
+
+  @Override
+  public @Nullable TextColor fromJson(final JsonReader reader) throws IOException {
+    final @Nullable TextColor color = fromString(reader.nextString());
+    if (color == null) {
+      return null;
+    }
+
+    return this.downsampleColor ? NamedTextColor.nearestTo(color) : color;
+  }
+
+  @Override
+  public void toJson(final JsonWriter writer, final TextColor value) throws IOException {
+    if (value instanceof NamedTextColor) {
+      writer.value(NamedTextColor.NAMES.key((NamedTextColor) value));
+    } else if (this.downsampleColor) {
+      writer.value(NamedTextColor.NAMES.key(NamedTextColor.nearestTo(value)));
+    } else {
+      writer.value(value.asHexString());
+    }
+  }
+
+  static @Nullable TextColor fromString(final @NotNull String value) {
+    if (value.startsWith("#")) {
+      return TextColor.fromHexString(value);
+    } else {
+      return NamedTextColor.NAMES.value(value);
+    }
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/TextColorWrapper.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/TextColorWrapper.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import java.io.IOException;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This is a hack.
+ */
+final class TextColorWrapper {
+  final @Nullable TextColor color;
+  final @Nullable TextDecoration decoration;
+  final boolean reset;
+
+  TextColorWrapper(final @Nullable TextColor color, final @Nullable TextDecoration decoration, final boolean reset) {
+    this.color = color;
+    this.decoration = decoration;
+    this.reset = reset;
+  }
+
+  static final class Serializer extends JsonAdapter<TextColorWrapper> {
+    static final Serializer INSTANCE = new Serializer();
+
+    private Serializer() {
+    }
+
+    @Override
+    public TextColorWrapper fromJson(final JsonReader reader) throws IOException {
+      final String input = reader.nextString();
+      final TextColor color = TextColorSerializer.fromString(input);
+      final TextDecoration decoration = TextDecoration.NAMES.value(input);
+      final boolean reset = decoration == null && input.equals("reset");
+      if (color == null && decoration == null && !reset) {
+        throw new JsonDataException("Don't know how to parse " + input + " at " + reader.getPath());
+      }
+      return new TextColorWrapper(color, decoration, reset);
+    }
+
+    @Override
+    public void toJson(final JsonWriter writer, final TextColorWrapper value) throws IOException {
+      throw new JsonDataException("Cannot write TextColorWrapper instances");
+    }
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/TextDecorationSerializer.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/TextDecorationSerializer.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import net.kyori.adventure.text.format.TextDecoration;
+
+final class TextDecorationSerializer {
+  static final JsonAdapter<TextDecoration> INSTANCE = IndexedAdapter.of("text decoration", TextDecoration.NAMES);
+
+  private TextDecorationSerializer() {
+  }
+}

--- a/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/package-info.java
+++ b/text-serializer-moshi/src/main/java/net/kyori/adventure/text/serializer/moshi/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Moshi based serialization and deserialization.
+ */
+package net.kyori.adventure.text.serializer.moshi;

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/BlockNBTComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/BlockNBTComponentTest.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import net.kyori.adventure.text.BlockNBTComponent;
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+class BlockNBTComponentTest extends ComponentTest {
+  @Test
+  void testLocal() {
+    test(
+      Component.blockNBT().nbtPath("abc").localPos(1.23d, 2.0d, 3.89d).build(),
+      object(json -> {
+        json.put(ComponentAdapter.NBT, "abc");
+        json.put(ComponentAdapter.NBT_INTERPRET, false);
+        json.put(ComponentAdapter.NBT_BLOCK, "^1.23 ^2.0 ^3.89");
+      })
+    );
+  }
+
+  @Test
+  void testAbsoluteWorld() {
+    test(
+      Component.blockNBT().nbtPath("xyz").absoluteWorldPos(4, 5, 6).interpret(true).build(),
+      object(json -> {
+        json.put(ComponentAdapter.NBT, "xyz");
+        json.put(ComponentAdapter.NBT_INTERPRET, true);
+        json.put(ComponentAdapter.NBT_BLOCK, "4 5 6");
+      })
+    );
+  }
+
+  @Test
+  void testRelativeWorld() {
+    test(
+      Component.blockNBT().nbtPath("eeee").relativeWorldPos(7, 83, 900).build(),
+      object(json -> {
+        json.put(ComponentAdapter.NBT, "eeee");
+        json.put(ComponentAdapter.NBT_INTERPRET, false);
+        json.put(ComponentAdapter.NBT_BLOCK, "~7 ~83 ~900");
+      })
+    );
+  }
+
+  @Test
+  void testMixedAbsoluteAndRelative() {
+    this.test(
+      Component.blockNBT().nbtPath("qwert").worldPos(
+        BlockNBTComponent.WorldPos.Coordinate.absolute(12),
+        BlockNBTComponent.WorldPos.Coordinate.relative(3),
+        BlockNBTComponent.WorldPos.Coordinate.absolute(1200)
+      ).build(),
+      object(json -> {
+        json.put(ComponentAdapter.NBT, "qwert");
+        json.put(ComponentAdapter.NBT_INTERPRET, false);
+        json.put(ComponentAdapter.NBT_BLOCK, "12 ~3 1200");
+      })
+    );
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/ComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/ComponentTest.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.Moshi;
+import net.kyori.adventure.text.Component;
+
+abstract class ComponentTest extends MoshiTest<Component> {
+  ComponentTest() {
+    this(MoshiComponentSerializer.moshi().serializer());
+  }
+
+  ComponentTest(final Moshi moshi) {
+    super(moshi, Component.class);
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/EntityNBTComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/EntityNBTComponentTest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+class EntityNBTComponentTest extends ComponentTest {
+  @Test
+  void testWithoutInterpret() {
+    this.test(
+      Component.entityNBT().nbtPath("abc").selector("test").build(),
+      object(json -> {
+        json.put(ComponentAdapter.NBT, "abc");
+        json.put(ComponentAdapter.NBT_INTERPRET, false);
+        json.put(ComponentAdapter.NBT_ENTITY, "test");
+      })
+    );
+  }
+
+  @Test
+  void testWithInterpret() {
+    this.test(
+      Component.entityNBT().nbtPath("abc").selector("test").interpret(true).build(),
+      object(json -> {
+        json.put(ComponentAdapter.NBT, "abc");
+        json.put(ComponentAdapter.NBT_INTERPRET, true);
+        json.put(ComponentAdapter.NBT_ENTITY, "test");
+      })
+    );
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/KeybindComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/KeybindComponentTest.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+class KeybindComponentTest extends ComponentTest {
+  private static final String KEY = "key.jump";
+
+  @Test
+  void test() {
+    this.test(Component.keybind(KEY), object(json -> json.put(ComponentAdapter.KEYBIND, KEY)));
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/MoshiComponentSerializerTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/MoshiComponentSerializerTest.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonDataException;
+import java.io.IOException;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.serializer.moshi.MoshiTest.array;
+import static net.kyori.adventure.text.serializer.moshi.MoshiTest.object;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MoshiComponentSerializerTest {
+  @Test
+  void testDeserializeNull() {
+    final JsonDataException jde = assertThrows(JsonDataException.class, () -> MoshiComponentSerializer.moshi().deserialize("null"));
+    assertTrue(jde.getMessage().contains("turn null into a Component"));
+  }
+
+  @Test
+  void testDeserializePrimitive() throws IOException {
+    assertEquals(Component.text("potato"), MoshiComponentSerializer.moshi().serializer().adapter(SerializerFactory.COMPONENT_TYPE).fromJson("potato"));
+  }
+
+  @Test
+  void testDeserializeArray_empty() throws IOException {
+    assertThrows(JsonDataException.class, () -> MoshiComponentSerializer.moshi().serializer().adapter(SerializerFactory.COMPONENT_TYPE).fromJson("[]"));
+  }
+
+  @Test
+  void testDeserializeArray() {
+    assertEquals(
+      Component.text("Hello, ").append(Component.text("world.")),
+      MoshiComponentSerializer.moshi().serializer().adapter(SerializerFactory.COMPONENT_TYPE).fromJsonValue(array(array -> {
+        array.add(object(object -> object.put(ComponentAdapter.TEXT, "Hello, ")));
+        array.add(object(object -> object.put(ComponentAdapter.TEXT, "world.")));
+      }))
+    );
+  }
+
+  @Test
+  public void testPre116Downsamples() {
+    final TextColor original = TextColor.color(0xAB2211);
+    final NamedTextColor downsampled = NamedTextColor.nearestTo(original);
+    final Component test = Component.text("meow", original);
+    assertEquals(
+      "{\"color\":\"" + name(downsampled) + "\",\"text\":\"meow\"}",
+      MoshiComponentSerializer.colorDownsamplingMoshi().serializer().adapter(SerializerFactory.COMPONENT_TYPE).toJson(test)
+    );
+  }
+
+  @Test
+  public void testPre116DownsamplesInChildren() {
+    final TextColor original = TextColor.color(0xEC41AA);
+    final NamedTextColor downsampled = NamedTextColor.nearestTo(original);
+    final Component test = Component.text(builder -> builder.content("hey").append(Component.text("there", original)));
+
+    assertEquals(
+      "{\"extra\":[{\"color\":\"" + name(downsampled) + "\",\"text\":\"there\"}],\"text\":\"hey\"}",
+      MoshiComponentSerializer.colorDownsamplingMoshi().serializer().adapter(SerializerFactory.COMPONENT_TYPE).toJson(test)
+    );
+  }
+
+  private static String name(final NamedTextColor color) {
+    return NamedTextColor.NAMES.key(color);
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/MoshiTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/MoshiTest.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.Moshi;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+abstract class MoshiTest<T> {
+  private final Moshi moshi;
+  private final Class<T> type;
+
+  MoshiTest(final Moshi moshi, final Class<T> type) {
+    this.moshi = moshi;
+    this.type = type;
+  }
+
+  final void test(final T object, final Object json) {
+    assertEquals(json, this.serialize(object));
+    assertEquals(object, this.deserialize(json));
+  }
+
+  final Object serialize(final T object) {
+    return this.moshi.adapter(this.type).toJsonValue(object);
+  }
+
+  final T deserialize(final Object json) {
+    return this.moshi.adapter(this.type).fromJsonValue(json);
+  }
+
+  static List<Object> array(final Consumer<? super List<Object>> consumer) {
+    final List<Object> json = new ArrayList<>();
+    consumer.accept(json);
+    return json;
+  }
+
+  static Map<String, Object> object(final Consumer<? super Map<String, Object>> consumer) {
+    final Map<String, Object> json = new LinkedHashMap<>();
+    consumer.accept(json);
+    return json;
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/ScoreComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/ScoreComponentTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import com.squareup.moshi.JsonDataException;
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ScoreComponentTest extends ComponentTest {
+  private static final String NAME = "abc";
+  private static final String OBJECTIVE = "def";
+  private static final String VALUE = "ghi";
+
+  @Test
+  void test() {
+    this.test(
+      Component.score(NAME, OBJECTIVE),
+      object(json -> json.put(ComponentAdapter.SCORE, object(score -> {
+        score.put(ComponentAdapter.SCORE_NAME, NAME);
+        score.put(ComponentAdapter.SCORE_OBJECTIVE, OBJECTIVE);
+      })))
+    );
+  }
+
+  @Test
+  void testWithValue() {
+    this.test(
+      Component.score(NAME, OBJECTIVE, VALUE),
+      object(json -> json.put(ComponentAdapter.SCORE, object(score -> {
+        score.put(ComponentAdapter.SCORE_NAME, NAME);
+        score.put(ComponentAdapter.SCORE_OBJECTIVE, OBJECTIVE);
+        score.put(ComponentAdapter.SCORE_VALUE, VALUE);
+      })))
+    );
+  }
+
+  @Test
+  void testWithoutObjective() {
+    assertThrows(JsonDataException.class, () -> this.deserialize(object(json -> json.put(ComponentAdapter.SCORE, object(score -> score.put(ComponentAdapter.SCORE_NAME, NAME))))));
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/SelectorComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/SelectorComponentTest.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+class SelectorComponentTest extends ComponentTest {
+  private static final String SELECTOR = "@p";
+
+  @Test
+  void test() {
+    this.test(Component.selector(SELECTOR), object(json -> json.put(ComponentAdapter.SELECTOR, SELECTOR)));
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/ShowItemSerializerTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/ShowItemSerializerTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import java.io.IOException;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.StringBinaryTag;
+import net.kyori.adventure.nbt.TagStringIO;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.event.HoverEvent;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.serializer.moshi.MoshiTest.object;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ShowItemSerializerTest {
+  @Test
+  void testDeserializeWithPopulatedTag() throws IOException {
+    assertEquals(
+      HoverEvent.ShowItem.of(Key.key("minecraft", "diamond"), 1, BinaryTagHolder.of(TagStringIO.get().asString(
+        CompoundBinaryTag.builder()
+          .put("display", CompoundBinaryTag.builder()
+            .put("Name", StringBinaryTag.of("A test!"))
+            .build())
+          .build()
+      ))),
+      MoshiComponentSerializer.moshi().serializer().adapter(HoverEvent.ShowItem.class).fromJsonValue(
+        object(json -> {
+          json.put(ShowItemAdapter.ID, "minecraft:diamond");
+          json.put(ShowItemAdapter.COUNT, 1);
+          json.put(ShowItemAdapter.TAG, "{display:{Name:\"A test!\"}}");
+        })
+      )
+    );
+  }
+
+  @Test
+  void testDeserializeWithNullTag() {
+    assertEquals(
+      HoverEvent.ShowItem.of(Key.key("minecraft", "diamond"), 1, null),
+      MoshiComponentSerializer.moshi().serializer().adapter(HoverEvent.ShowItem.class).fromJsonValue(
+        object(json -> {
+          json.put(ShowItemAdapter.ID, "minecraft:diamond");
+          json.put(ShowItemAdapter.COUNT, 1);
+          json.put(ShowItemAdapter.TAG, null);
+        })
+      )
+    );
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/StorageNBTComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/StorageNBTComponentTest.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+class StorageNBTComponentTest extends ComponentTest {
+  @Test
+  void testWithoutInterpret() {
+    this.test(
+      Component.storageNBT().nbtPath("abc").storage(Key.key("doom:apple")).build(),
+      object(json -> {
+        json.put(ComponentAdapter.NBT, "abc");
+        json.put(ComponentAdapter.NBT_INTERPRET, false);
+        json.put(ComponentAdapter.NBT_STORAGE, "doom:apple");
+      })
+    );
+  }
+
+  @Test
+  void testWithInterpret() {
+    this.test(
+      Component.storageNBT().nbtPath("abc").storage(Key.key("doom:apple")).build(),
+      object(json -> {
+        json.put(ComponentAdapter.NBT, "abc");
+        json.put(ComponentAdapter.NBT_INTERPRET, false);
+        json.put(ComponentAdapter.NBT_STORAGE, "doom:apple");
+      })
+    );
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/StyleTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/StyleTest.java
@@ -1,0 +1,190 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("CodeBlock2Expr")
+class StyleTest extends MoshiTest<Style> {
+  private static final Key FANCY_FONT = Key.key("kyori", "kittens");
+
+  StyleTest() {
+    super(MoshiComponentSerializer.moshi().serializer(), Style.class);
+  }
+
+  @Test
+  void testWithDecorationAsColor() {
+    final Style s0 = MoshiComponentSerializer.moshi().serializer().adapter(Style.class)
+      .fromJsonValue(object(object -> object.put(StyleAdapter.COLOR, TextDecoration.NAMES.key(TextDecoration.BOLD)) ));
+    assertNull(s0.color());
+    assertTrue(s0.hasDecoration(TextDecoration.BOLD));
+  }
+
+  @Test
+  void testWithResetAsColor() {
+    final Style s0 = MoshiComponentSerializer.moshi().serializer().adapter(Style.class)
+      .fromJsonValue(object(object -> object.put(StyleAdapter.COLOR, "reset")));
+    assertNull(s0.color());
+    assertThat(Style.empty().decorations()).containsExactlyEntriesIn(Stream.of(TextDecoration.values()).collect(Collectors.toMap(Function.identity(), decoration -> TextDecoration.State.NOT_SET)));
+  }
+
+  @Test
+  void testEmpty() {
+    this.test(Style.empty(), object(json -> {
+    }));
+  }
+
+  @Test
+  void testHexColor() {
+    this.test(Style.style(TextColor.color(0x0a1ab9)), object(json -> json.put(StyleAdapter.COLOR, "#0a1ab9")));
+  }
+
+  @Test
+  void testNamedColor() {
+    this.test(Style.style(NamedTextColor.LIGHT_PURPLE), object(json -> json.put(StyleAdapter.COLOR, name(NamedTextColor.LIGHT_PURPLE))));
+  }
+
+  @Test
+  void testDecoration() {
+    this.test(Style.style(TextDecoration.BOLD), object(json -> json.put(name(TextDecoration.BOLD), true)));
+  }
+
+  @Test
+  void testInsertion() {
+    this.test(Style.style().insertion("honk").build(), object(json -> json.put(StyleAdapter.INSERTION, "honk")));
+  }
+
+  @Test
+  void testMixedFontColorDecorationClickEvent() {
+    this.test(
+      Style.style()
+        .font(FANCY_FONT)
+        .color(NamedTextColor.RED)
+        .decoration(TextDecoration.BOLD, true)
+        .clickEvent(ClickEvent.openUrl("https://github.com"))
+        .build(),
+      object(json -> {
+        json.put(StyleAdapter.FONT, "kyori:kittens");
+        json.put(StyleAdapter.COLOR, name(NamedTextColor.RED));
+        json.put(name(TextDecoration.BOLD), true);
+        json.put(StyleAdapter.CLICK_EVENT, object(clickEvent -> {
+          clickEvent.put(StyleAdapter.CLICK_EVENT_ACTION, name(ClickEvent.Action.OPEN_URL));
+          clickEvent.put(StyleAdapter.CLICK_EVENT_VALUE, "https://github.com");
+        }));
+      })
+    );
+  }
+
+  @Test
+  void testShowEntityHoverEvent() {
+    final UUID dolores = UUID.randomUUID();
+    this.test(
+      Style.style()
+        .hoverEvent(HoverEvent.showEntity(HoverEvent.ShowEntity.of(
+          Key.key(Key.MINECRAFT_NAMESPACE, "pig"),
+          dolores,
+          Component.text("Dolores", TextColor.color(0x0a1ab9))
+        )))
+        .build(),
+      object(json -> {
+        json.put(StyleAdapter.HOVER_EVENT, object(hoverEvent -> {
+          hoverEvent.put(StyleAdapter.HOVER_EVENT_ACTION, name(HoverEvent.Action.SHOW_ENTITY));
+          hoverEvent.put(StyleAdapter.HOVER_EVENT_CONTENTS, object(contents -> {
+            contents.put(ShowEntityAdapter.TYPE, "minecraft:pig");
+            contents.put(ShowEntityAdapter.ID, dolores.toString());
+            contents.put(ShowEntityAdapter.NAME, object(name -> {
+              name.put(ComponentAdapter.TEXT, "Dolores");
+              name.put(StyleAdapter.COLOR, "#0a1ab9");
+            }));
+          }));
+        }));
+      })
+    );
+  }
+
+  @Test
+  void testShowItemHoverEvent() {
+    this.test(showItemStyle(1), showItemJson(1));
+    this.test(showItemStyle(2), showItemJson(2));
+  }
+
+  private static Style showItemStyle(final int count) {
+    return Style.style()
+      .hoverEvent(HoverEvent.showItem(HoverEvent.ShowItem.of(
+        Key.key(Key.MINECRAFT_NAMESPACE, "stone"),
+        count,
+        null // TODO: test for NBT?
+      )))
+      .build();
+  }
+
+  private static Map<String, Object> showItemJson(final int count) {
+    return object(json -> {
+      json.put(StyleAdapter.HOVER_EVENT, object(hoverEvent -> {
+        hoverEvent.put(StyleAdapter.HOVER_EVENT_ACTION, name(HoverEvent.Action.SHOW_ITEM));
+        hoverEvent.put(StyleAdapter.HOVER_EVENT_CONTENTS, object(contents -> {
+          contents.put(ShowItemAdapter.ID, "minecraft:stone");
+          if (count != 1) { // default count is 1, we don't serialize the value in this case
+            // Don't even ask why, but Moshi only encodes longs, and so, for this specific case,
+            // the map must contain a long.
+            contents.put(ShowItemAdapter.COUNT, (long) count);
+          }
+        }));
+      }));
+    });
+  }
+
+  static String name(final NamedTextColor color) {
+    return NamedTextColor.NAMES.key(color);
+  }
+
+  static String name(final TextDecoration decoration) {
+    return TextDecoration.NAMES.key(decoration);
+  }
+
+  static String name(final ClickEvent.Action action) {
+    return ClickEvent.Action.NAMES.key(action);
+  }
+
+  static <V> String name(final HoverEvent.Action<V> action) {
+    return HoverEvent.Action.NAMES.key(action);
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/TextComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/TextComponentTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.serializer.moshi.StyleTest.name;
+
+class TextComponentTest extends ComponentTest {
+  @Test
+  void testSimple() {
+    this.test(Component.text("Hello, world."), object(json -> json.put(ComponentAdapter.TEXT, "Hello, world.")));
+  }
+
+  @Test
+  void testComplex1() {
+    this.test(
+      Component.text().content("c")
+        .color(NamedTextColor.GOLD)
+        .append(Component.text("o", NamedTextColor.DARK_AQUA))
+        .append(Component.text("l", NamedTextColor.LIGHT_PURPLE))
+        .append(Component.text("o", NamedTextColor.DARK_PURPLE))
+        .append(Component.text("u", NamedTextColor.BLUE))
+        .append(Component.text("r", NamedTextColor.DARK_GREEN))
+        .append(Component.text("s", NamedTextColor.RED))
+        .build(),
+      object(json -> {
+        json.put(ComponentAdapter.TEXT, "c");
+        json.put(StyleAdapter.COLOR, name(NamedTextColor.GOLD));
+        json.put(ComponentAdapter.EXTRA, array(extra -> {
+          extra.add(object(item -> {
+            item.put(ComponentAdapter.TEXT, "o");
+            item.put(StyleAdapter.COLOR, name(NamedTextColor.DARK_AQUA));
+          }));
+          extra.add(object(item -> {
+            item.put(ComponentAdapter.TEXT, "l");
+            item.put(StyleAdapter.COLOR, name(NamedTextColor.LIGHT_PURPLE));
+          }));
+          extra.add(object(item -> {
+            item.put(ComponentAdapter.TEXT, "o");
+            item.put(StyleAdapter.COLOR, name(NamedTextColor.DARK_PURPLE));
+          }));
+          extra.add(object(item -> {
+            item.put(ComponentAdapter.TEXT, "u");
+            item.put(StyleAdapter.COLOR, name(NamedTextColor.BLUE));
+          }));
+          extra.add(object(item -> {
+            item.put(ComponentAdapter.TEXT, "r");
+            item.put(StyleAdapter.COLOR, name(NamedTextColor.DARK_GREEN));
+          }));
+          extra.add(object(item -> {
+            item.put(ComponentAdapter.TEXT, "s");
+            item.put(StyleAdapter.COLOR, name(NamedTextColor.RED));
+          }));
+        }));
+      })
+    );
+  }
+
+  @Test
+  void testComplex2() {
+    this.test(
+      Component.text().content("This is a test.")
+        .color(NamedTextColor.DARK_PURPLE)
+        .hoverEvent(HoverEvent.showText(Component.text("A test.")))
+        .append(Component.text(" "))
+        .append(Component.text("A what?", NamedTextColor.DARK_AQUA))
+        .build(),
+      object(json -> {
+        json.put(ComponentAdapter.TEXT, "This is a test.");
+        json.put(StyleAdapter.COLOR, name(NamedTextColor.DARK_PURPLE));
+        json.put(StyleAdapter.HOVER_EVENT, object(event -> {
+          event.put(StyleAdapter.HOVER_EVENT_ACTION, name(HoverEvent.Action.SHOW_TEXT));
+          event.put(StyleAdapter.HOVER_EVENT_CONTENTS, object(value -> value.put(ComponentAdapter.TEXT, "A test.")));
+        }));
+        json.put(ComponentAdapter.EXTRA, array(extra -> {
+          extra.add(object(item -> item.put(ComponentAdapter.TEXT, " ")));
+          extra.add(object(item -> {
+            item.put(ComponentAdapter.TEXT, "A what?");
+            item.put(StyleAdapter.COLOR, name(NamedTextColor.DARK_AQUA));
+          }));
+        }));
+      })
+    );
+  }
+}

--- a/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/TranslatableComponentTest.java
+++ b/text-serializer-moshi/src/test/java/net/kyori/adventure/text/serializer/moshi/TranslatableComponentTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.moshi;
+
+import java.util.UUID;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.serializer.moshi.StyleTest.name;
+
+class TranslatableComponentTest extends ComponentTest {
+  private static final String KEY = "multiplayer.player.left";
+
+  @Test
+  void testNoArgs() {
+    this.test(Component.translatable(KEY), object(json -> json.put(ComponentAdapter.TRANSLATE, KEY)));
+  }
+
+  @Test
+  void testSingleArgWithEvents() {
+    final UUID id = UUID.fromString("eb121687-8b1a-4944-bd4d-e0a818d9dfe2");
+    final String name = "kashike";
+    final String command = String.format("/msg %s ", name);
+
+    this.test(
+      Component.translatable(
+        KEY,
+        Component.text().content(name)
+          .clickEvent(ClickEvent.suggestCommand(command))
+          .hoverEvent(HoverEvent.showEntity(HoverEvent.ShowEntity.of(
+            Key.key("minecraft", "player"),
+            id,
+            Component.text(name)
+          )))
+          .build()
+      ).color(NamedTextColor.YELLOW),
+      object(json -> {
+        json.put(ComponentAdapter.TRANSLATE, KEY);
+        json.put(StyleAdapter.COLOR, name(NamedTextColor.YELLOW));
+        json.put(ComponentAdapter.TRANSLATE_WITH, array(with -> with.add(object(item -> {
+          item.put(ComponentAdapter.TEXT, name);
+          item.put(StyleAdapter.CLICK_EVENT, object(event -> {
+            event.put(StyleAdapter.CLICK_EVENT_ACTION, name(ClickEvent.Action.SUGGEST_COMMAND));
+            event.put(StyleAdapter.CLICK_EVENT_VALUE, command);
+          }));
+          item.put(StyleAdapter.HOVER_EVENT, object(event -> {
+            event.put(StyleAdapter.HOVER_EVENT_ACTION, name(HoverEvent.Action.SHOW_ENTITY));
+            event.put(StyleAdapter.HOVER_EVENT_CONTENTS, object(value -> {
+              value.put(ShowEntityAdapter.TYPE, "minecraft:player");
+              value.put(ShowEntityAdapter.ID, id.toString());
+              value.put(ShowEntityAdapter.NAME, object(namej -> {
+                namej.put(ComponentAdapter.TEXT, name);
+              }));
+            }));
+          }));
+        }))));
+      })
+    );
+  }
+}


### PR DESCRIPTION
As the title states, this PR adds a new component serializer using the [Moshi](https://github.com/squareup/moshi) JSON library. 
This serializer borrows a bit from Gson's code, as Moshi and Gson are similar in parts with the way they function.

I have also copied all of the tests over from the Gson serializer, as I think it is fair that this serializer should be able to at least do everything that the Gson one does, and they are all passing (I ran them all multiple times).

You may also notice that, as per @zml2008 's request, I have included some JMH benchmarks that I copied from [this PR](https://github.com/KyoriPowered/adventure/pull/373). I am running the tests as I am writing this, so I am unable to produce any results yet. Feel free to run these benchmarks yourself and post your results here, as it will help in determining performance differences.

I am also looking to implement more serializers for other JSON libraries in the near future, as I believe it would be useful for people to be able to natively serialize using a library of their choice, rather than being forced to use Gson. These will likely be kept separate from the main project, however, as I think that too many choices can confuse people a bit (unless you think that it is worth getting them merged).