### PR TITLE
Fix titles on 1.8

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -446,8 +446,8 @@ public interface Audience extends Pointered {
     final Title.Times times = title.times();
     if (times != null) this.sendTitlePart(TitlePart.TIMES, times);
     
-    this.sendTitlePart(TitlePart.TITLE, title.title());
     this.sendTitlePart(TitlePart.SUBTITLE, title.subtitle());
+    this.sendTitlePart(TitlePart.TITLE, title.title());
   }
 
   /**


### PR DESCRIPTION
Due to how 1.8 works, it's required to send times and subtitle packets before the main title packet.
I didn't test if this doesn't break newer versions, but I don't see a reason why it could.

I made the same fix for adventure-platform too: https://github.com/KyoriPowered/adventure-platform/pull/64