### PR TITLE
extra-kotlin: Add some `JoinConfiguration` related methods

### DIFF
--- a/extra-kotlin/src/main/kotlin/net/kyori/adventure/extra/kotlin/JoinConfigurationDSL.kt
+++ b/extra-kotlin/src/main/kotlin/net/kyori/adventure/extra/kotlin/JoinConfigurationDSL.kt
@@ -23,34 +23,14 @@
  */
 package net.kyori.adventure.extra.kotlin
 
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.ComponentLike
 import net.kyori.adventure.text.JoinConfiguration
 
 /**
- * Adds [that] as a child component.
+ * Builds a new join configuration from the provided [builder].
  *
- * @return a component
- * @since 4.6.0
- */
-public operator fun Component.plus(that: ComponentLike): Component = this.append(that)
-
-/**
- * Joins this array of components using the provided [config].
- *
- * @param config the join configuration
- * @return the resulting component
+ * @param builder the builder to configure the resulting join configuration
+ * @return a new join configuration
  * @since 4.10.0
  */
-public fun Array<out ComponentLike>.join(config: JoinConfiguration = JoinConfiguration.noSeparators()): Component =
-    this.toList().join(config)
-
-/**
- * Joins this iterable of components using the provided [config].
- *
- * @param config the join configuration
- * @return the resulting component
- * @since 4.10.0
- */
-public fun Iterable<ComponentLike>.join(config: JoinConfiguration = JoinConfiguration.noSeparators()): Component =
-    Component.join(config, this)
+public fun joinConfiguration(builder: JoinConfiguration.Builder.() -> Unit): JoinConfiguration =
+  JoinConfiguration.builder().also(builder).build()


### PR DESCRIPTION
Closes #467.

Note that the redundant visibility modifiers and return types are included based on the upcoming introduction of explicit API mode.