### PR TITLE
feat(pointer): add pointers() method to Pointers collection

### DIFF
--- a/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
@@ -23,13 +23,18 @@
  */
 package net.kyori.adventure.pointer;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import net.kyori.adventure.util.Buildable;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * A collection of {@link Pointer pointers}.
@@ -58,6 +63,36 @@ public interface Pointers extends Buildable<Pointers, Pointers.Builder> {
   @Contract(pure = true)
   static @NotNull Builder builder() {
     return new PointersImpl.BuilderImpl();
+  }
+
+  /**
+   * Gets all {@code pointer} in this collection which have the given value type.
+   *
+   * @param valueType the type class of the pointer
+   * @param <V> the type of the pointer
+   * @return an unmodifiable set of pointers filtered by the given type
+   * @since 4.10.0
+   */
+  @SuppressWarnings("unchecked")
+  default <V> @NotNull @Unmodifiable Set<Pointer<V>> pointers(final @NotNull Class<V> valueType) {
+    Objects.requireNonNull(valueType, "valueType");
+    final Set<Pointer<V>> filteredPointers = new HashSet<>();
+    for (final Pointer<?> pointer : this.pointers()) {
+      if (valueType.isAssignableFrom(pointer.type()))
+        filteredPointers.add((Pointer<V>) pointer);
+    }
+    return Collections.unmodifiableSet(filteredPointers);
+  }
+
+  /**
+   * Gets all {@code pointer} in this pointer collection.
+   *
+   * @return an unmodifiable set of pointers in this pointer collection
+   * @throws UnsupportedOperationException if the implementing class does not support querying for pointers
+   * @since 4.10.0
+   */
+  default @NotNull @Unmodifiable Set<Pointer<?>> pointers() {
+    throw new UnsupportedOperationException("The underlying Pointers implementation does not support querying for pointers.");
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
@@ -23,16 +23,23 @@
  */
 package net.kyori.adventure.pointer;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 final class PointersImpl implements Pointers {
   static final Pointers EMPTY = new Pointers() {
+    @Override
+    public @NotNull Set<Pointer<?>> pointers() {
+      return Collections.emptySet();
+    }
+
     @Override
     public @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
       return Optional.empty();
@@ -58,6 +65,11 @@ final class PointersImpl implements Pointers {
 
   PointersImpl(final @NotNull BuilderImpl builder) {
     this.pointers = new HashMap<>(builder.pointers);
+  }
+
+  @Override
+  public @NotNull Set<Pointer<?>> pointers() {
+    return Collections.unmodifiableSet(this.pointers.keySet());
   }
 
   @Override

--- a/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
+++ b/api/src/test/java/net/kyori/adventure/pointer/PointersTest.java
@@ -23,10 +23,15 @@
  */
 package net.kyori.adventure.pointer;
 
+import java.util.Set;
 import java.util.function.Supplier;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import org.junit.jupiter.api.Test;
 
+import static com.google.common.collect.testing.Helpers.assertContains;
+import static net.kyori.adventure.text.Component.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,5 +69,30 @@ final class PointersTest {
     assertTrue(p2.supports(pointer));
     assertEquals("test", p2.getOrDefault(pointer, null));
     assertEquals("tset", p2.getOrDefault(pointer, null)); // make sure the value does change
+  }
+
+  @Test
+  void pointers_filteredByPointerType() {
+    final Pointer<String> stringPointer = Pointer.pointer(String.class, Key.key("adventure:test"));
+    final Pointer<Component> componentPointer = Pointer.pointer(Component.class, Key.key("adventure:component-test"));
+    final Pointers pointers = Pointers.builder()
+      .withStatic(stringPointer, "test")
+      .withStatic(componentPointer, empty())
+      .build();
+    final Set<Pointer<String>> pointerSet = pointers.pointers(String.class);
+    assertEquals(1, pointerSet.size());
+    assertContains(pointerSet, stringPointer);
+  }
+
+  @Test
+  void pointers_filteredByAbstractType() {
+
+    final Pointer<Component> componentPointer = Pointer.pointer(Component.class, Key.key("adventure:test"));
+    final Pointers pointers = Pointers.builder()
+      .withStatic(componentPointer, empty())
+      .build();
+    final Set<Pointer<ComponentLike>> pointerSet = pointers.pointers(ComponentLike.class);
+    assertEquals(1, pointerSet.size());
+    assertContains(pointerSet, componentPointer);
   }
 }


### PR DESCRIPTION
It is now possible to query a Pointers collection for all contained Pointer.
This can be useful to create dynamic replacements for the pointer of a Pointered object.