### PR TITLE
api: Use initial style when replacement-rendering a hover event

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
@@ -52,6 +52,7 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
 
     final List<Component> oldChildren = component.children();
     final int oldChildrenSize = oldChildren.size();
+    final Style oldStyle = component.style();
     List<Component> children = null;
     Component modified = component;
     // replace the component itself
@@ -150,7 +151,7 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
     // Only visit children if we're running
     if (state.running) {
       // hover event
-      final HoverEvent<?> event = modified.style().hoverEvent();
+      final HoverEvent<?> event = oldStyle.hoverEvent();
       if (event != null) {
         final HoverEvent<?> rendered = event.withRenderedValue(this, state);
         if (event != rendered) {

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
@@ -52,7 +52,7 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
 
     final List<Component> oldChildren = component.children();
     final int oldChildrenSize = oldChildren.size();
-    final Style oldStyle = component.style();
+    Style oldStyle = component.style();
     List<Component> children = null;
     Component modified = component;
     // replace the component itself
@@ -78,6 +78,10 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
               .style(component.style()));
 
             modified = replacement == null ? Component.empty() : replacement.asComponent();
+
+            if (modified.style().hoverEvent() != null) {
+              oldStyle = oldStyle.hoverEvent(null); // Remove original hover if it has been replaced completely
+            }
 
             // merge style of the match into this component to prevent unexpected loss of style
             modified = modified.style(modified.style().merge(component.style(), Style.Merge.Strategy.IF_ABSENT_ON_TARGET));

--- a/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
@@ -283,11 +283,11 @@ class TextReplacementRendererTest {
   // https://github.com/KyoriPowered/adventure/issues/638
   @Test
   void testExactMatchHover() {
-    Component expected = Component.text("two").hoverEvent(Component.text("one!")).append(Component.text("one?"));
-    Component replacedExact = Component.text("one").replaceText(c -> c.match("one").replacement(expected));
+    final Component expected = Component.text("two").hoverEvent(Component.text("one!")).append(Component.text("one?"));
+    final Component replacedExact = Component.text("one").replaceText(c -> c.match("one").replacement(expected));
 
-    Component replacedNonExact = Component.text("one ").replaceText(c -> c.match("one").replacement(expected));
-    Component expectedNonExact = Component.text("")
+    final Component replacedNonExact = Component.text("one ").replaceText(c -> c.match("one").replacement(expected));
+    final Component expectedNonExact = Component.text("")
       .append(expected)
       .append(Component.space());
 

--- a/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
@@ -279,4 +279,19 @@ class TextReplacementRendererTest {
 
     TextAssertions.assertEquals(expected, replaced);
   }
+
+  // https://github.com/KyoriPowered/adventure/issues/638
+  @Test
+  void testExactMatchHover() {
+    Component expected = Component.text("two").hoverEvent(Component.text("one!")).append(Component.text("one?"));
+    Component replacedExact = Component.text("one").replaceText(c -> c.match("one").replacement(expected));
+
+    Component replacedNonExact = Component.text("one ").replaceText(c -> c.match("one").replacement(expected));
+    Component expectedNonExact = Component.text("")
+      .append(expected)
+      .append(Component.space());
+
+    TextAssertions.assertEquals(expected, replacedExact);
+    TextAssertions.assertEquals(expectedNonExact, replacedNonExact);
+  }
 }

--- a/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
@@ -294,4 +294,18 @@ class TextReplacementRendererTest {
     TextAssertions.assertEquals(expected, replacedExact);
     TextAssertions.assertEquals(expectedNonExact, replacedNonExact);
   }
+
+  @Test
+  void testHoverCollision() {
+    final Component original = Component.text("one")
+      .hoverEvent(Component.text("less important"));
+
+    final Component replaced = original.replaceText(c -> c.match("one")
+      .replacement(Component.text("two").hoverEvent(Component.text("important"))));
+
+    final Component expected = Component.text("two")
+      .hoverEvent(Component.text("important"));
+
+    TextAssertions.assertEquals(expected, replaced);
+  }
 }

--- a/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
@@ -308,4 +308,18 @@ class TextReplacementRendererTest {
 
     TextAssertions.assertEquals(expected, replaced);
   }
+
+  @Test
+  void testReplacementHoverWithOriginalHoverAlsoMatching() {
+    final Component original = Component.text("Hello")
+      .hoverEvent(Component.text("Hello Kyori"));
+
+    final Component replaced = original.replaceText(c -> c.match("Hello")
+      .replacement(Component.text("Goodbye world").hoverEvent(Component.text("Hello world"))));
+
+    final Component expected = Component.text("Goodbye world")
+      .hoverEvent(Component.text("Hello world"));
+
+    TextAssertions.assertEquals(expected, replaced);
+  }
 }


### PR DESCRIPTION
Fixes #638

This matters if the component is entirely replaced due to an exact match (whereas a non-exact match creates an empty parent with no style)

I'm not 100% sure this won't cause more issues in the future, but i tried to follow how children are implemented with oldChildren