### PR TITLE
text-minimessage: Expose the root node type to API

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -165,7 +165,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.10.0
    */
-  @NotNull Node deserializeToTree(@NotNull String input);
+  Node.@NotNull Root deserializeToTree(final @NotNull String input);
 
   /**
    * Deserializes a string into a tree of parsed elements, with a tag resolver to parse tags of the form {@code <key>}.
@@ -178,7 +178,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.10.0
    */
-  @NotNull Node deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver);
+  Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver);
 
   /**
    * Deserializes a string into a tree of parsed elements, with a tag resolver to parse tags of the form {@code <key>}.
@@ -191,7 +191,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.10.0
    */
-  default @NotNull Node deserializeToTree(final @NotNull String input, final @NotNull TagResolver... tagResolvers) {
+  default Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull TagResolver... tagResolvers) {
     return this.deserializeToTree(input, TagResolver.resolver(tagResolvers));
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -82,12 +82,12 @@ final class MiniMessageImpl implements MiniMessage {
   }
 
   @Override
-  public @NotNull Node deserializeToTree(final @NotNull String input) {
+  public Node.@NotNull Root deserializeToTree(final @NotNull String input) {
     return this.parser.parseToTree(input, this.newContext(input, null));
   }
 
   @Override
-  public @NotNull Node deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver) {
+  public Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver) {
     return this.parser.parseToTree(input, this.newContext(input, requireNonNull(tagResolver, "tagResolver")));
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -37,6 +37,7 @@ import net.kyori.adventure.text.minimessage.parser.Token;
 import net.kyori.adventure.text.minimessage.parser.TokenParser;
 import net.kyori.adventure.text.minimessage.parser.TokenType;
 import net.kyori.adventure.text.minimessage.parser.node.ElementNode;
+import net.kyori.adventure.text.minimessage.parser.node.RootNode;
 import net.kyori.adventure.text.minimessage.parser.node.TagNode;
 import net.kyori.adventure.text.minimessage.parser.node.ValueNode;
 import net.kyori.adventure.text.minimessage.tag.Inserting;
@@ -116,7 +117,7 @@ final class MiniMessageParser {
     }
   }
 
-  @NotNull ElementNode parseToTree(final @NotNull String richMessage, final @NotNull ContextImpl context) {
+  @NotNull RootNode parseToTree(final @NotNull String richMessage, final @NotNull ContextImpl context) {
     final TagResolver combinedResolver = TagResolver.resolver(this.tagResolver, context.extraTags());
     final Consumer<String> debug = context.debugOutput();
     if (debug != null) {
@@ -185,7 +186,7 @@ final class MiniMessageParser {
     final String preProcessed = TokenParser.resolvePreProcessTags(richMessage, transformationFactory);
     context.message(preProcessed);
     // Then, once MiniMessage placeholders have been inserted, we can do the real parse
-    final ElementNode root = TokenParser.parse(transformationFactory, tagNameChecker, preProcessed, context.strict());
+    final RootNode root = TokenParser.parse(transformationFactory, tagNameChecker, preProcessed, richMessage, context.strict());
 
     if (debug != null) {
       debug.accept("Text parsed into element tree:\n");

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
@@ -71,22 +71,24 @@ public final class TokenParser {
    * @param tagProvider provides tags based on the available information
    * @param tagNameChecker checker for tag names, performing necessary tag normalization
    * @param message the minimessage string to parse, after processing for preprocess tags
+   * @param originalMessage the string to parse, before preprocess tags
    * @param strict whether parsing in strict mode
    * @return the root of the resulting tree
    * @throws ParsingException if invalid input is provided when in strict mode
    * @since 4.10.0
    */
-  public static ElementNode parse(
+  public static RootNode parse(
     final @NotNull TagProvider tagProvider,
     final @NotNull Predicate<String> tagNameChecker,
     final @NotNull String message,
+    final @NotNull String originalMessage,
     final boolean strict
   ) throws ParsingException {
     // collect tokens...
     final List<Token> tokens = tokenize(message);
 
     // then build the tree!
-    return buildTree(tagProvider, tagNameChecker, tokens, message, strict);
+    return buildTree(tagProvider, tagNameChecker, tokens, message, originalMessage, strict);
   }
 
   /**
@@ -344,14 +346,15 @@ public final class TokenParser {
   /*
    * Build a tree from the OPEN_TAG and CLOSE_TAG tokens
    */
-  private static ElementNode buildTree(
+  private static RootNode buildTree(
     final @NotNull TagProvider tagProvider,
     final @NotNull Predicate<String> tagNameChecker,
     final @NotNull List<Token> tokens,
     final @NotNull String message,
+    final @NotNull String originalMessage,
     final boolean strict
   ) throws ParsingException {
-    final RootNode root = new RootNode(message);
+    final RootNode root = new RootNode(message, originalMessage);
     ElementNode node = root;
 
     for (final Token token : tokens) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/node/RootNode.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/parser/node/RootNode.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.minimessage.parser.node;
 
+import net.kyori.adventure.text.minimessage.tree.Node;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -30,14 +31,23 @@ import org.jetbrains.annotations.NotNull;
  *
  * @since 4.10.0
  */
-public final class RootNode extends ElementNode {
+public final class RootNode extends ElementNode implements Node.Root {
+  private final String beforePreprocessing;
+
   /**
    * Creates a new root node.
    *
    * @param sourceMessage the source message
+   * @param beforePreprocessing the source message before handling preProcess tags
    * @since 4.10.0
    */
-  public RootNode(final @NotNull String sourceMessage) {
+  public RootNode(final @NotNull String sourceMessage, final @NotNull String beforePreprocessing) {
     super(null, null, sourceMessage);
+    this.beforePreprocessing = beforePreprocessing;
+  }
+
+  @Override
+  public @NotNull String input() {
+    return this.beforePreprocessing;
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tree/Node.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tree/Node.java
@@ -63,4 +63,19 @@ public interface Node {
    * @since 4.10.0
    */
   @Nullable Node parent();
+
+  /**
+   * The root node of a parse.
+   *
+   * @since 4.10.0
+   */
+  interface Root extends Node {
+    /**
+     * Get the original provided message which produced this node.
+     *
+     * @return the input message
+     * @since 4.10.0
+     */
+    @NotNull String input();
+  }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tree/Node.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tree/Node.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.minimessage.tree;
 
 import java.util.List;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @since 4.10.0
  */
+@ApiStatus.NonExtendable
 public interface Node {
   /**
    * Get a human-readable representation of this node and its descendants for debugging purposes.
@@ -69,6 +71,7 @@ public interface Node {
    *
    * @since 4.10.0
    */
+  @ApiStatus.NonExtendable
   interface Root extends Node {
     /**
      * Get the original provided message which produced this node.


### PR DESCRIPTION
This allows holding the node as a reference to the raw input string.

Eventually, I'd like to implement `ComponentLike` on Node.Root, but that will likely happen later -- this is just the minimum needed to avoid breaking changes later on.