### PR TITLE
api: Add isEmpty to component

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -291,10 +291,6 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
     return this.styleBuilder;
   }
 
-  protected final boolean hasStyle() {
-    return this.styleBuilder != null || this.style != null;
-  }
-
   protected @NotNull Style buildStyle() {
     if (this.styleBuilder != null) {
       return this.styleBuilder.build();

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -35,6 +35,7 @@ import java.util.Spliterators;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Collector;
@@ -114,6 +115,13 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   BiPredicate<? super Component, ? super Component> EQUALS_IDENTITY = (a, b) -> a == b;
+
+  /**
+   * A predicate that checks if a component is non-empty.
+   *
+   * @since 4.10.0
+   */
+  Predicate<? super Component> NOT_EMPTY = c -> c != empty();
 
   /**
    * Gets an empty component.

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2006,6 +2006,17 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Tests if this {@link Component} is empty.
+   *
+   * @return {@code true} if the component is the empty component, {@code false} if
+   *     component is not a {@link TextComponent} or not empty.
+   * @since 4.10.0
+   */
+  default boolean isEmpty() {
+    return this == TextComponentImpl.EMPTY;
+  }
+
+  /**
    * Finds and replaces any text with this or child {@link Component}s using the configured options.
    *
    * @param configurer the configurer

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -745,7 +745,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_ -> new", pure = true)
   static @NotNull TextComponent text(final @NotNull String content) {
-    if (content.isEmpty()) return empty();
     return text(content, Style.empty());
   }
 
@@ -759,6 +758,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TextComponent text(final @NotNull String content, final @NotNull Style style) {
+    if (content.isEmpty() && style.isEmpty()) return empty();
     return new TextComponentImpl(Collections.emptyList(), style, content);
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2006,7 +2006,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Tests if this {@link Component} is empty.
+   * Tests if this component is empty.
    *
    * @return {@code true} if the component is the empty component, {@code false} if
    *     component is not a {@link TextComponent} or not empty.

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -766,8 +766,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TextComponent text(final @NotNull String content, final @NotNull Style style) {
-    if (content.isEmpty() && style.isEmpty()) return empty();
-    return new TextComponentImpl(Collections.emptyList(), style, content);
+    return TextComponentImpl.create(Collections.emptyList(), style, content);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -35,7 +35,6 @@ import java.util.Spliterators;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Collector;
@@ -115,13 +114,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @since 4.8.0
    */
   BiPredicate<? super Component, ? super Component> EQUALS_IDENTITY = (a, b) -> a == b;
-
-  /**
-   * A predicate that checks if a component is non-empty.
-   *
-   * @since 4.10.0
-   */
-  Predicate<? super Component> NOT_EMPTY = c -> c != empty();
 
   /**
    * Gets an empty component.

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -167,6 +167,6 @@ final class ComponentCompaction {
   }
 
   private static TextComponent joinText(final TextComponent one, final TextComponent two) {
-    return new TextComponentImpl(two.children(), one.style(), one.content() + two.content());
+    return TextComponentImpl.create(two.children(), one.style(), one.content() + two.content());
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -49,6 +49,13 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
     return new TextComponentImpl(Collections.emptyList(), Style.empty(), content);
   }
 
+  static @NotNull TextComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String content) {
+    if (children.isEmpty() && style.isEmpty() && content.isEmpty()) {
+      return Component.empty();
+    }
+    return new TextComponentImpl(children, style, content);
+  }
+
   private final String content;
 
   TextComponentImpl(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String content) {
@@ -79,27 +86,17 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   @Override
   public @NotNull TextComponent content(final @NotNull String content) {
     if (Objects.equals(this.content, content)) return this;
-    if (content.isEmpty() && this.children.isEmpty() && this.style.isEmpty()) {
-      return Component.empty();
-    }
-    return new TextComponentImpl(this.children, this.style, content);
+    return create(this.children, this.style, content);
   }
 
   @Override
   public @NotNull TextComponent children(final @NotNull List<? extends ComponentLike> children) {
-    final List<Component> components = ComponentLike.asComponents(children, NOT_EMPTY);
-    if (components.isEmpty() && this.style.isEmpty() && this.content.isEmpty()) {
-      return Component.empty();
-    }
-    return new TextComponentImpl(components, this.style, this.content);
+    return create(ComponentLike.asComponents(children, NOT_EMPTY), this.style, this.content);
   }
 
   @Override
   public @NotNull TextComponent style(final @NotNull Style style) {
-    if (style.isEmpty() && this.children.isEmpty() && this.content.isEmpty()) {
-      return Component.empty();
-    }
-    return new TextComponentImpl(this.children, style, this.content);
+    return create(this.children, style, this.content);
   }
 
   @Override
@@ -162,11 +159,7 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
 
     @Override
     public @NotNull TextComponent build() {
-      final Style style = this.buildStyle();
-      if (this.content.isEmpty() && this.children.isEmpty() && style.isEmpty()) {
-        return Component.empty();
-      }
-      return new TextComponentImpl(this.children, style, this.content);
+      return create(this.children, this.buildStyle(), this.content);
     }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -79,7 +79,7 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   @Override
   public @NotNull TextComponent content(final @NotNull String content) {
     if (Objects.equals(this.content, content)) return this;
-    if (this.children.isEmpty() && this.style.isEmpty() && content.isEmpty()) {
+    if (content.isEmpty() && this.children.isEmpty() && this.style.isEmpty()) {
       return Component.empty();
     }
     return new TextComponentImpl(this.children, this.style, content);
@@ -87,16 +87,16 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
 
   @Override
   public @NotNull TextComponent children(final @NotNull List<? extends ComponentLike> children) {
-    if (this.style.isEmpty() && this.content.isEmpty() && (children.isEmpty()
-      || children.stream().map(ComponentLike::asComponent).allMatch(Component::isEmpty))) {
+    final List<Component> components = ComponentLike.asComponents(children, NOT_EMPTY);
+    if (components.isEmpty() && this.style.isEmpty() && this.content.isEmpty()) {
       return Component.empty();
     }
-    return new TextComponentImpl(children, this.style, this.content);
+    return new TextComponentImpl(components, this.style, this.content);
   }
 
   @Override
   public @NotNull TextComponent style(final @NotNull Style style) {
-    if (this.children.isEmpty() && style.isEmpty() && this.content.isEmpty()) {
+    if (style.isEmpty() && this.children.isEmpty() && this.content.isEmpty()) {
       return Component.empty();
     }
     return new TextComponentImpl(this.children, style, this.content);

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -168,9 +168,5 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
       }
       return new TextComponentImpl(this.children, style, this.content);
     }
-
-    private boolean isEmpty() {
-      return this.content.isEmpty() && this.children.isEmpty() && !this.hasStyle();
-    }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -79,16 +79,26 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   @Override
   public @NotNull TextComponent content(final @NotNull String content) {
     if (Objects.equals(this.content, content)) return this;
-    return new TextComponentImpl(this.children, this.style, requireNonNull(content, "content"));
+    if (this.children.isEmpty() && this.style.isEmpty() && content.isEmpty()) {
+      return Component.empty();
+    }
+    return new TextComponentImpl(this.children, this.style, content);
   }
 
   @Override
   public @NotNull TextComponent children(final @NotNull List<? extends ComponentLike> children) {
+    if (this.style.isEmpty() && this.content.isEmpty() && (children.isEmpty()
+      || children.stream().map(ComponentLike::asComponent).allMatch(Component::isEmpty))) {
+      return Component.empty();
+    }
     return new TextComponentImpl(children, this.style, this.content);
   }
 
   @Override
   public @NotNull TextComponent style(final @NotNull Style style) {
+    if (this.children.isEmpty() && style.isEmpty() && this.content.isEmpty()) {
+      return Component.empty();
+    }
     return new TextComponentImpl(this.children, style, this.content);
   }
 
@@ -152,10 +162,11 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
 
     @Override
     public @NotNull TextComponent build() {
-      if (this.isEmpty()) {
+      final Style style = this.buildStyle();
+      if (this.content.isEmpty() && this.children.isEmpty() && style.isEmpty()) {
         return Component.empty();
       }
-      return new TextComponentImpl(this.children, this.buildStyle(), this.content);
+      return new TextComponentImpl(this.children, style, this.content);
     }
 
     private boolean isEmpty() {

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -50,10 +50,17 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   }
 
   static @NotNull TextComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String content) {
-    if (children.isEmpty() && style.isEmpty() && content.isEmpty()) {
+    requireNonNull(content, "content");
+    final boolean emptyStyleAndContent = style.isEmpty() && content.isEmpty();
+    if (emptyStyleAndContent && children.isEmpty()) {
       return Component.empty();
     }
-    return new TextComponentImpl(children, style, content);
+    final TextComponentImpl component = new TextComponentImpl(children, style, content);
+    //Checks if the children are empty after creation, through the filter in the constructor of AbstractComponent.
+    if (emptyStyleAndContent & component.children().isEmpty()) {
+      return Component.empty();
+    }
+    return component;
   }
 
   private final String content;
@@ -91,7 +98,7 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
 
   @Override
   public @NotNull TextComponent children(final @NotNull List<? extends ComponentLike> children) {
-    return create(ComponentLike.asComponents(children, NOT_EMPTY), this.style, this.content);
+    return create(children, this.style, this.content);
   }
 
   @Override

--- a/api/src/test/java/net/kyori/adventure/text/AbstractComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/AbstractComponentTest.java
@@ -308,6 +308,11 @@ abstract class AbstractComponentTest<C extends BuildableComponent<C, B> & Scoped
   }
 
   @Test
+  void testIsEmpty() {
+    assertFalse(this.buildOne().isEmpty());
+  }
+
+  @Test
   void testAsHoverEvent() {
     final C c0 = this.buildOne().color(null);
     final HoverEvent<Component> e0 = HoverEvent.showText(c0);

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import static net.kyori.adventure.text.TextAssertions.assertDecorations;
 import static net.kyori.test.WeirdAssertions.assertAllEqualToEachOther;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -135,5 +136,17 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
   @Test
   void testBuildEmptyIsEmpty() {
     assertSame(Component.empty(), Component.text().build());
+  }
+
+  @Test
+  void testTextIsEmpty() {
+    TextComponent component = Component.empty();
+    assertTrue(component.isEmpty());
+    component = Component.text("");
+    assertTrue(component.isEmpty());
+    component = Component.text().append(Component.empty()).build();
+    assertTrue(component.isEmpty());
+    component = Component.text(" ");
+    assertFalse(component.isEmpty());
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
@@ -144,8 +145,11 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
     assertTrue(component.isEmpty());
     component = Component.text("");
     assertTrue(component.isEmpty());
+    component = Component.text("", Style.empty());
+    assertTrue(component.isEmpty());
     component = Component.text().append(Component.empty()).append(Component.empty()).build();
     assertTrue(component.isEmpty());
+
     component = Component.text(" ");
     assertFalse(component.isEmpty());
     component = Component.text().append(Component.text(" ")).append(Component.empty()).build();
@@ -153,13 +157,28 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
   }
 
   @Test
-  void testTextReplaceIsEmpty() {
-    Component component = Component.text("a");
-    assertFalse(component.isEmpty());
-    component = component.replaceText(builder -> {
-      builder.matchLiteral("a");
-      builder.replacement("");
-    });
-    assertTrue(component.isEmpty(), component.toString());
+  void testIsEmptyBuilders() {
+    Component component = Component.text().content("").style(Style.empty()).asComponent();
+    assertTrue(component.isEmpty());
+    component = component.style(Style.empty());
+    assertTrue(component.isEmpty());
+    component = component.children(Collections.emptyList());
+    assertTrue(component.isEmpty());
+    component = component.children(Collections.singletonList(Component.empty()));
+    assertTrue(component.isEmpty());
+
+    final Style nonEmptyStyle = Style.style()
+      .decorate(TextDecoration.BOLD).build();
+    assertFalse(Component.empty().style(nonEmptyStyle).isEmpty());
+    assertFalse(Component.empty()
+      .children(Collections.singletonList(Component.text().content("a"))).isEmpty());
+    assertFalse(Component.empty()
+      .children(Collections.singletonList(Component.text().style(nonEmptyStyle))).isEmpty());
+
+    assertTrue(Component.empty().content("abc").content("").isEmpty());
+    assertTrue(Component.empty().style(nonEmptyStyle).style(Style.empty()).isEmpty());
+    assertTrue(Component.empty()
+      .children(Collections.singletonList(Component.text("a")))
+      .children(Collections.emptyList()).isEmpty());
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -144,9 +144,22 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
     assertTrue(component.isEmpty());
     component = Component.text("");
     assertTrue(component.isEmpty());
-    component = Component.text().append(Component.empty()).build();
+    component = Component.text().append(Component.empty()).append(Component.empty()).build();
     assertTrue(component.isEmpty());
     component = Component.text(" ");
     assertFalse(component.isEmpty());
+    component = Component.text().append(Component.text(" ")).append(Component.empty()).build();
+    assertFalse(component.isEmpty());
+  }
+
+  @Test
+  void testTextReplaceIsEmpty() {
+    Component component = Component.text("a");
+    assertFalse(component.isEmpty());
+    component = component.replaceText(builder -> {
+      builder.matchLiteral("a");
+      builder.replacement("");
+    });
+    assertTrue(component.isEmpty(), component.toString());
   }
 }


### PR DESCRIPTION
This PR adds ` Component#isEmpty` to easily test if the component is empty.

Like, for example, that an empty component shouldn't be sent to the player.
