### PR TITLE
StyleImpl DRY (#392)

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -89,8 +89,8 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
   private final int bitSet;
 
   // lazy
-  private EntrySet entrySet = null;
-  private Values values = null;
+  private volatile EntrySet entrySet = null;
+  private volatile Values values = null;
 
   private DecorationMap(final int bitSet) {
     this.bitSet = bitSet;
@@ -139,7 +139,12 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
   @Override
   public @NotNull Set<Entry<TextDecoration, TextDecoration.State>> entrySet() {
     if (this.entrySet == null) {
-      this.entrySet = new EntrySet();
+      synchronized (this) {
+        // re-check for lost race condition
+        if (this.entrySet == null) {
+          this.entrySet = new EntrySet();
+        }
+      }
     }
     return this.entrySet;
   }
@@ -152,7 +157,12 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
   @Override
   public @NotNull Collection<TextDecoration.State> values() {
     if (this.values == null) {
-      this.values = new Values();
+      synchronized (this) {
+        // re-check for lost race condition
+        if (this.values == null) {
+          this.values = new Values();
+        }
+      }
     }
     return this.values;
   }

--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.adventure.text.format;
 
-import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
@@ -36,18 +35,20 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterators;
+import java.util.stream.Stream;
+import net.kyori.examination.Examinable;
+import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
 @Unmodifiable
-final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.State> implements Serializable {
+final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.State> implements Examinable {
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
   private static final TextDecoration.State[] STATES = TextDecoration.State.values();
 
   static final DecorationMap EMPTY = fromMap(Collections.emptyMap());
   // key set is universal, all decorations always exist in any given style
   private static final KeySet KEY_SET = new KeySet();
-  private static final long serialVersionUID = 3072526425153408678L;
 
   static DecorationMap fromMap(final Map<TextDecoration, TextDecoration.State> decorationMap) {
     if (decorationMap instanceof DecorationMap) return (DecorationMap) decorationMap;
@@ -93,6 +94,12 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
       );
     }
     throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+  }
+
+  @Override
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Arrays.stream(DECORATIONS)
+      .map(decoration -> ExaminableProperty.of(decoration.toString(), this.get(decoration)));
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -1,0 +1,293 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.format;
+
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterators;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+
+final @Unmodifiable class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.State> implements Serializable {
+  static final DecorationMap EMPTY = new DecorationMap(
+    TextDecoration.State.NOT_SET,
+    TextDecoration.State.NOT_SET,
+    TextDecoration.State.NOT_SET,
+    TextDecoration.State.NOT_SET,
+    TextDecoration.State.NOT_SET
+  );
+  private static final TextDecoration[] DECORATIONS = TextDecoration.values();
+  // key set is universal, all decorations always exist in any given style
+  private static final KeySet KEY_SET = new KeySet();
+  private static final long serialVersionUID = 3072526425153408678L;
+
+  static DecorationMap fromMap(final Map<TextDecoration, TextDecoration.State> decorationMap) {
+    return new DecorationMap(
+      decorationMap.getOrDefault(TextDecoration.OBFUSCATED, TextDecoration.State.NOT_SET),
+      decorationMap.getOrDefault(TextDecoration.BOLD, TextDecoration.State.NOT_SET),
+      decorationMap.getOrDefault(TextDecoration.STRIKETHROUGH, TextDecoration.State.NOT_SET),
+      decorationMap.getOrDefault(TextDecoration.UNDERLINED, TextDecoration.State.NOT_SET),
+      decorationMap.getOrDefault(TextDecoration.ITALIC, TextDecoration.State.NOT_SET)
+    );
+  }
+
+  static DecorationMap merge(final Map<TextDecoration, TextDecoration.State> first, final Map<TextDecoration, TextDecoration.State> second) {
+    return new DecorationMap(
+      first.getOrDefault(TextDecoration.OBFUSCATED, second.getOrDefault(TextDecoration.OBFUSCATED, TextDecoration.State.NOT_SET)),
+      first.getOrDefault(TextDecoration.BOLD, second.getOrDefault(TextDecoration.BOLD, TextDecoration.State.NOT_SET)),
+      first.getOrDefault(TextDecoration.STRIKETHROUGH, second.getOrDefault(TextDecoration.STRIKETHROUGH, TextDecoration.State.NOT_SET)),
+      first.getOrDefault(TextDecoration.UNDERLINED, second.getOrDefault(TextDecoration.UNDERLINED, TextDecoration.State.NOT_SET)),
+      first.getOrDefault(TextDecoration.ITALIC, second.getOrDefault(TextDecoration.ITALIC, TextDecoration.State.NOT_SET))
+    );
+  }
+
+  private final TextDecoration.@NotNull State obfuscated;
+  private final TextDecoration.@NotNull State bold;
+  private final TextDecoration.@NotNull State strikethrough;
+  private final TextDecoration.@NotNull State underlined;
+  private final TextDecoration.@NotNull State italic;
+
+  // lazy
+  private transient EntrySet entrySet = null;
+  private transient Values values = null;
+
+  private DecorationMap(
+    final TextDecoration.@NotNull State obfuscated,
+    final TextDecoration.@NotNull State bold,
+    final TextDecoration.@NotNull State strikethrough,
+    final TextDecoration.@NotNull State underlined,
+    final TextDecoration.@NotNull State italic
+  ) {
+    this.obfuscated = obfuscated;
+    this.bold = bold;
+    this.strikethrough = strikethrough;
+    this.underlined = underlined;
+    this.italic = italic;
+  }
+
+  public @NotNull DecorationMap with(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+    Objects.requireNonNull(state, "state");
+    if (decoration == TextDecoration.OBFUSCATED) {
+      return new DecorationMap(state, this.bold, this.strikethrough, this.underlined, this.italic);
+    } else if (decoration == TextDecoration.BOLD) {
+      return new DecorationMap(this.obfuscated, state, this.strikethrough, this.underlined, this.italic);
+    } else if (decoration == TextDecoration.STRIKETHROUGH) {
+      return new DecorationMap(this.obfuscated, this.bold, state, this.underlined, this.italic);
+    } else if (decoration == TextDecoration.UNDERLINED) {
+      return new DecorationMap(this.obfuscated, this.bold, this.strikethrough, state, this.italic);
+    } else if (decoration == TextDecoration.ITALIC) {
+      return new DecorationMap(this.obfuscated, this.bold, this.strikethrough, this.underlined, state);
+    }
+    throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+  }
+
+  @Override
+  public TextDecoration.State get(final Object decoration) {
+    if (decoration == TextDecoration.OBFUSCATED) {
+      return this.obfuscated;
+    } else if (decoration == TextDecoration.BOLD) {
+      return this.bold;
+    } else if (decoration == TextDecoration.STRIKETHROUGH) {
+      return this.strikethrough;
+    } else if (decoration == TextDecoration.UNDERLINED) {
+      return this.underlined;
+    } else if (decoration == TextDecoration.ITALIC) {
+      return this.italic;
+    }
+
+    return null;
+  }
+
+  @Override
+  public boolean containsKey(final Object key) {
+    // null-safe
+    return key instanceof TextDecoration;
+  }
+
+  @Override
+  public int size() {
+    return DECORATIONS.length;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public @NotNull Set<Entry<TextDecoration, TextDecoration.State>> entrySet() {
+    if (this.entrySet == null) {
+      this.entrySet = new EntrySet();
+    }
+    return this.entrySet;
+  }
+
+  @Override
+  public @NotNull Set<TextDecoration> keySet() {
+    return KEY_SET;
+  }
+
+  @Override
+  public @NotNull Collection<TextDecoration.State> values() {
+    if (this.values == null) {
+      this.values = new Values();
+    }
+    return this.values;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (other == this) return true;
+    if (other == null || other.getClass() != DecorationMap.class) return false;
+    final DecorationMap that = (DecorationMap) other;
+    return this.obfuscated == that.obfuscated
+      && this.bold == that.bold
+      && this.strikethrough == that.strikethrough
+      && this.underlined == that.underlined
+      && this.italic == that.italic;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      this.obfuscated,
+      this.bold,
+      this.strikethrough,
+      this.underlined,
+      this.italic
+    );
+  }
+
+  final class EntrySet extends AbstractSet<Entry<TextDecoration, TextDecoration.State>> {
+    @Override
+    public @NotNull Iterator<Entry<TextDecoration, TextDecoration.State>> iterator() {
+      return new Iterator<Entry<TextDecoration, TextDecoration.State>>() {
+        private final Iterator<TextDecoration> decorations = KEY_SET.iterator();
+        private final Iterator<TextDecoration.State> states = DecorationMap.this.values().iterator();
+
+        @Override
+        public boolean hasNext() {
+          return this.decorations.hasNext() && this.states.hasNext();
+        }
+
+        @Override
+        public Entry<TextDecoration, TextDecoration.State> next() {
+          if (this.hasNext()) {
+            return new SimpleImmutableEntry<>(this.decorations.next(), this.states.next());
+          }
+          throw new NoSuchElementException();
+        }
+      };
+    }
+
+    @Override
+    public int size() {
+      return DECORATIONS.length;
+    }
+  }
+
+  final class Values extends AbstractCollection<TextDecoration.State> {
+    @Override
+    public @NotNull Iterator<TextDecoration.State> iterator() {
+      return Spliterators.iterator(Arrays.spliterator(this.toArray(new TextDecoration.State[0])));
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public Object @NotNull [] toArray() {
+      return new TextDecoration.State[] {DecorationMap.this.obfuscated, DecorationMap.this.bold, DecorationMap.this.strikethrough, DecorationMap.this.underlined, DecorationMap.this.italic};
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T @NotNull [] toArray(final T @NotNull [] a) {
+      if (a.length < DECORATIONS.length) {
+        return (T[]) Arrays.copyOf(this.toArray(), DECORATIONS.length, a.getClass());
+      }
+      System.arraycopy(this.toArray(), 0, a, 0, DECORATIONS.length);
+      return a;
+    }
+
+    @Override
+    public boolean contains(final Object o) {
+      return o instanceof TextDecoration.State && super.contains(o);
+    }
+
+    @Override
+    public int size() {
+      return DECORATIONS.length;
+    }
+  }
+
+  static final class KeySet extends AbstractSet<TextDecoration> {
+    @Override
+    public boolean contains(final Object o) {
+      // null-safe
+      return o instanceof TextDecoration;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public Object @NotNull [] toArray() {
+      return DECORATIONS.clone();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T @NotNull [] toArray(final T @NotNull [] a) {
+      if (a.length < DECORATIONS.length) {
+        return (T[]) Arrays.copyOf(DECORATIONS, DECORATIONS.length, a.getClass());
+      }
+      System.arraycopy(DECORATIONS, 0, a, 0, DECORATIONS.length);
+      return a;
+    }
+
+    @Override
+    public @NotNull Iterator<TextDecoration> iterator() {
+      return Spliterators.iterator(Arrays.spliterator(DECORATIONS));
+    }
+
+    @Override
+    public int size() {
+      return DECORATIONS.length;
+    }
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -215,12 +215,15 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T @NotNull [] toArray(final T @NotNull [] a) {
-      if (a.length < MAP_SIZE) {
-        return (T[]) Arrays.copyOf(this.toArray(), MAP_SIZE, a.getClass());
+    public <T> T @NotNull [] toArray(final T @NotNull [] dest) {
+      if (dest.length < MAP_SIZE) {
+        return (T[]) Arrays.copyOf(this.toArray(), MAP_SIZE, dest.getClass());
       }
-      System.arraycopy(this.toArray(), 0, a, 0, MAP_SIZE);
-      return a;
+      System.arraycopy(this.toArray(), 0, dest, 0, MAP_SIZE);
+      if (dest.length > MAP_SIZE) {
+        dest[MAP_SIZE] = null;
+      }
+      return dest;
     }
 
     @Override
@@ -253,12 +256,15 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T @NotNull [] toArray(final T @NotNull [] a) {
-      if (a.length < MAP_SIZE) {
-        return (T[]) Arrays.copyOf(StyleImpl.DECORATIONS, MAP_SIZE, a.getClass());
+    public <T> T @NotNull [] toArray(final T @NotNull [] dest) {
+      if (dest.length < MAP_SIZE) {
+        return (T[]) Arrays.copyOf(StyleImpl.DECORATIONS, MAP_SIZE, dest.getClass());
       }
-      System.arraycopy(StyleImpl.DECORATIONS, 0, a, 0, MAP_SIZE);
-      return a;
+      System.arraycopy(StyleImpl.DECORATIONS, 0, dest, 0, MAP_SIZE);
+      if (dest.length > MAP_SIZE) {
+        dest[MAP_SIZE] = null;
+      }
+      return dest;
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -210,7 +210,11 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
 
     @Override
     public Object @NotNull [] toArray() {
-      return Arrays.stream(StyleImpl.DECORATIONS).map(DecorationMap.this::get).toArray(TextDecoration.State[]::new);
+      final TextDecoration.State[] states = new TextDecoration.State[MAP_SIZE];
+      for (int i = 0; i < MAP_SIZE; i++) {
+        states[i] = DecorationMap.this.get(StyleImpl.DECORATIONS[i]);
+      }
+      return states;
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -42,6 +42,8 @@ import org.jetbrains.annotations.Unmodifiable;
 @Unmodifiable
 final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.State> implements Serializable {
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
+  private static final TextDecoration.State[] STATES = TextDecoration.State.values();
+
   static final DecorationMap EMPTY = fromMap(Collections.emptyMap());
   // key set is universal, all decorations always exist in any given style
   private static final KeySet KEY_SET = new KeySet();
@@ -96,7 +98,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
   @Override
   public TextDecoration.State get(final Object o) {
     if (o instanceof TextDecoration) {
-      return TextDecoration.State.values()[(int) (this.bitSet >> ((TextDecoration) o).ordinal() * 2 & 0b11)];
+      return STATES[this.bitSet >> ((TextDecoration) o).ordinal() * 2 & 0b11];
     }
     return null;
   }

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -109,8 +109,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
    * @since 4.0.0
    */
   static @NotNull Style style(final @Nullable TextColor color) {
-    if (color == null) return empty();
-    return new StyleImpl(null, color, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, null, null, null);
+    return empty().color(color);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -97,6 +97,7 @@ final class StyleImpl implements Style {
 
   @Override
   public TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
+    // null -> null
     final @Nullable TextDecoration.State state = this.decorations.get(decoration);
     if (state != null) {
       return state;
@@ -107,8 +108,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     requireNonNull(state, "state");
-    final @NotNull TextDecoration.State thisState = this.decoration(decoration);
-    if (thisState == state) return this;
+    if (this.decoration(decoration) == state) return this;
     return new StyleImpl(this.font, this.color, this.decorations.with(decoration, state), this.clickEvent, this.hoverEvent, this.insertion);
   }
 
@@ -190,17 +190,15 @@ final class StyleImpl implements Style {
 
   @Override
   public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
-    return Stream.of(
-      ExaminableProperty.of("color", this.color),
-      ExaminableProperty.of("obfuscated", this.decorations.get(TextDecoration.OBFUSCATED)),
-      ExaminableProperty.of("bold", this.decorations.get(TextDecoration.BOLD)),
-      ExaminableProperty.of("strikethrough", this.decorations.get(TextDecoration.STRIKETHROUGH)),
-      ExaminableProperty.of("underlined", this.decorations.get(TextDecoration.UNDERLINED)),
-      ExaminableProperty.of("italic", this.decorations.get(TextDecoration.ITALIC)),
-      ExaminableProperty.of("clickEvent", this.clickEvent),
-      ExaminableProperty.of("hoverEvent", this.hoverEvent),
-      ExaminableProperty.of("insertion", this.insertion),
-      ExaminableProperty.of("font", this.font)
+    return Stream.concat(
+      this.decorations.examinableProperties(),
+      Stream.of(
+        ExaminableProperty.of("color", this.color),
+        ExaminableProperty.of("clickEvent", this.clickEvent),
+        ExaminableProperty.of("hoverEvent", this.hoverEvent),
+        ExaminableProperty.of("insertion", this.insertion),
+        ExaminableProperty.of("font", this.font)
+      )
     );
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.format;
 
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -275,7 +276,8 @@ final class StyleImpl implements Style {
     @Override
     public @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
-      this.decorations.replace(decoration, state);
+      requireNonNull(decoration, "decoration");
+      this.decorations.put(decoration, state);
       return this;
     }
 

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -40,8 +40,7 @@ import static java.util.Objects.requireNonNull;
 
 final class StyleImpl implements Style {
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
-  private static final byte TRUSTED = 0;
-  static final StyleImpl EMPTY = new StyleImpl(null, null, DecorationMap.EMPTY, null, null, null, TRUSTED);
+  static final StyleImpl EMPTY = new StyleImpl(null, null, DecorationMap.EMPTY, null, null, null);
   // visible to avoid generating accessors when creating a builder
   final @Nullable Key font;
   final @Nullable TextColor color;
@@ -66,24 +65,6 @@ final class StyleImpl implements Style {
     this.insertion = insertion;
   }
 
-  // internal constructor, takes a 'trusted' decoration map (from another StyleImpl) to avoid copying
-  private StyleImpl(
-    final @Nullable Key font,
-    final @Nullable TextColor color,
-    final @NotNull DecorationMap decorations,
-    final @Nullable ClickEvent clickEvent,
-    final @Nullable HoverEvent<?> hoverEvent,
-    final @Nullable String insertion,
-    final byte trusted
-  ) {
-    this.font = font;
-    this.color = color;
-    this.decorations = decorations;
-    this.clickEvent = clickEvent;
-    this.hoverEvent = hoverEvent;
-    this.insertion = insertion;
-  }
-
   @Override
   public @Nullable Key font() {
     return this.font;
@@ -92,7 +73,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style font(final @Nullable Key font) {
     if (Objects.equals(this.font, font)) return this;
-    return new StyleImpl(font, this.color, this.decorations, this.clickEvent, this.hoverEvent, this.insertion, TRUSTED);
+    return new StyleImpl(font, this.color, this.decorations, this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -103,7 +84,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style color(final @Nullable TextColor color) {
     if (Objects.equals(this.color, color)) return this;
-    return new StyleImpl(this.font, color, this.decorations, this.clickEvent, this.hoverEvent, this.insertion, TRUSTED);
+    return new StyleImpl(this.font, color, this.decorations, this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -128,7 +109,7 @@ final class StyleImpl implements Style {
     requireNonNull(state, "state");
     final @NotNull TextDecoration.State thisState = this.decoration(decoration);
     if (thisState == state) return this;
-    return new StyleImpl(this.font, this.color, this.decorations.with(decoration, state), this.clickEvent, this.hoverEvent, this.insertion, TRUSTED);
+    return new StyleImpl(this.font, this.color, this.decorations.with(decoration, state), this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -138,7 +119,7 @@ final class StyleImpl implements Style {
 
   @Override
   public @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
-    return new StyleImpl(this.font, this.color, DecorationMap.merge(decorations, this.decorations), this.clickEvent, this.hoverEvent, this.insertion, TRUSTED);
+    return new StyleImpl(this.font, this.color, DecorationMap.merge(decorations, this.decorations), this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -148,7 +129,7 @@ final class StyleImpl implements Style {
 
   @Override
   public @NotNull Style clickEvent(final @Nullable ClickEvent event) {
-    return new StyleImpl(this.font, this.color, this.decorations, event, this.hoverEvent, this.insertion, TRUSTED);
+    return new StyleImpl(this.font, this.color, this.decorations, event, this.hoverEvent, this.insertion);
   }
 
   @Override
@@ -158,7 +139,7 @@ final class StyleImpl implements Style {
 
   @Override
   public @NotNull Style hoverEvent(final @Nullable HoverEventSource<?> source) {
-    return new StyleImpl(this.font, this.color, this.decorations, this.clickEvent, HoverEventSource.unbox(source), this.insertion, TRUSTED);
+    return new StyleImpl(this.font, this.color, this.decorations, this.clickEvent, HoverEventSource.unbox(source), this.insertion);
   }
 
   @Override
@@ -169,7 +150,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style insertion(final @Nullable String insertion) {
     if (Objects.equals(this.insertion, insertion)) return this;
-    return new StyleImpl(this.font, this.color, this.decorations, this.clickEvent, this.hoverEvent, insertion, TRUSTED);
+    return new StyleImpl(this.font, this.color, this.decorations, this.clickEvent, this.hoverEvent, insertion);
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 final class StyleImpl implements Style {
-  private static final TextDecoration[] DECORATIONS = TextDecoration.values();
+  static final TextDecoration[] DECORATIONS = TextDecoration.values();
   static final StyleImpl EMPTY = new StyleImpl(null, null, DecorationMap.EMPTY, null, null, null);
   // visible to avoid generating accessors when creating a builder
   final @Nullable Key font;

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -39,16 +39,13 @@ import org.jetbrains.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 final class StyleImpl implements Style {
-  static final StyleImpl EMPTY = new StyleImpl(null, null, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, TextDecoration.State.NOT_SET, null, null, null);
-  static final TextDecoration[] DECORATIONS = TextDecoration.values();
+  private static final TextDecoration[] DECORATIONS = TextDecoration.values();
+  private static final byte TRUSTED = 0;
+  static final StyleImpl EMPTY = new StyleImpl(null, null, DecorationMap.EMPTY, null, null, null, TRUSTED);
   // visible to avoid generating accessors when creating a builder
   final @Nullable Key font;
   final @Nullable TextColor color;
-  final TextDecoration.State obfuscated;
-  final TextDecoration.State bold;
-  final TextDecoration.State strikethrough;
-  final TextDecoration.State underlined;
-  final TextDecoration.State italic;
+  final @NotNull DecorationMap decorations;
   final @Nullable ClickEvent clickEvent;
   final @Nullable HoverEvent<?> hoverEvent;
   final @Nullable String insertion;
@@ -56,22 +53,32 @@ final class StyleImpl implements Style {
   StyleImpl(
     final @Nullable Key font,
     final @Nullable TextColor color,
-    final TextDecoration.State obfuscated,
-    final TextDecoration.State bold,
-    final TextDecoration.State strikethrough,
-    final TextDecoration.State underlined,
-    final TextDecoration.State italic,
+    final @NotNull Map<TextDecoration, TextDecoration.State> decorations,
     final @Nullable ClickEvent clickEvent,
     final @Nullable HoverEvent<?> hoverEvent,
     final @Nullable String insertion
   ) {
     this.font = font;
     this.color = color;
-    this.obfuscated = obfuscated;
-    this.bold = bold;
-    this.strikethrough = strikethrough;
-    this.underlined = underlined;
-    this.italic = italic;
+    this.decorations = DecorationMap.fromMap(decorations);
+    this.clickEvent = clickEvent;
+    this.hoverEvent = hoverEvent;
+    this.insertion = insertion;
+  }
+
+  // internal constructor, takes a 'trusted' decoration map (from another StyleImpl) to avoid copying
+  private StyleImpl(
+    final @Nullable Key font,
+    final @Nullable TextColor color,
+    final @NotNull DecorationMap decorations,
+    final @Nullable ClickEvent clickEvent,
+    final @Nullable HoverEvent<?> hoverEvent,
+    final @Nullable String insertion,
+    final byte trusted
+  ) {
+    this.font = font;
+    this.color = color;
+    this.decorations = decorations;
     this.clickEvent = clickEvent;
     this.hoverEvent = hoverEvent;
     this.insertion = insertion;
@@ -85,7 +92,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style font(final @Nullable Key font) {
     if (Objects.equals(this.font, font)) return this;
-    return new StyleImpl(font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
+    return new StyleImpl(font, this.color, this.decorations, this.clickEvent, this.hoverEvent, this.insertion, TRUSTED);
   }
 
   @Override
@@ -96,7 +103,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style color(final @Nullable TextColor color) {
     if (Objects.equals(this.color, color)) return this;
-    return new StyleImpl(this.font, color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
+    return new StyleImpl(this.font, color, this.decorations, this.clickEvent, this.hoverEvent, this.insertion, TRUSTED);
   }
 
   @Override
@@ -109,16 +116,9 @@ final class StyleImpl implements Style {
 
   @Override
   public TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
-    if (decoration == TextDecoration.BOLD) {
-      return this.bold;
-    } else if (decoration == TextDecoration.ITALIC) {
-      return this.italic;
-    } else if (decoration == TextDecoration.UNDERLINED) {
-      return this.underlined;
-    } else if (decoration == TextDecoration.STRIKETHROUGH) {
-      return this.strikethrough;
-    } else if (decoration == TextDecoration.OBFUSCATED) {
-      return this.obfuscated;
+    final @Nullable TextDecoration.State state = this.decorations.get(decoration);
+    if (state != null) {
+      return state;
     }
     throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
   }
@@ -126,28 +126,19 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
     requireNonNull(state, "state");
-    if (decoration == TextDecoration.BOLD) {
-      return new StyleImpl(this.font, this.color, this.obfuscated, state, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
-    } else if (decoration == TextDecoration.ITALIC) {
-      return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, state, this.clickEvent, this.hoverEvent, this.insertion);
-    } else if (decoration == TextDecoration.UNDERLINED) {
-      return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, state, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
-    } else if (decoration == TextDecoration.STRIKETHROUGH) {
-      return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, state, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
-    } else if (decoration == TextDecoration.OBFUSCATED) {
-      return new StyleImpl(this.font, this.color, state, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
-    }
-    throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+    final @NotNull TextDecoration.State thisState = this.decoration(decoration);
+    if (thisState == state) return this;
+    return new StyleImpl(this.font, this.color, this.decorations.with(decoration, state), this.clickEvent, this.hoverEvent, this.insertion, TRUSTED);
+  }
+
+  @Override
+  public @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
+    return this.decorations;
   }
 
   @Override
   public @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
-    final TextDecoration.State obfuscated = decorations.getOrDefault(TextDecoration.OBFUSCATED, this.obfuscated);
-    final TextDecoration.State bold = decorations.getOrDefault(TextDecoration.BOLD, this.bold);
-    final TextDecoration.State strikethrough = decorations.getOrDefault(TextDecoration.STRIKETHROUGH, this.strikethrough);
-    final TextDecoration.State underlined = decorations.getOrDefault(TextDecoration.UNDERLINED, this.underlined);
-    final TextDecoration.State italic = decorations.getOrDefault(TextDecoration.ITALIC, this.italic);
-    return new StyleImpl(this.font, this.color, obfuscated, bold, strikethrough, underlined, italic, this.clickEvent, this.hoverEvent, this.insertion);
+    return new StyleImpl(this.font, this.color, DecorationMap.merge(decorations, this.decorations), this.clickEvent, this.hoverEvent, this.insertion, TRUSTED);
   }
 
   @Override
@@ -157,7 +148,7 @@ final class StyleImpl implements Style {
 
   @Override
   public @NotNull Style clickEvent(final @Nullable ClickEvent event) {
-    return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, event, this.hoverEvent, this.insertion);
+    return new StyleImpl(this.font, this.color, this.decorations, event, this.hoverEvent, this.insertion, TRUSTED);
   }
 
   @Override
@@ -167,7 +158,7 @@ final class StyleImpl implements Style {
 
   @Override
   public @NotNull Style hoverEvent(final @Nullable HoverEventSource<?> source) {
-    return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, HoverEventSource.unbox(source), this.insertion);
+    return new StyleImpl(this.font, this.color, this.decorations, this.clickEvent, HoverEventSource.unbox(source), this.insertion, TRUSTED);
   }
 
   @Override
@@ -178,7 +169,7 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style insertion(final @Nullable String insertion) {
     if (Objects.equals(this.insertion, insertion)) return this;
-    return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, insertion);
+    return new StyleImpl(this.font, this.color, this.decorations, this.clickEvent, this.hoverEvent, insertion, TRUSTED);
   }
 
   @Override
@@ -220,11 +211,11 @@ final class StyleImpl implements Style {
   public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("color", this.color),
-      ExaminableProperty.of("obfuscated", this.obfuscated),
-      ExaminableProperty.of("bold", this.bold),
-      ExaminableProperty.of("strikethrough", this.strikethrough),
-      ExaminableProperty.of("underlined", this.underlined),
-      ExaminableProperty.of("italic", this.italic),
+      ExaminableProperty.of("obfuscated", this.decorations.get(TextDecoration.OBFUSCATED)),
+      ExaminableProperty.of("bold", this.decorations.get(TextDecoration.BOLD)),
+      ExaminableProperty.of("strikethrough", this.decorations.get(TextDecoration.STRIKETHROUGH)),
+      ExaminableProperty.of("underlined", this.decorations.get(TextDecoration.UNDERLINED)),
+      ExaminableProperty.of("italic", this.decorations.get(TextDecoration.ITALIC)),
       ExaminableProperty.of("clickEvent", this.clickEvent),
       ExaminableProperty.of("hoverEvent", this.hoverEvent),
       ExaminableProperty.of("insertion", this.insertion),
@@ -243,11 +234,7 @@ final class StyleImpl implements Style {
     if (!(other instanceof StyleImpl)) return false;
     final StyleImpl that = (StyleImpl) other;
     return Objects.equals(this.color, that.color)
-      && this.obfuscated == that.obfuscated
-      && this.bold == that.bold
-      && this.strikethrough == that.strikethrough
-      && this.underlined == that.underlined
-      && this.italic == that.italic
+      && this.decorations.equals(that.decorations)
       && Objects.equals(this.clickEvent, that.clickEvent)
       && Objects.equals(this.hoverEvent, that.hoverEvent)
       && Objects.equals(this.insertion, that.insertion)
@@ -257,11 +244,7 @@ final class StyleImpl implements Style {
   @Override
   public int hashCode() {
     int result = Objects.hashCode(this.color);
-    result = (31 * result) + this.obfuscated.hashCode();
-    result = (31 * result) + this.bold.hashCode();
-    result = (31 * result) + this.strikethrough.hashCode();
-    result = (31 * result) + this.underlined.hashCode();
-    result = (31 * result) + this.italic.hashCode();
+    result = (31 * result) + this.decorations.hashCode();
     result = (31 * result) + Objects.hashCode(this.clickEvent);
     result = (31 * result) + Objects.hashCode(this.hoverEvent);
     result = (31 * result) + Objects.hashCode(this.insertion);
@@ -272,25 +255,18 @@ final class StyleImpl implements Style {
   static final class BuilderImpl implements Builder {
     @Nullable Key font;
     @Nullable TextColor color;
-    TextDecoration.State obfuscated = TextDecoration.State.NOT_SET;
-    TextDecoration.State bold = TextDecoration.State.NOT_SET;
-    TextDecoration.State strikethrough = TextDecoration.State.NOT_SET;
-    TextDecoration.State underlined = TextDecoration.State.NOT_SET;
-    TextDecoration.State italic = TextDecoration.State.NOT_SET;
+    final Map<TextDecoration, TextDecoration.State> decorations;
     @Nullable ClickEvent clickEvent;
     @Nullable HoverEvent<?> hoverEvent;
     @Nullable String insertion;
 
     BuilderImpl() {
+      this.decorations = new EnumMap<>(DecorationMap.EMPTY);
     }
 
     BuilderImpl(final @NotNull StyleImpl style) {
       this.color = style.color;
-      this.obfuscated = style.obfuscated;
-      this.bold = style.bold;
-      this.strikethrough = style.strikethrough;
-      this.underlined = style.underlined;
-      this.italic = style.italic;
+      this.decorations = new EnumMap<>(style.decorations);
       this.clickEvent = style.clickEvent;
       this.hoverEvent = style.hoverEvent;
       this.insertion = style.insertion;
@@ -320,49 +296,16 @@ final class StyleImpl implements Style {
     @Override
     public @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
-      if (decoration == TextDecoration.BOLD) {
-        this.bold = state;
-      } else if (decoration == TextDecoration.ITALIC) {
-        this.italic = state;
-      } else if (decoration == TextDecoration.UNDERLINED) {
-        this.underlined = state;
-      } else if (decoration == TextDecoration.STRIKETHROUGH) {
-        this.strikethrough = state;
-      } else if (decoration == TextDecoration.OBFUSCATED) {
-        this.obfuscated = state;
-      } else {
-        throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
-      }
+      this.decorations.replace(decoration, state);
       return this;
     }
 
     // todo(kashike): promote to public api?
     @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
-      if (decoration == TextDecoration.BOLD) {
-        if (this.bold == TextDecoration.State.NOT_SET) {
-          this.bold = state;
-        }
-        return this;
-      } else if (decoration == TextDecoration.ITALIC) {
-        if (this.italic == TextDecoration.State.NOT_SET) {
-          this.italic = state;
-        }
-        return this;
-      } else if (decoration == TextDecoration.UNDERLINED) {
-        if (this.underlined == TextDecoration.State.NOT_SET) {
-          this.underlined = state;
-        }
-        return this;
-      } else if (decoration == TextDecoration.STRIKETHROUGH) {
-        if (this.strikethrough == TextDecoration.State.NOT_SET) {
-          this.strikethrough = state;
-        }
-        return this;
-      } else if (decoration == TextDecoration.OBFUSCATED) {
-        if (this.obfuscated == TextDecoration.State.NOT_SET) {
-          this.obfuscated = state;
-        }
+      final @Nullable TextDecoration.State thisState = this.decorations.get(decoration);
+      if (thisState == TextDecoration.State.NOT_SET) {
+        this.decorations.put(decoration, state);
         return this;
       }
       throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
@@ -448,16 +391,13 @@ final class StyleImpl implements Style {
       if (this.isEmpty()) {
         return EMPTY;
       }
-      return new StyleImpl(this.font, this.color, this.obfuscated, this.bold, this.strikethrough, this.underlined, this.italic, this.clickEvent, this.hoverEvent, this.insertion);
+      // copy map, don't use the 'trusted' constructor
+      return new StyleImpl(this.font, this.color, this.decorations, this.clickEvent, this.hoverEvent, this.insertion);
     }
 
     private boolean isEmpty() {
       return this.color == null
-        && this.obfuscated == TextDecoration.State.NOT_SET
-        && this.bold == TextDecoration.State.NOT_SET
-        && this.strikethrough == TextDecoration.State.NOT_SET
-        && this.underlined == TextDecoration.State.NOT_SET
-        && this.italic == TextDecoration.State.NOT_SET
+        && this.decorations.values().stream().allMatch(state -> state == TextDecoration.State.NOT_SET)
         && this.clickEvent == null
         && this.hoverEvent == null
         && this.insertion == null

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -306,6 +306,8 @@ final class StyleImpl implements Style {
       final @Nullable TextDecoration.State thisState = this.decorations.get(decoration);
       if (thisState == TextDecoration.State.NOT_SET) {
         this.decorations.put(decoration, state);
+      }
+      if (thisState != null) {
         return this;
       }
       throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -374,7 +374,6 @@ final class StyleImpl implements Style {
       if (this.isEmpty()) {
         return EMPTY;
       }
-      // copy map, don't use the 'trusted' constructor
       return new StyleImpl(this.font, this.color, this.decorations, this.clickEvent, this.hoverEvent, this.insertion);
     }
 


### PR DESCRIPTION
Reduces code repetition in `StyleImpl` by implementing a `DecorationMap`, a `Map<TextDecoration, TextDecoration.State>` that operates on bit flags.

Closes #392 