### PR TITLE
api: add TextDecoration#withState and add missing null pointer check

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
@@ -107,7 +107,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    *
    * @param state the state
    * @return a {@link TextDecorationAndState}
-   * @since 4.8.0
+   * @since 4.10.0
    */
   public final @NotNull TextDecorationAndState withState(final boolean state) {
     return this.as(State.byBoolean(state));
@@ -118,7 +118,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    *
    * @param state the state
    * @return a {@link TextDecorationAndState}
-   * @since 4.8.0
+   * @since 4.10.0
    */
   public final @NotNull TextDecorationAndState withState(final @NotNull State state) {
     return this.as(state);

--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
@@ -81,7 +81,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
   }
 
   /**
-   * Creates a {@link TextDecorationAndState}.
+   * Creates a {@link TextDecorationAndState}, annotating this decoration with the given {@code state}.
    *
    * @param state the state
    * @return a {@link TextDecorationAndState}
@@ -92,7 +92,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
   }
 
   /**
-   * Creates a {@link TextDecorationAndState}.
+   * Creates a {@link TextDecorationAndState}, annotating this decoration with the given {@code state}.
    *
    * @param state the state
    * @return a {@link TextDecorationAndState}
@@ -100,6 +100,28 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    */
   public final @NotNull TextDecorationAndState as(final @NotNull State state) {
     return new TextDecorationAndStateImpl(this, state);
+  }
+
+  /**
+   * An alias for {@link #as(boolean)}.
+   *
+   * @param state the state
+   * @return a {@link TextDecorationAndState}
+   * @since 4.8.0
+   */
+  public final @NotNull TextDecorationAndState withState(final boolean state) {
+    return this.as(State.byBoolean(state));
+  }
+
+  /**
+   * An alias for {@link #as(State)}.
+   *
+   * @param state the state
+   * @return a {@link TextDecorationAndState}
+   * @since 4.8.0
+   */
+  public final @NotNull TextDecorationAndState withState(final @NotNull State state) {
+    return this.as(state);
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
@@ -86,9 +86,11 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    * @param state the state
    * @return a {@link TextDecorationAndState}
    * @since 4.8.0
+   * @deprecated for removal since 4.10.0, use {@link #withState(boolean)} instead
    */
+  @Deprecated
   public final @NotNull TextDecorationAndState as(final boolean state) {
-    return this.as(State.byBoolean(state));
+    return this.withState(state);
   }
 
   /**
@@ -97,9 +99,11 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    * @param state the state
    * @return a {@link TextDecorationAndState}
    * @since 4.8.0
+   * @deprecated for removal since 4.10.0, use {@link #withState(State)} instead
    */
+  @Deprecated
   public final @NotNull TextDecorationAndState as(final @NotNull State state) {
-    return new TextDecorationAndStateImpl(this, state);
+    return this.withState(state);
   }
 
   /**
@@ -110,7 +114,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    * @since 4.10.0
    */
   public final @NotNull TextDecorationAndState withState(final boolean state) {
-    return this.as(State.byBoolean(state));
+    return new TextDecorationAndStateImpl(this, State.byBoolean(state));
   }
 
   /**
@@ -121,7 +125,18 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    * @since 4.10.0
    */
   public final @NotNull TextDecorationAndState withState(final @NotNull State state) {
-    return this.as(state);
+    return new TextDecorationAndStateImpl(this, state);
+  }
+
+  /**
+   * An alias for {@link #as(State)}.
+   *
+   * @param state the state
+   * @return a {@link TextDecorationAndState}
+   * @since 4.10.0
+   */
+  public final @NotNull TextDecorationAndState withState(final @NotNull TriState state) {
+    return new TextDecorationAndStateImpl(this, State.byTriState(state));
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecorationAndStateImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecorationAndStateImpl.java
@@ -27,13 +27,17 @@ import net.kyori.examination.string.StringExaminer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static java.util.Objects.requireNonNull;
+
 final class TextDecorationAndStateImpl implements TextDecorationAndState {
   private final TextDecoration decoration;
   private final TextDecoration.State state;
 
   TextDecorationAndStateImpl(final TextDecoration decoration, final TextDecoration.State state) {
+    // no null check is required on the decoration since this constructor is always invoked in such a way that
+    // decoration is always non-null
     this.decoration = decoration;
-    this.state = state;
+    this.state = requireNonNull(state, "state");
   }
 
   @Override

--- a/api/src/test/java/net/kyori/adventure/text/format/StyleTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/StyleTest.java
@@ -90,13 +90,13 @@ class StyleTest {
   @Test
   void testOfTextDecorationAndState() {
     final Style s0 = Style.style(
-      TextDecoration.BOLD.as(TextDecoration.State.TRUE),
-      TextDecoration.ITALIC.as(TextDecoration.State.FALSE)
+      TextDecoration.BOLD.withState(TextDecoration.State.TRUE),
+      TextDecoration.ITALIC.withState(TextDecoration.State.FALSE)
     );
     assertDecorations(s0, ImmutableSet.of(TextDecoration.BOLD), ImmutableSet.of(TextDecoration.ITALIC));
     final Style s1 = Style.style(
-      TextDecoration.BOLD.as(true),
-      TextDecoration.ITALIC.as(false)
+      TextDecoration.BOLD.withState(true),
+      TextDecoration.ITALIC.withState(false)
     );
     assertDecorations(s1, ImmutableSet.of(TextDecoration.BOLD), ImmutableSet.of(TextDecoration.ITALIC));
   }
@@ -104,13 +104,13 @@ class StyleTest {
   @Test
   void testOfTextDecorationAndStateOverridesWhenSame() {
     final Style s0 = Style.style(
-      TextDecoration.BOLD.as(TextDecoration.State.TRUE),
-      TextDecoration.BOLD.as(TextDecoration.State.FALSE)
+      TextDecoration.BOLD.withState(TextDecoration.State.TRUE),
+      TextDecoration.BOLD.withState(TextDecoration.State.FALSE)
     );
     assertDecorations(s0, ImmutableSet.of(), ImmutableSet.of(TextDecoration.BOLD));
     final Style s1 = Style.style(
-      TextDecoration.BOLD.as(true),
-      TextDecoration.BOLD.as(false)
+      TextDecoration.BOLD.withState(true),
+      TextDecoration.BOLD.withState(false)
     );
     assertDecorations(s1, ImmutableSet.of(), ImmutableSet.of(TextDecoration.BOLD));
   }

--- a/api/src/test/java/net/kyori/adventure/text/format/TextDecorationTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/TextDecorationTest.java
@@ -38,6 +38,12 @@ class TextDecorationTest {
     assertEquals(TextDecoration.State.FALSE, TextDecoration.State.byBoolean(false));
     assertEquals(TextDecoration.State.TRUE, TextDecoration.State.byBoolean(true));
   }
+  
+  @Test
+  void withStateOrAsThrowsOnNull() {
+    assertThrows(NullPointerException.class, () -> TextDecoration.BOLD.as(null));
+    assertThrows(NullPointerException.class, () -> TextDecoration.BOLD.withState(null));
+  }
 
   @Test
   void testByTristate() {

--- a/api/src/test/java/net/kyori/adventure/text/format/TextDecorationTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/TextDecorationTest.java
@@ -38,11 +38,11 @@ class TextDecorationTest {
     assertEquals(TextDecoration.State.FALSE, TextDecoration.State.byBoolean(false));
     assertEquals(TextDecoration.State.TRUE, TextDecoration.State.byBoolean(true));
   }
-  
+
   @Test
-  void withStateOrAsThrowsOnNull() {
-    assertThrows(NullPointerException.class, () -> TextDecoration.BOLD.as(null));
-    assertThrows(NullPointerException.class, () -> TextDecoration.BOLD.withState(null));
+  void testWithStateThrowsOnNull() {
+    assertThrows(NullPointerException.class, () -> TextDecoration.BOLD.withState((TextDecoration.State) null));
+    assertThrows(NullPointerException.class, () -> TextDecoration.BOLD.withState((TriState) null));
   }
 
   @Test


### PR DESCRIPTION
Fixes #431. While we're at it, I noticed there was no null check for the state in the `TextDecorationAndStateImpl` constructor so I fixed that too.