### PR TITLE
text-minimessage: Add Placeholder to format Numbers and TemporalAccessors

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Tag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Tag.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.minimessage.tag;
 
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
@@ -215,22 +214,6 @@ public /* sealed */ interface Tag /* permits Inserting, Modifying, ParserDirecti
         return OptionalDouble.of(Double.parseDouble(this.value()));
       } catch (final NumberFormatException ex) {
         return OptionalDouble.empty();
-      }
-    }
-
-    /**
-     * Try to return this argument as a {@code char}.
-     *
-     * <p>The optional will only be present if the value is a valid char.</p>
-     *
-     * @return an optional providing the value of this argument as an integer
-     * @since 4.10.0
-     */
-    default @NotNull Optional<Character> asChar() {
-      if (this.value().length() == 1) {
-        return Optional.of(this.value().charAt(0));
-      } else {
-        return Optional.empty();
       }
     }
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Tag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Tag.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.minimessage.tag;
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
@@ -214,6 +215,22 @@ public /* sealed */ interface Tag /* permits Inserting, Modifying, ParserDirecti
         return OptionalDouble.of(Double.parseDouble(this.value()));
       } catch (final NumberFormatException ex) {
         return OptionalDouble.empty();
+      }
+    }
+
+    /**
+     * Try to return this argument as a {@code char}.
+     *
+     * <p>The optional will only be present if the value is a valid char.</p>
+     *
+     * @return an optional providing the value of this argument as an integer
+     * @since 4.10.0
+     */
+    default @NotNull Optional<Character> asChar() {
+      if (this.value().length() == 1) {
+        return Optional.of(this.value().charAt(0));
+      } else {
+        return Optional.empty();
       }
     }
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -47,9 +47,9 @@ public final class Formatter {
   /**
    * Creates a replacement that inserts a number as a component. The component will be formatted by the provided DecimalFormat.
    *
-   * <p>This tag expects a format as attribute. Refer to {@link DecimalFormat} for usable patterns.</p>
+   * <p>This tag accepts a locale, a format pattern, both or nothing as arguments. The locale has to be provided as first argument.</p>
    *
-   * <p>You can specify the decimal and grouping separator by adding those as another attribute.</p>
+   * <p>Refer to {@link Locale} for usable locale tags. Refer to {@link DecimalFormat} for usable patterns.</p>
    *
    * <p>This replacement is auto-closing, so its style will not influence the style of following components.</p>
    *
@@ -111,27 +111,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.11.0
    */
-  public static @NotNull TagResolver choice(final @NotNull String key, final long number) {
-    return TagResolver.resolver(key, ((argumentQueue, context) -> {
-      final String format = argumentQueue.popOr("Format expected.").value();
-      final ChoiceFormat choiceFormat = new ChoiceFormat(format);
-      return Tag.inserting(context.deserialize(choiceFormat.format(number)));
-    }));
-  }
-
-  /**
-   * Creates a replacement that inserts a choice formatted text. The component will be formatted by the provided ChoiceFormat.
-   *
-   * <p>This tag expectes a format as attribute. Refer to {@link ChoiceFormat} for usable patterns.</p>
-   *
-   * <p>This replacement is auto-closing, so its style will not influence the style of following components.</p>
-   *
-   * @param key the key
-   * @param number the number
-   * @return the placeholder
-   * @since 4.11.0
-   */
-  public static @NotNull TagResolver choice(final @NotNull String key, final double number) {
+  public static @NotNull TagResolver choice(final @NotNull String key, final Number number) {
     return TagResolver.resolver(key, ((argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
       final ChoiceFormat choiceFormat = new ChoiceFormat(format);

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -114,11 +114,10 @@ public final class Formatter {
   public static TagResolver choice(final @NotNull String key, final long number) {
     return TagResolver.resolver(key, ((argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
-      ChoiceFormat choiceFormat = new ChoiceFormat(format);
+      final ChoiceFormat choiceFormat = new ChoiceFormat(format);
       return Tag.inserting(context.deserialize(choiceFormat.format(number)));
     }));
   }
-
 
   /**
    * Creates a replacement that inserts a choice formatted text. The component will be formatted by the provided ChoiceFormat.
@@ -135,7 +134,7 @@ public final class Formatter {
   public static TagResolver choice(final @NotNull String key, final double number) {
     return TagResolver.resolver(key, ((argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
-      ChoiceFormat choiceFormat = new ChoiceFormat(format);
+      final ChoiceFormat choiceFormat = new ChoiceFormat(format);
       return Tag.inserting(context.deserialize(choiceFormat.format(number)));
     }));
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.resolver;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Tag resolvers producing tags that insert formatted values.
+ *
+ * <p>These are effectively placeholders.</p>
+ *
+ * @since 4.10.0
+ */
+public final class Formatter {
+  private Formatter() {
+  }
+
+  /**
+   * Creates a replacement that inserts a number as a component. The component will be formatted by the provided DecimalFormat.
+   *
+   * <p>This tag expects a format as attribute. Refer to {@link DecimalFormat} for usable patterns.</p>
+   *
+   * <p>You can specify the decimal and grouping separator by adding those as another attribute.</p>
+   *
+   * <p>This replacement is auto-closing, so its style will not influence the style of following components.</p>
+   *
+   * @param key the key
+   * @param number the number
+   * @return the placeholder
+   * @since 4.10.0
+   */
+  public static TagResolver formatNumber(final @NotNull String key, final Number number) {
+    return TagResolver.resolver(key, (argumentQueue, context) -> {
+      final NumberFormat decimalFormat;
+      if (argumentQueue.hasNext()) {
+        final String locale = argumentQueue.pop().value();
+        if (argumentQueue.hasNext()) {
+          final String format = argumentQueue.pop().value();
+          decimalFormat = new DecimalFormat(format, new DecimalFormatSymbols(Locale.forLanguageTag(locale)));
+        } else {
+          if (locale.contains(".")) {
+            decimalFormat = new DecimalFormat(locale, DecimalFormatSymbols.getInstance());
+          } else {
+            decimalFormat = DecimalFormat.getInstance(Locale.forLanguageTag(locale));
+          }
+        }
+      } else {
+        decimalFormat = DecimalFormat.getInstance();
+      }
+      return Tag.inserting(context.deserialize(decimalFormat.format(number)));
+    });
+  }
+
+  /**
+   * Creates a replacement that inserts a date or a time as a component. The component will be formatted by the provided Date Format.
+   *
+   * <p>This tag expects a format as attribute. Refer to {@link DateTimeFormatter} for usable patterns.</p>
+   *
+   * <p>This replacement is auto-closing, so its style will not influence the style of following components.</p>
+   *
+   * @param key the key
+   * @param time the time
+   * @return the placeholder
+   * @since 4.10.0
+   */
+  public static TagResolver formatDate(final @NotNull String key, final TemporalAccessor time) {
+    return TagResolver.resolver(key, (argumentQueue, context) -> {
+      final String format = argumentQueue.popOr("Format expected.").value();
+      return Tag.inserting(context.deserialize(DateTimeFormatter.ofPattern(format).format(time)));
+    });
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.minimessage.tag.resolver;
 
+import java.text.ChoiceFormat;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
@@ -37,7 +38,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p>These are effectively placeholders.</p>
  *
- * @since 4.10.0
+ * @since 4.11.0
  */
 public final class Formatter {
   private Formatter() {
@@ -55,9 +56,9 @@ public final class Formatter {
    * @param key the key
    * @param number the number
    * @return the placeholder
-   * @since 4.10.0
+   * @since 4.11.0
    */
-  public static TagResolver formatNumber(final @NotNull String key, final Number number) {
+  public static TagResolver number(final @NotNull String key, final @NotNull Number number) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final NumberFormat decimalFormat;
       if (argumentQueue.hasNext()) {
@@ -89,12 +90,53 @@ public final class Formatter {
    * @param key the key
    * @param time the time
    * @return the placeholder
-   * @since 4.10.0
+   * @since 4.11.0
    */
-  public static TagResolver formatDate(final @NotNull String key, final TemporalAccessor time) {
+  public static TagResolver date(final @NotNull String key, final @NotNull TemporalAccessor time) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
       return Tag.inserting(context.deserialize(DateTimeFormatter.ofPattern(format).format(time)));
     });
+  }
+
+  /**
+   * Creates a replacement that inserts a choice formatted text. The component will be formatted by the provided ChoiceFormat.
+   *
+   * <p>This tag expectes a format as attribute. Refer to {@link ChoiceFormat} for usable patterns.</p>
+   *
+   * <p>This replacement is auto-closing, so its style will not influence the style of following components.</p>
+   *
+   * @param key the key
+   * @param number the number
+   * @return the placeholder
+   * @since 4.11.0
+   */
+  public static TagResolver choice(final @NotNull String key, final long number) {
+    return TagResolver.resolver(key, ((argumentQueue, context) -> {
+      final String format = argumentQueue.popOr("Format expected.").value();
+      ChoiceFormat choiceFormat = new ChoiceFormat(format);
+      return Tag.inserting(context.deserialize(choiceFormat.format(number)));
+    }));
+  }
+
+
+  /**
+   * Creates a replacement that inserts a choice formatted text. The component will be formatted by the provided ChoiceFormat.
+   *
+   * <p>This tag expectes a format as attribute. Refer to {@link ChoiceFormat} for usable patterns.</p>
+   *
+   * <p>This replacement is auto-closing, so its style will not influence the style of following components.</p>
+   *
+   * @param key the key
+   * @param number the number
+   * @return the placeholder
+   * @since 4.11.0
+   */
+  public static TagResolver choice(final @NotNull String key, final double number) {
+    return TagResolver.resolver(key, ((argumentQueue, context) -> {
+      final String format = argumentQueue.popOr("Format expected.").value();
+      ChoiceFormat choiceFormat = new ChoiceFormat(format);
+      return Tag.inserting(context.deserialize(choiceFormat.format(number)));
+    }));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -58,7 +58,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.11.0
    */
-  public static TagResolver number(final @NotNull String key, final @NotNull Number number) {
+  public static @NotNull TagResolver number(final @NotNull String key, final @NotNull Number number) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final NumberFormat decimalFormat;
       if (argumentQueue.hasNext()) {
@@ -92,7 +92,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.11.0
    */
-  public static TagResolver date(final @NotNull String key, final @NotNull TemporalAccessor time) {
+  public static @NotNull TagResolver date(final @NotNull String key, final @NotNull TemporalAccessor time) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
       return Tag.inserting(context.deserialize(DateTimeFormatter.ofPattern(format).format(time)));
@@ -111,7 +111,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.11.0
    */
-  public static TagResolver choice(final @NotNull String key, final long number) {
+  public static @NotNull TagResolver choice(final @NotNull String key, final long number) {
     return TagResolver.resolver(key, ((argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
       final ChoiceFormat choiceFormat = new ChoiceFormat(format);
@@ -131,7 +131,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.11.0
    */
-  public static TagResolver choice(final @NotNull String key, final double number) {
+  public static @NotNull TagResolver choice(final @NotNull String key, final double number) {
     return TagResolver.resolver(key, ((argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
       final ChoiceFormat choiceFormat = new ChoiceFormat(format);

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/FormatterTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/FormatterTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.formatDate;
+import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.formatNumber;
+
+public class FormatterTest extends AbstractTest {
+  @Test
+  void testNumberFormatter() {
+    final String input = "<mynumber:'en-EN':'#.00'> is a nice number";
+    final Component expected = text("20.00 is a nice number");
+
+    this.assertParsedEquals(
+      expected,
+      input,
+      formatNumber("mynumber", 20d)
+    );
+  }
+
+  @Test
+  void testNumberFormatterLang() {
+    final String input = "<mynumber:'de-DE':'#.00'> is a nice number";
+    final Component expected = text("20,00 is a nice number");
+
+    this.assertParsedEquals(
+      expected,
+      input,
+      formatNumber("mynumber", 20d)
+    );
+  }
+
+  @Test
+  void testNumberFormatterWithDecimal() {
+    final String input = "<double:'de-DE':'#,##0.00'> is a nice number";
+    final Component expected = text("2.000,00 is a nice number");
+
+    this.assertParsedEquals(
+      expected,
+      input,
+      formatNumber("double", 2000d)
+    );
+  }
+
+  @Test
+  void testNumberFormatterNegative() {
+    final String input = "<double:'en-EN':'<green>#.00;<red>-#.00'><blue> is a nice number";
+    final Component expectedNegative = text("-5.00", NamedTextColor.RED).append(text(" is a nice number", NamedTextColor.BLUE));
+    final Component expectedPositive = text("5.00", NamedTextColor.GREEN).append(text(" is a nice number", NamedTextColor.BLUE));
+
+    this.assertParsedEquals(
+      expectedNegative,
+      input,
+      formatNumber("double", -5)
+    );
+    this.assertParsedEquals(
+      expectedPositive,
+      input,
+      formatNumber("double", 5)
+    );
+  }
+
+  @Test
+  void testDateFormatter() {
+    final String input = "<date:'yyyy-MM-dd HH:mm:ss'> is a date";
+    final Component expected = text("2022-02-26 21:00:00 is a date");
+
+    this.assertParsedEquals(
+      expected,
+      input,
+      formatDate("date", LocalDateTime.of(2022, Month.FEBRUARY, 26, 21, 0, 0))
+    );
+  }
+}

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/FormatterTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/FormatterTest.java
@@ -31,8 +31,9 @@ import net.kyori.adventure.text.minimessage.AbstractTest;
 import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.formatDate;
-import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.formatNumber;
+import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.choice;
+import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.date;
+import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.number;
 
 public class FormatterTest extends AbstractTest {
   @Test
@@ -43,7 +44,7 @@ public class FormatterTest extends AbstractTest {
     this.assertParsedEquals(
       expected,
       input,
-      formatNumber("mynumber", 20d)
+      number("mynumber", 20d)
     );
   }
 
@@ -55,7 +56,7 @@ public class FormatterTest extends AbstractTest {
     this.assertParsedEquals(
       expected,
       input,
-      formatNumber("mynumber", 20d)
+      number("mynumber", 20d)
     );
   }
 
@@ -67,7 +68,7 @@ public class FormatterTest extends AbstractTest {
     this.assertParsedEquals(
       expected,
       input,
-      formatNumber("double", 2000d)
+      number("double", 2000d)
     );
   }
 
@@ -80,12 +81,12 @@ public class FormatterTest extends AbstractTest {
     this.assertParsedEquals(
       expectedNegative,
       input,
-      formatNumber("double", -5)
+      number("double", -5)
     );
     this.assertParsedEquals(
       expectedPositive,
       input,
-      formatNumber("double", 5)
+      number("double", 5)
     );
   }
 
@@ -97,7 +98,23 @@ public class FormatterTest extends AbstractTest {
     this.assertParsedEquals(
       expected,
       input,
-      formatDate("date", LocalDateTime.of(2022, Month.FEBRUARY, 26, 21, 0, 0))
+      date("date", LocalDateTime.of(2022, Month.FEBRUARY, 26, 21, 0, 0))
     );
+  }
+
+  @Test
+  void testChoiceFormatter() {
+    final String input = "<choice:'-2#is small|-1#minus one|0#zero|1#one|1<is big'> result";
+    final Component verySmall = text("is small result");
+    final Component minusOne = text("minus one result");
+    final Component zero = text("zero result");
+    final Component one = text("one result");
+    final Component bigResult = text("is big result");
+
+    this.assertParsedEquals(verySmall, input, choice("choice", -5));
+    this.assertParsedEquals(minusOne, input, choice("choice", -1));
+    this.assertParsedEquals(zero, input, choice("choice", 0));
+    this.assertParsedEquals(one, input, choice("choice", 1));
+    this.assertParsedEquals(bigResult, input, choice("choice", 2));
   }
 }


### PR DESCRIPTION
It might be a good idea to have a decent way of formatting Numbers and Dates.
Currently I have to use `miniMessage.deserialize("Number is <no>", Placeholder.unparsed("no", String.valueOf(doubleValue)));`

Would be nice if it could be smth like `miniMessage.deserialize("Number is <no:'de-DE':'#,00'>, Formatter.formatNumber("no", doubleValue));` where `#,00` is the DecimalFormat used to convert the number and `de-DE` is the locale tag.

Same thing for Formats for Date, Time and both combined. `(miniMessage.deserialize("Date is <date:'YYYY-MM-DD'>", Placeholder.formatDate("date", myDateAsInstant)))`

This PR should add those things to Placeholders. It works already fine.
However I want to add fallback values to formatDate and formatNumber. Better display a "bad" formatted message than nothing.

Possible things:

- `<number:'locale':'format'>`
- `<number:'format'>`
- `<number:'locale'>`
- `<date:'pattern'>`

Missing stuff:

- [x] Pull Request for Docs
- [x] Fallback Value for the DecimalFormat
- [x] Fallback Value for the DateFormatter
- [x] Better determination whether a string is a locale or the format for the DecimalFormat