### PR TITLE
text-minimessage: Reduce the API surface of the parse context a little bit

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.minimessage;
 
 import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Parser context for use within transformations.
@@ -32,6 +33,7 @@ import net.kyori.adventure.text.Component;
  *
  * @since 4.10.0
  */
+@ApiStatus.NonExtendable
 public interface Context {
   /**
    * Returns original message as provided to the parser.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.minimessage;
 
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Parser context for use within transformations.
@@ -41,7 +42,7 @@ public interface Context {
    * @return ogMessage
    * @since 4.10.0
    */
-  String originalMessage();
+  @NotNull String originalMessage();
 
   /**
    * Parses a MiniMessage using all the settings of this context, including placeholders.
@@ -50,5 +51,5 @@ public interface Context {
    * @return the parsed message
    * @since 4.10.0
    */
-  Component parse(String message);
+  @NotNull Component parse(final @NotNull String message);
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -23,72 +23,23 @@
  */
 package net.kyori.adventure.text.minimessage;
 
-import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.parser.node.ElementNode;
-import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
 
 /**
  * Parser context for use within transformations.
+ *
+ * <p>This allows operating recursive parses, for cases where messages may include tokens.</p>
  *
  * @since 4.10.0
  */
 public interface Context {
   /**
-   * Returns strict mode.
-   *
-   * @return if strict mode is enabled
-   * @since 4.10.0
-   */
-  boolean strict();
-
-  /**
-   * Returns the appendable to print debug output to.
-   *
-   * @return the debug output to print to
-   * @since 4.10.0
-   */
-  Appendable debugOutput();
-
-  /**
-   * Returns the root element.
-   *
-   * @return root
-   * @since 4.10.0
-   */
-  ElementNode tokens();
-
-  /**
-   * Returns original message.
+   * Returns original message as provided to the parser.
    *
    * @return ogMessage
    * @since 4.10.0
    */
   String originalMessage();
-
-  /**
-   * Returns replaced message.
-   *
-   * @return replacedMessage
-   * @since 4.10.0
-   */
-  String replacedMessage();
-
-  /**
-   * Returns the placeholder resolver.
-   *
-   * @return the placeholder resolver
-   * @since 4.10.0
-   */
-  PlaceholderResolver placeholderResolver();
-
-  /**
-   * Returns callback ran at the end of parsing which could be used to compact the output.
-   *
-   * @return Post-processing function
-   * @since 4.10.0
-   */
-  UnaryOperator<Component> postProcessor();
 
   /**
    * Parses a MiniMessage using all the settings of this context, including placeholders.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -26,153 +26,21 @@ package net.kyori.adventure.text.minimessage;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.parser.node.ElementNode;
-import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
- * Carries needed context for minimessage around, ranging from debug info to the configured minimessage instance.
+ * Parser context for use within transformations.
  *
  * @since 4.10.0
  */
-public class Context {
-  private final boolean strict;
-  private final Appendable debugOutput;
-  private ElementNode root;
-  private final String originalMessage;
-  private String replacedMessage;
-  private final MiniMessage miniMessage;
-  private final PlaceholderResolver placeholderResolver;
-  private final UnaryOperator<Component> postProcessor;
-
-  Context(final boolean strict, final Appendable debugOutput, final ElementNode root, final String originalMessage, final String replacedMessage, final MiniMessage miniMessage, final @NotNull PlaceholderResolver placeholderResolver, final UnaryOperator<Component> postProcessor) {
-    this.strict = strict;
-    this.debugOutput = debugOutput;
-    this.root = root;
-    this.originalMessage = originalMessage;
-    this.replacedMessage = replacedMessage;
-    this.miniMessage = miniMessage;
-    this.placeholderResolver = placeholderResolver;
-    this.postProcessor = postProcessor == null ? UnaryOperator.identity() : postProcessor;
-  }
-
-  /**
-   * Init.
-   *
-   * @param strict if strict mode is enabled
-   * @param input the input message
-   * @param miniMessage the minimessage instance
-   * @return the debug context
-   * @since 4.10.0
-   */
-  public static Context of(final boolean strict, final String input, final MiniMessage miniMessage) {
-    return new Context(strict, null, null, input, null, miniMessage, PlaceholderResolver.empty(), null);
-  }
-
-  /**
-   * Init.
-   *
-   * @param strict if strict mode is enabled
-   * @param debugOutput where to print debug output
-   * @param input the input message
-   * @param miniMessage the minimessage instance
-   * @return the debug context
-   * @since 4.10.0
-   */
-  public static Context of(final boolean strict, final Appendable debugOutput, final String input, final MiniMessage miniMessage) {
-    return new Context(strict, debugOutput, null, input, null, miniMessage, PlaceholderResolver.empty(), null);
-  }
-
-  /**
-   * Init.
-   *
-   * @param strict if strict mode is enabled
-   * @param input the input message
-   * @param miniMessage the minimessage instance
-   * @param placeholders the placeholders passed to minimessage
-   * @return the debug context
-   * @since 4.10.0
-   */
-  public static Context of(final boolean strict, final String input, final MiniMessageImpl miniMessage, @NotNull final Placeholder @Nullable [] placeholders) {
-    return new Context(strict, null, null, input, null, miniMessage, placeholders == null ? PlaceholderResolver.empty() : PlaceholderResolver.placeholders(placeholders), null);
-  }
-
-  /**
-   * Init.
-   *
-   * @param strict if strict mode is enabled
-   * @param debugOutput where to print debug output
-   * @param input the input message
-   * @param miniMessage the minimessage instance
-   * @param placeholders the placeholders passed to minimessage
-   * @return the debug context
-   * @since 4.10.0
-   */
-  public static Context of(final boolean strict, final Appendable debugOutput, final String input, final MiniMessageImpl miniMessage, @NotNull final Placeholder @Nullable [] placeholders) {
-    return new Context(strict, debugOutput, null, input, null, miniMessage, placeholders == null ? PlaceholderResolver.empty() : PlaceholderResolver.placeholders(placeholders), null);
-  }
-
-  /**
-   * Init.
-   *
-   * @param strict if strict mode is enabled
-   * @param debugOutput where to print debug output
-   * @param input the input message
-   * @param miniMessage the minimessage instance
-   * @param placeholderResolver the placeholder resolver passed to minimessage
-   * @return the debug context
-   * @since 4.10.0
-   */
-  public static Context of(final boolean strict, final Appendable debugOutput, final String input, final MiniMessageImpl miniMessage, final PlaceholderResolver placeholderResolver) {
-    return new Context(strict, debugOutput, null, input, null, miniMessage, placeholderResolver, null);
-  }
-
-  /**
-   * Init.
-   *
-   * @param strict if strict mode is enabled
-   * @param debugOutput where to print debug output
-   * @param input the input message
-   * @param miniMessage the minimessage instance
-   * @param placeholderResolver the placeholder resolver passed to minimessage
-   * @param postProcessor callback ran at the end of parsing which could be used to compact the output
-   * @return the debug context
-   * @since 4.10.0
-   */
-  public static Context of(final boolean strict, final Appendable debugOutput, final String input, final MiniMessageImpl miniMessage, final PlaceholderResolver placeholderResolver, final UnaryOperator<Component> postProcessor) {
-    return new Context(strict, debugOutput, null, input, null, miniMessage, placeholderResolver, postProcessor);
-  }
-
-  /**
-   * Sets the root element.
-   *
-   * @param root the root element.
-   * @since 4.10.0
-   */
-  public void root(final ElementNode root) {
-    this.root = root;
-  }
-
-  /**
-   * sets the replaced message.
-   *
-   * @param replacedMessage the replaced message
-   * @since 4.10.0
-   */
-  public void replacedMessage(final String replacedMessage) {
-    this.replacedMessage = replacedMessage;
-  }
-
+public interface Context {
   /**
    * Returns strict mode.
    *
    * @return if strict mode is enabled
    * @since 4.10.0
    */
-  public boolean strict() {
-    return this.strict;
-  }
+  boolean strict();
 
   /**
    * Returns the appendable to print debug output to.
@@ -180,9 +48,7 @@ public class Context {
    * @return the debug output to print to
    * @since 4.10.0
    */
-  public Appendable debugOutput() {
-    return this.debugOutput;
-  }
+  Appendable debugOutput();
 
   /**
    * Returns the root element.
@@ -190,9 +56,7 @@ public class Context {
    * @return root
    * @since 4.10.0
    */
-  public ElementNode tokens() {
-    return this.root;
-  }
+  ElementNode tokens();
 
   /**
    * Returns original message.
@@ -200,9 +64,7 @@ public class Context {
    * @return ogMessage
    * @since 4.10.0
    */
-  public String originalMessage() {
-    return this.originalMessage;
-  }
+  String originalMessage();
 
   /**
    * Returns replaced message.
@@ -210,19 +72,7 @@ public class Context {
    * @return replacedMessage
    * @since 4.10.0
    */
-  public String replacedMessage() {
-    return this.replacedMessage;
-  }
-
-  /**
-   * Returns minimessage.
-   *
-   * @return minimessage
-   * @since 4.10.0
-   */
-  public MiniMessage miniMessage() {
-    return this.miniMessage;
-  }
+  String replacedMessage();
 
   /**
    * Returns the placeholder resolver.
@@ -230,9 +80,7 @@ public class Context {
    * @return the placeholder resolver
    * @since 4.10.0
    */
-  public @NotNull PlaceholderResolver placeholderResolver() {
-    return this.placeholderResolver;
-  }
+  PlaceholderResolver placeholderResolver();
 
   /**
    * Returns callback ran at the end of parsing which could be used to compact the output.
@@ -240,9 +88,7 @@ public class Context {
    * @return Post-processing function
    * @since 4.10.0
    */
-  public UnaryOperator<Component> postProcessor() {
-    return this.postProcessor;
-  }
+  UnaryOperator<Component> postProcessor();
 
   /**
    * Parses a MiniMessage using all the settings of this context, including placeholders.
@@ -251,7 +97,5 @@ public class Context {
    * @return the parsed message
    * @since 4.10.0
    */
-  public Component parse(final String message) {
-    return this.miniMessage.deserialize(message, this.placeholderResolver);
-  }
+  Component parse(String message);
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.minimessage;
 
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.parser.node.ElementNode;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,9 +37,7 @@ import org.jetbrains.annotations.NotNull;
 class ContextImpl implements Context {
   private final boolean strict;
   private final Appendable debugOutput;
-  private ElementNode root;
   private final String originalMessage;
-  private final String replacedMessage;
   private final MiniMessage miniMessage;
   private final PlaceholderResolver placeholderResolver;
   private final UnaryOperator<Component> postProcessor;
@@ -48,18 +45,14 @@ class ContextImpl implements Context {
   ContextImpl(
     final boolean strict,
     final Appendable debugOutput,
-    final ElementNode root,
     final String originalMessage,
-    final String replacedMessage,
     final MiniMessage miniMessage,
     final @NotNull PlaceholderResolver placeholderResolver,
     final UnaryOperator<Component> postProcessor
   ) {
     this.strict = strict;
     this.debugOutput = debugOutput;
-    this.root = root;
     this.originalMessage = originalMessage;
-    this.replacedMessage = replacedMessage;
     this.miniMessage = miniMessage;
     this.placeholderResolver = placeholderResolver;
     this.postProcessor = postProcessor == null ? UnaryOperator.identity() : postProcessor;
@@ -73,26 +66,15 @@ class ContextImpl implements Context {
     final PlaceholderResolver placeholderResolver,
     final UnaryOperator<Component> postProcessor
   ) {
-    return new ContextImpl(strict, debugOutput, null, input, null, miniMessage, placeholderResolver, postProcessor);
+    return new ContextImpl(strict, debugOutput, input, miniMessage, placeholderResolver, postProcessor);
   }
 
-  void root(final ElementNode root) {
-    this.root = root;
-  }
-
-  @Override
   public boolean strict() {
     return this.strict;
   }
 
-  @Override
   public Appendable debugOutput() {
     return this.debugOutput;
-  }
-
-  @Override
-  public ElementNode tokens() {
-    return this.root;
   }
 
   @Override
@@ -100,21 +82,10 @@ class ContextImpl implements Context {
     return this.originalMessage;
   }
 
-  @Override
-  public String replacedMessage() {
-    return this.replacedMessage;
-  }
-
-  public MiniMessage miniMessage() {
-    return this.miniMessage;
-  }
-
-  @Override
   public @NotNull PlaceholderResolver placeholderResolver() {
     return this.placeholderResolver;
   }
 
-  @Override
   public UnaryOperator<Component> postProcessor() {
     return this.postProcessor;
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -28,6 +28,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
 import org.jetbrains.annotations.NotNull;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Carries needed context for minimessage around, ranging from debug info to the
  * configured minimessage instance.
@@ -78,7 +80,7 @@ class ContextImpl implements Context {
   }
 
   @Override
-  public String originalMessage() {
+  public @NotNull String originalMessage() {
     return this.originalMessage;
   }
 
@@ -91,7 +93,7 @@ class ContextImpl implements Context {
   }
 
   @Override
-  public Component parse(final String message) {
-    return this.miniMessage.deserialize(message, this.placeholderResolver);
+  public @NotNull Component parse(final @NotNull String message) {
+    return this.miniMessage.deserialize(requireNonNull(message, "message"), this.placeholderResolver);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -1,0 +1,126 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage;
+
+import java.util.function.UnaryOperator;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.parser.node.ElementNode;
+import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Carries needed context for minimessage around, ranging from debug info to the
+ * configured minimessage instance.
+ *
+ * @since 4.10.0
+ */
+class ContextImpl implements Context {
+  private final boolean strict;
+  private final Appendable debugOutput;
+  private ElementNode root;
+  private final String originalMessage;
+  private final String replacedMessage;
+  private final MiniMessage miniMessage;
+  private final PlaceholderResolver placeholderResolver;
+  private final UnaryOperator<Component> postProcessor;
+
+  ContextImpl(
+    final boolean strict,
+    final Appendable debugOutput,
+    final ElementNode root,
+    final String originalMessage,
+    final String replacedMessage,
+    final MiniMessage miniMessage,
+    final @NotNull PlaceholderResolver placeholderResolver,
+    final UnaryOperator<Component> postProcessor
+  ) {
+    this.strict = strict;
+    this.debugOutput = debugOutput;
+    this.root = root;
+    this.originalMessage = originalMessage;
+    this.replacedMessage = replacedMessage;
+    this.miniMessage = miniMessage;
+    this.placeholderResolver = placeholderResolver;
+    this.postProcessor = postProcessor == null ? UnaryOperator.identity() : postProcessor;
+  }
+
+  static ContextImpl of(
+    final boolean strict,
+    final Appendable debugOutput,
+    final String input,
+    final MiniMessageImpl miniMessage,
+    final PlaceholderResolver placeholderResolver,
+    final UnaryOperator<Component> postProcessor
+  ) {
+    return new ContextImpl(strict, debugOutput, null, input, null, miniMessage, placeholderResolver, postProcessor);
+  }
+
+  void root(final ElementNode root) {
+    this.root = root;
+  }
+
+  @Override
+  public boolean strict() {
+    return this.strict;
+  }
+
+  @Override
+  public Appendable debugOutput() {
+    return this.debugOutput;
+  }
+
+  @Override
+  public ElementNode tokens() {
+    return this.root;
+  }
+
+  @Override
+  public String originalMessage() {
+    return this.originalMessage;
+  }
+
+  @Override
+  public String replacedMessage() {
+    return this.replacedMessage;
+  }
+
+  public MiniMessage miniMessage() {
+    return this.miniMessage;
+  }
+
+  @Override
+  public @NotNull PlaceholderResolver placeholderResolver() {
+    return this.placeholderResolver;
+  }
+
+  @Override
+  public UnaryOperator<Component> postProcessor() {
+    return this.postProcessor;
+  }
+
+  @Override
+  public Component parse(final String message) {
+    return this.miniMessage.deserialize(message, this.placeholderResolver);
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -95,11 +95,11 @@ final class MiniMessageImpl implements MiniMessage {
     return this.parser.stripTokens(input, this.newContext(input, placeholders));
   }
 
-  private @NotNull Context newContext(final @NotNull String input, final @Nullable PlaceholderResolver resolver) {
+  private @NotNull ContextImpl newContext(final @NotNull String input, final @Nullable PlaceholderResolver resolver) {
     if (resolver == null) {
-      return Context.of(this.strict, this.debugOutput, input, this, PlaceholderResolver.empty(), this.postProcessor);
+      return ContextImpl.of(this.strict, this.debugOutput, input, this, PlaceholderResolver.empty(), this.postProcessor);
     } else {
-      return Context.of(this.strict, this.debugOutput, input, this, resolver, this.postProcessor);
+      return ContextImpl.of(this.strict, this.debugOutput, input, this, resolver, this.postProcessor);
     }
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -61,13 +61,13 @@ final class MiniMessageParser {
     this.placeholderResolver = placeholderResolver;
   }
 
-  @NotNull String escapeTokens(final @NotNull String richMessage, final @NotNull Context context) {
+  @NotNull String escapeTokens(final @NotNull String richMessage, final @NotNull ContextImpl context) {
     final StringBuilder sb = new StringBuilder(richMessage.length());
     this.escapeTokens(sb, richMessage, context);
     return sb.toString();
   }
 
-  void escapeTokens(final StringBuilder sb, final @NotNull String richMessage, final @NotNull Context context) {
+  void escapeTokens(final StringBuilder sb, final @NotNull String richMessage, final @NotNull ContextImpl context) {
     this.processTokens(sb, richMessage, context, (token, builder) -> {
       builder.append('\\').append(Tokens.TAG_START);
       if (token.type() == TokenType.CLOSE_TAG) {
@@ -84,13 +84,13 @@ final class MiniMessageParser {
     });
   }
 
-  @NotNull String stripTokens(final @NotNull String richMessage, final @NotNull Context context) {
+  @NotNull String stripTokens(final @NotNull String richMessage, final @NotNull ContextImpl context) {
     final StringBuilder sb = new StringBuilder(richMessage.length());
     this.processTokens(sb, richMessage, context, (token, builder) -> {});
     return sb.toString();
   }
 
-  private void processTokens(final @NotNull StringBuilder sb, final @NotNull String richMessage, final @NotNull Context context, final BiConsumer<Token, StringBuilder> tagHandler) {
+  private void processTokens(final @NotNull StringBuilder sb, final @NotNull String richMessage, final @NotNull ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {
     final PlaceholderResolver combinedResolver = PlaceholderResolver.combining(context.placeholderResolver(), this.placeholderResolver);
     final List<Token> root = TokenParser.tokenize(richMessage);
     for (final Token token : root) {
@@ -186,11 +186,10 @@ final class MiniMessageParser {
       }
     }
 
-    context.root(root);
     return Objects.requireNonNull(context.postProcessor().apply(this.treeToComponent(root, context)), "Post-processor must not return null");
   }
 
-  @NotNull Component treeToComponent(final @NotNull ElementNode node, final @NotNull Context context) {
+  @NotNull Component treeToComponent(final @NotNull ElementNode node, final @NotNull ContextImpl context) {
     Component comp;
     Transformation transformation = null;
     if (node instanceof ValueNode) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -118,7 +118,7 @@ final class MiniMessageParser {
     }
   }
 
-  @NotNull Component parseFormat(final @NotNull String richMessage, final @NotNull Context context) {
+  @NotNull Component parseFormat(final @NotNull String richMessage, final @NotNull ContextImpl context) {
     final PlaceholderResolver combinedResolver = PlaceholderResolver.combining(context.placeholderResolver(), this.placeholderResolver);
     final Appendable debug = context.debugOutput();
     if (debug != null) {


### PR DESCRIPTION
Can more of these methods be removed? The only truly essential one is imo `parse(String)`, but I'm not sure what sort of usecases others might have