### PR TITLE
Introduce a method by which to create raw replacements.

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Placeholder.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Placeholder.java
@@ -56,6 +56,18 @@ public interface Placeholder<T> extends Replacement<T> {
   }
 
   /**
+   * Creates a placeholder that inserts a raw string, ignoring any MiniMessage tags present.
+   *
+   * @param key the key
+   * @param value the replacement
+   * @return the placeholder
+   * @since 4.10.0
+   */
+  static @NotNull Placeholder<Component> raw(final @NotNull String key, final @NotNull String value) {
+    return Placeholder.component(key, Component.text(value));
+  }
+
+  /**
    * Creates a replacement that inserts a component.
    *
    * @param key the key

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Replacement.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/placeholder/Replacement.java
@@ -52,6 +52,17 @@ public interface Replacement<T> extends Examinable {
   }
 
   /**
+   * Creates a replacement that inserts a raw string, ignoring any MiniMessage tags present.
+   *
+   * @param raw the string
+   * @return the replacement
+   * @since 4.10.0
+   */
+  static @NotNull Replacement<Component> raw(final @NotNull String raw) {
+    return Replacement.component(Component.text(raw));
+  }
+
+  /**
    * Creates a replacement that inserts a component.
    *
    * @param component the component


### PR DESCRIPTION
Moreso meant to start conversation, because I bet there's a better stage at which to escape, using the specific MiniMessage object and not just the default one. 

Presently, only a minimessage-parsed string replacement is offered. Manually doing escapeTokens all the time gets tiring, so I hope to introduce a built-into-adventure method by which to do this. Otherwise, I'll just be creating my own simple helper method to automate.

To quote @kezz 
> maybe we can do a pass right at the end once all the tokens are made


![image](https://user-images.githubusercontent.com/181668/147705477-6c7ea1e0-7d34-4627-978f-438065485397.png)
