### PR TITLE
Fix accidental float and double NaN parsing

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -259,10 +259,16 @@ final class TagStringReader {
                 result = LongBinaryTag.of(Long.parseLong(builder.toString()));
                 break;
               case Tokens.TYPE_FLOAT:
-                result = FloatBinaryTag.of(Float.parseFloat(builder.toString()));
+                final float floatValue = Float.parseFloat(builder.toString());
+                if (!Float.isNaN(floatValue)) { // don't accept NaN
+                  result = FloatBinaryTag.of(floatValue);
+                }
                 break;
               case Tokens.TYPE_DOUBLE:
-                result = DoubleBinaryTag.of(Double.parseDouble(builder.toString()));
+                final double doubleValue = Double.parseDouble(builder.toString());
+                if (!Double.isNaN(doubleValue)) { // don't accept NaN
+                  result = DoubleBinaryTag.of(doubleValue);
+                }
                 break;
             }
           } catch (final NumberFormatException ex) {

--- a/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
@@ -200,6 +200,13 @@ class StringIOTest {
   }
 
   @Test
+  void testSpecialFloatingPointNumbers() throws IOException {
+    assertEquals(StringBinaryTag.of("NaNd"), this.stringToTag("NaNd"));
+    assertEquals(StringBinaryTag.of("NaNf"), this.stringToTag("NaNf"));
+    assertEquals(StringBinaryTag.of("Infinityd"), this.stringToTag("Infinityd"));
+  }
+
+  @Test
   void testByteArrayTag() throws IOException {
     assertEquals("[B;1B,2B,3B]", this.tagToString(ByteArrayBinaryTag.of((byte) 1, (byte) 2, (byte) 3)));
     assertEquals(ByteArrayBinaryTag.of((byte) 1, (byte) 1, (byte) 2, (byte) 3, (byte) 5, (byte) 8), this.stringToTag("[B; 1b, 1b, 2b, 3b, 5b, 8b]"));


### PR DESCRIPTION
More cursed snbt parity issues by yours truly. `NaNd` is parsed as a double with adventure, but as a String by all Vanilla versions, same for the float equivalent. I didn't test the following statement, but as far as I can tell `Infinityd` happens to get caught by a NFE with the first f in the word already, but I figured an extra test case wouldn't hurt.