### PR TITLE
Add standard join configurations

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/JoinConfiguration.java
+++ b/api/src/main/java/net/kyori/adventure/text/JoinConfiguration.java
@@ -100,6 +100,48 @@ public interface JoinConfiguration extends Buildable<JoinConfiguration, JoinConf
   }
 
   /**
+   * Provides a join configuration with no prefix or suffix that simply joins the components together using the {@link Component#newline()} component.
+   *
+   * <p>A purely text based example of this syntax, without introducing the concepts of components, would join the two strings 'hello' and 'there' together,
+   * creating the following output: 'hello\nthere'.</p>
+   *
+   * @return the join configuration
+   * @since 4.10.0
+   */
+  static @NotNull JoinConfiguration newlines() {
+    return JoinConfigurationImpl.STANDARD_NEW_LINES;
+  }
+
+  /**
+   * Provides a join configuration with no prefix or suffix that simply joins the components together using a single comma, matching a CSV like layout.
+   *
+   * <p>A purely text based example of this syntax, without introducing the concepts of components, would join the two strings 'hello' and 'there' together,
+   * creating either the output 'hello,there' or 'hello, there' depending on whether the passed boolean flag was {@code false} or {@code true} respectively.</p>
+   *
+   * @param spaces a plain boolean flag indicating whether the returned comma-based join configuration should append a single space after each comma or not
+   * @return the join configuration
+   * @since 4.10.0
+   */
+  static @NotNull JoinConfiguration commas(final boolean spaces) {
+    return spaces ? JoinConfigurationImpl.STANDARD_COMMA_SPACE_SEPARATED : JoinConfigurationImpl.STANDARD_COMMA_SEPARATED;
+  }
+
+  /**
+   * Provides a join configuration that joins components together in the same manner {@link java.util.Arrays#toString(Object[])} stringifies an array.
+   * Specifically, the join configuration prefixes and suffixes the components with an open or closed square bracket respectively.
+   * Components themselves are joined together using a comma and a space.
+   *
+   * <p>A purely text based example of this syntax, without introducing the concepts of components, would join the two strings 'hello' and 'there' together,
+   * creating the following output: '[hello, there]'.</p>
+   *
+   * @return the join configuration
+   * @since 4.10.0
+   */
+  static @NotNull JoinConfiguration arrayLike() {
+    return JoinConfigurationImpl.STANDARD_ARRAY_LIKE;
+  }
+
+  /**
    * Creates a join configuration with a separator and no prefix or suffix.
    *
    * @param separator the separator

--- a/api/src/main/java/net/kyori/adventure/text/JoinConfigurationImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/JoinConfigurationImpl.java
@@ -39,6 +39,15 @@ final class JoinConfigurationImpl implements JoinConfiguration {
   static final Predicate<ComponentLike> DEFAULT_PREDICATE = componentLike -> true;
   static final JoinConfigurationImpl NULL = new JoinConfigurationImpl();
 
+  static final JoinConfiguration STANDARD_NEW_LINES = JoinConfiguration.separator(Component.newline());
+  static final JoinConfiguration STANDARD_COMMA_SEPARATED = JoinConfiguration.separator(Component.text(","));
+  static final JoinConfiguration STANDARD_COMMA_SPACE_SEPARATED = JoinConfiguration.separator(Component.text(", "));
+  static final JoinConfiguration STANDARD_ARRAY_LIKE = JoinConfiguration.builder()
+    .separator(Component.text(", "))
+    .prefix(Component.text("["))
+    .suffix(Component.text("]"))
+    .build();
+
   private final Component prefix;
   private final Component suffix;
   private final Component separator;

--- a/api/src/test/java/net/kyori/adventure/text/JoinTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/JoinTest.java
@@ -257,6 +257,68 @@ class JoinTest {
     );
   }
 
+  @Test
+  final void testStandardJoinConfigurationsNewLines() {
+    final Component result = Component.join(JoinConfiguration.newlines(), Component.text("line 1"), Component.text("line 2"), Component.text("line 3"));
+    assertEquals(
+      Component.text()
+        .append(Component.text("line 1"))
+        .append(Component.newline())
+        .append(Component.text("line 2"))
+        .append(Component.newline())
+        .append(Component.text("line 3"))
+        .build(),
+      result
+    );
+  }
+
+  @Test
+  final void testStandardJoinConfigurationsCommas() {
+    final Component result = Component.join(JoinConfiguration.commas(false), Component.text("line 1"), Component.text("line 2"), Component.text("line 3"));
+    assertEquals(
+      Component.text()
+        .append(Component.text("line 1"))
+        .append(Component.text(","))
+        .append(Component.text("line 2"))
+        .append(Component.text(","))
+        .append(Component.text("line 3"))
+        .build(),
+      result
+    );
+  }
+
+  @Test
+  final void testStandardJoinConfigurationsCommasSpaced() {
+    final Component result = Component.join(JoinConfiguration.commas(true), Component.text("line 1"), Component.text("line 2"), Component.text("line 3"));
+    assertEquals(
+      Component.text()
+        .append(Component.text("line 1"))
+        .append(Component.text(", "))
+        .append(Component.text("line 2"))
+        .append(Component.text(", "))
+        .append(Component.text("line 3"))
+        .build(),
+      result
+    );
+  }
+
+  @Test
+  final void testStandardJoinConfigurationsArrayLike() {
+    final Component result = Component.join(JoinConfiguration.arrayLike(), Component.text("line 1"), Component.text("line 2"), Component.text("line 3"));
+    assertEquals(
+      Component.text()
+        .append(Component.text("["))
+        .append(Component.text("line 1"))
+        .append(Component.text(", "))
+        .append(Component.text("line 2"))
+        .append(Component.text(", "))
+        .append(Component.text("line 3"))
+        .append(Component.text("]"))
+        .build(),
+      result
+    );
+  }
+
   private static final class TestComponentLike implements ComponentLike {
 
     @Override


### PR DESCRIPTION
While using join configurations is already rather simple, they tend to
clutter up already rather verbose source code. While the initial
creation of the JoinConfiguration already included a null configuration,
accessible through 'JoinConfiguration#noSeparators', other standards or
often used layouts were not added.

This commit adds three more defaults/standards to the join configuration
implementation that are exposed through static accessors in the join
configuration interface.
Specifically:

newLines:
  A straight forward instance of the join configuraiton that uses the
  new line component to join together components.

commas:
  Another straight forward instance of the join configuration that uses
  a single comma to join together components, creating a CSV like
  layout.

arrayLike:
  A more complex join configuration that recreates the layout used by
  the java.util.Arrays#toString method.

Resolves: #466

----------------------------------------------------------------------------------------------------

Pretty open about suggestions for the `arrayLike` method name.
If others have more suggestions for often used standard styling (tho `arrayLike` and `newLines` are by far my most used ones) I'd be happy to implement them in the context of this PR as well.