### PR TITLE
minimessage: Add a reset tag via a parser directive

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -235,10 +235,13 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
     @NotNull Builder editTags(final @NotNull Consumer<TagResolver.Builder> adder);
 
     /**
-     * Allows to enable strict mode (disabled by default).
+     * Enables strict mode (disabled by default).
      *
      * <p>By default, MiniMessage will allow {@link net.kyori.adventure.text.minimessage.tag.Inserting#allowsChildren() child-allowing} tags to be implicitly closed. When strict mode
      * is enabled, all child-allowing tags which are {@code <opened>} must be explicitly {@code </closed>} as well.</p>
+     *
+     * <p>Additionally, the {@link net.kyori.adventure.text.minimessage.tag.ParserDirective#RESET reset tag} is disabled in this mode.
+     * Any usage of this tag will throw a parser exception if strict mode is enabled.</p>
      *
      * @param strict if strict mode should be enabled
      * @return this builder

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/ParserDirective.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/ParserDirective.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Tags implementing this interface are used to provide directives, or instructions, to the parser directly.
+ *
+ * @see #RESET
+ * @since 4.10.0
+ */
+@ApiStatus.NonExtendable
+public /* sealed */ interface ParserDirective extends Tag {
+  /**
+   * Instructs the parser to reset all style, events, insertions, etc.
+   *
+   * <p>If {@link net.kyori.adventure.text.minimessage.MiniMessage.Builder#strict(boolean) strict mode} is enabled, usage of
+   * this tag is disallowed and a parse exception will be thrown if this tag is present.</p>
+   *
+   * @since 4.10.0
+   */
+  Tag RESET = new ParserDirective() {
+    @Override
+    public String toString() {
+      return "ParserDirective.RESET";
+    }
+  };
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Tag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Tag.java
@@ -40,11 +40,12 @@ import static java.util.Objects.requireNonNull;
 /**
  * A tag definition for the MiniMessage language.
  *
- * <p>All implementations of {@code Tag} must implement one of {@link Inserting}, {@link Modifying}, or {@link PreProcess}.</p>
+ * <p>All implementations of {@code Tag} must implement one of {@link Inserting}, {@link Modifying},
+ * {@link ParserDirective} or {@link PreProcess}.</p>
  *
  * @since 4.10.0
  */
-public /* sealed */ interface Tag /* permits Inserting, Modifying, PreProcess, /internal/ AbstractTag */ {
+public /* sealed */ interface Tag /* permits Inserting, Modifying, ParserDirective, PreProcess, /internal/ AbstractTag */ {
 
   /**
    * Create a tag that inserts the content literally into the parse string.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.minimessage.tag.ParserDirective;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 /**
@@ -39,6 +40,8 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
  * @since 4.10.0
  */
 public final class StandardTags {
+  private static final String RESET_TAG = "reset";
+
   private StandardTags() {
   }
 
@@ -62,6 +65,7 @@ public final class StandardTags {
   private static final TagResolver FONT = TagResolver.resolver(FontTag.FONT, FontTag::create);
   private static final TagResolver GRADIENT = TagResolver.resolver(GradientTag.GRADIENT, GradientTag::create);
   private static final TagResolver RAINBOW = TagResolver.resolver(RainbowTag.RAINBOW, RainbowTag::create);
+  private static final TagResolver RESET = TagResolver.resolver(RESET_TAG, ParserDirective.RESET);
   private static final TagResolver ALL = TagResolver.builder()
       .resolvers(
         HOVER_EVENT,
@@ -73,7 +77,8 @@ public final class StandardTags {
         FONT,
         DECORATION,
         GRADIENT,
-        RAINBOW
+        RAINBOW,
+        RESET
       )
       .build();
 
@@ -169,6 +174,16 @@ public final class StandardTags {
    */
   public static TagResolver rainbow() {
     return RAINBOW;
+  }
+
+  /**
+   * Get a resolver for the {@value RESET_TAG} tag.
+   *
+   * @return a resolver for the {@value RESET_TAG} tag.
+   * @since 4.10.0
+   */
+  public static TagResolver reset() {
+    return RESET;
   }
 
   /**


### PR DESCRIPTION
This PR adds a `ParserDirective` tag, used solely to provide a direct instruction to the parser. It also adds a single implementation of this tag, the `RESET` directive and adds this as a tag.

Closes #621.