### PR TITLE
Add a new tag for line breaks (<br>)

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NewlineTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NewlineTag.java
@@ -37,8 +37,8 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public final class NewlineTag {
-  public static final String NEWLINE_2 = "newline";
-  public static final String NEWLINE = "br";
+  public static final String NEWLINE_2 = "br";
+  public static final String NEWLINE = "newline";
 
   private NewlineTag() {
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NewlineTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NewlineTag.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.Context;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Newline tag.
+ *
+ * @since 4.10.0
+ */
+@ApiStatus.Internal
+public final class NewlineTag {
+  public static final String NEWLINE_2 = "newline";
+  public static final String NEWLINE = "br";
+
+  private NewlineTag() {
+  }
+
+  static Tag create(final ArgumentQueue args, final Context ctx) throws ParsingException {
+    return Tag.inserting(Component.newline());
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -64,6 +64,7 @@ public final class StandardTags {
   private static final TagResolver GRADIENT = TagResolver.resolver(GradientTag.GRADIENT, GradientTag::create);
   private static final TagResolver RAINBOW = TagResolver.resolver(RainbowTag.RAINBOW, RainbowTag::create);
   private static final TagResolver RESET = TagResolver.resolver(RESET_TAG, ParserDirective.RESET);
+  private static final TagResolver NEW_LINE = TagResolver.resolver(names(NewlineTag.NEWLINE, NewlineTag.NEWLINE_2), NewlineTag::create);
   private static final TagResolver ALL = TagResolver.builder()
       .resolvers(
         HOVER_EVENT,
@@ -76,7 +77,8 @@ public final class StandardTags {
         DECORATION,
         GRADIENT,
         RAINBOW,
-        RESET
+        RESET,
+        NEW_LINE
       )
       .build();
 
@@ -194,6 +196,18 @@ public final class StandardTags {
    */
   public static TagResolver reset() {
     return RESET;
+  }
+
+  /**
+   * Get a resolver for the {@value NewlineTag#NEWLINE} tag.
+   *
+   * <p>This tag also responds to {@value NewlineTag#NEWLINE_2}.</p>
+   *
+   * @return a resolver for the {@value NewlineTag#NEWLINE} tag.
+   * @since 4.10.0
+   */
+  public static TagResolver newline() {
+    return NEW_LINE;
   }
 
   /**

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -64,7 +64,7 @@ public final class StandardTags {
   private static final TagResolver GRADIENT = TagResolver.resolver(GradientTag.GRADIENT, GradientTag::create);
   private static final TagResolver RAINBOW = TagResolver.resolver(RainbowTag.RAINBOW, RainbowTag::create);
   private static final TagResolver RESET = TagResolver.resolver(RESET_TAG, ParserDirective.RESET);
-  private static final TagResolver NEW_LINE = TagResolver.resolver(names(NewlineTag.NEWLINE, NewlineTag.NEWLINE_2), NewlineTag::create);
+  private static final TagResolver NEWLINE = TagResolver.resolver(names(NewlineTag.NEWLINE, NewlineTag.NEWLINE_2), NewlineTag::create);
   private static final TagResolver ALL = TagResolver.builder()
       .resolvers(
         HOVER_EVENT,
@@ -78,7 +78,7 @@ public final class StandardTags {
         GRADIENT,
         RAINBOW,
         RESET,
-        NEW_LINE
+        NEWLINE
       )
       .build();
 
@@ -207,7 +207,7 @@ public final class StandardTags {
    * @since 4.10.0
    */
   public static TagResolver newline() {
-    return NEW_LINE;
+    return NEWLINE;
   }
 
   /**

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -1711,4 +1711,18 @@ public class MiniMessageParserTest extends TestBase {
 
     assertEquals(expected, tree.toString());
   }
+
+  @Test
+  void testNewLine() {
+    final String input = "<red>Line<br><gray>break!";
+    final Component expected = Component.text().color(RED)
+      .append(
+        text("Line"),
+        Component.newline(),
+        text("break!", color(GRAY))
+      )
+      .build();
+
+    this.assertParsedEquals(expected, input);
+  }
 }


### PR DESCRIPTION
Previous problem is here https://github.com/KyoriPowered/adventure/issues/686 :

Sometimes it's not possible or a bad idea to use `\n` for a line break. Maybe your message storage doesn't support that (or you'd have to escape it there).

With this PR I want to add a `<br>` tag as alternative to \n. It'll replace `<br>` with the Component for a new line.