### PR TITLE
Add orThrow and orDefault methods to Index

### DIFF
--- a/api/src/main/java/net/kyori/adventure/util/Index.java
+++ b/api/src/main/java/net/kyori/adventure/util/Index.java
@@ -33,7 +33,6 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
-
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -183,7 +182,7 @@ public final class Index<K, V> {
    * @since 4.11.0
    */
   @Contract("_, null -> null; _, !null -> !null")
-  public K keyOrDefault(final @NotNull V value, @Nullable K defaultKey) {
+  public K keyOrDefault(final @NotNull V value, final @Nullable K defaultKey) {
     final K key = this.key(value);
     return key == null ? defaultKey : key;
   }
@@ -235,7 +234,7 @@ public final class Index<K, V> {
    * @since 4.11.0
    */
   @Contract("_, null -> null; _, !null -> !null")
-  public V valueOrDefault(final @NotNull K key, @Nullable V defaultValue) {
+  public V valueOrDefault(final @NotNull K key, final @Nullable V defaultValue) {
     final V value = this.value(key);
     return value == null ? defaultValue : value;
   }

--- a/api/src/main/java/net/kyori/adventure/util/Index.java
+++ b/api/src/main/java/net/kyori/adventure/util/Index.java
@@ -29,6 +29,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -155,6 +156,22 @@ public final class Index<K, V> {
   }
 
   /**
+   * Gets the key for a value or throws an exception.
+   *
+   * @param value the value
+   * @return the key
+   * @throws NoSuchElementException if there is no key for the value
+   * @since 4.11.0
+   */
+  public @NotNull K keyOrThrow(final @NotNull V value) {
+    final K key = this.key(value);
+    if (key == null) {
+      throw new NoSuchElementException("There is no key for value " + value);
+    }
+    return key;
+  }
+
+  /**
    * Gets the keys.
    *
    * @return the keys
@@ -173,6 +190,22 @@ public final class Index<K, V> {
    */
   public @Nullable V value(final @NotNull K key) {
     return this.keyToValue.get(key);
+  }
+
+  /**
+   * Gets a value by its key.
+   *
+   * @param key the key
+   * @return the value
+   * @throws NoSuchElementException if there is no value for the key
+   * @since 4.11.0
+   */
+  public @NotNull V valueOrThrow(final @NotNull K key) {
+    final V value = this.value(key);
+    if (value == null) {
+      throw new NoSuchElementException("There is no value for key " + key);
+    }
+    return value;
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/util/Index.java
+++ b/api/src/main/java/net/kyori/adventure/util/Index.java
@@ -33,6 +33,8 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -172,6 +174,21 @@ public final class Index<K, V> {
   }
 
   /**
+   * Gets a key by its value or returns
+   * a fallback key.
+   *
+   * @param value the value
+   * @param defaultKey the fallback key
+   * @return the key
+   * @since 4.11.0
+   */
+  @Contract("_, null -> null; _, !null -> !null")
+  public K keyOrDefault(final @NotNull V value, @Nullable K defaultKey) {
+    final K key = this.key(value);
+    return key == null ? defaultKey : key;
+  }
+
+  /**
    * Gets the keys.
    *
    * @return the keys
@@ -206,6 +223,21 @@ public final class Index<K, V> {
       throw new NoSuchElementException("There is no value for key " + key);
     }
     return value;
+  }
+
+  /**
+   * Gets a value by its key or returns
+   * a fallback value.
+   *
+   * @param key the key
+   * @param defaultValue the fallback value
+   * @return the value
+   * @since 4.11.0
+   */
+  @Contract("_, null -> null; _, !null -> !null")
+  public V valueOrDefault(final @NotNull K key, @Nullable V defaultValue) {
+    final V value = this.value(key);
+    return value == null ? defaultValue : value;
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/util/Index.java
+++ b/api/src/main/java/net/kyori/adventure/util/Index.java
@@ -173,8 +173,7 @@ public final class Index<K, V> {
   }
 
   /**
-   * Gets a key by its value or returns
-   * a fallback key.
+   * Gets a key by its value or returns a fallback key.
    *
    * @param value the value
    * @param defaultKey the fallback key
@@ -182,7 +181,7 @@ public final class Index<K, V> {
    * @since 4.11.0
    */
   @Contract("_, null -> null; _, !null -> !null")
-  public K keyOrDefault(final @NotNull V value, final @Nullable K defaultKey) {
+  public K keyOr(final @NotNull V value, final @Nullable K defaultKey) {
     final K key = this.key(value);
     return key == null ? defaultKey : key;
   }
@@ -225,8 +224,7 @@ public final class Index<K, V> {
   }
 
   /**
-   * Gets a value by its key or returns
-   * a fallback value.
+   * Gets a value by its key or returns a fallback value.
    *
    * @param key the key
    * @param defaultValue the fallback value
@@ -234,7 +232,7 @@ public final class Index<K, V> {
    * @since 4.11.0
    */
   @Contract("_, null -> null; _, !null -> !null")
-  public V valueOrDefault(final @NotNull K key, final @Nullable V defaultValue) {
+  public V valueOr(final @NotNull K key, final @Nullable V defaultValue) {
     final V value = this.value(key);
     return value == null ? defaultValue : value;
   }

--- a/api/src/test/java/net/kyori/adventure/util/IndexTest.java
+++ b/api/src/test/java/net/kyori/adventure/util/IndexTest.java
@@ -72,12 +72,12 @@ class IndexTest {
 
   @Test
   void testValueOrDefault() {
-    assertEquals(Thing.NOT_PRESENT, THINGS.valueOrDefault("__NO_VALUE__", Thing.NOT_PRESENT));
+    assertEquals(Thing.NOT_PRESENT, THINGS.valueOr("__NO_VALUE__", Thing.NOT_PRESENT));
   }
 
   @Test
   void testKeyOrDefault() {
-    assertEquals("__DEFAULT__", THINGS.keyOrDefault(Thing.NOT_PRESENT, "__DEFAULT__"));
+    assertEquals("__DEFAULT__", THINGS.keyOr(Thing.NOT_PRESENT, "__DEFAULT__"));
   }
 
   @Test

--- a/api/src/test/java/net/kyori/adventure/util/IndexTest.java
+++ b/api/src/test/java/net/kyori/adventure/util/IndexTest.java
@@ -61,13 +61,23 @@ class IndexTest {
   }
 
   @Test
-  void testNoValue() {
+  void testValueOrThrow() {
     assertThrows(NoSuchElementException.class, () -> THINGS.valueOrThrow("__NO_VALUE__"));
   }
 
   @Test
-  void testNoKey() {
+  void testKeyOrThrow() {
     assertThrows(NoSuchElementException.class, () -> THINGS.keyOrThrow(Thing.NOT_PRESENT));
+  }
+
+  @Test
+  void testValueOrDefault() {
+    assertEquals(Thing.NOT_PRESENT, THINGS.valueOrDefault("__NO_VALUE__", Thing.NOT_PRESENT));
+  }
+
+  @Test
+  void testKeyOrDefault() {
+    assertEquals("__DEFAULT__", THINGS.keyOrDefault(Thing.NOT_PRESENT, "__DEFAULT__"));
   }
 
   @Test

--- a/api/src/test/java/net/kyori/adventure/util/IndexTest.java
+++ b/api/src/test/java/net/kyori/adventure/util/IndexTest.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.util;
 
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class IndexTest {
-  private static final Index<String, Thing> THINGS = Index.create(Thing.class, thing -> thing.name);
+  private static final Index<String, Thing> THINGS = Index.create(Thing.class, thing -> thing.name, Thing.ABC, Thing.DEF);
 
   @Test
   void testCreateWithNonUniqueKey() {
@@ -46,6 +47,7 @@ class IndexTest {
   @Test
   void testKey() {
     for (final Thing thing : Thing.values()) {
+      if (thing == Thing.NOT_PRESENT) continue;
       assertEquals(thing.name, THINGS.key(thing));
     }
   }
@@ -53,8 +55,19 @@ class IndexTest {
   @Test
   void testValue() {
     for (final Thing thing : Thing.values()) {
+      if (thing == Thing.NOT_PRESENT) continue;
       assertEquals(thing, THINGS.value(thing.name));
     }
+  }
+
+  @Test
+  void testNoValue() {
+    assertThrows(NoSuchElementException.class, () -> THINGS.valueOrThrow("__NO_VALUE__"));
+  }
+
+  @Test
+  void testNoKey() {
+    assertThrows(NoSuchElementException.class, () -> THINGS.keyOrThrow(Thing.NOT_PRESENT));
   }
 
   @Test
@@ -69,7 +82,8 @@ class IndexTest {
 
   private enum Thing {
     ABC("abc"),
-    DEF("def");
+    DEF("def"),
+    NOT_PRESENT("not_present");
 
     private final String name;
 


### PR DESCRIPTION
Adds orThrow and orDefault methods to Index. It was kind of annoying how Index#key and Index#value were marked as Nullable when in certain situations you know that they won't return nullable. Like `NamedTextColor.NAMES.key(NamedTextColor.RED)`. These orThrow methods are just helpers to avoid wrapping calls in requireNonNulls or ignoring warnings.

Also added orDefault methods since that's a common map need.