### PR TITLE
Fix joining text components with children

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -106,7 +106,7 @@ final class ComponentCompaction {
       final Style childStyle = child.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
       final Style neighborStyle = neighbor.style().merge(childParentStyle, Style.Merge.Strategy.IF_ABSENT_ON_TARGET);
 
-      if (child instanceof TextComponent && neighbor instanceof TextComponent && childStyle.equals(neighborStyle)) {
+      if (child.children().isEmpty() && child instanceof TextComponent && neighbor instanceof TextComponent && childStyle.equals(neighborStyle)) {
         final Component combined = joinText((TextComponent) child, (TextComponent) neighbor);
 
         // replace the child and its neighbor with the single, combined component
@@ -167,6 +167,6 @@ final class ComponentCompaction {
   }
 
   private static TextComponent joinText(final TextComponent one, final TextComponent two) {
-    return Component.text(one.content() + two.content(), one.style());
+    return Component.text(one.content() + two.content(), one.style()).children(two.children());
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -167,6 +167,6 @@ final class ComponentCompaction {
   }
 
   private static TextComponent joinText(final TextComponent one, final TextComponent two) {
-    return Component.text(one.content() + two.content(), one.style()).children(two.children());
+    return new TextComponentImpl(two.children(), one.style(), one.content() + two.content());
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
@@ -290,4 +290,22 @@ class ComponentCompactingTest {
 
     assertEquals(expectedCompact, notCompact.compact());
   }
+
+  @Test
+  void testJoinTextWithChildren() {
+    final Component expectedCompact = empty()
+      .append(text('2', NamedTextColor.AQUA))
+      .append(text('-')
+        .append(text('3', NamedTextColor.BLUE))
+        .append(text('4', NamedTextColor.DARK_BLUE)));
+    final Component notCompact = empty()
+      .append(text('2', NamedTextColor.AQUA))
+      .append(text('-'))
+      .append(empty()
+        .append(text('3', NamedTextColor.BLUE))
+        .append(text('4', NamedTextColor.DARK_BLUE))
+      );
+
+    assertEquals(expectedCompact, notCompact.compact());
+  }
 }

--- a/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
@@ -291,6 +291,7 @@ class ComponentCompactingTest {
     assertEquals(expectedCompact, notCompact.compact());
   }
 
+  // https://github.com/KyoriPowered/adventure-text-minimessage/issues/181
   @Test
   void testJoinTextWithChildren() {
     final Component expectedCompact = text().append(

--- a/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
@@ -293,18 +293,23 @@ class ComponentCompactingTest {
 
   @Test
   void testJoinTextWithChildren() {
-    final Component expectedCompact = empty()
-      .append(text('2', NamedTextColor.AQUA))
-      .append(text('-')
-        .append(text('3', NamedTextColor.BLUE))
-        .append(text('4', NamedTextColor.DARK_BLUE)));
-    final Component notCompact = empty()
-      .append(text('2', NamedTextColor.AQUA))
-      .append(text('-'))
-      .append(empty()
-        .append(text('3', NamedTextColor.BLUE))
-        .append(text('4', NamedTextColor.DARK_BLUE))
-      );
+    final Component expectedCompact = text().append(
+      text('2', NamedTextColor.AQUA),
+      text().content("-").append(
+        text('3', NamedTextColor.BLUE),
+        text('4', NamedTextColor.DARK_BLUE)
+      ),
+      text("end")
+    ).build();
+    final Component notCompact = text().append(
+      text('2', NamedTextColor.AQUA),
+      text('-'),
+      text().append(
+        text('3', NamedTextColor.BLUE),
+        text('4', NamedTextColor.DARK_BLUE)
+      ),
+      text("end")
+    ).build();
 
     assertEquals(expectedCompact, notCompact.compact());
   }


### PR DESCRIPTION
*Fixes KyoriPowered/adventure-text-minimessage#181*

Text joining during compaction may remove some child components.

## Example
The compaction of the component added in the unit test would return:  `2-end`
```java
final Component incorrectlyCompacted = text().append(
  text('2', NamedTextColor.AQUA),
  text('-'),
  text().append(
    text('3', NamedTextColor.BLUE),
    text('4', NamedTextColor.DARK_BLUE)
  ),
  text("end")
).build();
// Would be compacted without this fix into:
final Component compactionResult = text().append(
  text('2', NamedTextColor.AQUA),
  text("-end")
).build();
```