### PR TITLE
Add tests for Title and Title.Times

### DIFF
--- a/api/src/main/java/net/kyori/adventure/title/TitleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/title/TitleImpl.java
@@ -64,6 +64,7 @@ final class TitleImpl implements Title {
   @Override
   @SuppressWarnings("unchecked") // compared with parts directly
   public <T> @UnknownNullability T part(final @NotNull TitlePart<T> part) {
+    requireNonNull(part, "part");
     if (part == TitlePart.TITLE) {
       return (T) this.title;
     } else if (part == TitlePart.SUBTITLE) {

--- a/api/src/test/java/net/kyori/adventure/text/title/TitleTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/title/TitleTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.title;
+
+import java.time.Duration;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.title.Title;
+import net.kyori.adventure.title.TitlePart;
+import net.kyori.test.EqualityAssertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TitleTest {
+
+  private final Component foo = Component.text("foo");
+  private final Component bar = Component.text("bar");
+  private final Title.Times times = Title.Times.times(Duration.ofMillis(500), Duration.ofMillis(1000), Duration.ofMillis(1500));
+
+  @Test
+  void testCreateSimple() {
+    final Title title = Title.title(this.foo, this.bar);
+    assertEquals(this.foo, title.title());
+    assertEquals(this.bar, title.subtitle());
+    assertEquals(Title.DEFAULT_TIMES, title.times());
+  }
+
+  @Test
+  void testCreateCustomTimes() {
+    final Title title = Title.title(this.bar, this.foo, this.times);
+    assertEquals(this.bar, title.title());
+    assertEquals(this.foo, title.subtitle());
+    assertEquals(this.times, title.times());
+  }
+
+  @Test
+  void testGetTitleParts() {
+    final Title title = Title.title(this.foo, this.bar, this.times);
+    assertEquals(this.foo, title.part(TitlePart.TITLE));
+    assertEquals(this.bar, title.part(TitlePart.SUBTITLE));
+    assertEquals(this.times, title.part(TitlePart.TIMES));
+  }
+
+  @Test
+  void testIllegalTitleParts() {
+    final Title title = Title.title(this.foo, this.bar);
+    final TitlePart<Component> unknownPart = new TitlePart<Component>() {
+      @Override
+      public String toString() {
+        return "TitlePart.CAT";
+      }
+    };
+
+    assertThrows(IllegalArgumentException.class, () -> title.part(unknownPart));
+    assertThrows(NullPointerException.class, () -> title.part(null));
+  }
+
+  @Test
+  void testEquality() {
+    final Title title = Title.title(this.foo, this.bar, this.times);
+    final Title equalTitle = Title.title(Component.text("foo"), Component.text("bar"), Title.Times.times(Duration.ofMillis(500), Duration.ofMillis(1000), Duration.ofMillis(1500)));
+    final Title notEqualSubtitle = Title.title(Component.text("foo"), Component.text("cat"), Title.Times.times(Duration.ofMillis(500), Duration.ofMillis(1000), Duration.ofMillis(1500)));
+    final Title notEqualTitle = Title.title(Component.text("cat"), Component.text("bar"), Title.Times.times(Duration.ofMillis(500), Duration.ofMillis(1000), Duration.ofMillis(1500)));
+    final Title notEqualTimes = Title.title(Component.text("foo"), Component.text("bar"), Title.Times.times(Duration.ofMillis(499), Duration.ofMillis(1000), Duration.ofMillis(1500)));
+
+    EqualityAssertions.assertEqualityAndNonEquality(title, equalTitle, notEqualSubtitle, notEqualTitle, notEqualTimes);
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/title/TitleTimesTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/title/TitleTimesTest.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.title;
+
+import java.time.Duration;
+import net.kyori.adventure.title.Title;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.test.EqualityAssertions.assertEqualityAndNonEquality;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TitleTimesTest {
+
+  private final Duration d0 = Duration.ofMillis(1000);
+  private final Duration d1 = Duration.ofMillis(2000);
+  private final Duration d2 = Duration.ofMillis(1234);
+
+  @Test
+  void testCreate() {
+    final Title.Times times = Title.Times.times(this.d0, this.d1, this.d2);
+    assertEquals(this.d0, times.fadeIn());
+    assertEquals(this.d1, times.stay());
+    assertEquals(this.d2, times.fadeOut());
+  }
+
+  @Test
+  void testEquality() {
+    final Title.Times times = Title.Times.times(this.d0, this.d1, this.d2);
+    final Title.Times equalTimes = Title.Times.times(Duration.ofMillis(1000), Duration.ofMillis(2000), Duration.ofMillis(1234));
+    final Title.Times notEqualFadeIn = Title.Times.times(Duration.ofMillis(999), Duration.ofMillis(2000), Duration.ofMillis(1234));
+    final Title.Times notEqualStay = Title.Times.times(Duration.ofMillis(1000), Duration.ofMillis(2001), Duration.ofMillis(1234));
+    final Title.Times notEqualFadeOut = Title.Times.times(Duration.ofMillis(1000), Duration.ofMillis(2000), Duration.ofMillis(1235));
+
+    assertEqualityAndNonEquality(times, equalTimes, notEqualFadeIn, notEqualStay, notEqualFadeOut);
+  }
+}

--- a/api/src/test/java/net/kyori/test/EqualityAssertions.java
+++ b/api/src/test/java/net/kyori/test/EqualityAssertions.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.test;
+
+import org.jetbrains.annotations.NotNull;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public final class EqualityAssertions {
+
+  private EqualityAssertions() {
+  }
+
+  //Covers all branches in the standard #equals and #hashcode used in this project
+  @SafeVarargs
+  public static <T> void assertEqualityAndNonEquality(final @NotNull T value, final @NotNull T equalToValue, final @NotNull T@NotNull... notEqualToValue) {
+    assertEquals(value, value);
+    assertEquals(value, equalToValue);
+    assertNotEquals(value, null);
+    assertNotEquals(value, value instanceof String ? new boolean[0] : "");
+    assertEquals(value.hashCode(), equalToValue.hashCode());
+
+    for (final T t : notEqualToValue) {
+      assertNotEquals(value, t);
+      assertNotEquals(value.hashCode(), t.hashCode());
+    }
+  }
+}


### PR DESCRIPTION
Adresses: #394

Also:
- Adds an util method for testing #equals and #hashcode
- Adds `requireNonNull(part)` to the title part method in `TitleImpl`