### PR TITLE
api: Remove useless empty root components when compacting

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -61,7 +61,7 @@ final class ComponentCompaction {
           final Component child = children.get(0);
 
           // merge the updated/parent style into the child before we return
-          return child.style(child.style().merge(optimized.style(), Style.Merge.Strategy.IF_ABSENT_ON_TARGET));
+          return child.style(child.style().merge(optimized.style(), Style.Merge.Strategy.IF_ABSENT_ON_TARGET)).compact();
         }
       }
     }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -52,17 +52,15 @@ final class ComponentCompaction {
       return optimized;
     }
 
-    if (childrenSize == 1) {
-      // if there is only one child, check if self a useless empty component
-      if (self instanceof TextComponent) {
-        final TextComponent textComponent = (TextComponent) self;
+    // if there is only one child, check if self a useless empty component
+    if (childrenSize == 1 && self instanceof TextComponent) {
+      final TextComponent textComponent = (TextComponent) self;
 
-        if (textComponent.content().isEmpty()) {
-          final Component child = children.get(0);
+      if (textComponent.content().isEmpty()) {
+        final Component child = children.get(0);
 
-          // merge the updated/parent style into the child before we return
-          return child.style(child.style().merge(optimized.style(), Style.Merge.Strategy.IF_ABSENT_ON_TARGET)).compact();
-        }
+        // merge the updated/parent style into the child before we return
+        return child.style(child.style().merge(optimized.style(), Style.Merge.Strategy.IF_ABSENT_ON_TARGET)).compact();
       }
     }
 

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -45,9 +45,25 @@ final class ComponentCompaction {
       optimized = optimized.style(simplifyStyle(self.style(), parentStyle));
     }
 
-    if (children.isEmpty()) {
+    final int childrenSize = children.size();
+
+    if (childrenSize == 0) {
       // leaf nodes do not need to be further optimized - there is no point
       return optimized;
+    }
+
+    if (childrenSize == 1) {
+      // if there is only one child, check if self a useless empty component
+      if (self instanceof TextComponent) {
+        final TextComponent textComponent = (TextComponent) self;
+
+        if (textComponent.content().isEmpty()) {
+          final Component child = children.get(0);
+
+          // merge the updated/parent style into the child before we return
+          return child.style(child.style().merge(optimized.style(), Style.Merge.Strategy.IF_ABSENT_ON_TARGET));
+        }
+      }
     }
 
     // propagate the parent style context to children

--- a/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
 import static net.kyori.adventure.key.Key.key;
+import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.format.Style.style;
@@ -258,5 +259,21 @@ class ComponentCompactingTest {
         .build(),
       input.compact()
     );
+  }
+
+  @Test
+  void testCompactWithEmptyRootComponent() {
+    final Component c0 = empty().append(text("meow"));
+    assertEquals(text("meow"), c0.compact());
+
+    final Component c1 = text("", NamedTextColor.RED).append(text("meow"));
+    assertEquals(text("meow", NamedTextColor.RED), c1.compact());
+
+    final Component c2 = text("", NamedTextColor.RED).append(text("meow", NamedTextColor.BLUE));
+    assertEquals(text("meow", NamedTextColor.BLUE), c2.compact());
+
+    final Component c3 = empty().decoration(TextDecoration.BOLD, true)
+      .append(text("meow").decoration(TextDecoration.BOLD, TextDecoration.State.NOT_SET));
+    assertEquals(text("meow").decoration(TextDecoration.BOLD, true), c3.compact());
   }
 }


### PR DESCRIPTION
This PR brings Adventure's compacting system closer in line with MiniMessage's one by removing useless empty root components when compacting.