### PR TITLE
Fix reading of trailing comma in nbt list/array/compound

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -309,7 +309,7 @@ final class TagStringReader {
       return true;
     }
     this.buffer.expect(Tokens.VALUE_SEPARATOR);
-    return false;
+    return this.buffer.takeIf(endCharacter);
   }
 
   /**

--- a/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
@@ -276,6 +276,13 @@ class StringIOTest {
     assertEquals(LongArrayBinaryTag.of(), this.stringToTag("[L; ]"));
   }
 
+  @Test
+  void testTrailingComma() throws IOException {
+    assertEquals(CompoundBinaryTag.builder().putString("test", "hello").build(), this.stringToTag("{test: \"hello\",}"));
+    assertEquals(IntArrayBinaryTag.of(1), this.stringToTag("[I;1,]"));
+    assertEquals(ListBinaryTag.builder().add(StringBinaryTag.of("hello")).build(), this.stringToTag("[\"hello\",]"));
+  }
+
   private String tagToString(final BinaryTag tag) throws IOException {
     final StringWriter writer = new StringWriter();
     try(final TagStringWriter emitter = new TagStringWriter(writer, "")) {


### PR DESCRIPTION
Legacy and modern Vanilla can parse the following SNBT with a trailing comma in compound tags, list tags, and any kind of array tag, which adventure currently cannot:
`{test: \"hello\",}`
`[I;1,2,3,]`
`[\"hello\",]`