### PR TITLE
feature: Placeholder cleanup

### DIFF
--- a/text-minimessage/src/jmh/java/net/kyori/adventure/text/minimessage/benchmark/MiniMessageBenchmark.java
+++ b/text-minimessage/src/jmh/java/net/kyori/adventure/text/minimessage/benchmark/MiniMessageBenchmark.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.text.minimessage.benchmark;
 import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -47,7 +48,10 @@ public class MiniMessageBenchmark {
   @Benchmark
   public Component testSimple() {
     final String input = "<yellow><test><bold>stranger";
-    return MiniMessage.miniMessage().deserialize(input, PlaceholderResolver.resolving("test", "test2"));
+    return MiniMessage.miniMessage().deserialize(
+      input,
+      PlaceholderResolver.placeholders(Placeholder.component("test", Component.text("test2")))
+    );
   }
 
   @Benchmark

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -106,7 +106,7 @@ final class MiniMessageParser {
             continue;
           }
           final String sanitized = this.sanitizePlaceholderName(token.childTokens().get(0).get(richMessage).toString());
-          if (this.registry.exists(sanitized, combinedResolver) || combinedResolver.canResolve(sanitized)) {
+          if (this.registry.exists(sanitized, combinedResolver) || combinedResolver.resolve(sanitized) != null) {
             tagHandler.accept(token, sb);
           } else {
             sb.append(richMessage, token.startIndex(), token.endIndex());
@@ -173,7 +173,7 @@ final class MiniMessageParser {
     }
     final BiPredicate<String, Boolean> tagNameChecker = (name, includePlaceholders) -> {
       final String sanitized = this.sanitizePlaceholderName(name);
-      return this.registry.exists(sanitized) || (includePlaceholders && combinedResolver.canResolve(name));
+      return this.registry.exists(sanitized) || (includePlaceholders && combinedResolver.resolve(name) != null);
     };
 
     final ElementNode root = TokenParser.parse(transformationFactory, tagNameChecker, combinedResolver, richMessage, context.strict());

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
@@ -528,8 +528,8 @@ public final class TokenParser {
 
               if (value instanceof String) {
                 sb.append((String) value);
+                break;
               }
-              break;
             }
           }
           sb.append(token.get(message));

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
@@ -42,9 +42,8 @@ import net.kyori.adventure.text.minimessage.parser.node.RootNode;
 import net.kyori.adventure.text.minimessage.parser.node.TagNode;
 import net.kyori.adventure.text.minimessage.parser.node.TagPart;
 import net.kyori.adventure.text.minimessage.parser.node.TextNode;
-import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
-import net.kyori.adventure.text.minimessage.placeholder.Placeholder.StringPlaceholder;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
+import net.kyori.adventure.text.minimessage.placeholder.Replacement;
 import net.kyori.adventure.text.minimessage.transformation.Inserting;
 import net.kyori.adventure.text.minimessage.transformation.Transformation;
 import org.jetbrains.annotations.NotNull;
@@ -369,11 +368,19 @@ public final class TokenParser {
             }
             node = root;
           } else {
-            final Placeholder placeholder = placeholderResolver.resolve(tagNode.name());
-            if (placeholder instanceof StringPlaceholder) {
-              // String placeholders are inserted into the tree as raw text nodes, not parsed
-              node.addChild(new PlaceholderNode(node, token, message, ((StringPlaceholder) placeholder).value()));
-            } else if (tagNameChecker.test(tagNode.name(), true)) {
+            final Replacement<?> replacement = placeholderResolver.resolve(tagNode.name());
+
+            if (replacement != null) {
+              final Object value = replacement.value();
+
+              if (value instanceof String) {
+                // String placeholders are inserted into the tree as raw text nodes, not parsed
+                node.addChild(new PlaceholderNode(node, token, message, (String) value));
+                break;
+              }
+            }
+
+            if (tagNameChecker.test(tagNode.name(), true)) {
               final Transformation transformation = transformationFactory.apply(tagNode);
               if (transformation == null) {
                 // something went wrong, ignore it
@@ -515,9 +522,13 @@ public final class TokenParser {
         case OPEN_TAG:
           if (token.childTokens() != null && token.childTokens().size() == 1) {
             final CharSequence name = token.childTokens().get(0).get(message);
-            final Placeholder placeholder = placeholderResolver.resolve(name.toString().toLowerCase(Locale.ROOT));
-            if (placeholder instanceof StringPlaceholder) {
-              sb.append(((StringPlaceholder) placeholder).value());
+            final Replacement<?> replacement = placeholderResolver.resolve(name.toString().toLowerCase(Locale.ROOT));
+            if (replacement != null) {
+              final Object value = replacement.value();
+
+              if (value instanceof String) {
+                sb.append((String) value);
+              }
               break;
             }
           }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/match/StringResolvingMatchedTokenConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/match/StringResolvingMatchedTokenConsumer.java
@@ -73,17 +73,15 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
         this.builder.append(match);
       } else {
         // we might care if it's a placeholder!
-        if (this.placeholderResolver.canResolve(tag)) {
-          final Replacement<?> replacement = this.placeholderResolver.resolve(tag);
+        final Replacement<?> replacement = this.placeholderResolver.resolve(tag);
 
-          if (replacement != null) {
-            final Object value = replacement.value();
+        if (replacement != null) {
+          final Object value = replacement.value();
 
-            // we only care about string placeholders!
-            if (value instanceof String) {
-              this.builder.append((String) value);
-              return;
-            }
+          // we only care about string placeholders!
+          if (value instanceof String) {
+            this.builder.append((String) value);
+            return;
           }
         }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/match/StringResolvingMatchedTokenConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/match/StringResolvingMatchedTokenConsumer.java
@@ -25,9 +25,8 @@ package net.kyori.adventure.text.minimessage.parser.match;
 
 import java.util.function.Predicate;
 import net.kyori.adventure.text.minimessage.parser.TokenType;
-import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
-import net.kyori.adventure.text.minimessage.placeholder.Placeholder.StringPlaceholder;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
+import net.kyori.adventure.text.minimessage.placeholder.Replacement;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -75,11 +74,15 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
       } else {
         // we might care if it's a placeholder!
         if (this.placeholderResolver.canResolve(tag)) {
-          final Placeholder placeholder = this.placeholderResolver.resolve(tag);
+          final Replacement<?> replacement = this.placeholderResolver.resolve(tag);
 
-          if (placeholder instanceof StringPlaceholder) {
+          if (replacement != null) {
+            final Object value = replacement.value();
+
             // we only care about string placeholders!
-            this.builder.append(((StringPlaceholder) placeholder).value());
+            if (value instanceof String) {
+              this.builder.append((String) value);
+            }
             return;
           }
         }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/match/StringResolvingMatchedTokenConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/match/StringResolvingMatchedTokenConsumer.java
@@ -82,8 +82,8 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
             // we only care about string placeholders!
             if (value instanceof String) {
               this.builder.append((String) value);
+              return;
             }
-            return;
           }
         }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/DynamicPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/DynamicPlaceholderResolver.java
@@ -35,11 +35,6 @@ final class DynamicPlaceholderResolver implements PlaceholderResolver {
   }
 
   @Override
-  public boolean canResolve(final @NotNull String key) {
-    return this.resolver.apply(key) != null;
-  }
-
-  @Override
   public @Nullable Replacement<?> resolve(final @NotNull String key) {
     return this.resolver.apply(key);
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/DynamicPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/DynamicPlaceholderResolver.java
@@ -24,32 +24,23 @@
 package net.kyori.adventure.text.minimessage.placeholder;
 
 import java.util.function.Function;
-import net.kyori.adventure.text.ComponentLike;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 final class DynamicPlaceholderResolver implements PlaceholderResolver {
-  private final Function<String, ?> resolver;
+  private final Function<String, Placeholder> resolver;
 
-  DynamicPlaceholderResolver(final Function<String, ?> resolver) {
+  DynamicPlaceholderResolver(final Function<String, Placeholder> resolver) {
     this.resolver = resolver;
   }
 
   @Override
   public boolean canResolve(final @NotNull String key) {
-    final Object result = this.resolver.apply(key);
-    return result instanceof String || result instanceof ComponentLike || result instanceof Placeholder;
+    return this.resolver.apply(key) != null;
   }
 
   @Override
   public @Nullable Placeholder resolve(final @NotNull String key) {
-    final Object result = this.resolver.apply(key);
-
-    if (result == null) return null;
-    else if (result instanceof String) return Placeholder.placeholder(key, (String) result);
-    else if (result instanceof ComponentLike) return Placeholder.placeholder(key, (ComponentLike) result);
-    else if (result instanceof Placeholder) return (Placeholder) result;
-
-    throw new IllegalArgumentException("Dynamic placeholder resolver must return instances of String or ComponentLike, instead found " + result.getClass().getName());
+    return this.resolver.apply(key);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/DynamicPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/DynamicPlaceholderResolver.java
@@ -23,19 +23,23 @@
  */
 package net.kyori.adventure.text.minimessage.placeholder;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 final class DynamicPlaceholderResolver implements PlaceholderResolver {
   private final Function<String, Replacement<?>> resolver;
+  private final Map<String, Replacement<?>> cache;
 
   DynamicPlaceholderResolver(final Function<String, Replacement<?>> resolver) {
     this.resolver = resolver;
+    this.cache = new HashMap<>();
   }
 
   @Override
   public @Nullable Replacement<?> resolve(final @NotNull String key) {
-    return this.resolver.apply(key);
+    return this.cache.computeIfAbsent(key, this.resolver);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/EmptyPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/EmptyPlaceholderResolver.java
@@ -26,9 +26,6 @@ package net.kyori.adventure.text.minimessage.placeholder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * An empty placeholder resolver that has no placeholders.
- */
 final class EmptyPlaceholderResolver implements PlaceholderResolver {
   static final EmptyPlaceholderResolver INSTANCE = new EmptyPlaceholderResolver();
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/EmptyPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/EmptyPlaceholderResolver.java
@@ -38,7 +38,7 @@ final class EmptyPlaceholderResolver implements PlaceholderResolver {
   }
 
   @Override
-  public @Nullable Placeholder resolve(final @NotNull String key) {
+  public @Nullable Replacement<?> resolve(final @NotNull String key) {
     return null;
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/EmptyPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/EmptyPlaceholderResolver.java
@@ -33,11 +33,6 @@ final class EmptyPlaceholderResolver implements PlaceholderResolver {
   }
 
   @Override
-  public boolean canResolve(final @NotNull String key) {
-    return false;
-  }
-
-  @Override
   public @Nullable Replacement<?> resolve(final @NotNull String key) {
     return null;
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/GroupedPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/GroupedPlaceholderResolver.java
@@ -34,15 +34,6 @@ final class GroupedPlaceholderResolver implements PlaceholderResolver {
   }
 
   @Override
-  public boolean canResolve(final @NotNull String key) {
-    for (final PlaceholderResolver placeholderResolver : this.placeholderResolvers) {
-      if (placeholderResolver.canResolve(key)) return true;
-    }
-
-    return false;
-  }
-
-  @Override
   public @Nullable Replacement<?> resolve(final @NotNull String key) {
     for (final PlaceholderResolver placeholderResolver : this.placeholderResolvers) {
       final Replacement<?> placeholder = placeholderResolver.resolve(key);

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/GroupedPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/GroupedPlaceholderResolver.java
@@ -26,9 +26,6 @@ package net.kyori.adventure.text.minimessage.placeholder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * A placeholder resolver that resolves from multiple sources.
- */
 final class GroupedPlaceholderResolver implements PlaceholderResolver {
   private final Iterable<? extends PlaceholderResolver> placeholderResolvers;
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/GroupedPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/GroupedPlaceholderResolver.java
@@ -43,9 +43,9 @@ final class GroupedPlaceholderResolver implements PlaceholderResolver {
   }
 
   @Override
-  public @Nullable Placeholder resolve(final @NotNull String key) {
+  public @Nullable Replacement<?> resolve(final @NotNull String key) {
     for (final PlaceholderResolver placeholderResolver : this.placeholderResolvers) {
-      final Placeholder placeholder = placeholderResolver.resolve(key);
+      final Replacement<?> placeholder = placeholderResolver.resolve(key);
       if (placeholder != null) return placeholder;
     }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/MapPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/MapPlaceholderResolver.java
@@ -35,11 +35,6 @@ final class MapPlaceholderResolver implements PlaceholderResolver {
   }
 
   @Override
-  public boolean canResolve(final @NotNull String key) {
-    return this.resolve(key) != null;
-  }
-
-  @Override
   public @Nullable Replacement<?> resolve(final @NotNull String key) {
     return this.placeholderMap.get(key);
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/MapPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/MapPlaceholderResolver.java
@@ -28,19 +28,19 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 final class MapPlaceholderResolver implements PlaceholderResolver {
-  private final Map<String, Placeholder> placeholderMap;
+  private final Map<String, ? extends Replacement<?>> placeholderMap;
 
-  MapPlaceholderResolver(final @NotNull Map<String, Placeholder> placeholderMap) {
+  MapPlaceholderResolver(final @NotNull Map<String, ? extends Replacement<?>> placeholderMap) {
     this.placeholderMap = placeholderMap;
   }
 
   @Override
   public boolean canResolve(final @NotNull String key) {
-    return this.placeholderMap.containsKey(key);
+    return this.resolve(key) != null;
   }
 
   @Override
-  public @Nullable Placeholder resolve(final @NotNull String key) {
+  public @Nullable Replacement<?> resolve(final @NotNull String key) {
     return this.placeholderMap.get(key);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/MapPlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/MapPlaceholderResolver.java
@@ -27,9 +27,6 @@ import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * A placeholder resolver based on a map.
- */
 final class MapPlaceholderResolver implements PlaceholderResolver {
   private final Map<String, Placeholder> placeholderMap;
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Placeholder.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Placeholder.java
@@ -79,9 +79,7 @@ public interface Placeholder<T> extends Replacement<T> {
   /**
    * Get the key for this placeholder.
    *
-   * <p>
-   *   The key will always be lowercase.
-   * </p>
+   * <p>The key will always be lowercase.</p>
    *
    * @return the key
    * @since 4.10.0

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Placeholder.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Placeholder.java
@@ -74,21 +74,6 @@ public interface Placeholder extends Examinable {
   }
 
   /**
-   * Constructs a placeholder that gets replaced with a component lazily.
-   *
-   * @param key the placeholder
-   * @param value the supplier that supplies the component to replace the key with
-   * @return the constructed placeholder
-   * @since 4.10.0
-   */
-  static @NotNull Placeholder placeholder(final @NotNull String key, final @NotNull Supplier<? extends ComponentLike> value) {
-    return new LazyComponentPlaceholder(
-        requireNonNull(key, "key"),
-        requireNonNull(value, "value")
-    );
-  }
-
-  /**
    * Get the key for this placeholder.
    *
    * @return the key
@@ -181,36 +166,6 @@ public interface Placeholder extends Examinable {
     public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("key", this.key),
-        ExaminableProperty.of("value", this.value)
-      );
-    }
-  }
-
-  /**
-   * A placeholder with a lazily provided {@link Component} value that will be inserted directly.
-   *
-   * @since 4.10.0
-   */
-  @ApiStatus.Internal
-  class LazyComponentPlaceholder extends ComponentPlaceholder {
-    private final @NotNull Supplier<? extends ComponentLike> value;
-
-    public LazyComponentPlaceholder(final @NotNull String key, final @NotNull Supplier<? extends ComponentLike> value) {
-      super(key, Component.empty());
-      this.value = value;
-    }
-
-    @Override
-    public @NotNull Component value() {
-      return requireNonNull(requireNonNull(
-          this.value.get(), () -> "get() value of " + this.value)
-          .asComponent(), () -> "asComponent() on value of " + this.value);
-    }
-
-    @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
-      return Stream.of(
-        ExaminableProperty.of("key", this.key()),
         ExaminableProperty.of("value", this.value)
       );
     }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderImpl.java
@@ -23,24 +23,40 @@
  */
 package net.kyori.adventure.text.minimessage.placeholder;
 
-import java.util.function.Function;
+import java.util.stream.Stream;
+import net.kyori.examination.ExaminableProperty;
+import net.kyori.examination.string.StringExaminer;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-final class DynamicPlaceholderResolver implements PlaceholderResolver {
-  private final Function<String, Replacement<?>> resolver;
+final class PlaceholderImpl<T> implements Placeholder<T> {
+  private final String key;
+  private final T value;
 
-  DynamicPlaceholderResolver(final Function<String, Replacement<?>> resolver) {
-    this.resolver = resolver;
+  PlaceholderImpl(final @NotNull String key, final @NotNull T value) {
+    this.key = key;
+    this.value = value;
   }
 
   @Override
-  public boolean canResolve(final @NotNull String key) {
-    return this.resolver.apply(key) != null;
+  public @NotNull String key() {
+    return this.key;
   }
 
   @Override
-  public @Nullable Replacement<?> resolve(final @NotNull String key) {
-    return this.resolver.apply(key);
+  public @NotNull T value() {
+    return this.value;
+  }
+
+  @Override
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("key", this.key),
+      ExaminableProperty.of("value", this.value)
+    );
+  }
+
+  @Override
+  public String toString() {
+    return StringExaminer.simpleEscaping().examine(this);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderResolver.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @since 4.10.0
  */
+@FunctionalInterface
 public interface PlaceholderResolver {
   /**
    * Constructs a placeholder resolver from a map.
@@ -144,15 +145,6 @@ public interface PlaceholderResolver {
   static @NotNull PlaceholderResolver empty() {
     return EmptyPlaceholderResolver.INSTANCE;
   }
-
-  /**
-   * Checks if this placeholder resolver can resolve a placeholder from a key.
-   *
-   * @param key the key
-   * @return if a placeholder can be resolved from this key
-   * @since 4.10.0
-   */
-  boolean canResolve(final @NotNull String key);
 
   /**
    * Returns the replacement for a given key, if any exist.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderResolver.java
@@ -126,7 +126,11 @@ public interface PlaceholderResolver {
   /**
    * Constructs a placeholder resolver capable of dynamically resolving placeholders.
    *
-   * <p>The resolver can return {@code null} to indicate it cannot resolve a placeholder.</p>
+   * <p>
+   *   The resolver can return {@code null} to indicate it cannot resolve a placeholder.
+   *   Once a string to replacement mapping has been created, it will be cached to avoid
+   *   the cost of recreating the replacement.
+   * </p>
    *
    * @param resolver the resolver
    * @return the placeholder resolver
@@ -148,6 +152,12 @@ public interface PlaceholderResolver {
 
   /**
    * Returns the replacement for a given key, if any exist.
+   *
+   * <p>
+   *   This method might be called multiple times during each parse attempt. This is due to the
+   *   fact that it is used in places to check if a tag is a placeholder or not. Therefore, you
+   *   should prefer using fixed or cached replacements instead of dynamic construction.
+   * </p>
    *
    * @param key the key
    * @return the replacement

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderResolver.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -52,7 +51,7 @@ public interface PlaceholderResolver {
    * @return the placeholder resolver
    * @since 4.10.0
    */
-  static @NotNull PlaceholderResolver map(final @NotNull Map<String, Placeholder> map) {
+  static @NotNull PlaceholderResolver map(final @NotNull Map<String, Replacement<?>> map) {
     return new MapPlaceholderResolver(Objects.requireNonNull(map, "map"));
   }
 
@@ -63,7 +62,7 @@ public interface PlaceholderResolver {
    * @return the placeholder resolver
    * @since 4.10.0
    */
-  static @NotNull PlaceholderResolver placeholders(final @NotNull Placeholder @NotNull ... placeholders) {
+  static @NotNull PlaceholderResolver placeholders(final @NotNull Placeholder<?> @NotNull ... placeholders) {
     if (Objects.requireNonNull(placeholders, "placeholders").length == 0) return empty();
     return placeholders(Arrays.asList(placeholders));
   }
@@ -75,10 +74,10 @@ public interface PlaceholderResolver {
    * @return the placeholder resolver
    * @since 4.10.0
    */
-  static @NotNull PlaceholderResolver placeholders(final @NotNull Iterable<? extends Placeholder> placeholders) {
-    final Map<String, Placeholder> placeholderMap = new HashMap<>();
+  static @NotNull PlaceholderResolver placeholders(final @NotNull Iterable<? extends Placeholder<?>> placeholders) {
+    final Map<String, Placeholder<?>> placeholderMap = new HashMap<>();
 
-    for (final Placeholder placeholder : Objects.requireNonNull(placeholders, "placeholders")) {
+    for (final Placeholder<?> placeholder : Objects.requireNonNull(placeholders, "placeholders")) {
       Objects.requireNonNull(placeholder, "placeholders must not contain null elements");
       placeholderMap.put(placeholder.key(), placeholder);
     }
@@ -132,23 +131,8 @@ public interface PlaceholderResolver {
    * @return the placeholder resolver
    * @since 4.10.0
    */
-  static @NotNull PlaceholderResolver dynamic(final @NotNull Function<String, Placeholder> resolver) {
+  static @NotNull PlaceholderResolver dynamic(final @NotNull Function<String, Replacement<?>> resolver) {
     return new DynamicPlaceholderResolver(Objects.requireNonNull(resolver, "resolver"));
-  }
-
-  /**
-   * Constructs a placeholder resolver that uses the provided filter to prevent the resolving of placeholders that match the filter.
-   *
-   * @param placeholderResolver the placeholder resolver
-   * @param filter the filter
-   * @return the placeholder resolver
-   * @since 4.10.0
-   */
-  static @NotNull PlaceholderResolver filtering(final @NotNull PlaceholderResolver placeholderResolver, final @NotNull Predicate<Placeholder> filter) {
-    return new FilteringPlaceholderResolver(
-      Objects.requireNonNull(placeholderResolver, "placeholderResolver"),
-      Objects.requireNonNull(filter, "filter")
-    );
   }
 
   /**
@@ -171,11 +155,11 @@ public interface PlaceholderResolver {
   boolean canResolve(final @NotNull String key);
 
   /**
-   * Returns a placeholder from a given key, if any exist.
+   * Returns the replacement for a given key, if any exist.
    *
    * @param key the key
-   * @return the placeholder
+   * @return the replacement
    * @since 4.10.0
    */
-  @Nullable Placeholder resolve(final @NotNull String key);
+  @Nullable Replacement<?> resolve(final @NotNull String key);
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/PlaceholderResolver.java
@@ -43,10 +43,8 @@ public interface PlaceholderResolver {
   /**
    * Constructs a placeholder resolver from a map.
    *
-   * <p>
-   *   The provided map is used as the backing for the returned placeholder resolver. This means
-   *   that changes to the map will be reflected in the placeholder resolver.
-   * </p>
+   * <p>The provided map is used as the backing for the returned placeholder resolver.
+   * This means that changes to the map will be reflected in the placeholder resolver.</p>
    *
    * @param map the map
    * @return the placeholder resolver
@@ -126,11 +124,9 @@ public interface PlaceholderResolver {
   /**
    * Constructs a placeholder resolver capable of dynamically resolving placeholders.
    *
-   * <p>
-   *   The resolver can return {@code null} to indicate it cannot resolve a placeholder.
-   *   Once a string to replacement mapping has been created, it will be cached to avoid
-   *   the cost of recreating the replacement.
-   * </p>
+   * <p>The resolver can return {@code null} to indicate it cannot resolve a placeholder.
+   * Once a string to replacement mapping has been created, it will be cached to avoid
+   * the cost of recreating the replacement.</p>
    *
    * @param resolver the resolver
    * @return the placeholder resolver
@@ -153,11 +149,9 @@ public interface PlaceholderResolver {
   /**
    * Returns the replacement for a given key, if any exist.
    *
-   * <p>
-   *   This method might be called multiple times during each parse attempt. This is due to the
-   *   fact that it is used in places to check if a tag is a placeholder or not. Therefore, you
-   *   should prefer using fixed or cached replacements instead of dynamic construction.
-   * </p>
+   * <p>This method might be called multiple times during each parse attempt. This is due to the
+   * fact that it is used in places to check if a tag is a placeholder or not. Therefore, you
+   * should prefer using fixed or cached replacements instead of dynamic construction.</p>
    *
    * @param key the key
    * @return the replacement

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Replacement.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Replacement.java
@@ -23,68 +23,55 @@
  */
 package net.kyori.adventure.text.minimessage.placeholder;
 
-import java.util.Locale;
 import java.util.Objects;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
+import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A replacement with an associated key.
+ * The result of a resolved placeholder.
  *
  * @param <T> the type of the replacement
  * @since 4.10.0
  */
 @ApiStatus.NonExtendable
-public interface Placeholder<T> extends Replacement<T> {
+public interface Replacement<T> extends Examinable {
 
   /**
-   * Creates a placeholder that inserts a MiniMessage string. The inserted string will impact
+   * Creates a replacement that inserts a MiniMessage string. The inserted string will impact
    * the rest of the parse process.
    *
-   * @param key the key
-   * @param value the replacement
-   * @return the placeholder
+   * @param miniMessage the string
+   * @return the replacement
    * @since 4.10.0
    */
-  static @NotNull Placeholder<String> miniMessage(final @NotNull String key, final @NotNull String value) {
-    if (!Objects.requireNonNull(key, "key").equals(key.toLowerCase(Locale.ROOT)))
-      throw new IllegalArgumentException("key must be lowercase, was " + key);
-
-    return new PlaceholderImpl<>(key, Objects.requireNonNull(value, "value"));
+  static @NotNull Replacement<String> miniMessage(final @NotNull String miniMessage) {
+    return new ReplacementImpl<>(Objects.requireNonNull(miniMessage, "miniMessage"));
   }
 
   /**
    * Creates a replacement that inserts a component.
    *
-   * @param key the key
-   * @param value the replacement
-   * @return the placeholder
+   * @param component the component
+   * @return the replacement
    * @since 4.10.0
    */
-  static @NotNull Placeholder<Component> component(final @NotNull String key, final @NotNull ComponentLike value) {
-    if (!Objects.requireNonNull(key, "key").equals(key.toLowerCase(Locale.ROOT)))
-      throw new IllegalArgumentException("key must be lowercase, was " + key);
-
-    return new PlaceholderImpl<>(
-      key,
+  static @NotNull Replacement<Component> component(final @NotNull ComponentLike component) {
+    return new ReplacementImpl<>(
       Objects.requireNonNull(
-        Objects.requireNonNull(value, "value").asComponent(),
-        "value must not resolve to null"
+        Objects.requireNonNull(component, "component").asComponent(),
+        "component cannot resolve to null"
       )
     );
   }
 
   /**
-   * Get the key for this placeholder.
+   * The value of the replacement.
    *
-   * <p>
-   *   The key will always be lowercase.
-   * </p>
-   *
-   * @return the key
+   * @return the value
    * @since 4.10.0
    */
-  @NotNull String key();
+  @NotNull T value();
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/ReplacementImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/ReplacementImpl.java
@@ -23,28 +23,30 @@
  */
 package net.kyori.adventure.text.minimessage.placeholder;
 
-import java.util.function.Predicate;
+import java.util.stream.Stream;
+import net.kyori.examination.ExaminableProperty;
+import net.kyori.examination.string.StringExaminer;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-final class FilteringPlaceholderResolver implements PlaceholderResolver {
-  private final PlaceholderResolver placeholderResolver;
-  private final Predicate<Placeholder> filter;
+final class ReplacementImpl<T> implements Replacement<T> {
+  private final T value;
 
-  FilteringPlaceholderResolver(final PlaceholderResolver placeholderResolver, final Predicate<Placeholder> filter) {
-    this.placeholderResolver = placeholderResolver;
-    this.filter = filter;
+  ReplacementImpl(final @NotNull T value) {
+    this.value = value;
   }
 
   @Override
-  public boolean canResolve(final @NotNull String key) {
-    return this.resolve(key) != null;
+  public @NotNull T value() {
+    return this.value;
   }
 
   @Override
-  public @Nullable Placeholder resolve(final @NotNull String key) {
-    final Placeholder placeholder = this.placeholderResolver.resolve(key);
-    if (placeholder == null || this.filter.test(placeholder)) return null;
-    return placeholder;
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(ExaminableProperty.of("value", this.value));
+  }
+
+  @Override
+  public String toString() {
+    return StringExaminer.simpleEscaping().examine(this);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistryImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistryImpl.java
@@ -26,13 +26,13 @@ package net.kyori.adventure.text.minimessage.transformation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.parser.ParsingException;
 import net.kyori.adventure.text.minimessage.parser.node.TagPart;
-import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
-import net.kyori.adventure.text.minimessage.placeholder.Placeholder.ComponentPlaceholder;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
-import net.kyori.adventure.text.minimessage.transformation.inbuild.PlaceholderTransformation;
+import net.kyori.adventure.text.minimessage.placeholder.Replacement;
+import net.kyori.adventure.text.minimessage.transformation.inbuild.ComponentTransformation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -83,11 +83,13 @@ final class TransformationRegistryImpl implements TransformationRegistry {
   @Override
   public @Nullable Transformation get(final String name, final List<TagPart> inners, final PlaceholderResolver placeholderResolver, final Context context) {
     // first try if we have a custom placeholder resolver
-    final Placeholder placeholder = placeholderResolver.resolve(name);
-    if (placeholder != null) {
+    final Replacement<?> replacement = placeholderResolver.resolve(name);
+    if (replacement != null) {
+      final Object value = replacement.value();
+
       // The parser handles StringPlaceholders
-      if (placeholder instanceof ComponentPlaceholder) {
-        return this.tryLoad(PlaceholderTransformation.factory(new ComponentPlaceholder(name, ((ComponentPlaceholder) placeholder).value())), name, inners, context);
+      if (value instanceof Component) {
+        return this.tryLoad(ComponentTransformation.factory((Component) value), name, inners, context);
       }
     }
     // then check our registry

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistryImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistryImpl.java
@@ -115,7 +115,7 @@ final class TransformationRegistryImpl implements TransformationRegistry {
   @Override
   public boolean exists(final String name, final PlaceholderResolver placeholderResolver) {
     // first check the placeholder resolver
-    if (placeholderResolver.canResolve(name)) {
+    if (placeholderResolver.resolve(name) != null) {
       return true;
     }
     // then check registry

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/ComponentTransformation.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/ComponentTransformation.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.minimessage.transformation.inbuild;
 import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
 import net.kyori.adventure.text.minimessage.transformation.Inserting;
 import net.kyori.adventure.text.minimessage.transformation.Transformation;
 import net.kyori.adventure.text.minimessage.transformation.TransformationFactory;
@@ -34,49 +33,48 @@ import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Inserts a formatted placeholder component into the result.
+ * Inserts a component into the result.
  *
  * @since 4.10.0
  */
-public final class PlaceholderTransformation extends Transformation implements Inserting {
-  private final Placeholder.@NotNull ComponentPlaceholder placeholder;
+public final class ComponentTransformation extends Transformation implements Inserting {
+  private final Component component;
 
-  private PlaceholderTransformation(final Placeholder.@NotNull ComponentPlaceholder placeholder) {
-    this.placeholder = placeholder;
+  private ComponentTransformation(final @NotNull Component component) {
+    this.component = component;
   }
 
   /**
-   * Create a new factory for placeholder transformations applying {@code placeholder}.
+   * Create a new factory for component transformations applying {@code component}.
    *
-   * @param placeholder the placeholder to apply
+   * @param component the component to apply
    * @since 4.10.0
    */
-  public static @NotNull TransformationFactory<PlaceholderTransformation> factory(final Placeholder.@NotNull ComponentPlaceholder placeholder) {
-    final PlaceholderTransformation instance = new PlaceholderTransformation(placeholder);
+  public static @NotNull TransformationFactory<ComponentTransformation> factory(final @NotNull Component component) {
+    final ComponentTransformation instance = new ComponentTransformation(Objects.requireNonNull(component, "component"));
     return (ctx, name, args) -> instance;
   }
 
   @Override
   public Component apply() {
-    return this.placeholder.value();
+    return this.component;
   }
 
   @Override
   public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
-    return Stream.of(ExaminableProperty.of("placeholder", this.placeholder));
+    return Stream.of(ExaminableProperty.of("component", this.component));
   }
 
   @Override
   public boolean equals(final Object other) {
     if (this == other) return true;
     if (other == null || this.getClass() != other.getClass()) return false;
-    final PlaceholderTransformation that = (PlaceholderTransformation) other;
-    return Objects.equals(this.placeholder, that.placeholder);
+    final ComponentTransformation that = (ComponentTransformation) other;
+    return Objects.equals(this.component, that.component);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.placeholder);
+    return Objects.hash(this.component);
   }
-
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/GradientTransformation.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/GradientTransformation.java
@@ -136,7 +136,7 @@ public final class GradientTransformation extends Transformation implements Modi
       this.size += value.codePointCount(0, value.length());
     } else if (curr instanceof TagNode) {
       final TagNode tag = (TagNode) curr;
-      if (tag.transformation() instanceof PlaceholderTransformation) {
+      if (tag.transformation() instanceof ComponentTransformation) {
         // PlaceholderTransformation.apply() returns the value of the component placeholder
         ComponentFlattener.textOnly().flatten(tag.transformation().apply(), s -> this.size += s.codePointCount(0, s.length()));
       }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/RainbowTransformation.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/RainbowTransformation.java
@@ -103,7 +103,7 @@ public final class RainbowTransformation extends Transformation implements Modif
       this.size += value.codePointCount(0, value.length());
     } else if (curr instanceof TagNode) {
       final TagNode tag = (TagNode) curr;
-      if (tag.transformation() instanceof PlaceholderTransformation) {
+      if (tag.transformation() instanceof ComponentTransformation) {
         // PlaceholderTransformation.apply() returns the value of the component placeholder
         ComponentFlattener.textOnly().flatten(tag.transformation().apply(), s -> this.size += s.codePointCount(0, s.length()));
       }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -248,7 +248,7 @@ public class MiniMessageParserTest extends TestBase {
   void testStripPlaceholders() {
     final String input = "Hello, <red><name>!";
     final String expected = "Hello, !";
-    assertEquals(expected, this.PARSER.stripTokens(input, PlaceholderResolver.placeholders(Placeholder.placeholder("name", "you"))));
+    assertEquals(expected, this.PARSER.stripTokens(input, PlaceholderResolver.placeholders(Placeholder.miniMessage("name", "you"))));
   }
 
   @Test
@@ -284,7 +284,7 @@ public class MiniMessageParserTest extends TestBase {
   void testEscapePlaceholders() {
     final String input = "Hello, <red><name>!";
     final String expected = "Hello, \\<red>\\<name>!";
-    assertEquals(expected, this.PARSER.escapeTokens(input, PlaceholderResolver.placeholders(Placeholder.placeholder("name", "you"))));
+    assertEquals(expected, this.PARSER.escapeTokens(input, PlaceholderResolver.placeholders(Placeholder.miniMessage("name", "you"))));
   }
 
   @Test
@@ -318,7 +318,7 @@ public class MiniMessageParserTest extends TestBase {
   void checkPlaceholder() {
     final String input = "<test>";
     final Component expected = text("Hello!");
-    final Component comp = this.PARSER.deserialize(input, PlaceholderResolver.resolving("test", "Hello!"));
+    final Component comp = this.PARSER.deserialize(input, PlaceholderResolver.placeholders(Placeholder.miniMessage("test", "Hello!")));
 
     assertEquals(expected, comp);
   }
@@ -552,7 +552,7 @@ public class MiniMessageParserTest extends TestBase {
     this.assertParsedEquals(expected, input);
 
     // shouldnt throw an error
-    this.PARSER.deserialize(input, PlaceholderResolver.resolving("url", "https://www.google.com"));
+    this.PARSER.deserialize(input, PlaceholderResolver.placeholders(Placeholder.miniMessage("url", "https://www.google.com")));
   }
 
   @Test
@@ -1492,18 +1492,18 @@ public class MiniMessageParserTest extends TestBase {
     final Component expected3 = text().append(text("a", GOLD), text("a", YELLOW), text("a", YELLOW)).build();
     final Component expected4 = text().append(text("a", GOLD), text("a", TextColor.color(0xffd52b)), text("a", YELLOW), text("a", YELLOW)).build();
 
-    this.assertParsedEquals(expected1, input, Placeholder.placeholder("dum", text("a")));
-    this.assertParsedEquals(expected2, input, Placeholder.placeholder("dum", text("aa")));
-    this.assertParsedEquals(expected3, input, Placeholder.placeholder("dum", text("aaa")));
-    this.assertParsedEquals(expected4, input, Placeholder.placeholder("dum", text("aaaa")));
-    this.assertParsedEquals(expected4, input2, Placeholder.placeholder("dum", text("aaa")));
+    this.assertParsedEquals(expected1, input, Placeholder.component("dum", text("a")));
+    this.assertParsedEquals(expected2, input, Placeholder.component("dum", text("aa")));
+    this.assertParsedEquals(expected3, input, Placeholder.component("dum", text("aaa")));
+    this.assertParsedEquals(expected4, input, Placeholder.component("dum", text("aaaa")));
+    this.assertParsedEquals(expected4, input2, Placeholder.component("dum", text("aaa")));
   }
 
   @Test
   void gh147() {
     final String input = "<rainbow><msg>";
     final Component expected1 = text().append(text("y", color(0xf3801f)), text("o", color(0x0c80e0))).build();
-    this.assertParsedEquals(expected1, input, Placeholder.placeholder("msg", text("yo")));
+    this.assertParsedEquals(expected1, input, Placeholder.component("msg", text("yo")));
   }
 
   @Test

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -57,6 +57,8 @@ import static net.kyori.adventure.text.format.TextColor.color;
 import static net.kyori.adventure.text.format.TextDecoration.BOLD;
 import static net.kyori.adventure.text.format.TextDecoration.ITALIC;
 import static net.kyori.adventure.text.format.TextDecoration.UNDERLINED;
+import static net.kyori.adventure.text.minimessage.placeholder.Placeholder.component;
+import static net.kyori.adventure.text.minimessage.placeholder.Placeholder.miniMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -336,7 +338,7 @@ public class MiniMessageParserTest extends TestBase {
         .append(text("FEEL</underlined> it").decorate(BOLD))
       );
 
-    this.assertParsedEquals(expected, input, "test", "Hello!");
+    this.assertParsedEquals(expected, input, component("test", text("Hello!")));
   }
 
   @Test
@@ -521,7 +523,7 @@ public class MiniMessageParserTest extends TestBase {
         .append(text("CLICK HERE").decorate(BOLD).color(GREEN).clickEvent(openUrl("https://www.google.com")).hoverEvent(showText(text("/!\\ install it from Options/ResourcePacks in your game").color(GREEN))))
       );
 
-    this.assertParsedEquals(expected, input, "pack_url", "https://www.google.com");
+    this.assertParsedEquals(expected, input, miniMessage("pack_url","https://www.google.com"));
   }
 
   @Test
@@ -535,7 +537,7 @@ public class MiniMessageParserTest extends TestBase {
       );
 
     // should work
-    this.assertParsedEquals(expected, input, "pack_url", "https://www.google.com");
+    this.assertParsedEquals(expected, input, miniMessage("pack_url", "https://www.google.com"));
   }
 
   @Test
@@ -1359,8 +1361,14 @@ public class MiniMessageParserTest extends TestBase {
       );
     final String input = "<gray><arg1><red><arg2> <arg3> <arg4>";
 
-    this.assertParsedEquals(expected, input, "arg1", text("ONE"), "arg2", text("TWO"), "arg3", text("THREE"), "arg4",
-      text("FOUR"));
+    this.assertParsedEquals(
+      expected,
+      input,
+      component("arg1", text("ONE")),
+      component("arg2", text("TWO")),
+      component("arg3", text("THREE")),
+      component("arg4", text("FOUR"))
+    );
   }
 
   @Test
@@ -1373,8 +1381,14 @@ public class MiniMessageParserTest extends TestBase {
       .append(text("FOUR").color(GREEN));
     final String input = "<gray><arg1></gray><red><arg2></red><blue><arg3></blue> <green><arg4>";
 
-    this.assertParsedEquals(expected, input, "arg1", text("ONE"), "arg2", text("TWO"), "arg3", text("THREE"), "arg4",
-      text("FOUR"));
+    this.assertParsedEquals(
+      expected,
+      input,
+      component("arg1", text("ONE")),
+      component("arg2", text("TWO")),
+      component("arg3", text("THREE")),
+      component("arg4", text("FOUR"))
+    );
   }
 
   // GH-68, GH-93
@@ -1492,18 +1506,18 @@ public class MiniMessageParserTest extends TestBase {
     final Component expected3 = text().append(text("a", GOLD), text("a", YELLOW), text("a", YELLOW)).build();
     final Component expected4 = text().append(text("a", GOLD), text("a", TextColor.color(0xffd52b)), text("a", YELLOW), text("a", YELLOW)).build();
 
-    this.assertParsedEquals(expected1, input, Placeholder.component("dum", text("a")));
-    this.assertParsedEquals(expected2, input, Placeholder.component("dum", text("aa")));
-    this.assertParsedEquals(expected3, input, Placeholder.component("dum", text("aaa")));
-    this.assertParsedEquals(expected4, input, Placeholder.component("dum", text("aaaa")));
-    this.assertParsedEquals(expected4, input2, Placeholder.component("dum", text("aaa")));
+    this.assertParsedEquals(expected1, input, component("dum", text("a")));
+    this.assertParsedEquals(expected2, input, component("dum", text("aa")));
+    this.assertParsedEquals(expected3, input, component("dum", text("aaa")));
+    this.assertParsedEquals(expected4, input, component("dum", text("aaaa")));
+    this.assertParsedEquals(expected4, input2, component("dum", text("aaa")));
   }
 
   @Test
   void gh147() {
     final String input = "<rainbow><msg>";
     final Component expected1 = text().append(text("y", color(0xf3801f)), text("o", color(0x0c80e0))).build();
-    this.assertParsedEquals(expected1, input, Placeholder.component("msg", text("yo")));
+    this.assertParsedEquals(expected1, input, component("msg", text("yo")));
   }
 
   @Test
@@ -1551,7 +1565,7 @@ public class MiniMessageParserTest extends TestBase {
     final String input = "<click:run_command:'word <word>'><gold>Click to run the word!";
     final Component expected = text("Click to run the word!", GOLD)
         .clickEvent(ClickEvent.runCommand("word Adventure"));
-    this.assertParsedEquals(expected, input, "word", "Adventure");
+    this.assertParsedEquals(expected, input, miniMessage("word", "Adventure"));
   }
 
   @Test
@@ -1559,7 +1573,7 @@ public class MiniMessageParserTest extends TestBase {
     final String input = "<click:run_command:'word <unknown> </word>'><gold>Click to run the word!";
     final Component expected = text("Click to run the word!", GOLD)
         .clickEvent(ClickEvent.runCommand("word <unknown> </word>"));
-    this.assertParsedEquals(expected, input, "word", "Adventure");
+    this.assertParsedEquals(expected, input, component("word", text("Adventure")));
   }
 
   // https://github.com/KyoriPowered/adventure-text-minimessage/issues/166
@@ -1591,7 +1605,7 @@ public class MiniMessageParserTest extends TestBase {
     final Component expected = text("Hover to see the word!", GOLD)
         .hoverEvent(text("Word: Adventure"));
 
-    this.assertParsedEquals(expected, input, "word", "Adventure");
+    this.assertParsedEquals(expected, input, component("word", text("Adventure")));
   }
 
   @Test
@@ -1645,6 +1659,11 @@ public class MiniMessageParserTest extends TestBase {
 
     final Component expected = text("cat makes a sound", RED);
 
-    assertParsedEquals(expected, input, "animal", "<red><feline>", "feline", "cat");
+    assertParsedEquals(
+      expected,
+      input,
+      miniMessage("animal", "<red><feline>"),
+      component("feline", text("cat"))
+    );
   }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -523,7 +523,7 @@ public class MiniMessageParserTest extends TestBase {
         .append(text("CLICK HERE").decorate(BOLD).color(GREEN).clickEvent(openUrl("https://www.google.com")).hoverEvent(showText(text("/!\\ install it from Options/ResourcePacks in your game").color(GREEN))))
       );
 
-    this.assertParsedEquals(expected, input, miniMessage("pack_url","https://www.google.com"));
+    this.assertParsedEquals(expected, input, miniMessage("pack_url", "https://www.google.com"));
   }
 
   @Test

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -28,10 +28,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.minimessage.parser.ParsingException;
 import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
+import net.kyori.adventure.text.minimessage.placeholder.Replacement;
 import net.kyori.adventure.text.minimessage.transformation.TransformationRegistry;
 import net.kyori.adventure.text.minimessage.transformation.TransformationType;
 import org.junit.jupiter.api.Test;
@@ -102,23 +102,12 @@ public class MiniMessageTest extends TestBase {
   }
 
   @Test
-  void testObjectPlaceholdersUnbalanced() {
-    assertThrows(IllegalArgumentException.class, () -> MiniMessage.miniMessage().deserialize("<red>ONE<two><blue>THREE<four><five>",
-      PlaceholderResolver.resolving(
-        "two", text("TWO", GREEN),
-        "four", "FOUR",
-        "five"
-      )
-      ));
-  }
-
-  @Test
   void testPlaceholderSimple() {
     final Component expected = text("TEST");
     final String input = "<test>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.placeholder("test", "TEST"));
+    this.assertParsedEquals(miniMessage, expected, input, Placeholder.miniMessage("test", "TEST"));
   }
 
   @Test
@@ -127,7 +116,7 @@ public class MiniMessageTest extends TestBase {
     final String string = "<test>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, string, Placeholder.placeholder("test", text("TEST", RED)));
+    this.assertParsedEquals(miniMessage, expected, string, Placeholder.component("test", text("TEST", RED)));
   }
 
   @Test
@@ -136,7 +125,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<green><bold><test>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.placeholder("test", text("TEST", RED, UNDERLINED)));
+    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("test", text("TEST", RED, UNDERLINED)));
   }
 
   @Test
@@ -147,8 +136,8 @@ public class MiniMessageTest extends TestBase {
     final String input = "<green><bold><test><test2>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    final Placeholder t1 = Placeholder.placeholder("test", text("TEST", style(RED, UNDERLINED)));
-    final Placeholder t2 = Placeholder.placeholder("test2", "Test2");
+    final Placeholder t1 = Placeholder.component("test", text("TEST", style(RED, UNDERLINED)));
+    final Placeholder t2 = Placeholder.miniMessage("test2", "Test2");
 
     this.assertParsedEquals(miniMessage, expected, input, t1, t2);
   }
@@ -162,7 +151,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<hover:show_text:'<prefix>'>This is a test message.";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.placeholder("prefix", MiniMessage.miniMessage().parse("<#FF0000>[Plugin]<reset>")));
+    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("prefix", MiniMessage.miniMessage().parse("<#FF0000>[Plugin]<reset>")));
   }
 
   @Test
@@ -195,32 +184,14 @@ public class MiniMessageTest extends TestBase {
 
     final String input = "<green><bold><test>";
 
-    final Function<String, ComponentLike> resolver = name -> {
+    final Function<String, Replacement<?>> resolver = name -> {
       if (name.equalsIgnoreCase("test")) {
-        return text("TEST").color(RED);
+        return Replacement.component(text("TEST", RED));
       }
       return null;
     };
 
     final MiniMessage miniMessage = MiniMessage.builder().placeholderResolver(PlaceholderResolver.dynamic(resolver)).build();
-
-    this.assertParsedEquals(miniMessage, expected, input);
-  }
-
-  @Test
-  void testFilteringPlaceholderResolver() {
-    final Component expected = empty()
-        .append(text("ONE", RED))
-        .append(text("<filtered>"))
-        .append(text("TWO", RED));
-
-    final String input = "<one><filtered><two>";
-
-    final Function<String, ComponentLike> resolver = name -> text(name.toUpperCase()).color(RED);
-
-    final MiniMessage miniMessage = MiniMessage.builder().placeholderResolver(
-        PlaceholderResolver.filtering(PlaceholderResolver.dynamic(resolver), name -> name.key().equals("filtered"))
-    ).build();
 
     this.assertParsedEquals(miniMessage, expected, input);
   }
@@ -234,9 +205,9 @@ public class MiniMessageTest extends TestBase {
 
     final String input = "<one><none><two>";
 
-    final Function<String, ComponentLike> resolver = name -> {
+    final Function<String, Replacement<?>> resolver = name -> {
       if (name.equalsIgnoreCase("one")) {
-        return text("ONE").color(RED);
+        return Replacement.component(text("ONE").color(RED));
       }
       return null;
     };
@@ -244,7 +215,7 @@ public class MiniMessageTest extends TestBase {
     final MiniMessage miniMessage = MiniMessage.builder().placeholderResolver(
         PlaceholderResolver.combining(
             PlaceholderResolver.dynamic(resolver),
-            PlaceholderResolver.placeholders(Placeholder.placeholder("two", text("TWO", GREEN)))
+            PlaceholderResolver.placeholders(Placeholder.component("two", text("TWO", GREEN)))
         )
     ).build();
 
@@ -268,7 +239,7 @@ public class MiniMessageTest extends TestBase {
   @Test
   void testUnbalancedPlaceholders() {
     final String expected = "Argument 1 in pairs must be a String or ComponentLike value, was java.lang.Integer";
-    assertEquals(expected, assertThrows(IllegalArgumentException.class, () -> MiniMessage.miniMessage().deserialize("<a>", PlaceholderResolver.resolving("a", 2))).getMessage());
+    assertEquals(expected, assertThrows(IllegalArgumentException.class, () -> MiniMessage.miniMessage().deserialize("<a>", PlaceholderResolver.placeholders(Placeholder.component("a", text(2))))).getMessage());
   }
 
   @Test
@@ -282,7 +253,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<red><username><gray>: <red><message>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.placeholder("username", text("MiniDigger")), Placeholder.placeholder("message", text("</pre><red>Test")));
+    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("username", text("MiniDigger")), Placeholder.component("message", text("</pre><red>Test")));
   }
 
   @Test
@@ -292,7 +263,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "This is a <test>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.placeholder("test", () -> text("TEST")));
+    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("test", () -> text("TEST")));
   }
 
   @Test

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -237,12 +237,6 @@ public class MiniMessageTest extends TestBase {
   }
 
   @Test
-  void testUnbalancedPlaceholders() {
-    final String expected = "Argument 1 in pairs must be a String or ComponentLike value, was java.lang.Integer";
-    assertEquals(expected, assertThrows(IllegalArgumentException.class, () -> MiniMessage.miniMessage().deserialize("<a>", PlaceholderResolver.placeholders(Placeholder.component("a", text(2))))).getMessage());
-  }
-
-  @Test
   void testNodesInPlaceholder() {
     final Component expected = empty().color(RED)
         .append(text("MiniDigger"))

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -45,11 +45,11 @@ import static net.kyori.adventure.text.format.NamedTextColor.GOLD;
 import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
 import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
 import static net.kyori.adventure.text.format.NamedTextColor.RED;
-import static net.kyori.adventure.text.format.NamedTextColor.YELLOW;
 import static net.kyori.adventure.text.format.Style.style;
 import static net.kyori.adventure.text.format.TextColor.color;
 import static net.kyori.adventure.text.format.TextDecoration.BOLD;
 import static net.kyori.adventure.text.format.TextDecoration.UNDERLINED;
+import static net.kyori.adventure.text.minimessage.placeholder.Placeholder.component;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -80,25 +80,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<red><test>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, "test", "TEST");
-  }
-
-  @Test
-  void testObjectPlaceholders() {
-    final Component expected = empty().color(RED)
-      .append(text("ONE"))
-      .append(text("TWO", GREEN))
-      .append(empty().color(BLUE)
-        .append(text("THREE"))
-        .append(text("FOUR"))
-        .append(text("FIVE", YELLOW))
-      );
-    final String input = "<red>ONE<two><blue>THREE<four><five>";
-    final MiniMessage miniMessage = MiniMessage.miniMessage();
-    this.assertParsedEquals(miniMessage, expected, input,
-      "two", text("TWO", GREEN),
-      "four", "FOUR",
-      "five", text("FIVE", YELLOW));
+    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("test", text("TEST")));
   }
 
   @Test
@@ -116,7 +98,7 @@ public class MiniMessageTest extends TestBase {
     final String string = "<test>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, string, Placeholder.component("test", text("TEST", RED)));
+    this.assertParsedEquals(miniMessage, expected, string, component("test", text("TEST", RED)));
   }
 
   @Test
@@ -125,7 +107,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<green><bold><test>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("test", text("TEST", RED, UNDERLINED)));
+    this.assertParsedEquals(miniMessage, expected, input, component("test", text("TEST", RED, UNDERLINED)));
   }
 
   @Test
@@ -136,7 +118,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<green><bold><test><test2>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    final Placeholder t1 = Placeholder.component("test", text("TEST", style(RED, UNDERLINED)));
+    final Placeholder t1 = component("test", text("TEST", style(RED, UNDERLINED)));
     final Placeholder t2 = Placeholder.miniMessage("test2", "Test2");
 
     this.assertParsedEquals(miniMessage, expected, input, t1, t2);
@@ -151,7 +133,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<hover:show_text:'<prefix>'>This is a test message.";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("prefix", MiniMessage.miniMessage().parse("<#FF0000>[Plugin]<reset>")));
+    this.assertParsedEquals(miniMessage, expected, input, component("prefix", MiniMessage.miniMessage().parse("<#FF0000>[Plugin]<reset>")));
   }
 
   @Test
@@ -160,7 +142,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<green><bold><test>";
     final MiniMessage miniMessage = MiniMessage.builder().transformations(TransformationRegistry.empty()).build();
 
-    this.assertParsedEquals(miniMessage, expected, input, "test", "TEST");
+    this.assertParsedEquals(miniMessage, expected, input, component("test", text("TEST")));
   }
 
   @Test
@@ -175,7 +157,7 @@ public class MiniMessageTest extends TestBase {
             .build();
     final MiniMessage miniMessage = MiniMessage.builder().transformations(registry).build();
 
-    this.assertParsedEquals(miniMessage, expected, input, "test", "TEST");
+    this.assertParsedEquals(miniMessage, expected, input, component("test", text("TEST")));
   }
 
   @Test
@@ -215,7 +197,7 @@ public class MiniMessageTest extends TestBase {
     final MiniMessage miniMessage = MiniMessage.builder().placeholderResolver(
         PlaceholderResolver.combining(
             PlaceholderResolver.dynamic(resolver),
-            PlaceholderResolver.placeholders(Placeholder.component("two", text("TWO", GREEN)))
+            PlaceholderResolver.placeholders(component("two", text("TWO", GREEN)))
         )
     ).build();
 
@@ -230,10 +212,14 @@ public class MiniMessageTest extends TestBase {
     final String input = "<a><b><_c>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input,
-      "a", text("A"),
-      "b", text("B"),
-      "_c", text("C"));
+    this.assertParsedEquals(
+      miniMessage,
+      expected,
+      input,
+      component("a", text("A")),
+      component("b", text("B")),
+      component("_c", text("C"))
+    );
   }
 
   @Test
@@ -247,7 +233,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "<red><username><gray>: <red><message>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("username", text("MiniDigger")), Placeholder.component("message", text("</pre><red>Test")));
+    this.assertParsedEquals(miniMessage, expected, input, component("username", text("MiniDigger")), component("message", text("</pre><red>Test")));
   }
 
   @Test
@@ -257,7 +243,7 @@ public class MiniMessageTest extends TestBase {
     final String input = "This is a <test>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
-    this.assertParsedEquals(miniMessage, expected, input, Placeholder.component("test", () -> text("TEST")));
+    this.assertParsedEquals(miniMessage, expected, input, component("test", () -> text("TEST")));
   }
 
   @Test

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/PlaceholderTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/PlaceholderTest.java
@@ -34,8 +34,8 @@ public class PlaceholderTest {
   // https://github.com/KyoriPowered/adventure-text-minimessage/issues/190
   @Test
   void testCaseOfPlaceholders() {
-    assertThrows(IllegalArgumentException.class, () -> Placeholder.placeholder("HI", "hi"));
-    assertThrows(IllegalArgumentException.class, () -> Placeholder.placeholder("HI", text("hi")));
-    assertThrows(IllegalArgumentException.class, () -> Placeholder.placeholder("HI", () -> text("hi")));
+    assertThrows(IllegalArgumentException.class, () -> Placeholder.miniMessage("HI", "hi"));
+    assertThrows(IllegalArgumentException.class, () -> Placeholder.component("HI", text("hi")));
+    assertThrows(IllegalArgumentException.class, () -> Placeholder.component("HI", () -> text("hi")));
   }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/TestBase.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/TestBase.java
@@ -23,9 +23,15 @@
  */
 package net.kyori.adventure.text.minimessage;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
+import net.kyori.adventure.text.minimessage.placeholder.Replacement;
 import net.kyori.examination.string.MultiLineStringExaminer;
 import org.jetbrains.annotations.NotNull;
 
@@ -51,11 +57,55 @@ public class TestBase {
 
   void assertParsedEquals(final MiniMessage miniMessage, final Component expected, final String input, final @NotNull Object... args) {
     final String expectedSerialized = this.prettyPrint(expected.compact());
-    final String actual = this.prettyPrint(miniMessage.deserialize(input, PlaceholderResolver.resolving(args)).compact());
+    final String actual = this.prettyPrint(miniMessage.deserialize(input, resolving(args)).compact());
     assertEquals(expectedSerialized, actual);
   }
 
   final String prettyPrint(final Component component) {
     return component.examine(MultiLineStringExaminer.simpleEscaping()).collect(Collectors.joining("\n"));
+  }
+
+  final PlaceholderResolver resolving(final @NotNull Object @NotNull ... objects) {
+    final int size = Objects.requireNonNull(objects, "pairs").length;
+
+    if (size == 0) return PlaceholderResolver.empty();
+
+    String key = null;
+
+    final Map<String, Replacement<?>> replacementMap = new HashMap<>(size);
+    for (int i = 0; i < size; i++) {
+      final Object obj = objects[i];
+
+      if (key == null) {
+        // we are looking for a key or a placeholder
+        if (obj instanceof Placeholder<?>) {
+          final Placeholder<?> placeholder = (Placeholder<?>) obj;
+          replacementMap.put(placeholder.key(), placeholder);
+        } else if (obj instanceof String) {
+          key = (String) obj;
+        } else {
+          throw new IllegalArgumentException("Argument " + i + " in pairs must be a String key or a Placeholder, was " + obj.getClass().getName());
+        }
+      } else {
+        // we are looking for a value
+        if (obj instanceof String) {
+          replacementMap.put(key, Replacement.miniMessage((String) obj));
+        } else if (obj instanceof ComponentLike) {
+          replacementMap.put(key, Replacement.component((ComponentLike) obj));
+        } else {
+          throw new IllegalArgumentException("Argument " + i + " in pairs must be a String or ComponentLike value, was " + obj.getClass().getName());
+        }
+
+        key = null;
+      }
+    }
+
+    if (key != null) {
+      throw new IllegalArgumentException("Found key \"" + key + "\" in objects that wasn't followed by a value.");
+    }
+
+    if (replacementMap.isEmpty()) return PlaceholderResolver.empty();
+
+    return PlaceholderResolver.map(replacementMap);
   }
 }


### PR DESCRIPTION
This PR provides a cleanup of the placeholder system and closes #518 and closes #517.

The following changes are made:
- Remove the hacky placeholder resolver methods in favour of forcing people to not use weird hacky methods.
- Swap placeholder resolvers to return a new class, `Replacement` instead, thus removing the need for a key.
- Change the map placeholder resolver constructor to use this new replacement class.
- Remove the `LazyComponentPlaceholder` as it is no longer needed due to the resolver system being lazy, if desired.
- Remove `PlaceholderResolver#canResolve` to allow easier implementation of `PlaceholderResolver` due to it being a functional interface.

Essentially, this is a move to a placeholder system that is safe at compile time. This means that (unless you ignore `@ApiStatus.NonExtendable`) you cannot construct any placeholder resolver that will fail at runtime (for example, if you have an integer replacement).