### PR TITLE
fix negative number parsing for positions

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
@@ -326,8 +326,8 @@ final class BlockNBTComponentImpl extends NBTComponentImpl<BlockNBTComponent, Bl
   }
 
   static final class Tokens {
-    static final Pattern LOCAL_PATTERN = Pattern.compile("^\\^(\\d+(\\.\\d+)?) \\^(\\d+(\\.\\d+)?) \\^(\\d+(\\.\\d+)?)$");
-    static final Pattern WORLD_PATTERN = Pattern.compile("^(~?)(\\d+) (~?)(\\d+) (~?)(\\d+)$");
+    static final Pattern LOCAL_PATTERN = Pattern.compile("^\\^(-?\\d+(\\.\\d+)?) \\^(-?\\d+(\\.\\d+)?) \\^(-?\\d+(\\.\\d+)?)$");
+    static final Pattern WORLD_PATTERN = Pattern.compile("^(~?)(-?\\d+) (~?)(-?\\d+) (~?)(-?\\d+)$");
 
     static final String LOCAL_SYMBOL = "^";
     static final String RELATIVE_SYMBOL = "~";

--- a/api/src/test/java/net/kyori/adventure/text/BlockNBTComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/BlockNBTComponentTest.java
@@ -115,4 +115,20 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
       BlockNBTComponent.Pos.fromString("12 ~3 1200")
     );
   }
+
+  @Test
+  void testLocalPosParsingWithNegatives() {
+    assertEquals(
+      BlockNBTComponent.LocalPos.localPos(-4.5, 3, -35.67),
+      BlockNBTComponent.Pos.fromString("^-4.5 ^3 ^-35.67")
+    );
+  }
+
+  @Test
+  void testWorldPosParsingWithNegatives() {
+    assertEquals(
+      BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.relative(-6), BlockNBTComponent.WorldPos.Coordinate.absolute(-34), BlockNBTComponent.WorldPos.Coordinate.relative(13)),
+      BlockNBTComponent.Pos.fromString("~-6 -34 ~13")
+    );
+  }
 }


### PR DESCRIPTION
Parsing of positions failed to account for negative numbers which according to Minecraft's parsing of these positions should be accounted for.