### PR TITLE
Implement MiniMessage preprocessor and cleanup parsing

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -62,7 +62,8 @@ class ContextImpl implements Context {
     final MiniMessage miniMessage,
     final @NotNull TagResolver extraTags,
     final UnaryOperator<String> preProcessor,
-    final UnaryOperator<Component> postProcessor) {
+    final UnaryOperator<Component> postProcessor
+  ) {
     this.strict = strict;
     this.debugOutput = debugOutput;
     this.message = message;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -61,7 +61,7 @@ class ContextImpl implements Context {
     final String message,
     final MiniMessage miniMessage,
     final @NotNull TagResolver extraTags,
-    UnaryOperator<String> preProcessor,
+    final UnaryOperator<String> preProcessor,
     final UnaryOperator<Component> postProcessor) {
     this.strict = strict;
     this.debugOutput = debugOutput;
@@ -108,7 +108,9 @@ class ContextImpl implements Context {
     return this.postProcessor;
   }
 
-  public UnaryOperator<String> preProcessor() { return this.preProcessor; }
+  public UnaryOperator<String> preProcessor() {
+    return this.preProcessor;
+  }
 
   @Override
   public @NotNull Component deserialize(final @NotNull String message) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -52,6 +52,7 @@ class ContextImpl implements Context {
   private String message;
   private final MiniMessage miniMessage;
   private final TagResolver tagResolver;
+  private final UnaryOperator<String> preProcessor;
   private final UnaryOperator<Component> postProcessor;
 
   ContextImpl(
@@ -60,13 +61,14 @@ class ContextImpl implements Context {
     final String message,
     final MiniMessage miniMessage,
     final @NotNull TagResolver extraTags,
-    final UnaryOperator<Component> postProcessor
-  ) {
+    UnaryOperator<String> preProcessor,
+    final UnaryOperator<Component> postProcessor) {
     this.strict = strict;
     this.debugOutput = debugOutput;
     this.message = message;
     this.miniMessage = miniMessage;
     this.tagResolver = extraTags;
+    this.preProcessor = preProcessor == null ? UnaryOperator.identity() : preProcessor;
     this.postProcessor = postProcessor == null ? UnaryOperator.identity() : postProcessor;
   }
 
@@ -76,9 +78,10 @@ class ContextImpl implements Context {
     final String input,
     final MiniMessageImpl miniMessage,
     final TagResolver extraTags,
+    final UnaryOperator<String> preProcessor,
     final UnaryOperator<Component> postProcessor
   ) {
-    return new ContextImpl(strict, debugOutput, input, miniMessage, extraTags, postProcessor);
+    return new ContextImpl(strict, debugOutput, input, miniMessage, extraTags, preProcessor, postProcessor);
   }
 
   public boolean strict() {
@@ -104,6 +107,8 @@ class ContextImpl implements Context {
   public UnaryOperator<Component> postProcessor() {
     return this.postProcessor;
   }
+
+  public UnaryOperator<String> preProcessor() { return this.preProcessor; }
 
   @Override
   public @NotNull Component deserialize(final @NotNull String message) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -276,7 +276,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * Specify a function that takes the string at the start of the parser process.
      * <p>By default, this does absolutely nothing.</p>
      *
-     * @param preProcessor method run at the end of parsing
+     * @param preProcessor method run at the start of parsing
      * @return this builder
      * @since 4.11.0
      */

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -273,6 +273,16 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
     @NotNull Builder postProcessor(final @NotNull UnaryOperator<Component> postProcessor);
 
     /**
+     * Specify a function that takes the string at the start of the parser process.
+     * <p>By default, this does absolutely nothing.</p>
+     *
+     * @param preProcessor method run at the end of parsing
+     * @return this builder
+     * @since 4.11.0
+     */
+    @NotNull Builder preProcessor(final @NotNull UnaryOperator<String> preProcessor);
+
+    /**
      * Builds the serializer.
      *
      * @return the built serializer

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -73,22 +73,22 @@ final class MiniMessageImpl implements MiniMessage {
 
   @Override
   public @NotNull Component deserialize(final @NotNull String input) {
-    return this.parser.parseFormat(input, this.newContext(input, null));
+    return this.parser.parseFormat(this.newContext(input, null));
   }
 
   @Override
   public @NotNull Component deserialize(final @NotNull String input, final @NotNull TagResolver tagResolver) {
-    return this.parser.parseFormat(input, this.newContext(input, requireNonNull(tagResolver, "tagResolver")));
+    return this.parser.parseFormat(this.newContext(input, requireNonNull(tagResolver, "tagResolver")));
   }
 
   @Override
   public Node.@NotNull Root deserializeToTree(final @NotNull String input) {
-    return this.parser.parseToTree(input, this.newContext(input, null));
+    return this.parser.parseToTree(this.newContext(input, null));
   }
 
   @Override
   public Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver) {
-    return this.parser.parseToTree(input, this.newContext(input, requireNonNull(tagResolver, "tagResolver")));
+    return this.parser.parseToTree(this.newContext(input, requireNonNull(tagResolver, "tagResolver")));
   }
 
   @Override
@@ -113,12 +113,12 @@ final class MiniMessageImpl implements MiniMessage {
 
   @Override
   public @NotNull String escapeTags(final @NotNull String input) {
-    return this.parser.escapeTokens(input, this.newContext(input, null));
+    return this.parser.escapeTokens(this.newContext(input, null));
   }
 
   @Override
   public @NotNull String escapeTags(final @NotNull String input, final @NotNull TagResolver tagResolver) {
-    return this.parser.escapeTokens(input, this.newContext(input, tagResolver));
+    return this.parser.escapeTokens(this.newContext(input, tagResolver));
   }
 
   @Override
@@ -128,7 +128,7 @@ final class MiniMessageImpl implements MiniMessage {
 
   @Override
   public @NotNull String stripTags(final @NotNull String input, final @NotNull TagResolver tagResolver) {
-    return this.parser.stripTokens(input, this.newContext(input, tagResolver));
+    return this.parser.stripTokens(this.newContext(input, tagResolver));
   }
 
   private @NotNull ContextImpl newContext(final @NotNull String input, final @Nullable TagResolver resolver) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -54,20 +54,23 @@ final class MiniMessageImpl implements MiniMessage {
   static final class Instances {
     static final MiniMessage INSTANCE = SERVICE
       .map(Provider::miniMessage)
-      .orElseGet(() -> new MiniMessageImpl(TagResolver.standard(), false, null, DEFAULT_COMPACTING_METHOD));
+      .orElseGet(() -> new MiniMessageImpl(TagResolver.standard(), false, null, DEFAULT_NO_OP, DEFAULT_COMPACTING_METHOD));
   }
 
+  static final UnaryOperator<String> DEFAULT_NO_OP = UnaryOperator.identity();
   static final UnaryOperator<Component> DEFAULT_COMPACTING_METHOD = Component::compact;
 
   private final boolean strict;
   private final @Nullable Consumer<String> debugOutput;
   private final UnaryOperator<Component> postProcessor;
+  private final UnaryOperator<String> preProcessor;
   final MiniMessageParser parser;
 
-  MiniMessageImpl(final @NotNull TagResolver resolver, final boolean strict, final @Nullable Consumer<String> debugOutput, final @NotNull UnaryOperator<Component> postProcessor) {
+  MiniMessageImpl(final @NotNull TagResolver resolver, final boolean strict, final @Nullable Consumer<String> debugOutput, final @NotNull UnaryOperator<String> preProcessor, final @NotNull UnaryOperator<Component> postProcessor) {
     this.parser = new MiniMessageParser(resolver);
     this.strict = strict;
     this.debugOutput = debugOutput;
+    this.preProcessor = preProcessor;
     this.postProcessor = postProcessor;
   }
 
@@ -123,7 +126,7 @@ final class MiniMessageImpl implements MiniMessage {
 
   @Override
   public @NotNull String stripTags(final @NotNull String input) {
-    return this.parser.stripTokens(input, this.newContext(input, null));
+    return this.parser.stripTokens(this.newContext(input, null));
   }
 
   @Override
@@ -134,9 +137,9 @@ final class MiniMessageImpl implements MiniMessage {
   private @NotNull ContextImpl newContext(final @NotNull String input, final @Nullable TagResolver resolver) {
     requireNonNull(input, "input");
     if (resolver == null) {
-      return ContextImpl.of(this.strict, this.debugOutput, input, this, TagResolver.empty(), this.postProcessor);
+      return ContextImpl.of(this.strict, this.debugOutput, input, this, TagResolver.empty(), this.preProcessor, this.postProcessor);
     } else {
-      return ContextImpl.of(this.strict, this.debugOutput, input, this, resolver, this.postProcessor);
+      return ContextImpl.of(this.strict, this.debugOutput, input, this, resolver, this.preProcessor, this.postProcessor);
     }
   }
 
@@ -145,6 +148,7 @@ final class MiniMessageImpl implements MiniMessage {
     private boolean strict = false;
     private Consumer<String> debug = null;
     private UnaryOperator<Component> postProcessor = DEFAULT_COMPACTING_METHOD;
+    private UnaryOperator<String> preProcessor = DEFAULT_NO_OP;
 
     BuilderImpl() {
       BUILDER.accept(this);
@@ -156,6 +160,7 @@ final class MiniMessageImpl implements MiniMessage {
       this.strict = serializer.strict;
       this.debug = serializer.debugOutput;
       this.postProcessor = serializer.postProcessor;
+      this.preProcessor = serializer.preProcessor;
     }
 
     @Override
@@ -192,8 +197,14 @@ final class MiniMessageImpl implements MiniMessage {
     }
 
     @Override
+    public @NotNull Builder preProcessor(final @NotNull UnaryOperator<String> preProcessor) {
+      this.preProcessor = Objects.requireNonNull(preProcessor, "preProcessor");
+      return this;
+    }
+
+    @Override
     public @NotNull MiniMessage build() {
-      return new MiniMessageImpl(this.tagResolver, this.strict, this.debug, this.postProcessor);
+      return new MiniMessageImpl(this.tagResolver, this.strict, this.debug, this.preProcessor, this.postProcessor);
     }
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -66,10 +66,10 @@ final class MiniMessageParser {
   }
 
   void escapeTokens(final StringBuilder sb, final @NotNull ContextImpl context) {
-    escapeTokens(sb, context.message(), context);
+    this.escapeTokens(sb, context.message(), context);
   }
 
-  private void escapeTokens(StringBuilder sb, String richMessage, ContextImpl context) {
+  private void escapeTokens(final StringBuilder sb, final String richMessage, final ContextImpl context) {
     this.processTokens(sb, richMessage, context, (token, builder) -> {
       builder.append('\\').append(TokenParser.TAG_START);
       if (token.type() == TokenType.CLOSE_TAG) {
@@ -93,7 +93,7 @@ final class MiniMessageParser {
   }
 
   private void processTokens(final @NotNull StringBuilder sb, final @NotNull ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {
-    processTokens(sb, context.message(), context, tagHandler);
+    this.processTokens(sb, context.message(), context, tagHandler);
   }
 
   private void processTokens(final @NotNull StringBuilder sb, final @NotNull String richMessage, final @NotNull ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -66,7 +66,11 @@ final class MiniMessageParser {
   }
 
   void escapeTokens(final StringBuilder sb, final @NotNull ContextImpl context) {
-    this.processTokens(sb, context, (token, builder) -> {
+    escapeTokens(sb, context.message(), context);
+  }
+
+  private void escapeTokens(StringBuilder sb, String richMessage, ContextImpl context) {
+    this.processTokens(sb, richMessage, context, (token, builder) -> {
       builder.append('\\').append(TokenParser.TAG_START);
       if (token.type() == TokenType.CLOSE_TAG) {
         builder.append(TokenParser.CLOSE_TAG);
@@ -76,7 +80,7 @@ final class MiniMessageParser {
         if (i != 0) {
           builder.append(TokenParser.SEPARATOR);
         }
-        this.escapeTokens(builder, context); // todo: do we need to unwrap quotes on this?
+        this.escapeTokens(builder, childTokens.get(i).get(richMessage).toString(), context); // todo: do we need to unwrap quotes on this?
       }
       builder.append(TokenParser.TAG_END);
     });
@@ -89,8 +93,11 @@ final class MiniMessageParser {
   }
 
   private void processTokens(final @NotNull StringBuilder sb, final @NotNull ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {
+    processTokens(sb, context.message(), context, tagHandler);
+  }
+
+  private void processTokens(final @NotNull StringBuilder sb, final @NotNull String richMessage, final @NotNull ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {
     final TagResolver combinedResolver = TagResolver.resolver(this.tagResolver, context.extraTags());
-    final String richMessage = context.message();
     final List<Token> root = TokenParser.tokenize(richMessage);
     for (final Token token : root) {
       switch (token.type()) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -120,11 +120,11 @@ final class MiniMessageParser {
 
   @NotNull RootNode parseToTree(final @NotNull ContextImpl context) {
     final TagResolver combinedResolver = TagResolver.resolver(this.tagResolver, context.extraTags());
-    final String richMessage = context.message();
+    final String processedMessage = context.preProcessor().apply(context.message());
     final Consumer<String> debug = context.debugOutput();
     if (debug != null) {
       debug.accept("Beginning parsing message ");
-      debug.accept(richMessage);
+      debug.accept(processedMessage);
       debug.accept("\n");
     }
 
@@ -185,10 +185,10 @@ final class MiniMessageParser {
       return combinedResolver.has(sanitized);
     };
 
-    final String preProcessed = TokenParser.resolvePreProcessTags(richMessage, transformationFactory);
+    final String preProcessed = TokenParser.resolvePreProcessTags(processedMessage, transformationFactory);
     context.message(preProcessed);
     // Then, once MiniMessage placeholders have been inserted, we can do the real parse
-    final RootNode root = TokenParser.parse(transformationFactory, tagNameChecker, preProcessed, richMessage, context.strict());
+    final RootNode root = TokenParser.parse(transformationFactory, tagNameChecker, preProcessed, processedMessage, context.strict());
 
     if (debug != null) {
       debug.accept("Text parsed into element tree:\n");

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/AbstractTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/AbstractTest.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.minimessage;
 
 import java.util.Collections;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
@@ -68,7 +69,7 @@ public abstract class AbstractTest {
   }
 
   public static Context dummyContext(final String originalMessage) {
-    return ContextImpl.of(false, null, originalMessage, (MiniMessageImpl) PARSER, TagResolver.empty(), Component::compact);
+    return ContextImpl.of(false, null, originalMessage, (MiniMessageImpl) PARSER, TagResolver.empty(), UnaryOperator.identity(), Component::compact);
   }
 
   public static ArgumentQueue emptyArgumentQueue(final Context context) {

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -122,6 +122,15 @@ public class MiniMessageTest extends AbstractTest {
     this.assertParsedEquals(miniMessage, expected, input, t1, t2);
   }
 
+  @Test
+  void testPreprocessing() {
+    final Component expected = MiniMessage.miniMessage().deserialize("<red>Hello, world!</red>");
+
+    final String input = "Hello";
+    final MiniMessage miniMessage = MiniMessage.builder().preProcessor(str -> "<red>" + str + ", world!</red>").build();
+    this.assertParsedEquals(miniMessage, expected, input);
+  }
+
   // GH-103
   @Test
   void testPlaceholderInHover() {


### PR DESCRIPTION
This pull request combines two changes to MiniMessage, one internal and the other external.

On the user-facing side, a new feature is implemented: **preprocessing**. This is essentially exactly opposite to the existing post-processing in MiniMessage: it's simply a unary operator that is applied to every string input prior to deserialising it into a tree.

On the internal side, this also removes the explicit `richMessage` parameters from most MiniMessageParser methods, opting to instead deduce the value from ContextImpl where possible. A notable outlier here is the process of escaping tokens, where the `richMessage` parameter is explicitly required for escaping to work.