### PR TITLE
text-minimessage: Expose start/end indices on parsing exceptions

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ParsingException.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ParsingException.java
@@ -68,6 +68,16 @@ public abstract class ParsingException extends RuntimeException {
   public abstract @NotNull String originalText();
 
   /**
+   * Get the detail message optionally passed with this exception.
+   *
+   * <p>Unlike {@link #getMessage()}, this method does not include location information.</p>
+   *
+   * @return the detail message passed to this exception
+   * @since 4.10.0
+   */
+  public abstract @Nullable String detailMessage();
+
+  /**
    * Get the start index of the location which caused this exception.
    *
    * <p>This index is an index into {@link #originalText()}. If location is unknown, {@link #LOCATION_UNKNOWN} will be returned instead.</p>

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ParsingException.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ParsingException.java
@@ -23,13 +23,20 @@
  */
 package net.kyori.adventure.text.minimessage;
 
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * An exception thrown when an error occurs while parsing a MiniMessage string.
  *
  * @since 4.10.0
  */
+@ApiStatus.NonExtendable
 public abstract class ParsingException extends RuntimeException {
   private static final long serialVersionUID = 4502774670340827070L;
+
+  public static final int LOCATION_UNKNOWN = -1;
 
   /**
    * Create a new parsing exception with only a message.
@@ -37,7 +44,7 @@ public abstract class ParsingException extends RuntimeException {
    * @param message a detail message describing the error
    * @since 4.10.0
    */
-  protected ParsingException(final String message) {
+  protected ParsingException(final @Nullable String message) {
     super(message);
   }
 
@@ -48,7 +55,7 @@ public abstract class ParsingException extends RuntimeException {
    * @param cause the cause
    * @since 4.10.0
    */
-  protected ParsingException(final String message, final Throwable cause) {
+  protected ParsingException(final @Nullable String message, final @Nullable Throwable cause) {
     super(message, cause);
   }
 
@@ -58,5 +65,25 @@ public abstract class ParsingException extends RuntimeException {
    * @return the original input message
    * @since 4.10.0
    */
-  public abstract String originalText();
+  public abstract @NotNull String originalText();
+
+  /**
+   * Get the start index of the location which caused this exception.
+   *
+   * <p>This index is an index into {@link #originalText()}. If location is unknown, {@link #LOCATION_UNKNOWN} will be returned instead.</p>
+   *
+   * @return the start index
+   * @since 4.10.0
+   */
+  public abstract int startIndex();
+
+  /**
+   * Get the end index of the location which caused this exception.
+   *
+   * <p>This index is an index into {@link #originalText()}. If location is unknown, {@link #LOCATION_UNKNOWN} will be returned instead.</p>
+   *
+   * @return the end index
+   * @since 4.10.0
+   */
+  public abstract int endIndex();
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/ParsingExceptionImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/ParsingExceptionImpl.java
@@ -45,7 +45,7 @@ public class ParsingExceptionImpl extends ParsingException {
    * Create a new parsing exception.
    *
    * @param message the detail message
-   * @param originalText the origina text which was parsed
+   * @param originalText the original text which was parsed
    * @param tokens the token which caused the error
    * @since 4.10.0
    */
@@ -141,4 +141,15 @@ public class ParsingExceptionImpl extends ParsingException {
     return this;
   }
 
+  @Override
+  public int startIndex() {
+    if (this.tokens.length == 0) return LOCATION_UNKNOWN;
+    return this.tokens[0].startIndex();
+  }
+
+  @Override
+  public int endIndex() {
+    if (this.tokens.length == 0) return LOCATION_UNKNOWN;
+    return this.tokens[this.tokens.length - 1].endIndex();
+  }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/ParsingExceptionImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/ParsingExceptionImpl.java
@@ -90,6 +90,11 @@ public class ParsingExceptionImpl extends ParsingException {
     return super.getMessage() + messageInfo;
   }
 
+  @Override
+  public @Nullable String detailMessage() {
+    return super.getMessage();
+  }
+
   /**
    * Get the message which caused this exception.
    *


### PR DESCRIPTION
This allows, for example, command libraries to get the actual index where parsing failed when reporting errors.

(note before this is actually merged: would be nice to expose the raw exception message, not just the one formatted with location information)