### PR TITLE
Fix premature SNBT parsing as number

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -257,7 +257,7 @@ final class TagStringReader {
 
     final int length = builder.length();
     final String built = builder.toString();
-    if (noLongerNumericAt == length) {
+    if (noLongerNumericAt == length && length > 1) {
       final char last = built.charAt(length - 1);
       try {
         switch (Character.toLowerCase(last)) { // try to read and return as a number

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -238,60 +238,53 @@ final class TagStringReader {
    */
   private BinaryTag scalar() {
     final StringBuilder builder = new StringBuilder();
-    boolean possiblyNumeric = true;
+    int noLongerNumericAt = -1;
     while (this.buffer.hasMore()) {
-      final char current = this.buffer.peek();
-      if (possiblyNumeric && !Tokens.numeric(current)) {
-        if (builder.length() != 0) {
-          BinaryTag result = null;
-          try {
-            switch (Character.toLowerCase(current)) { // try to read and return as a number
-              case Tokens.TYPE_BYTE:
-                result = ByteBinaryTag.of(Byte.parseByte(builder.toString()));
-                break;
-              case Tokens.TYPE_SHORT:
-                result = ShortBinaryTag.of(Short.parseShort(builder.toString()));
-                break;
-              case Tokens.TYPE_INT:
-                result = IntBinaryTag.of(Integer.parseInt(builder.toString()));
-                break;
-              case Tokens.TYPE_LONG:
-                result = LongBinaryTag.of(Long.parseLong(builder.toString()));
-                break;
-              case Tokens.TYPE_FLOAT:
-                final float floatValue = Float.parseFloat(builder.toString());
-                if (!Float.isNaN(floatValue)) { // don't accept NaN
-                  result = FloatBinaryTag.of(floatValue);
-                }
-                break;
-              case Tokens.TYPE_DOUBLE:
-                final double doubleValue = Double.parseDouble(builder.toString());
-                if (!Double.isNaN(doubleValue)) { // don't accept NaN
-                  result = DoubleBinaryTag.of(doubleValue);
-                }
-                break;
-            }
-          } catch (final NumberFormatException ex) {
-            possiblyNumeric = false; // fallback to treating as a String
-          }
-          if (result != null) {
-            this.buffer.take();
-            return result;
-          }
-        }
-      }
+      char current = this.buffer.peek();
       if (current == '\\') { // escape -- we are significantly more lenient than original format at the moment
         this.buffer.advance();
-        builder.append(this.buffer.take());
+        current = this.buffer.take();
       } else if (Tokens.id(current)) {
-        builder.append(this.buffer.take());
+        this.buffer.advance();
       } else { // end of value
         break;
       }
+      builder.append(current);
+      if (noLongerNumericAt == -1 && !Tokens.numeric(current)) {
+        noLongerNumericAt = builder.length();
+      }
     }
-    // if we run out of content without an explicit value separator, then we're either an integer or string tag -- all others have a character at the end
+
+    final int length = builder.length();
     final String built = builder.toString();
-    if (possiblyNumeric) {
+    if (noLongerNumericAt == length) {
+      final char last = built.charAt(length - 1);
+      try {
+        switch (Character.toLowerCase(last)) { // try to read and return as a number
+          case Tokens.TYPE_BYTE:
+            return ByteBinaryTag.of(Byte.parseByte(built.substring(0, length - 1)));
+          case Tokens.TYPE_SHORT:
+            return ShortBinaryTag.of(Short.parseShort(built.substring(0, length - 1)));
+          case Tokens.TYPE_INT:
+            return IntBinaryTag.of(Integer.parseInt(built.substring(0, length - 1)));
+          case Tokens.TYPE_LONG:
+            return LongBinaryTag.of(Long.parseLong(built.substring(0, length - 1)));
+          case Tokens.TYPE_FLOAT:
+            final float floatValue = Float.parseFloat(built.substring(0, length - 1));
+            if (Float.isFinite(floatValue)) { // don't accept NaN and Infinity
+             return FloatBinaryTag.of(floatValue);
+            }
+            break;
+          case Tokens.TYPE_DOUBLE:
+            final double doubleValue = Double.parseDouble(built.substring(0, length - 1));
+            if (Double.isFinite(doubleValue)) { // don't accept NaN and Infinity
+              return DoubleBinaryTag.of(doubleValue);
+            }
+            break;
+        }
+      } catch (final NumberFormatException ignored) {
+      }
+    } else if (noLongerNumericAt == -1) { // if we run out of content without an explicit value separator, then we're either an integer or string tag -- all others have a character at the end
       try {
         return IntBinaryTag.of(Integer.parseInt(built));
       } catch (final NumberFormatException ex) {

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -272,7 +272,7 @@ final class TagStringReader {
           case Tokens.TYPE_FLOAT:
             final float floatValue = Float.parseFloat(built.substring(0, length - 1));
             if (Float.isFinite(floatValue)) { // don't accept NaN and Infinity
-             return FloatBinaryTag.of(floatValue);
+              return FloatBinaryTag.of(floatValue);
             }
             break;
           case Tokens.TYPE_DOUBLE:

--- a/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
@@ -204,6 +204,14 @@ class StringIOTest {
     assertEquals(StringBinaryTag.of("NaNd"), this.stringToTag("NaNd"));
     assertEquals(StringBinaryTag.of("NaNf"), this.stringToTag("NaNf"));
     assertEquals(StringBinaryTag.of("Infinityd"), this.stringToTag("Infinityd"));
+    assertEquals(StringBinaryTag.of("Infinityf"), this.stringToTag("Infinityf"));
+  }
+
+  @Test
+  void testPrematureNumericParsing() throws IOException {
+    assertEquals(StringBinaryTag.of("0da"), this.stringToTag("0da"));
+    assertEquals(StringBinaryTag.of("00000faa"), this.stringToTag("00000faa"));
+    assertEquals(StringBinaryTag.of("1350diamonds_plz"), this.stringToTag("1350diamonds_plz"));
   }
 
   @Test


### PR DESCRIPTION
┬┴┬┴┤(･_├┬┴┬┴

If a numeric token is found before an unquoted string's end, it will be prematurely parsed as a number and errors because of remaining/unread characters for strings such as `0dd`, `11fa`, or `1350diamonds_plz`.

Instead of constantly looking for the numeric tokens, this just reads the full string and if all chars meet the required criterea (previously `possiblyNumeric`) ***except*** for the very last character, the token parser will be called. If it's possibly numeric all the way through, it goes to the int parser, otherwise to the same code below.