### PR TITLE
chore: Rename some static constructer methods

### DIFF
--- a/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolder.java
+++ b/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolder.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.nbt.api;
 
 import net.kyori.adventure.util.Codec;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -57,8 +58,22 @@ public interface BinaryTagHolder {
    *
    * @param string the encoded binary tag value
    * @return the encoded binary tag
-   * @since 4.0.0
+   * @since 4.10.0
    */
+  static @NotNull BinaryTagHolder binaryTagHolder(final @NotNull String string) {
+    return new BinaryTagHolderImpl(string);
+  }
+
+  /**
+   * Creates an encoded binary tag holder.
+   *
+   * @param string the encoded binary tag value
+   * @return the encoded binary tag
+   * @since 4.0.0
+   * @deprecated for removal since 4.10.0, use {@link #binaryTagHolder(String)} instead.
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   static @NotNull BinaryTagHolder of(final @NotNull String string) {
     return new BinaryTagHolderImpl(string);
   }

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponent.java
@@ -27,6 +27,7 @@ import java.util.regex.Matcher;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -75,7 +76,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
    */
   @Contract(pure = true)
   default @NotNull BlockNBTComponent localPos(final double left, final double up, final double forwards) {
-    return this.pos(LocalPos.of(left, up, forwards));
+    return this.pos(LocalPos.localPos(left, up, forwards));
   }
 
   /**
@@ -89,7 +90,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
    */
   @Contract(pure = true)
   default @NotNull BlockNBTComponent worldPos(final WorldPos.@NotNull Coordinate x, final WorldPos.@NotNull Coordinate y, final WorldPos.@NotNull Coordinate z) {
-    return this.pos(WorldPos.of(x, y, z));
+    return this.pos(WorldPos.worldPos(x, y, z));
   }
 
   /**
@@ -157,7 +158,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      */
     @Contract("_, _, _ -> this")
     default @NotNull Builder localPos(final double left, final double up, final double forwards) {
-      return this.pos(LocalPos.of(left, up, forwards));
+      return this.pos(LocalPos.localPos(left, up, forwards));
     }
 
     /**
@@ -171,7 +172,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      */
     @Contract("_, _, _ -> this")
     default @NotNull Builder worldPos(final WorldPos.@NotNull Coordinate x, final WorldPos.@NotNull Coordinate y, final WorldPos.@NotNull Coordinate z) {
-      return this.pos(WorldPos.of(x, y, z));
+      return this.pos(WorldPos.worldPos(x, y, z));
     }
 
     /**
@@ -224,7 +225,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
     static @NotNull Pos fromString(final @NotNull String input) throws IllegalArgumentException {
       final Matcher localMatch = BlockNBTComponentImpl.Tokens.LOCAL_PATTERN.matcher(input);
       if (localMatch.matches()) {
-        return BlockNBTComponent.LocalPos.of(
+        return BlockNBTComponent.LocalPos.localPos(
           Double.parseDouble(localMatch.group(1)),
           Double.parseDouble(localMatch.group(3)),
           Double.parseDouble(localMatch.group(5))
@@ -233,7 +234,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
 
       final Matcher worldMatch = BlockNBTComponentImpl.Tokens.WORLD_PATTERN.matcher(input);
       if (worldMatch.matches()) {
-        return BlockNBTComponent.WorldPos.of(
+        return BlockNBTComponent.WorldPos.worldPos(
           BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(1), worldMatch.group(2)),
           BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(3), worldMatch.group(4)),
           BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(5), worldMatch.group(6))
@@ -266,8 +267,24 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @param up the up value
      * @param forwards the forwards value
      * @return a local position
-     * @since 4.0.0
+     * @since 4.10.0
      */
+    static @NotNull LocalPos localPos(final double left, final double up, final double forwards) {
+      return new BlockNBTComponentImpl.LocalPosImpl(left, up, forwards);
+    }
+
+    /**
+     * Creates a local position with the given values.
+     *
+     * @param left the left value
+     * @param up the up value
+     * @param forwards the forwards value
+     * @return a local position
+     * @since 4.0.0
+     * @deprecated for removal since 4.10.0, use {@link #localPos(double, double, double)} instead.
+     */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
     static @NotNull LocalPos of(final double left, final double up, final double forwards) {
       return new BlockNBTComponentImpl.LocalPosImpl(left, up, forwards);
     }
@@ -310,8 +327,24 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
      * @param y the y coordinate
      * @param z the z coordinate
      * @return a world position
-     * @since 4.0.0
+     * @since 4.10.0
      */
+    static @NotNull WorldPos worldPos(final @NotNull Coordinate x, final @NotNull Coordinate y, final @NotNull Coordinate z) {
+      return new BlockNBTComponentImpl.WorldPosImpl(x, y, z);
+    }
+
+    /**
+     * Creates a world position with the given coordinates.
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param z the z coordinate
+     * @return a world position
+     * @since 4.0.0
+     * @deprecated for removal since 4.10.0, use {@link #worldPos(WorldPos.Coordinate, WorldPos.Coordinate, WorldPos.Coordinate)} instead.
+     */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
     static @NotNull WorldPos of(final @NotNull Coordinate x, final @NotNull Coordinate y, final @NotNull Coordinate z) {
       return new BlockNBTComponentImpl.WorldPosImpl(x, y, z);
     }
@@ -354,7 +387,7 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
        * @since 4.0.0
        */
       static @NotNull Coordinate absolute(final int value) {
-        return of(value, Type.ABSOLUTE);
+        return coordinate(value, Type.ABSOLUTE);
       }
 
       /**
@@ -365,7 +398,19 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
        * @since 4.0.0
        */
       static @NotNull Coordinate relative(final int value) {
-        return of(value, Type.RELATIVE);
+        return coordinate(value, Type.RELATIVE);
+      }
+
+      /**
+       * Creates a coordinate with the given value and type.
+       *
+       * @param value the value
+       * @param type the type
+       * @return a coordinate
+       * @since 4.10.0
+       */
+      static @NotNull Coordinate coordinate(final int value, final @NotNull Type type) {
+        return new BlockNBTComponentImpl.WorldPosImpl.CoordinateImpl(value, type);
       }
 
       /**
@@ -375,7 +420,10 @@ public interface BlockNBTComponent extends NBTComponent<BlockNBTComponent, Block
        * @param type the type
        * @return a coordinate
        * @since 4.0.0
+       * @deprecated for removal since 4.10.0, use {@link #coordinate(int, Coordinate.Type)} instead.
        */
+      @Deprecated
+      @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
       static @NotNull Coordinate of(final int value, final @NotNull Type type) {
         return new BlockNBTComponentImpl.WorldPosImpl.CoordinateImpl(value, type);
       }

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1809,7 +1809,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(pure = true)
   default @NotNull Component mergeStyle(final @NotNull Component that, final Style.@NotNull Merge@NotNull... merges) {
-    return this.mergeStyle(that, Style.Merge.of(merges));
+    return this.mergeStyle(that, Style.Merge.merges(merges));
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
@@ -362,7 +362,7 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
    */
   @Contract("_, _ -> this")
   default @NotNull B mergeStyle(final @NotNull Component that, final Style.@NotNull Merge@NotNull... merges) {
-    return this.mergeStyle(that, Style.Merge.of(merges));
+    return this.mergeStyle(that, Style.Merge.merges(merges));
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import net.kyori.adventure.util.HSVLike;
 import net.kyori.adventure.util.Index;
 import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -168,8 +169,40 @@ public final class NamedTextColor implements TextColor {
    *
    * @param value the color to match
    * @return the matched color, or null
-   * @since 4.0.0
+   * @since 4.10.0
    */
+  public static @Nullable NamedTextColor namedColor(final int value) {
+    switch (value) {
+      case BLACK_VALUE: return BLACK;
+      case DARK_BLUE_VALUE: return DARK_BLUE;
+      case DARK_GREEN_VALUE: return DARK_GREEN;
+      case DARK_AQUA_VALUE: return DARK_AQUA;
+      case DARK_RED_VALUE: return DARK_RED;
+      case DARK_PURPLE_VALUE: return DARK_PURPLE;
+      case GOLD_VALUE: return GOLD;
+      case GRAY_VALUE: return GRAY;
+      case DARK_GRAY_VALUE: return DARK_GRAY;
+      case BLUE_VALUE: return BLUE;
+      case GREEN_VALUE: return GREEN;
+      case AQUA_VALUE: return AQUA;
+      case RED_VALUE: return RED;
+      case LIGHT_PURPLE_VALUE: return LIGHT_PURPLE;
+      case YELLOW_VALUE: return YELLOW;
+      case WHITE_VALUE: return WHITE;
+      default: return null;
+    }
+  }
+
+  /**
+   * Gets the named color exactly matching the provided color.
+   *
+   * @param value the color to match
+   * @return the matched color, or null
+   * @since 4.0.0
+   * @deprecated for removal since 4.10.0, use {@link #namedColor(int)} instead
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   public static @Nullable NamedTextColor ofExact(final int value) {
     switch (value) {
       case BLACK_VALUE: return BLACK;

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -478,7 +478,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
    * @since 4.0.0
    */
   default @NotNull Style merge(final @NotNull Style that, final @NotNull Merge@NotNull... merges) {
-    return this.merge(that, Merge.of(merges));
+    return this.merge(that, Merge.merges(merges));
   }
 
   /**
@@ -491,7 +491,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
    * @since 4.0.0
    */
   default @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Merge@NotNull... merges) {
-    return this.merge(that, strategy, Merge.of(merges));
+    return this.merge(that, strategy, Merge.merges(merges));
   }
 
   /**
@@ -571,8 +571,8 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
      */
     FONT;
 
-    static final Set<Merge> ALL = of(values());
-    static final Set<Merge> COLOR_AND_DECORATIONS = of(COLOR, DECORATIONS);
+    static final Set<Merge> ALL = merges(values());
+    static final Set<Merge> COLOR_AND_DECORATIONS = merges(COLOR, DECORATIONS);
 
     /**
      * Gets a merge set of all merge types.
@@ -599,8 +599,22 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
      *
      * @param merges the merge parts
      * @return a merge set
-     * @since 4.0.0
+     * @since 4.10.0
      */
+    public static @Unmodifiable @NotNull Set<Merge> merges(final Merge@NotNull... merges) {
+      return MonkeyBars.enumSet(Merge.class, merges);
+    }
+
+    /**
+     * Creates a merge set.
+     *
+     * @param merges the merge parts
+     * @return a merge set
+     * @since 4.0.0
+     * @deprecated for removal since 4.10.0, use {@link #merges(Style.Merge...)} instead.
+     */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
     public static @Unmodifiable @NotNull Set<Merge> of(final Merge@NotNull... merges) {
       return MonkeyBars.enumSet(Merge.class, merges);
     }
@@ -816,7 +830,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
     @Contract("_, _ -> this")
     default @NotNull Builder merge(final @NotNull Style that, final @NotNull Merge@NotNull... merges) {
       if (merges.length == 0) return this;
-      return this.merge(that, Merge.of(merges));
+      return this.merge(that, Merge.merges(merges));
     }
 
     /**
@@ -831,7 +845,7 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
     @Contract("_, _, _ -> this")
     default @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Merge@NotNull... merges) {
       if (merges.length == 0) return this;
-      return this.merge(that, strategy, Merge.of(merges));
+      return this.merge(that, strategy, Merge.merges(merges));
     }
 
     /**

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -53,7 +53,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    */
   static @NotNull TextColor color(final int value) {
     final int truncatedValue = value & 0xffffff;
-    final NamedTextColor named = NamedTextColor.ofExact(truncatedValue);
+    final NamedTextColor named = NamedTextColor.namedColor(truncatedValue);
     return named != null ? named : new TextColorImpl(truncatedValue);
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -57,7 +57,7 @@ import static java.util.Objects.requireNonNull;
  * @since 4.0.0
  */
 public abstract class TranslatableComponentRenderer<C> extends AbstractComponentRenderer<C> {
-  private static final Set<Style.Merge> MERGES = Style.Merge.of(Style.Merge.COLOR, Style.Merge.DECORATIONS, Style.Merge.INSERTION, Style.Merge.FONT);
+  private static final Set<Style.Merge> MERGES = Style.Merge.merges(Style.Merge.COLOR, Style.Merge.DECORATIONS, Style.Merge.INSERTION, Style.Merge.FONT);
 
   /**
    * Creates a {@link TranslatableComponentRenderer} using the {@link Translator} to translate.

--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslator.java
@@ -29,6 +29,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import net.kyori.examination.Examinable;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -45,8 +46,21 @@ public interface GlobalTranslator extends Translator, Examinable {
    * Gets the global translation source.
    *
    * @return the source
-   * @since 4.0.0
+   * @since 4.10.0
    */
+  static @NotNull GlobalTranslator translator() {
+    return GlobalTranslatorImpl.INSTANCE;
+  }
+
+  /**
+   * Gets the global translation source.
+   *
+   * @return the source
+   * @since 4.0.0
+   * @deprecated for removal since 4.10.0, use {@link #translator()} instead.
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   static @NotNull GlobalTranslator get() {
     return GlobalTranslatorImpl.INSTANCE;
   }

--- a/api/src/main/java/net/kyori/adventure/util/Codec.java
+++ b/api/src/main/java/net/kyori/adventure/util/Codec.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.util;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -45,8 +46,37 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
    * @param <DX> the decode exception type
    * @param <EX> the encode exception type
    * @return a codec
-   * @since 4.0.0
+   * @since 4.10.0
    */
+  static <D, E, DX extends Throwable, EX extends Throwable> @NotNull Codec<D, E, DX, EX> codec(final @NotNull Decoder<D, E, DX> decoder, final @NotNull Encoder<D, E, EX> encoder) {
+    return new Codec<D, E, DX, EX>() {
+      @Override
+      public @NotNull D decode(final @NotNull E encoded) throws DX {
+        return decoder.decode(encoded);
+      }
+
+      @Override
+      public @NotNull E encode(final @NotNull D decoded) throws EX {
+        return encoder.encode(decoded);
+      }
+    };
+  }
+
+  /**
+   * Creates a codec.
+   *
+   * @param decoder the decoder
+   * @param encoder the encoder
+   * @param <D> the decoded type
+   * @param <E> the encoded type
+   * @param <DX> the decode exception type
+   * @param <EX> the encode exception type
+   * @return a codec
+   * @since 4.0.0
+   * @deprecated for removal since 4.10.0, use {@link #codec(Codec.Decoder, Codec.Encoder)} instead.
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   static <D, E, DX extends Throwable, EX extends Throwable> @NotNull Codec<D, E, DX, EX> of(final @NotNull Decoder<D, E, DX> decoder, final @NotNull Encoder<D, E, EX> encoder) {
     return new Codec<D, E, DX, EX>() {
       @Override

--- a/api/src/main/java/net/kyori/adventure/util/HSVLike.java
+++ b/api/src/main/java/net/kyori/adventure/util/HSVLike.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.util;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 
@@ -44,8 +45,24 @@ public interface HSVLike extends Examinable {
    * @param s saturation color component
    * @param v value color component
    * @return a new HSVLike
-   * @since 4.6.0
+   * @since 4.10.0
    */
+  static @NotNull HSVLike hsvLike(final float h, final float s, final float v) {
+    return new HSVLikeImpl(h, s, v);
+  }
+
+  /**
+   * Creates a new HSVLike.
+   *
+   * @param h hue color component
+   * @param s saturation color component
+   * @param v value color component
+   * @return a new HSVLike
+   * @since 4.6.0
+   * @deprecated for removal since 4.10.0, use {@link #hsvLike(float, float, float)} instead.
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   static @NotNull HSVLike of(final float h, final float s, final float v) {
     return new HSVLikeImpl(h, s, v);
   }

--- a/api/src/test/java/net/kyori/adventure/text/BlockNBTComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/BlockNBTComponentTest.java
@@ -39,19 +39,19 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
 
   @Test
   void testOf() {
-    final BlockNBTComponent component = Component.blockNBT("abc", BlockNBTComponent.LocalPos.of(1d, 2d, 3d));
+    final BlockNBTComponent component = Component.blockNBT("abc", BlockNBTComponent.LocalPos.localPos(1d, 2d, 3d));
     assertEquals("abc", component.nbtPath());
-    assertEquals(BlockNBTComponent.LocalPos.of(1d, 2d, 3d), component.pos());
+    assertEquals(BlockNBTComponent.LocalPos.localPos(1d, 2d, 3d), component.pos());
     assertNull(component.color());
     TextAssertions.assertDecorations(component, ImmutableSet.of(), ImmutableSet.of());
   }
 
   @Test
   void testPos() {
-    final BlockNBTComponent c0 = Component.blockNBT("abc", BlockNBTComponent.LocalPos.of(1d, 2d, 3d));
-    final BlockNBTComponent c1 = c0.pos(BlockNBTComponent.WorldPos.of(BlockNBTComponent.WorldPos.Coordinate.absolute(1), BlockNBTComponent.WorldPos.Coordinate.relative(2), BlockNBTComponent.WorldPos.Coordinate.absolute(3)));
-    assertEquals(BlockNBTComponent.LocalPos.of(1d, 2d, 3d), c0.pos());
-    assertEquals(BlockNBTComponent.WorldPos.of(BlockNBTComponent.WorldPos.Coordinate.absolute(1), BlockNBTComponent.WorldPos.Coordinate.relative(2), BlockNBTComponent.WorldPos.Coordinate.absolute(3)), c1.pos());
+    final BlockNBTComponent c0 = Component.blockNBT("abc", BlockNBTComponent.LocalPos.localPos(1d, 2d, 3d));
+    final BlockNBTComponent c1 = c0.pos(BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.absolute(1), BlockNBTComponent.WorldPos.Coordinate.relative(2), BlockNBTComponent.WorldPos.Coordinate.absolute(3)));
+    assertEquals(BlockNBTComponent.LocalPos.localPos(1d, 2d, 3d), c0.pos());
+    assertEquals(BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.absolute(1), BlockNBTComponent.WorldPos.Coordinate.relative(2), BlockNBTComponent.WorldPos.Coordinate.absolute(3)), c1.pos());
     assertEquals("abc", c1.nbtPath());
 
     assertTrue(c0.pos() instanceof BlockNBTComponent.LocalPos);
@@ -71,15 +71,15 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
   @Test
   void testPosEquality() {
     new EqualsTester()
-      .addEqualityGroup(BlockNBTComponent.LocalPos.of(1d, 2d, 3d))
-      .addEqualityGroup(BlockNBTComponent.WorldPos.of(BlockNBTComponent.WorldPos.Coordinate.absolute(1), BlockNBTComponent.WorldPos.Coordinate.absolute(2), BlockNBTComponent.WorldPos.Coordinate.absolute(3)))
+      .addEqualityGroup(BlockNBTComponent.LocalPos.localPos(1d, 2d, 3d))
+      .addEqualityGroup(BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.absolute(1), BlockNBTComponent.WorldPos.Coordinate.absolute(2), BlockNBTComponent.WorldPos.Coordinate.absolute(3)))
       .testEquals();
   }
 
   @Test
   void testLocalPosNoDecimalParsing() {
     assertEquals(
-      BlockNBTComponent.LocalPos.of(1.0d, 2.0d, 3.89d),
+      BlockNBTComponent.LocalPos.localPos(1.0d, 2.0d, 3.89d),
       BlockNBTComponent.Pos.fromString("^1 ^2 ^3.89")
     );
   }
@@ -87,7 +87,7 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
   @Test
   void testLocalPosParsing() {
     assertEquals(
-      BlockNBTComponent.LocalPos.of(1.23d, 2.0d, 3.89d),
+      BlockNBTComponent.LocalPos.localPos(1.23d, 2.0d, 3.89d),
       BlockNBTComponent.Pos.fromString("^1.23 ^2.0 ^3.89")
     );
   }
@@ -95,7 +95,7 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
   @Test
   void testAbsoluteWorldPosParsing() {
     assertEquals(
-      BlockNBTComponent.WorldPos.of(BlockNBTComponent.WorldPos.Coordinate.absolute(4), BlockNBTComponent.WorldPos.Coordinate.absolute(5), BlockNBTComponent.WorldPos.Coordinate.absolute(6)),
+      BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.absolute(4), BlockNBTComponent.WorldPos.Coordinate.absolute(5), BlockNBTComponent.WorldPos.Coordinate.absolute(6)),
       BlockNBTComponent.Pos.fromString("4 5 6")
     );
   }
@@ -103,7 +103,7 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
   @Test
   void testRelativeWorldPosParsing() {
     assertEquals(
-      BlockNBTComponent.WorldPos.of(BlockNBTComponent.WorldPos.Coordinate.relative(7), BlockNBTComponent.WorldPos.Coordinate.relative(83), BlockNBTComponent.WorldPos.Coordinate.relative(900)),
+      BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.relative(7), BlockNBTComponent.WorldPos.Coordinate.relative(83), BlockNBTComponent.WorldPos.Coordinate.relative(900)),
       BlockNBTComponent.Pos.fromString("~7 ~83 ~900")
     );
   }
@@ -111,7 +111,7 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
   @Test
   void testWorldPosParsing() {
     assertEquals(
-      BlockNBTComponent.WorldPos.of(BlockNBTComponent.WorldPos.Coordinate.absolute(12), BlockNBTComponent.WorldPos.Coordinate.relative(3), BlockNBTComponent.WorldPos.Coordinate.absolute(1200)),
+      BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.absolute(12), BlockNBTComponent.WorldPos.Coordinate.relative(3), BlockNBTComponent.WorldPos.Coordinate.absolute(1200)),
       BlockNBTComponent.Pos.fromString("12 ~3 1200")
     );
   }

--- a/api/src/test/java/net/kyori/adventure/text/format/StyleTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/StyleTest.java
@@ -204,7 +204,7 @@ class StyleTest {
   @Test
   void testMerge_none() {
     final Style s0 = Style.empty();
-    final Style s1 = s0.merge(Style.style(NamedTextColor.DARK_PURPLE), Style.Merge.of());
+    final Style s1 = s0.merge(Style.style(NamedTextColor.DARK_PURPLE), Style.Merge.merges());
     assertNull(s1.color());
     assertDecorations(s1, ImmutableSet.of(), ImmutableSet.of());
     assertNull(s1.clickEvent());

--- a/api/src/test/java/net/kyori/adventure/translation/GlobalTranslatorTest.java
+++ b/api/src/test/java/net/kyori/adventure/translation/GlobalTranslatorTest.java
@@ -42,12 +42,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class GlobalTranslatorTest {
   @BeforeEach
   void removeDummySourceBeforeEachTest() {
-    GlobalTranslator.get().removeSource(DummyTranslator.INSTANCE);
+    GlobalTranslator.translator().removeSource(DummyTranslator.INSTANCE);
   }
 
   @Test
   void testRender() {
-    GlobalTranslator.get().addSource(DummyTranslator.INSTANCE);
+    GlobalTranslator.translator().addSource(DummyTranslator.INSTANCE);
     assertEquals(
       Component.text()
         .append(Component.text("Hello "))
@@ -60,22 +60,22 @@ class GlobalTranslatorTest {
 
   @Test
   void testAddingSelf() {
-    assertThrows(IllegalArgumentException.class, () -> GlobalTranslator.get().addSource(GlobalTranslator.get()));
+    assertThrows(IllegalArgumentException.class, () -> GlobalTranslator.translator().addSource(GlobalTranslator.translator()));
   }
 
   @Test
   void testAddAndRemoveSource() {
-    assertTrue(GlobalTranslator.get().addSource(DummyTranslator.INSTANCE));
-    assertThat(GlobalTranslator.get().sources()).contains(DummyTranslator.INSTANCE);
-    assertTrue(GlobalTranslator.get().removeSource(DummyTranslator.INSTANCE));
-    assertThat(GlobalTranslator.get().sources()).doesNotContain(DummyTranslator.INSTANCE);
+    assertTrue(GlobalTranslator.translator().addSource(DummyTranslator.INSTANCE));
+    assertThat(GlobalTranslator.translator().sources()).contains(DummyTranslator.INSTANCE);
+    assertTrue(GlobalTranslator.translator().removeSource(DummyTranslator.INSTANCE));
+    assertThat(GlobalTranslator.translator().sources()).doesNotContain(DummyTranslator.INSTANCE);
   }
 
   @Test
   void testTranslate() {
-    assertNull(GlobalTranslator.get().translate("testDummy", Locale.US));
-    GlobalTranslator.get().addSource(DummyTranslator.INSTANCE);
-    assertEquals(new MessageFormat("Hello {0}!"), GlobalTranslator.get().translate("testDummy", Locale.US));
+    assertNull(GlobalTranslator.translator().translate("testDummy", Locale.US));
+    GlobalTranslator.translator().addSource(DummyTranslator.INSTANCE);
+    assertEquals(new MessageFormat("Hello {0}!"), GlobalTranslator.translator().translate("testDummy", Locale.US));
   }
 
   static class DummyTranslator implements Translator {

--- a/api/src/test/java/net/kyori/adventure/util/HSVLikeTest.java
+++ b/api/src/test/java/net/kyori/adventure/util/HSVLikeTest.java
@@ -69,13 +69,13 @@ class HSVLikeTest {
 
   @Test
   void testRange() {
-    assertThrows(IllegalArgumentException.class, () -> HSVLike.of(2, 1, 1));
-    assertThrows(IllegalArgumentException.class, () -> HSVLike.of(1, -1, 1));
-    assertThrows(IllegalArgumentException.class, () -> HSVLike.of(1, 1, 2));
+    assertThrows(IllegalArgumentException.class, () -> HSVLike.hsvLike(2, 1, 1));
+    assertThrows(IllegalArgumentException.class, () -> HSVLike.hsvLike(1, -1, 1));
+    assertThrows(IllegalArgumentException.class, () -> HSVLike.hsvLike(1, 1, 2));
     assertDoesNotThrow(() -> {
-      HSVLike.of(1, 1, 1);
-      HSVLike.of(0, 0, 0);
-      HSVLike.of(0.5f, 0.5f, 0.5f);
+      HSVLike.hsvLike(1, 1, 1);
+      HSVLike.hsvLike(0, 0, 0);
+      HSVLike.hsvLike(0.5f, 0.5f, 0.5f);
     });
   }
 }

--- a/key/src/main/java/net/kyori/adventure/key/KeyedValue.java
+++ b/key/src/main/java/net/kyori/adventure/key/KeyedValue.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.key;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
@@ -41,8 +42,24 @@ public interface KeyedValue<T> extends Keyed {
    * @param value the value
    * @param <T> the value type
    * @return the keyed
-   * @since 4.0.0
+   * @since 4.10.0
    */
+  static <T> @NotNull KeyedValue<T> keyedValue(final @NotNull Key key, final @NotNull T value) {
+    return new KeyedValueImpl<>(key, requireNonNull(value, "value"));
+  }
+
+  /**
+   * Creates a link.
+   *
+   * @param key the key
+   * @param value the value
+   * @param <T> the value type
+   * @return the keyed
+   * @since 4.0.0
+   * @deprecated for removal since 4.10.0, use {@link #keyedValue(Key, Object)} instead.
+   */
+  @Deprecated
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   static <T> @NotNull KeyedValue<T> of(final @NotNull Key key, final @NotNull T value) {
     return new KeyedValueImpl<>(key, requireNonNull(value, "value"));
   }

--- a/key/src/test/java/net/kyori/adventure/key/KeyedValueTest.java
+++ b/key/src/test/java/net/kyori/adventure/key/KeyedValueTest.java
@@ -33,7 +33,7 @@ class KeyedValueTest {
   @Test
   void testGetters() {
     final Foo foo = new Foo();
-    final KeyedValue<Foo> kv = KeyedValue.of(Key.key("foo"), foo);
+    final KeyedValue<Foo> kv = KeyedValue.keyedValue(Key.key("foo"), foo);
     assertEquals(Key.key("foo"), kv.key());
     assertSame(foo, kv.value());
   }
@@ -43,8 +43,8 @@ class KeyedValueTest {
     final Foo foo = new Foo();
     new EqualsTester()
       .addEqualityGroup(
-        KeyedValue.of(Key.key("foo"), foo),
-        KeyedValue.of(Key.key("foo"), foo)
+        KeyedValue.keyedValue(Key.key("foo"), foo),
+        KeyedValue.keyedValue(Key.key("foo"), foo)
       )
       .testEquals();
   }

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowItemSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/HoverEventShowItemSerializer.java
@@ -54,7 +54,7 @@ final class HoverEventShowItemSerializer implements TypeSerializer<HoverEvent.Sh
     final int count = value.getNode(COUNT).getInt(1);
     final String tag = value.getNode(TAG).getString();
 
-    return HoverEvent.ShowItem.of(id, count, tag == null ? null : BinaryTagHolder.of(tag));
+    return HoverEvent.ShowItem.of(id, count, tag == null ? null : BinaryTagHolder.binaryTagHolder(tag));
   }
 
   @Override

--- a/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/HoverEventSerializersTest.java
+++ b/serializer-configurate3/src/test/java/net/kyori/adventure/serializer/configurate3/HoverEventSerializersTest.java
@@ -95,7 +95,7 @@ class HoverEventSerializersTest implements ConfigurateTestBase {
       .color(NamedTextColor.AQUA)
       .append(Component.translatable("item.minecraft.purple_wool"))
       .append(Component.text("]"))
-      .hoverEvent(HoverEvent.showItem(HoverEvent.ShowItem.of(Key.key("minecraft:purple_wool"), 2, BinaryTagHolder.of("{Damage: 5b}"))))
+      .hoverEvent(HoverEvent.showItem(HoverEvent.ShowItem.of(Key.key("minecraft:purple_wool"), 2, BinaryTagHolder.binaryTagHolder("{Damage: 5b}"))))
       .build();
 
     this.assertRoundtrippable(component, node);

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowItemSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowItemSerializer.java
@@ -52,7 +52,7 @@ final class HoverEventShowItemSerializer implements TypeSerializer<HoverEvent.Sh
     final int count = value.node(COUNT).getInt(1);
     final String tag = value.node(TAG).getString();
 
-    return HoverEvent.ShowItem.of(id, count, tag == null ? null : BinaryTagHolder.of(tag));
+    return HoverEvent.ShowItem.of(id, count, tag == null ? null : BinaryTagHolder.binaryTagHolder(tag));
   }
 
   @Override

--- a/serializer-configurate4/src/test/java/net/kyori/adventure/serializer/configurate4/HoverEventSerializersTest.java
+++ b/serializer-configurate4/src/test/java/net/kyori/adventure/serializer/configurate4/HoverEventSerializersTest.java
@@ -95,7 +95,7 @@ class HoverEventSerializersTest implements ConfigurateTestBase {
       .color(NamedTextColor.AQUA)
       .append(Component.translatable("item.minecraft.purple_wool"))
       .append(Component.text("]"))
-      .hoverEvent(HoverEvent.showItem(HoverEvent.ShowItem.of(Key.key("minecraft:purple_wool"), 2, BinaryTagHolder.of("{Damage: 5b}"))))
+      .hoverEvent(HoverEvent.showItem(HoverEvent.ShowItem.of(Key.key("minecraft:purple_wool"), 2, BinaryTagHolder.binaryTagHolder("{Damage: 5b}"))))
       .build();
 
     this.assertRoundtrippable(component, node);

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/HoverTransformation.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/HoverTransformation.java
@@ -96,7 +96,7 @@ public final class HoverTransformation extends Transformation {
         count = 1;
       }
       if (args.size() == 3) {
-        return HoverEvent.ShowItem.of(key, count, BinaryTagHolder.of(args.get(2).value()));
+        return HoverEvent.ShowItem.of(key, count, BinaryTagHolder.binaryTagHolder(args.get(2).value()));
       }
       return HoverEvent.ShowItem.of(key, count);
     } catch (final InvalidKeyException | NumberFormatException ex) {

--- a/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
+++ b/text-serializer-gson-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/gson/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
 final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSerializer {
   static final NBTLegacyHoverEventSerializerImpl INSTANCE = new NBTLegacyHoverEventSerializerImpl();
   private static final TagStringIO SNBT_IO = TagStringIO.get();
-  private static final Codec<CompoundBinaryTag, String, IOException, IOException> SNBT_CODEC = Codec.of(SNBT_IO::asCompound, SNBT_IO::asString);
+  private static final Codec<CompoundBinaryTag, String, IOException, IOException> SNBT_CODEC = Codec.codec(SNBT_IO::asCompound, SNBT_IO::asString);
 
   static final String ITEM_TYPE = "id";
   static final String ITEM_COUNT = "Count";

--- a/text-serializer-gson/src/jmh/java/net/kyori/adventure/text/serializer/gson/ComponentDeserializationBenchmark.java
+++ b/text-serializer-gson/src/jmh/java/net/kyori/adventure/text/serializer/gson/ComponentDeserializationBenchmark.java
@@ -69,7 +69,7 @@ public class ComponentDeserializationBenchmark {
     this.componentTreeWithEvents = gson().serialize(text()
                                                       .decorate(TextDecoration.UNDERLINED, TextDecoration.ITALIC)
                                                       .append(text("Component ", style(color(0x8cfbde), openUrl("https://kyori.net/"))))
-                                                      .append(text("with ", style(color(0x0fff95), TextDecoration.BOLD, showItem(Key.key("iron_sword"), 1, BinaryTagHolder.of("{Damage: 30, RepairCost: 4, Enchantments: [{id: 'minecraft:sharpness', lvl: 3s}, {id: 'minecraft:unbreaking', lvl: 1s}]}")))))
+                                                      .append(text("with ", style(color(0x0fff95), TextDecoration.BOLD, showItem(Key.key("iron_sword"), 1, BinaryTagHolder.binaryTagHolder("{Damage: 30, RepairCost: 4, Enchantments: [{id: 'minecraft:sharpness', lvl: 3s}, {id: 'minecraft:unbreaking', lvl: 1s}]}")))))
                                                       .append(text("hex ", style(color(0x06ba63), showEntity(Key.key("pig"), UUID.randomUUID(), text("Piggy", NamedTextColor.YELLOW)))))
                                                       .append(text("colors", style(color(0x103900), showText(text("Text hover!")))))
                                                       .build());

--- a/text-serializer-gson/src/jmh/java/net/kyori/adventure/text/serializer/gson/ComponentSerializationBenchmark.java
+++ b/text-serializer-gson/src/jmh/java/net/kyori/adventure/text/serializer/gson/ComponentSerializationBenchmark.java
@@ -69,7 +69,7 @@ public class ComponentSerializationBenchmark {
     this.componentTreeWithEvents = text()
       .decorate(TextDecoration.UNDERLINED, TextDecoration.ITALIC)
       .append(text("Component ", style(color(0x8cfbde), openUrl("https://kyori.net/"))))
-      .append(text("with ", style(color(0x0fff95), TextDecoration.BOLD, showItem(Key.key("iron_sword"), 1, BinaryTagHolder.of("{Damage: 30, RepairCost: 4, Enchantments: [{id: 'minecraft:sharpness', lvl: 3s}, {id: 'minecraft:unbreaking', lvl: 1s}]}")))))
+      .append(text("with ", style(color(0x0fff95), TextDecoration.BOLD, showItem(Key.key("iron_sword"), 1, BinaryTagHolder.binaryTagHolder("{Damage: 30, RepairCost: 4, Enchantments: [{id: 'minecraft:sharpness', lvl: 3s}, {id: 'minecraft:unbreaking', lvl: 1s}]}")))))
       .append(text("hex ", style(color(0x06ba63), showEntity(Key.key("pig"), UUID.randomUUID(), text("Piggy", NamedTextColor.YELLOW)))))
       .append(text("colors", style(color(0x103900), showText(text("Text hover!")))))
       .build();

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
@@ -67,9 +67,9 @@ final class ShowItemSerializer extends TypeAdapter<HoverEvent.ShowItem> {
       } else if (fieldName.equals(TAG)) {
         final JsonToken token = in.peek();
         if (token == JsonToken.STRING || token == JsonToken.NUMBER) {
-          nbt = BinaryTagHolder.of(in.nextString());
+          nbt = BinaryTagHolder.binaryTagHolder(in.nextString());
         } else if (token == JsonToken.BOOLEAN) {
-          nbt = BinaryTagHolder.of(String.valueOf(in.nextBoolean()));
+          nbt = BinaryTagHolder.binaryTagHolder(String.valueOf(in.nextBoolean()));
         } else if (token == JsonToken.NULL) {
           in.nextNull();
         } else {

--- a/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializerTest.java
+++ b/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializerTest.java
@@ -39,7 +39,7 @@ class ShowItemSerializerTest {
   @Test
   void testDeserializeWithPopulatedTag() throws IOException {
     assertEquals(
-      HoverEvent.ShowItem.of(Key.key("minecraft", "diamond"), 1, BinaryTagHolder.of(TagStringIO.get().asString(
+      HoverEvent.ShowItem.of(Key.key("minecraft", "diamond"), 1, BinaryTagHolder.binaryTagHolder(TagStringIO.get().asString(
         CompoundBinaryTag.builder()
           .put("display", CompoundBinaryTag.builder()
             .put("Name", StringBinaryTag.of("A test!"))


### PR DESCRIPTION
Adresses all points in #454 except for `adventure-nbt` and the two in `HoverEvent`