### PR TITLE
MiniMessage: Handle arguments for PreProcessTags correctly

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/StringResolvingMatchedTokenConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/StringResolvingMatchedTokenConsumer.java
@@ -23,15 +23,22 @@
  */
 package net.kyori.adventure.text.minimessage.internal.parser.match;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.text.minimessage.internal.TagInternals;
+import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenParser;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenParser.TagProvider;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenType;
+import net.kyori.adventure.text.minimessage.internal.parser.node.TagPart;
 import net.kyori.adventure.text.minimessage.tag.PreProcess;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static net.kyori.adventure.text.minimessage.internal.parser.TokenParser.SEPARATOR;
+import static net.kyori.adventure.text.minimessage.internal.parser.TokenParser.tokenize;
 
 /**
  * A matched token consumer that produces a string and returns a copy of the string with {@link PreProcess} tags resolved.
@@ -68,12 +75,23 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
     } else {
       // well, now we need to work out if it's a tag or a placeholder!
       final String match = this.input.substring(start, end);
-      final String tag = this.input.substring(start + 1, end - 1);
+      final String cleanup = this.input.substring(start + 1, end - 1);
+
+      final int index = cleanup.indexOf(SEPARATOR);
+      final String tag = index == -1 ? cleanup : cleanup.substring(0, index);
 
       // we might care if it's a valid tag!
       if (TagInternals.sanitizeAndCheckValidTagName(tag)) {
+        final List<Token> tokens = tokenize(match);
+        final List<TagPart> parts = new ArrayList<>();
+        final List<Token> childs = tokens.isEmpty() ? null : tokens.get(0).childTokens();
+        if (childs != null) {
+          for (int i = 1; i < childs.size(); i++) {
+            parts.add(new TagPart(match, childs.get(i), this.tagProvider));
+          }
+        }
         // we might care if it's a pre-process!
-        final @Nullable Tag replacement = this.tagProvider.resolve(TokenParser.TagProvider.sanitizePlaceholderName(tag));
+        final @Nullable Tag replacement = this.tagProvider.resolve(TokenParser.TagProvider.sanitizePlaceholderName(tag), parts, tokens.get(0));
 
         if (replacement instanceof PreProcess) {
           this.builder.append(Objects.requireNonNull(((PreProcess) replacement).value(), "PreProcess replacements cannot return null"));

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/PreProcess.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/PreProcess.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * A tag that is applied at the tokenization stage, before the tree is constructed.
  *
- * <p>Its value must be a MiniMessage string, and cannot accept any arguments</p>
+ * <p>Its value must be a MiniMessage string.</p>
  *
  * @since 4.10.0
  */

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.AbstractTest;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.parsed;
+
+public class PreProcessTagTest extends AbstractTest {
+
+  @Test
+  void checkPreProcessTag() {
+    final String input = "<test:'Hello! ':bla>";
+    final Component expected = text("Hello! bla");
+
+    this.assertParsedEquals(
+      expected,
+      input,
+      TagResolver.resolver("test", ((argumentQueue, context) ->
+        Tag.preProcessParsed(argumentQueue.pop().value() + argumentQueue.pop().value())))
+    );
+  }
+
+  @Test
+  void checkSpecialChars() {
+    final String input = "<test:'::':'<bla>'>";
+    final Component expected = text("::<bla>");
+
+    this.assertParsedEquals(
+      expected,
+      input,
+      TagResolver.resolver("test", ((argumentQueue, context) ->
+        Tag.preProcessParsed(argumentQueue.pop().value() + argumentQueue.pop().value())))
+    );
+  }
+
+  @Test
+  void recursionTest() {
+    final String input = "This is <recursion>!";
+    final Component expected = text("This is !");
+
+    this.assertParsedEquals(
+      expected,
+      input,
+      parsed("recursion", "<recursion>")
+    );
+  }
+}


### PR DESCRIPTION
This should fix https://github.com/KyoriPowered/adventure/issues/732

The tests should be a good example how to use arguments in pre process tags.

Currently the code looks a little bit ugly. Maybe use the first token from the childTokens? Or something else.