### PR TITLE
text-minimessage: Limit characters allowed in tag names

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/TagInternals.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/TagInternals.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.internal;
+
+import java.util.Locale;
+import java.util.Objects;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Utility class for tag naming.
+ *
+ * @since 4.10.0
+ */
+@ApiStatus.Internal
+public final class TagInternals {
+  private static final String TAG_NAME_PATTERN = "[!?#]?[a-z0-9_-]*";
+
+  private TagInternals() {
+  }
+
+  /**
+   * Checks if a tag name matches the pattern for allowed tag names. If it does not, then
+   * this method will throw an {@link IllegalArgumentException}
+   *
+   * @param tagName the name of the tag
+   * @since 4.10.0
+   */
+  public static void checkTagName(final @NotNull String tagName) {
+    if (!Objects.requireNonNull(tagName).matches(TAG_NAME_PATTERN)) {
+      throw new IllegalArgumentException("Tag name must match pattern " + TAG_NAME_PATTERN + ", was " + tagName);
+    }
+  }
+
+  /**
+   * Checks if a tag name matches the pattern for allowed tag names, first sanitizing it
+   * by converting the tag name to lowercase. If it does not match the pattern, then this
+   * method will throw an {@link IllegalArgumentException}
+   *
+   * @param tagName the name of the tag
+   * @since 4.10.0
+   */
+  public static void sanitizeAndCheckTagName(final @NotNull String tagName) {
+    checkTagName(Objects.requireNonNull(tagName).toLowerCase(Locale.ROOT));
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/TagInternals.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/TagInternals.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.minimessage.internal;
 
 import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,7 +36,7 @@ import org.jetbrains.annotations.NotNull;
  */
 @ApiStatus.Internal
 public final class TagInternals {
-  private static final String TAG_NAME_PATTERN = "[!?#]?[a-z0-9_-]*";
+  private static final Pattern TAG_NAME_PATTERN = Pattern.compile("[!?#]?[a-z0-9_-]*");
 
   private TagInternals() {
   }
@@ -48,8 +49,8 @@ public final class TagInternals {
    * @since 4.10.0
    */
   public static void checkTagName(final @NotNull String tagName) {
-    if (!Objects.requireNonNull(tagName).matches(TAG_NAME_PATTERN)) {
-      throw new IllegalArgumentException("Tag name must match pattern " + TAG_NAME_PATTERN + ", was " + tagName);
+    if (!TAG_NAME_PATTERN.matcher(Objects.requireNonNull(tagName)).matches()) {
+      throw new IllegalArgumentException("Tag name must match pattern " + TAG_NAME_PATTERN.pattern() + ", was " + tagName);
     }
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TagNode.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TagNode.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.text.minimessage.internal.parser.node;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.internal.parser.ParsingExceptionImpl;
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenParser;
@@ -59,6 +60,18 @@ public final class TagNode extends ElementNode {
   ) {
     super(parent, token, sourceMessage);
     this.parts = genParts(token, sourceMessage, tagProvider);
+
+    // Assert the tag node has parts.
+    if (this.parts.isEmpty()) {
+      throw new ParsingExceptionImpl("Tag has no parts? " + this, this.sourceMessage(), this.token());
+    }
+
+    // Then assert the tag node has a proper name.
+    try {
+      TagInternals.sanitizeAndCheckTagName(this.name());
+    } catch (final IllegalArgumentException | NullPointerException e) {
+      throw new ParsingExceptionImpl("Invalid tag name " + this.name(), this.sourceMessage(), e, this.token());
+    }
   }
 
   private static @NotNull List<TagPart> genParts(
@@ -94,9 +107,6 @@ public final class TagNode extends ElementNode {
    * @since 4.10.0
    */
   public @NotNull String name() {
-    if (this.parts.isEmpty()) {
-      throw new ParsingExceptionImpl("Tag has no parts? " + this, this.sourceMessage(), this.token());
-    }
     return this.parts.get(0).value();
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/SerializableResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/SerializableResolver.java
@@ -25,14 +25,13 @@ package net.kyori.adventure.text.minimessage.internal.serializer;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -72,7 +71,7 @@ public interface SerializableResolver {
   static @NotNull TagResolver claimingComponent(final @NotNull Set<String> names, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler, final @NotNull Function<Component, @Nullable Emitable> componentClaim) {
     final Set<String> ownNames = new HashSet<>(names);
     for (final String name : ownNames) {
-      checkKey(name);
+      TagInternals.checkTagName(name);
     }
     requireNonNull(handler, "handler");
     return new ComponentClaimingResolverImpl(ownNames, handler, componentClaim);
@@ -103,24 +102,10 @@ public interface SerializableResolver {
   static @NotNull TagResolver claimingStyle(final @NotNull Set<String> names, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler, final @NotNull StyleClaim<?> styleClaim) {
     final Set<String> ownNames = new HashSet<>(names);
     for (final String name : ownNames) {
-      checkKey(name);
+      TagInternals.checkTagName(name);
     }
     requireNonNull(handler, "handler");
     return new StyleClaimingResolverImpl(ownNames, handler, styleClaim);
-  }
-
-  /**
-   * Check a key.
-   *
-   * <p>Temporary copy of {@code SingleResolver#checkKey(String)} until we have a better idea.</p>
-   *
-   * @param key the key
-   * @since 4.10.0
-   */
-  static void checkKey(final @NotNull String key) {
-    if (!Objects.requireNonNull(key, "key").equals(key.toLowerCase(Locale.ROOT))) {
-      throw new IllegalArgumentException("key must be lowercase, was " + key);
-    }
   }
 
   /**

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SingleResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SingleResolver.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.adventure.text.minimessage.tag.resolver;
 
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import net.kyori.adventure.text.minimessage.tag.Tag;
@@ -32,12 +31,6 @@ import org.jetbrains.annotations.NotNull;
 final class SingleResolver implements TagResolver.Single, MappableResolver {
   private final String key;
   private final Tag tag;
-
-  static void checkKey(final @NotNull String key) {
-    if (!Objects.requireNonNull(key, "key").equals(key.toLowerCase(Locale.ROOT))) {
-      throw new IllegalArgumentException("key must be lowercase, was " + key);
-    }
-  }
 
   SingleResolver(final String key, final Tag tag) {
     this.key = key;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/TagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/TagResolver.java
@@ -32,6 +32,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collector;
 import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import org.jetbrains.annotations.ApiStatus;
@@ -91,7 +92,7 @@ public interface TagResolver {
    * @since 4.10.0
    */
   static TagResolver.@NotNull Single resolver(final @NotNull String name, final @NotNull Tag tag) {
-    SingleResolver.checkKey(name);
+    TagInternals.checkTagName(name);
     return new SingleResolver(
       name,
       requireNonNull(tag, "tag")
@@ -121,7 +122,7 @@ public interface TagResolver {
   static @NotNull TagResolver resolver(final @NotNull Set<String> names, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler) {
     final Set<String> ownNames = new HashSet<>(names);
     for (final String name : ownNames) {
-      SingleResolver.checkKey(name);
+      TagInternals.checkTagName(name);
     }
     requireNonNull(handler, "handler");
 

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -200,7 +200,7 @@ public class MiniMessageTest extends AbstractTest {
     final Component expected = text("A")
       .append(text("B"))
       .append(text("C"));
-    final String input = "<a><b><_c>";
+    final String input = "<a><b><!c>";
     final MiniMessage miniMessage = MiniMessage.miniMessage();
 
     this.assertParsedEquals(
@@ -209,7 +209,7 @@ public class MiniMessageTest extends AbstractTest {
       input,
       component("a", text("A")),
       component("b", text("B")),
-      component("_c", text("C"))
+      component("!c", text("C"))
     );
   }
 

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/TagResolverTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/TagResolverTest.java
@@ -38,8 +38,10 @@ import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.format.TextColor.color;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class TagResolverTest {
@@ -116,6 +118,24 @@ class TagResolverTest {
       .build();
 
     assertEquals(expected, input);
+  }
+
+  @Test
+  void testInvalidTagName() {
+    assertThrows(IllegalArgumentException.class, () -> TagResolver.resolver("INVALID_NAME", Tag.preProcessParsed("something")));
+    assertThrows(IllegalArgumentException.class, () -> TagResolver.resolver("!invalid!", Tag.preProcessParsed("something")));
+    assertThrows(IllegalArgumentException.class, () -> TagResolver.resolver("???", Tag.preProcessParsed("something")));
+    assertThrows(IllegalArgumentException.class, () -> TagResolver.resolver("#test#", Tag.preProcessParsed("something")));
+  }
+
+  @Test
+  void testValidTagName() {
+    assertDoesNotThrow(() -> TagResolver.resolver("valid_-name0909", Tag.preProcessParsed("something")));
+    assertDoesNotThrow(() -> TagResolver.resolver("!valid", Tag.preProcessParsed("something")));
+    assertDoesNotThrow(() -> TagResolver.resolver("?valid", Tag.preProcessParsed("something")));
+    assertDoesNotThrow(() -> TagResolver.resolver("#valid", Tag.preProcessParsed("something")));
+    assertDoesNotThrow(() -> TagResolver.resolver("valid99", Tag.preProcessParsed("something")));
+    assertDoesNotThrow(() -> TagResolver.resolver("v_9_v", Tag.preProcessParsed("something")));
   }
 
   private static @NotNull Tag resolveForTest(final TagResolver resolver, final String tag) {


### PR DESCRIPTION
Limits tag names to the pattern `[!?#]?[a-z0-9_-]*`.

Or, in plain text:
> Tag names must only contain the characters a-z, 0-9, `_`, and `-`. They can also optionally start with any of the following characters: `!?#`.