### PR TITLE
Cache component's hashcode for faster equality check

### DIFF
--- a/api/src/jmh/java/net/kyori/adventure/text/ComponentEqualityBenchmark.java
+++ b/api/src/jmh/java/net/kyori/adventure/text/ComponentEqualityBenchmark.java
@@ -1,0 +1,103 @@
+package net.kyori.adventure.text;
+
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+import static net.kyori.adventure.key.Key.key;
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.Style.style;
+
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class ComponentEqualityBenchmark {
+
+  Component component1;
+  Component componentAlmost;
+  Component component2;
+
+  Component component3;
+
+  @Setup
+  public void setup() {
+    component1 = create1();
+    componentAlmost = createAlmost1();
+    component2 = create1();
+
+    component3 = create2();
+  }
+
+  @Benchmark
+  public void constantEquals(final Blackhole blackhole) {
+    blackhole.consume(component1.equals(component2));
+  }
+
+  @Benchmark
+  public void constantAlmostEquals(final Blackhole blackhole) {
+    blackhole.consume(component1.equals(componentAlmost));
+  }
+
+  @Benchmark
+  public void constantNotEquals(final Blackhole blackhole) {
+    blackhole.consume(component1.equals(component3));
+  }
+
+  @Benchmark
+  public void singleConstantEquals(final Blackhole blackhole) {
+    blackhole.consume(component1.equals(create1()));
+  }
+
+  @Benchmark
+  public void singleConstantNotEqual(final Blackhole blackhole) {
+    blackhole.consume(component1.equals(create2()));
+  }
+
+  Component create1() {
+    return text().content("Hello ")
+      .style(style(NamedTextColor.RED, TextDecoration.BOLD, TextDecoration.OBFUSCATED))
+      .append(text("World! "))
+      .append(text("What a ", NamedTextColor.RED))
+      .append(text(c -> c.content("beautiful day ")
+        .color(NamedTextColor.BLUE)
+        .append(text("to create ", style(TextDecoration.ITALIC)))
+        .append(text("a PR ", style(TextDecoration.BOLD)))
+        .append(text("on Adventure!"))
+      ))
+      .build();
+  }
+
+  Component createAlmost1() {
+    return text().content("Hello ")
+      .style(style(NamedTextColor.RED, TextDecoration.BOLD, TextDecoration.OBFUSCATED))
+      .append(text("World! "))
+      .append(text("What a ", NamedTextColor.RED))
+      .append(text(c -> c.content("beautiful day ")
+        .color(NamedTextColor.BLUE)
+        .append(text("to create ", style(TextDecoration.ITALIC)))
+        .append(text("a PR ", style(TextDecoration.BOLD)))
+        .append(text("on GitHub!"))
+      ))
+      .build();
+  }
+
+  Component create2() {
+    Style simpleScenarioStyle = style()
+      .color(NamedTextColor.AQUA)
+      .font(key("uniform"))
+      .decorate(TextDecoration.BOLD, TextDecoration.ITALIC)
+      .build();
+    return text()
+      .content("Hello ")
+      .style(simpleScenarioStyle)
+      .append(text("World!", style(TextDecoration.BOLD).font(key("uniform"))))
+      .build();
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -59,6 +59,10 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
 
   private final String content;
 
+  // hashCode cache
+  private int code;
+  private boolean cached;
+
   TextComponentImpl(final @NotNull List<Component> children, final @NotNull Style style, final @NotNull String content) {
     super(children, style);
     this.content = content;
@@ -104,16 +108,29 @@ final class TextComponentImpl extends AbstractComponent implements TextComponent
   public boolean equals(final @Nullable Object other) {
     if (this == other) return true;
     if (!(other instanceof TextComponentImpl)) return false;
-    if (!super.equals(other)) return false;
     final TextComponentImpl that = (TextComponentImpl) other;
+    // Fast exit for constant components
+    {
+      final boolean cached = this.cached;
+      final boolean thatCached = that.cached;
+      if (!cached) this.cached = true;
+      if (!thatCached) that.cached = true;
+      if (cached && thatCached && hashCode() != that.hashCode()) return false;
+    }
+    if (!super.equals(that)) return false;
     return Objects.equals(this.content, that.content);
   }
 
   @Override
   public int hashCode() {
-    int result = super.hashCode();
-    result = (31 * result) + this.content.hashCode();
-    return result;
+    int cached = this.code;
+    if (cached == 0) {
+      int result = super.hashCode();
+      result = (31 * result) + this.content.hashCode();
+      this.code = cached = result;
+      this.cached = true;
+    }
+    return cached;
   }
 
   @Override


### PR DESCRIPTION
Drastically improve `TextComponent#equals` performance when the two components are "constant" (used for equality more than once) and not equals. Dynamic components are not affected by this change.

OpenJDK 18 bench result on `main
```
Benchmark                                          Mode  Cnt    Score    Error  Units
ComponentEqualityBenchmark.constantAlmostEquals    avgt   30   71.454 ± 14.591  ns/op
ComponentEqualityBenchmark.constantEquals          avgt   30   76.149 ± 14.636  ns/op
ComponentEqualityBenchmark.constantNotEquals       avgt   30   11.750 ±  0.090  ns/op
ComponentEqualityBenchmark.singleConstantEquals    avgt   30  248.790 ±  7.518  ns/op
ComponentEqualityBenchmark.singleConstantNotEqual  avgt   30   69.418 ±  8.904  ns/op
```
my branch:
```
Benchmark                                          Mode  Cnt    Score    Error  Units
ComponentEqualityBenchmark.constantAlmostEquals    avgt   30    2.501 ±  0.039  ns/op
ComponentEqualityBenchmark.constantEquals          avgt   30   83.614 ± 14.917  ns/op
ComponentEqualityBenchmark.constantNotEquals       avgt   30    2.495 ±  0.035  ns/op
ComponentEqualityBenchmark.singleConstantEquals    avgt   30  246.227 ±  6.951  ns/op
ComponentEqualityBenchmark.singleConstantNotEqual  avgt   30   79.535 ±  9.221  ns/op
```

I am getting some weird delta on both jdk 18 & 11, so another check would be appreciated.

Overall, I agree that such change could bring unnecessary complexity, but this does seem to help a lot and is IMO easily rollback-able/test-able.