### PR TITLE
Implement component interning for faster equality check

### DIFF
--- a/api/src/jmh/java/net/kyori/adventure/text/ComponentInternshipBenchmark.java
+++ b/api/src/jmh/java/net/kyori/adventure/text/ComponentInternshipBenchmark.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.concurrent.TimeUnit;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static net.kyori.adventure.key.Key.key;
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.Style.style;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class ComponentInternshipBenchmark {
+
+  private Component alreadyInternedInput;
+  private Component simpleScenarioInput;
+  private Component moreComplexInput;
+
+  @Setup(Level.Trial)
+  public void prepare() {
+    this.alreadyInternedInput = Component.text()
+      .content("Hello World!")
+      .color(NamedTextColor.RED)
+      .append(Component.text(" aaaa", style(b -> b.color(NamedTextColor.BLUE).font(Key.key("uniform")))))
+      .build()
+      .intern();
+
+    final Style simpleScenarioStyle = style()
+      .color(NamedTextColor.AQUA)
+      .font(key("uniform"))
+      .decorate(TextDecoration.BOLD, TextDecoration.ITALIC)
+      .build();
+    this.simpleScenarioInput = text()
+      .content("Hello ")
+      .style(simpleScenarioStyle)
+      .append(text("World!", style(TextDecoration.BOLD).font(key("uniform"))))
+      .build();
+
+    this.moreComplexInput =
+      text().content("Hello ")
+        .style(style(NamedTextColor.RED, TextDecoration.BOLD, TextDecoration.OBFUSCATED))
+        .append(text("World! "))
+        .append(text("What a ", NamedTextColor.RED))
+        .append(text(c -> c.content("beautiful day ")
+          .color(NamedTextColor.BLUE)
+          .append(text("to create ", style(TextDecoration.ITALIC)))
+          .append(text("a PR ", style(TextDecoration.BOLD)))
+          .append(text("on Adventure!"))
+        ))
+        .build();
+  }
+
+  @Benchmark
+  @SuppressWarnings("unused")
+  public Component alreadyInterned() {
+    final boolean comparison = this.alreadyInternedInput == this.alreadyInternedInput.intern();
+    return this.alreadyInternedInput.intern();
+  }
+
+  @Benchmark
+  @SuppressWarnings("unused")
+  public Component simpleScenario() {
+    final boolean comparison = this.simpleScenarioInput == this.simpleScenarioInput.intern();
+    return this.simpleScenarioInput.intern();
+  }
+
+  @Benchmark
+  @SuppressWarnings("unused")
+  public Component moreComplex() {
+    final boolean comparison = this.moreComplexInput == this.moreComplexInput.intern();
+    return this.moreComplexInput.intern();
+  }
+
+  public static void main(final String[] args) throws RunnerException {
+    final Options opt = new OptionsBuilder()
+      .include(ComponentInternshipBenchmark.class.getSimpleName())
+      .forks(1)
+      .build();
+
+    new Runner(opt).run();
+  }
+
+}

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponent.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -44,6 +45,8 @@ import org.jetbrains.annotations.Nullable;
 @Debug.Renderer(text = "this.debuggerString()", childrenArray = "this.children().toArray()", hasChildren = "!this.children().isEmpty()")
 @Deprecated
 public abstract class AbstractComponent implements Component {
+  private static final HashMap<Integer, Component> COMPONENT_POOL = new HashMap<>();
+
   protected final List<Component> children;
   protected final Style style;
 
@@ -60,6 +63,17 @@ public abstract class AbstractComponent implements Component {
   @Override
   public final @NotNull Style style() {
     return this.style;
+  }
+
+  @Override
+  public @NotNull Component intern() {
+    synchronized (AbstractComponent.COMPONENT_POOL) {
+      final int hash = this.hashCode();
+      final Component component = AbstractComponent.COMPONENT_POOL.get(hash);
+      if (component != null) return component;
+      AbstractComponent.COMPONENT_POOL.put(hash, this);
+      return this;
+    }
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1706,6 +1706,14 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Returns a canonical representation of this component.
+   *
+   * @return the canonical representation of this component
+   * @since 4.11.0
+   */
+  @NotNull Component intern();
+
+  /**
    * Appends a component to this component.
    *
    * @param like the component to append

--- a/api/src/test/java/net/kyori/adventure/text/AbstractComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/AbstractComponentTest.java
@@ -324,6 +324,13 @@ abstract class AbstractComponentTest<C extends BuildableComponent<C, B> & Scoped
       .testEquals();
   }
 
+  @Test
+  void testInternEquals() {
+    final C c0 = (C) this.buildOne().intern();
+    final C c1 = (C) this.buildOne().intern();
+    assertSame(c0, c1);
+  }
+
   // -----------------
   // ---- Builder ----
   // -----------------


### PR DESCRIPTION
Hey guys! I've been working on a cool optimisation feature for a while and now I'm finally ready to show this to you, going back to the all beloved heap! I have taken it upon myself to implement component interning, so here are a few examples of how it currently looks like:

Components have a simple, yet wonderful new method to them, with functionality the current components do not have:

![`Component.intern()`!](https://user-images.githubusercontent.com/1917406/161271992-b77f1941-6a45-4ce8-b64d-eb6142a862e7.png)

Object churn is back to its old glory with amazing looking memory leaks: 

![idea64.exe has stopped responding](https://user-images.githubusercontent.com/1917406/161276807-28879783-0ca7-4df5-9c6b-59636ccd54f4.png)

Text components are as powerful as ever with different colors and clickable info links: 

![Something happened](https://user-images.githubusercontent.com/1917406/161272785-5e55da6c-5e0d-4637-b9dd-6662c50148bb.png)
![Something happened](https://user-images.githubusercontent.com/1917406/161272569-efc3f3a6-2867-42d7-9354-d35510bf698f.png)

And here is a preview of some benchmarks; instead of the component interning being slower than not interning the component, I have made it take longer, as a cheeky easter egg ;) 

![Let's name your PCMake it your with a unique name that's easy to recognize when connecting to it from other devices. Your PC will restart after you name it.No more than 15 charactersNo spaces or any of the following special characters:](https://user-images.githubusercontent.com/1917406/161272167-ba0ef6e9-dda4-43bf-8396-e60fd41a13e5.png)

I am eager to receive feedback on this new optimisation, I'm sure it's finally going to be the last one! It simply needs some slight adjustments to the build script so it can build again.
