### PR TITLE
text-minimessage: add deserialization method returning parsed tree

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -159,6 +159,16 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
   }
 
   /**
+   * Deserializes a string into a tree of parsed elements,
+   * This is intended for inspecting the output of the parser for debugging purposes.
+   *
+   * @param input the input string
+   * @return the root of the resulting tree
+   * @since 4.10.0
+   */
+  @NotNull Node deserializeToTree(@NotNull String input);
+
+  /**
    * Deserializes a string into a tree of parsed elements, with a tag resolver to parse tags of the form {@code <key>}.
    * This is intended for inspecting the output of the parser for debugging purposes.
    *
@@ -170,6 +180,21 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @since 4.10.0
    */
   @NotNull Node deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver);
+
+  /**
+   * Deserializes a string into a tree of parsed elements, with a tag resolver to parse tags of the form {@code <key>}.
+   * This is intended for inspecting the output of the parser for debugging purposes.
+   *
+   * <p>Tags will be resolved from the resolver parameter before the resolver provided in the builder is used.</p>
+   *
+   * @param input the input string
+   * @param tagResolvers a series of tag resolvers to apply extra tags from, last specified taking priority
+   * @return the root of the resulting tree
+   * @since 4.10.0
+   */
+  default @NotNull Node deserializeToTree(final @NotNull String input, final @NotNull TagResolver... tagResolvers) {
+    return this.deserializeToTree(input, TagResolver.resolver(tagResolvers));
+  }
 
   /**
    * Creates a new {@link MiniMessage.Builder}.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.minimessage.tree.Node;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;
 import org.jetbrains.annotations.NotNull;
@@ -156,6 +157,19 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
   default @NotNull Component deserialize(final @NotNull String input, final @NotNull TagResolver... tagResolvers) {
     return this.deserialize(input, TagResolver.resolver(tagResolvers));
   }
+
+  /**
+   * Deserializes a string into a tree of parsed elements, with a tag resolver to parse tags of the form {@code <key>}.
+   * This is intended for inspecting the output of the parser for debugging purposes.
+   *
+   * <p>Tags will be resolved from the resolver parameter before the resolver provided in the builder is used.</p>
+   *
+   * @param input the input string
+   * @param tagResolver the tag resolver for any additional tags to handle
+   * @return the root of the resulting tree
+   * @since 4.10.0
+   */
+  @NotNull Node deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver);
 
   /**
    * Creates a new {@link MiniMessage.Builder}.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.minimessage.tree.Node;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -67,6 +68,11 @@ final class MiniMessageImpl implements MiniMessage {
   @Override
   public @NotNull Component deserialize(final @NotNull String input, final @NotNull TagResolver tagResolver) {
     return this.parser.parseFormat(input, this.newContext(input, requireNonNull(tagResolver, "tagResolver")));
+  }
+
+  @Override
+  public @NotNull Node deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver) {
+    return this.parser.parseToTree(input, this.newContext(input, requireNonNull(tagResolver, "tagResolver")));
   }
 
   @Override

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -71,6 +71,11 @@ final class MiniMessageImpl implements MiniMessage {
   }
 
   @Override
+  public @NotNull Node deserializeToTree(final @NotNull String input) {
+    return this.parser.parseToTree(input, this.newContext(input, null));
+  }
+
+  @Override
   public @NotNull Node deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver) {
     return this.parser.parseToTree(input, this.newContext(input, requireNonNull(tagResolver, "tagResolver")));
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -43,6 +43,7 @@ import net.kyori.adventure.text.minimessage.tag.Inserting;
 import net.kyori.adventure.text.minimessage.tag.Modifying;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.minimessage.tree.Node;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.string.MultiLineStringExaminer;
 import org.jetbrains.annotations.NotNull;
@@ -116,7 +117,7 @@ final class MiniMessageParser {
     }
   }
 
-  @NotNull Component parseFormat(final @NotNull String richMessage, final @NotNull ContextImpl context) {
+  @NotNull Node parseToTree(final @NotNull String richMessage, final @NotNull ContextImpl context) {
     final TagResolver combinedResolver = TagResolver.resolver(this.tagResolver, context.extraTags());
     final Consumer<String> debug = context.debugOutput();
     if (debug != null) {
@@ -192,6 +193,11 @@ final class MiniMessageParser {
       debug.accept(root.toString());
     }
 
+    return root;
+  }
+
+  @NotNull Component parseFormat(final @NotNull String richMessage, final @NotNull ContextImpl context) {
+    final ElementNode root = (ElementNode) this.parseToTree(richMessage, context);
     return Objects.requireNonNull(context.postProcessor().apply(this.treeToComponent(root, context)), "Post-processor must not return null");
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -43,7 +43,6 @@ import net.kyori.adventure.text.minimessage.tag.Inserting;
 import net.kyori.adventure.text.minimessage.tag.Modifying;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import net.kyori.adventure.text.minimessage.tree.Node;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.string.MultiLineStringExaminer;
 import org.jetbrains.annotations.NotNull;
@@ -117,7 +116,7 @@ final class MiniMessageParser {
     }
   }
 
-  @NotNull Node parseToTree(final @NotNull String richMessage, final @NotNull ContextImpl context) {
+  @NotNull ElementNode parseToTree(final @NotNull String richMessage, final @NotNull ContextImpl context) {
     final TagResolver combinedResolver = TagResolver.resolver(this.tagResolver, context.extraTags());
     final Consumer<String> debug = context.debugOutput();
     if (debug != null) {
@@ -197,7 +196,7 @@ final class MiniMessageParser {
   }
 
   @NotNull Component parseFormat(final @NotNull String richMessage, final @NotNull ContextImpl context) {
-    final ElementNode root = (ElementNode) this.parseToTree(richMessage, context);
+    final ElementNode root = this.parseToTree(richMessage, context);
     return Objects.requireNonNull(context.postProcessor().apply(this.treeToComponent(root, context)), "Post-processor must not return null");
   }
 

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -31,6 +31,9 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.minimessage.tree.Node;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.junit.jupiter.api.Test;
 
@@ -1683,5 +1686,29 @@ public class MiniMessageParserTest extends TestBase {
       .build();
 
     this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testTreeOutput() {
+    final String input = "<red> RED <blue> <name> <click:open_url:https://github.com> good <action> </click>";
+
+    final TagResolver resolver = TagResolver.resolver(Placeholder.parsed("name", "you"), Placeholder.component("action", Component.text("click")));
+    final Node tree = MiniMessage.miniMessage().deserializeToTree(input, resolver);
+    final String expected = "Node {\n" +
+      "  TagNode('red') {\n" +
+      "    TextNode(' RED ')\n" +
+      "    TagNode('blue') {\n" +
+      "      TextNode(' you ')\n" +
+      "      TagNode('click', 'open_url', 'https://github.com') {\n" +
+      "        TextNode(' good ')\n" +
+      "        TagNode('action') {\n" +
+      "        }\n" +
+      "        TextNode(' ')\n" +
+      "      }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}\n";
+
+    assertEquals(expected, tree.toString());
   }
 }


### PR DESCRIPTION
Related to KyoriPowered/adventure-webui#68.

Introduces a method returning the `ElementNode` tree, right before it would be turned into a component.

As this is mostly a debug feature with not much actual practical use, I'm wondering if it should somehow be more hidden in the API...