### PR TITLE
Allow parsing with custom Tag Resolvers

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -43,7 +43,7 @@ public interface Context {
    * Parses a MiniMessage string using all the settings of this context.
    *
    * @param message the message to parse
-   * @param resolvers additional tag resolvers
+   * @param resolvers additional tag resolvers, added to all other resolvers in this parse, but taking priority in the event of a name overlap
    * @return the parsed message
    * @since 4.10.0
    */

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.minimessage;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,10 +43,11 @@ public interface Context {
    * Parses a MiniMessage string using all the settings of this context.
    *
    * @param message the message to parse
+   * @param resolvers additional tag resolvers
    * @return the parsed message
    * @since 4.10.0
    */
-  @NotNull Component parse(final @NotNull String message);
+  @NotNull Component parse(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers);
 
   /**
    * Create a new parsing exception.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -39,15 +39,35 @@ import org.jetbrains.annotations.Nullable;
  */
 @ApiStatus.NonExtendable
 public interface Context {
+
   /**
-   * Parses a MiniMessage string using all the settings of this context.
+   * Deserializes a MiniMessage string using all the settings of this context.
+   *
+   * @param message the message to parse
+   * @return the parsed message
+   * @since 4.10.0
+   */
+  @NotNull Component deserialize(final @NotNull String message);
+
+  /**
+   * Deserializes a MiniMessage string using all the settings of this context.
+   *
+   * @param message the message to parse
+   * @param resolver additional tag resolver, added to all other resolvers in this parse, but taking priority in the event of a name overlap
+   * @return the parsed message
+   * @since 4.10.0
+   */
+  @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver resolver);
+
+  /**
+   * Deserializes a MiniMessage string using all the settings of this context.
    *
    * @param message the message to parse
    * @param resolvers additional tag resolvers, added to all other resolvers in this parse, but taking priority in the event of a name overlap
    * @return the parsed message
    * @since 4.10.0
    */
-  @NotNull Component parse(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers);
+  @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers);
 
   /**
    * Create a new parsing exception.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -106,9 +106,20 @@ class ContextImpl implements Context {
   }
 
   @Override
-  public @NotNull Component parse(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers) {
+  public @NotNull Component deserialize(final @NotNull String message) {
+    return this.miniMessage.deserialize(requireNonNull(message, "message"), this.tagResolver);
+  }
+
+  @Override
+  public @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver resolver) {
     return this.miniMessage.deserialize(requireNonNull(message, "message"),
-      TagResolver.builder().resolver(this.tagResolver).resolvers(resolvers).build());
+      TagResolver.builder().resolver(this.tagResolver).resolver(requireNonNull(resolver, "resolver")).build());
+  }
+
+  @Override
+  public @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers) {
+    return this.miniMessage.deserialize(requireNonNull(message, "message"),
+      TagResolver.builder().resolver(this.tagResolver).resolvers(requireNonNull(resolvers, "resolvers")).build());
   }
 
   @Override

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -108,7 +108,7 @@ class ContextImpl implements Context {
   @Override
   public @NotNull Component parse(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers) {
     return this.miniMessage.deserialize(requireNonNull(message, "message"),
-      TagResolver.resolver(this.tagResolver, TagResolver.resolver(resolvers)));
+      TagResolver.builder().resolver(this.tagResolver).resolvers(resolvers).build());
   }
 
   @Override

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -106,8 +106,9 @@ class ContextImpl implements Context {
   }
 
   @Override
-  public @NotNull Component parse(final @NotNull String message) {
-    return this.miniMessage.deserialize(requireNonNull(message, "message"), this.tagResolver);
+  public @NotNull Component parse(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers) {
+    return this.miniMessage.deserialize(requireNonNull(message, "message"),
+      TagResolver.resolver(this.tagResolver, TagResolver.resolver(resolvers)));
   }
 
   @Override

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
@@ -54,7 +54,7 @@ public final class HoverTag {
     final HoverEvent.Action<Object> action = (HoverEvent.Action<Object>) HoverEvent.Action.NAMES.value(actionName);
     final Object value;
     if (action == (Object) HoverEvent.Action.SHOW_TEXT) {
-      value = ctx.parse(args.popOr("show_text action requires a message").value());
+      value = ctx.deserialize(args.popOr("show_text action requires a message").value());
     } else if (action == (Object) HoverEvent.Action.SHOW_ITEM) {
       value = parseShowItem(args, ctx);
     } else if (action == (Object) HoverEvent.Action.SHOW_ENTITY) {
@@ -85,7 +85,7 @@ public final class HoverTag {
       final Key key = Key.key(args.popOr("Show entity needs a type argument").value());
       final UUID id = UUID.fromString(args.popOr("Show entity needs an entity UUID").value());
       if (args.hasNext()) {
-        final Component name = context.parse(args.pop().value());
+        final Component name = context.deserialize(args.pop().value());
         return HoverEvent.ShowEntity.of(key, id, name);
       }
       return HoverEvent.ShowEntity.of(key, id);

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableTag.java
@@ -51,7 +51,7 @@ public final class TranslatableTag {
     if (args.hasNext()) {
       with = new ArrayList<>();
       while (args.hasNext()) {
-        with.add(ctx.parse(args.pop().value()));
+        with.add(ctx.deserialize(args.pop().value()));
       }
     } else {
       with = Collections.emptyList();

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/TagResolverTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/TagResolverTest.java
@@ -86,10 +86,6 @@ class TagResolverTest {
 
   @Test
   void testParseInResolver() {
-    final List<TagResolver> placeholders = Arrays.asList(
-      Placeholder.parsed("foo", "<red>Hello</red>"),
-      Placeholder.parsed("bar", "<yellow>World</yellow>")
-    );
     final Context ctx = TestBase.dummyContext("dummy text");
     final Component input = ctx.parse("<foo> <bar>",
       Placeholder.parsed("foo", "<red>Hello</red>"), Placeholder.parsed("bar", "<yellow>World</yellow>"));

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/TagResolverTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/TagResolverTest.java
@@ -85,16 +85,33 @@ class TagResolverTest {
   }
 
   @Test
-  void testParseInResolver() {
+  void testContextParseOne() {
     final Context ctx = TestBase.dummyContext("dummy text");
-    final Component input = ctx.parse("<foo> <bar>",
+    final Component input = ctx.deserialize("<foo> <bar><green>!</green>", Placeholder.parsed("foo", "<red>Hello</red>"));
+
+    final Component expected = Component.text()
+      .append(
+        text("Hello", color(NamedTextColor.RED)),
+        text(" <bar>"),
+        text("!", color(NamedTextColor.GREEN))
+      )
+      .build();
+
+    assertEquals(expected, input);
+  }
+
+  @Test
+  void testContextParseVarargs() {
+    final Context ctx = TestBase.dummyContext("dummy text");
+    final Component input = ctx.deserialize("<foo> <bar><green>!</green>",
       Placeholder.parsed("foo", "<red>Hello</red>"), Placeholder.parsed("bar", "<yellow>World</yellow>"));
 
     final Component expected = Component.text()
       .append(
         text("Hello", color(NamedTextColor.RED)),
         text(" "),
-        text("World", color(NamedTextColor.YELLOW))
+        text("World", color(NamedTextColor.YELLOW)),
+        text("!", color(NamedTextColor.GREEN))
       )
       .build();
 

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/TagResolverTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/TagResolverTest.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.text.minimessage.tag;
 import java.util.Arrays;
 import java.util.List;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.ParsingException;
 import net.kyori.adventure.text.minimessage.TestBase;
@@ -35,6 +36,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.TextColor.color;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -79,6 +82,27 @@ class TagResolverTest {
 
     // shared, resolver takes priority
     assertEquals("from resolver", ((PreProcess) resolveForTest(built, "overlapping")).value());
+  }
+
+  @Test
+  void testParseInResolver() {
+    final List<TagResolver> placeholders = Arrays.asList(
+      Placeholder.parsed("foo", "<red>Hello</red>"),
+      Placeholder.parsed("bar", "<yellow>World</yellow>")
+    );
+    final Context ctx = TestBase.dummyContext("dummy text");
+    final Component input = ctx.parse("<foo> <bar>",
+      Placeholder.parsed("foo", "<red>Hello</red>"), Placeholder.parsed("bar", "<yellow>World</yellow>"));
+
+    final Component expected = Component.text()
+      .append(
+        text("Hello", color(NamedTextColor.RED)),
+        text(" "),
+        text("World", color(NamedTextColor.YELLOW))
+      )
+      .build();
+
+    assertEquals(expected, input);
   }
 
   private static @NotNull Tag resolveForTest(final TagResolver resolver, final String tag) {


### PR DESCRIPTION
I want to create a new List tag to format lists.
My minimessage syntax is: `<list:'[entry format]':'[separator]>`

The entry format will have some placeholder tags so I modify the output of the list.
E.g.: `My unique list is: <list:'<red><name></red>':', '> - that's it.`

In java I would call:
```java
    miniMessage.deserialize(format, new ListResolver(Placeholder.parsed("name", "Joo200"), Placeholder.parsed("name", "MiniDigger")));
```

this should result in the output `My unique list is: Joo200, MiniDigger - that's it.`

Unfortunatly I'm unable to pass the Placeholder for "name" as TagResolver:
```java
    @Override
    public @Nullable Tag resolve(@NotNull String name, @NotNull ArgumentQueue arguments, @NotNull Context ctx) throws ParsingException {
        if (!this.has(name)) return null;

        String format = arguments.popOr("expected list format").value();
        String separator = arguments.popOr("expected separator").value();
        return Tag.inserting(resolvers.stream().map(r -> ctx.parse(format /*, r (this doesn't work)*/))
             .collect(Component.toComponent(ctx.parse(separator))));
    }
```

With this PR it should be possible to pass the Context dynamic Tag Resolvers. This would be really handy.