### PR TITLE
Added common abstraction between JSON serializers

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
       "text-serializer-gson",
       "text-serializer-gson-legacy-impl",
       "text-serializer-json",
+      "text-serializer-json-legacy-impl",
       "text-serializer-legacy",
       "text-serializer-plain"
     ).forEach {

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
       "text-minimessage",
       "text-serializer-gson",
       "text-serializer-gson-legacy-impl",
+      "text-serializer-json",
       "text-serializer-legacy",
       "text-serializer-plain"
     ).forEach {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ sequenceOf(
   "text-minimessage",
   "text-serializer-gson",
   "text-serializer-gson-legacy-impl",
+  "text-serializer-json",
   "text-serializer-legacy",
   "text-serializer-plain"
 ).forEach {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ sequenceOf(
   "text-serializer-gson",
   "text-serializer-gson-legacy-impl",
   "text-serializer-json",
+  "text-serializer-json-legacy-impl",
   "text-serializer-legacy",
   "text-serializer-plain"
 ).forEach {

--- a/text-serializer-gson-legacy-impl/build.gradle.kts
+++ b/text-serializer-gson-legacy-impl/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   api(project(":adventure-api"))
   api(project(":adventure-text-serializer-gson"))
+  api(project(":adventure-text-serializer-json-legacy-impl"))
   api(project(":adventure-nbt"))
 }
 

--- a/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializer.java
+++ b/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializer.java
@@ -25,13 +25,17 @@ package net.kyori.adventure.text.serializer.gson.legacyimpl;
 
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.gson.LegacyHoverEventSerializer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A legacy {@link HoverEvent} serializer.
  *
  * @since 4.3.0
+ * @deprecated For removal since 4.9.0, use {@link net.kyori.adventure.text.serializer.json.legacyimpl.NBTLegacyHoverEventSerializer} instead.
  */
+@Deprecated
+@ApiStatus.ScheduledForRemoval
 public interface NBTLegacyHoverEventSerializer extends LegacyHoverEventSerializer {
   /**
    * Gets the legacy {@link HoverEvent} serializer.

--- a/text-serializer-gson/build.gradle.kts
+++ b/text-serializer-gson/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
   api(project(":adventure-api"))
+  api(project(":adventure-text-serializer-json"))
   api("com.google.code.gson:gson:2.8.0")
   testImplementation(project(":adventure-nbt"))
 }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -125,6 +125,12 @@ public interface GsonComponentSerializer extends JsonComponentSerializer {
    * @since 4.0.0
    */
   interface Builder extends JsonComponentSerializer.Builder {
+    @Override
+    @NotNull Builder downsampleColors();
+
+    @Override
+    @NotNull Builder legacyHoverEventSerializer(final @Nullable net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer serializer);
+
     /**
      * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
      * If the serializer is {@code null}, then only {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}
@@ -139,11 +145,9 @@ public interface GsonComponentSerializer extends JsonComponentSerializer {
     @ApiStatus.ScheduledForRemoval
     @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
 
-    /**
-     * Builds the serializer.
-     *
-     * @return the built serializer
-     */
+    @Override
+    @NotNull Builder emitLegacyHoverEvent();
+
     @Override
     @NotNull GsonComponentSerializer build();
   }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -29,8 +29,7 @@ import com.google.gson.JsonElement;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.ComponentSerializer;
-import net.kyori.adventure.util.Buildable;
+import net.kyori.adventure.text.serializer.json.JsonComponentSerializer;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @since 4.0.0
  */
-public interface GsonComponentSerializer extends ComponentSerializer<Component, Component, String>, Buildable<GsonComponentSerializer, GsonComponentSerializer.Builder> {
+public interface GsonComponentSerializer extends JsonComponentSerializer {
   /**
    * Gets a component serializer for gson serialization and deserialization.
    *
@@ -112,19 +111,20 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
   @NotNull JsonElement serializeToTree(final @NotNull Component component);
 
   /**
+   * Creates a new {@link Builder} from this {@link GsonComponentSerializer}.
+   *
+   * @return a new {@link Builder}
+   * @since 4.9.0
+   */
+  @Override
+  @NotNull GsonComponentSerializer.Builder toBuilder();
+
+  /**
    * A builder for {@link GsonComponentSerializer}.
    *
    * @since 4.0.0
    */
-  interface Builder extends Buildable.Builder<GsonComponentSerializer> {
-    /**
-     * Sets that the serializer should downsample hex colors to named colors.
-     *
-     * @return this builder
-     * @since 4.0.0
-     */
-    @NotNull Builder downsampleColors();
-
+  interface Builder extends JsonComponentSerializer.Builder {
     /**
      * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
      * If the serializer is {@code null}, then only {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}
@@ -133,19 +133,11 @@ public interface GsonComponentSerializer extends ComponentSerializer<Component, 
      * @param serializer serializer
      * @return this builder
      * @since 4.0.0
+     * @deprecated For removal, use {@link JsonComponentSerializer.Builder#legacyHoverEventSerializer(net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer)}
      */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval
     @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
-
-    /**
-     * Output a legacy hover event {@code value} in addition to the modern {@code contents}.
-     *
-     * <p>A {@link #legacyHoverEventSerializer(LegacyHoverEventSerializer) legacy hover serializer} must also be set
-     * to serialize any hover events beyond those with action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}</p>
-     *
-     * @return this builder
-     * @since 4.0.0
-     */
-    @NotNull Builder emitLegacyHoverEvent();
 
     /**
      * Builds the serializer.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
 import net.kyori.adventure.util.Services;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -140,6 +141,12 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
 
     @Override
     public @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer) {
+      this.legacyHoverSerializer = serializer;
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder legacyHoverEventSerializer(final net.kyori.adventure.text.serializer.gson.@Nullable LegacyHoverEventSerializer serializer) {
       this.legacyHoverSerializer = serializer;
       return this;
     }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/SerializerFactory.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/SerializerFactory.java
@@ -35,6 +35,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
 import org.jetbrains.annotations.Nullable;
 
 final class SerializerFactory implements TypeAdapterFactory {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -43,6 +43,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
 import net.kyori.adventure.util.Codec;
 import org.jetbrains.annotations.Nullable;
 

--- a/text-serializer-json-legacy-impl/build.gradle.kts
+++ b/text-serializer-json-legacy-impl/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+  id("adventure.common-conventions")
+}
+
+dependencies {
+  api(project(":adventure-api"))
+  api(project(":adventure-text-serializer-json"))
+  api(project(":adventure-nbt"))
+}
+
+applyJarMetadata("net.kyori.adventure.text.serializer.json.legacyimpl")

--- a/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializer.java
+++ b/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializer.java
@@ -21,8 +21,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package net.kyori.adventure.text.serializer.json.legacyimpl;
+
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
+import org.jetbrains.annotations.NotNull;
+
 /**
- * Gson legacy hover event serialization and deserialization.
+ * A legacy {@link HoverEvent} serializer.
+ *
+ * @since 4.9.0
  */
-@Deprecated
-package net.kyori.adventure.text.serializer.gson.legacyimpl;
+public interface NBTLegacyHoverEventSerializer extends LegacyHoverEventSerializer {
+  /**
+   * Gets the legacy {@link HoverEvent} serializer.
+   *
+   * @return a legacy {@link HoverEvent} serializer
+   * @since 4.9.0
+   */
+  static @NotNull LegacyHoverEventSerializer get() {
+    return NBTLegacyHoverEventSerializerImpl.INSTANCE;
+  }
+}

--- a/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
+++ b/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.json.legacyimpl;
+
+import java.io.IOException;
+import java.util.UUID;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.TagStringIO;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
+import net.kyori.adventure.util.Codec;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSerializer {
+  static final NBTLegacyHoverEventSerializerImpl INSTANCE = new NBTLegacyHoverEventSerializerImpl();
+  private static final TagStringIO SNBT_IO = TagStringIO.get();
+  private static final Codec<CompoundBinaryTag, String, IOException, IOException> SNBT_CODEC = Codec.of(SNBT_IO::asCompound, SNBT_IO::asString);
+
+  static final String ITEM_TYPE = "id";
+  static final String ITEM_COUNT = "Count";
+  static final String ITEM_TAG = "tag";
+
+  static final String ENTITY_NAME = "name";
+  static final String ENTITY_TYPE = "type";
+  static final String ENTITY_ID = "id";
+
+  private NBTLegacyHoverEventSerializerImpl() {
+  }
+
+  @Override
+  public HoverEvent.@NotNull ShowItem deserializeShowItem(final @NotNull Component input) throws IOException {
+    assertTextComponent(input);
+    final CompoundBinaryTag contents = SNBT_CODEC.decode(((TextComponent) input).content());
+    final CompoundBinaryTag tag = contents.getCompound(ITEM_TAG);
+    return HoverEvent.ShowItem.of(
+      Key.key(contents.getString(ITEM_TYPE)),
+      contents.getByte(ITEM_COUNT, (byte) 1),
+      tag == CompoundBinaryTag.empty() ? null : BinaryTagHolder.encode(tag, SNBT_CODEC)
+    );
+  }
+
+  @Override
+  public HoverEvent.@NotNull ShowEntity deserializeShowEntity(final @NotNull Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
+    assertTextComponent(input);
+    final CompoundBinaryTag contents = SNBT_CODEC.decode(((TextComponent) input).content());
+    return HoverEvent.ShowEntity.of(
+      Key.key(contents.getString(ENTITY_TYPE)),
+      UUID.fromString(contents.getString(ENTITY_ID)),
+      componentCodec.decode(contents.getString(ENTITY_NAME))
+    );
+  }
+
+  private static void assertTextComponent(final Component component) {
+    if (!(component instanceof TextComponent) || !component.children().isEmpty()) {
+      throw new IllegalArgumentException("Legacy events must be single Component instances");
+    }
+  }
+
+  @Override
+  public @NotNull Component serializeShowItem(final HoverEvent.@NotNull ShowItem input) throws IOException {
+    final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
+      .putString(ITEM_TYPE, input.item().asString())
+      .putByte(ITEM_COUNT, (byte) input.count());
+    final @Nullable BinaryTagHolder nbt = input.nbt();
+    if (nbt != null) {
+      builder.put(ITEM_TAG, nbt.get(SNBT_CODEC));
+    }
+    return Component.text(SNBT_CODEC.encode(builder.build()));
+  }
+
+  @Override
+  public @NotNull Component serializeShowEntity(final HoverEvent.@NotNull ShowEntity input, final Codec.Encoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
+    final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
+      .putString(ENTITY_ID, input.id().toString())
+      .putString(ENTITY_TYPE, input.type().asString());
+    final @Nullable Component name = input.name();
+    if (name != null) {
+      builder.putString(ENTITY_NAME, componentCodec.encode(name));
+    }
+    return Component.text(SNBT_CODEC.encode(builder.build()));
+  }
+}

--- a/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/package-info.java
+++ b/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/package-info.java
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 /**
- * Gson legacy hover event serialization and deserialization.
+ * JSON legacy hover event serialization and deserialization.
  */
-@Deprecated
-package net.kyori.adventure.text.serializer.gson.legacyimpl;
+package net.kyori.adventure.text.serializer.json.legacyimpl;

--- a/text-serializer-json/build.gradle.kts
+++ b/text-serializer-json/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("adventure.common-conventions")
+}
+
+dependencies {
+  api(project(":adventure-api"))
+}
+
+applyJarMetadata("net.kyori.adventure.text.serializer.gson")

--- a/text-serializer-json/build.gradle.kts
+++ b/text-serializer-json/build.gradle.kts
@@ -6,4 +6,4 @@ dependencies {
   api(project(":adventure-api"))
 }
 
-applyJarMetadata("net.kyori.adventure.text.serializer.gson")
+applyJarMetadata("net.kyori.adventure.text.serializer.json")

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/Instances.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/Instances.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.json;
+
+import java.util.Optional;
+import net.kyori.adventure.util.Services;
+
+final class Instances {
+  private static final Optional<JsonComponentSerializer.Provider> PROVIDER = Services.service(JsonComponentSerializer.Provider.class);
+
+  static final Optional<JsonComponentSerializer> INSTANCE = PROVIDER.map(JsonComponentSerializer.Provider::json);
+  static final Optional<JsonComponentSerializer> LEGACY_INSTANCE = PROVIDER.map(JsonComponentSerializer.Provider::jsonLegacy);
+
+  static Optional<JsonComponentSerializer.Builder> builder() {
+    return PROVIDER.map(JsonComponentSerializer.Provider::builder);
+  }
+
+  private Instances() {
+  }
+}

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JsonComponentSerializer.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JsonComponentSerializer.java
@@ -107,14 +107,6 @@ public interface JsonComponentSerializer extends ComponentSerializer<Component, 
      * @since 4.9.0
      */
     @NotNull Builder emitLegacyHoverEvent();
-
-    /**
-     * Builds the serializer.
-     *
-     * @return the built serializer
-     */
-    @Override
-    @NotNull JsonComponentSerializer build();
   }
 
   /**

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JsonComponentSerializer.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JsonComponentSerializer.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.json;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.ComponentSerializer;
+import net.kyori.adventure.util.Buildable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A generic JSON component serializer.
+ *
+ * <p>Use {@link Builder#downsampleColors()} to support platforms
+ * that do not understand hex colors that were introduced in Minecraft 1.16.</p>
+ *
+ * @since 4.9.0
+ */
+public interface JsonComponentSerializer extends ComponentSerializer<Component, Component, String>, Buildable<JsonComponentSerializer, JsonComponentSerializer.Builder> {
+  /**
+   * Gets a component serializer for JSON serialization and deserialization.
+   *
+   * @return a JSON component serializer
+   * @since 4.9.0
+   */
+  static @NotNull JsonComponentSerializer json() {
+    return Instances.INSTANCE.orElseThrow(() -> new IllegalStateException("A provider for JsonComponentSerializer was not found!"));
+  }
+
+  /**
+   * Gets a component serializer for JSON serialization and deserialization.
+   *
+   * <p>Hex colors are coerced to the nearest named color, and legacy hover events are
+   * emitted for action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}.</p>
+   *
+   * @return a JSON component serializer
+   * @since 4.9.0
+   */
+  static @NotNull JsonComponentSerializer colorDownsamplingJson() {
+    return Instances.LEGACY_INSTANCE.orElseThrow(() -> new IllegalStateException("A provider for JsonComponentSerializer was not found!"));
+  }
+
+  /**
+   * Creates a new {@link JsonComponentSerializer.Builder}.
+   *
+   * @return a builder
+   * @since 4.9.0
+   */
+  static Builder builder() {
+    return Instances.builder().orElseThrow(() -> new IllegalStateException("A provider for JsonComponentSerializer was not found!"));
+  }
+
+  /**
+   * A builder for {@link JsonComponentSerializer}.
+   *
+   * @since 4.9.0
+   */
+  interface Builder extends Buildable.Builder<JsonComponentSerializer> {
+    /**
+     * Sets that the serializer should downsample hex colors to named colors.
+     *
+     * @return this builder
+     * @since 4.9.0
+     */
+    @NotNull Builder downsampleColors();
+
+    /**
+     * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
+     * If the serializer is {@code null}, then only {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}
+     * legacy hover events can be deserialized.
+     *
+     * @param serializer serializer
+     * @return this builder
+     * @since 4.9.0
+     */
+    @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
+
+    /**
+     * Output a legacy hover event {@code value} in addition to the modern {@code contents}.
+     *
+     * <p>A {@link #legacyHoverEventSerializer(LegacyHoverEventSerializer) legacy hover serializer} must also be set
+     * to serialize any hover events beyond those with action {@link net.kyori.adventure.text.event.HoverEvent.Action#SHOW_TEXT}</p>
+     *
+     * @return this builder
+     * @since 4.9.0
+     */
+    @NotNull Builder emitLegacyHoverEvent();
+
+    /**
+     * Builds the serializer.
+     *
+     * @return the built serializer
+     */
+    @Override
+    @NotNull JsonComponentSerializer build();
+  }
+
+  /**
+   * A {@link JsonComponentSerializer} service provider.
+   *
+   * @since 4.9.0
+   */
+  @ApiStatus.Internal
+  interface Provider {
+    /**
+     * Provides a standard {@link JsonComponentSerializer}.
+     *
+     * @return a {@link JsonComponentSerializer}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull JsonComponentSerializer json();
+
+    /**
+     * Provides a legacy {@link JsonComponentSerializer}.
+     *
+     * @return a {@link JsonComponentSerializer}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull JsonComponentSerializer jsonLegacy();
+
+    /**
+     * Provides a new {@link Builder}.
+     *
+     * @return a {@link Builder}
+     * @since 4.9.0
+     */
+    @ApiStatus.Internal
+    @NotNull Builder builder();
+  }
+}

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/LegacyHoverEventSerializer.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/LegacyHoverEventSerializer.java
@@ -21,24 +21,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package net.kyori.adventure.text.serializer.gson;
+package net.kyori.adventure.text.serializer.json;
 
 import java.io.IOException;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.util.Codec;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Adapter to convert between modern and legacy hover event formats.
  *
  * @since 4.0.0
- * @deprecated For removal, use {@link net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer}
  */
-@Deprecated
-@ApiStatus.ScheduledForRemoval
-public interface LegacyHoverEventSerializer extends net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer {
+public interface LegacyHoverEventSerializer {
   /**
    * Convert a legacy hover event {@code show_item} value to its modern format.
    *

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/package-info.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Common abstraction between JSON serializer implementations to allow platforms to choose which serializer
+ * they wish to provide.
+ */
+package net.kyori.adventure.text.serializer.json;


### PR DESCRIPTION
The idea for this stems from #422 , though this has been split off due to PR scope issues.

This adds two new modules that will act as abstraction layer modules to allow implementations to define their own JSON serializers to use whilst end users can simply use JSON (de)serialization without needing to depend on a specific library's implementation.