### PR TITLE
text-logger-slf4j: introduce wrapper for formatted logging

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -8,6 +8,9 @@
   <suppress files="src[\\/](test|jmh)[\\/]java[\\/].*" checks="(FilteringWriteTag|JavadocPackage|MissingJavadoc.*)"/>
   <suppress files="api[\\/]src[\\/]main[\\/]java[\\/]net[\\/]kyori[\\/]adventure[\\/]internal[\\/].*" checks="(FilteringWriteTag|JavadocPackage|MissingJavadoc.*)"/>
   <suppress files="minimessage[\\/]src[\\/]main[\\/]java[\\/]net[\\/]kyori[\\/]adventure[\\/]text[\\/]minimessage[\\/]parser[\\/].*" checks="(FilteringWriteTag|JavadocPackage|MissingJavadoc.*)"/>
+  
+  <!-- no package JD on multirelease variants -->
+  <suppress files="src[\\/]main[\\/]java\d+[\\/].*" checks="JavadocPackage"/>
 
   <suppress files=".*[\\/]nbt[\\/](List|Compound)BinaryTag.java" checks="MethodName"/>
 </suppressions>

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
       "nbt",
       "serializer-configurate3",
       "serializer-configurate4",
+      "text-logger-slf4j",
       "text-minimessage",
       "text-serializer-gson",
       "text-serializer-gson-legacy-impl",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ indra = "2.1.1"
 jmh = "1.35"
 jmhPlugin = "0.6.6"
 junit = "5.8.2"
+slf4j = "1.7.36"
 truth = "1.1.3"
 
 [libraries]
@@ -27,6 +28,11 @@ kotlin-testJunit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
 # serializer-configurate*
 configurate-v3 = "org.spongepowered:configurate-core:3.7.3"
 configurate-v4 = "org.spongepowered:configurate-core:4.1.2"
+
+# text-logger-slf4j
+slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+slf4j-ext = { module = "org.slf4j:slf4j-ext", version.ref = "slf4j" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 
 # text-serializer-gson
 gson = "com.google.code.gson:gson:2.8.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ indra = "2.1.1"
 jmh = "1.35"
 jmhPlugin = "0.6.6"
 junit = "5.8.2"
+mockito = "4.5.1"
 slf4j = "1.7.36"
 truth = "1.1.3"
 
@@ -33,6 +34,9 @@ configurate-v4 = "org.spongepowered:configurate-core:4.1.2"
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-ext = { module = "org.slf4j:slf4j-ext", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+mockSlf4j = "org.simplify4u:slf4j-mock:2.2.0"
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 
 # text-serializer-gson
 gson = "com.google.code.gson:gson:2.8.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,10 +33,7 @@ configurate-v4 = "org.spongepowered:configurate-core:4.1.2"
 # text-logger-slf4j
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-ext = { module = "org.slf4j:slf4j-ext", version.ref = "slf4j" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
-mockSlf4j = "org.simplify4u:slf4j-mock:2.2.0"
-mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
-mockito-junit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+slf4jtest = "com.github.valfirst:slf4j-test:2.6.1" # Specific versions are needed for different SLF4J versions
 
 # text-serializer-gson
 gson = "com.google.code.gson:gson:2.8.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,6 @@ configurate-v4 = "org.spongepowered:configurate-core:4.1.2"
 
 # text-logger-slf4j
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
-slf4j-ext = { module = "org.slf4j:slf4j-ext", version.ref = "slf4j" }
 slf4jtest = "com.github.valfirst:slf4j-test:2.6.1" # Specific versions are needed for different SLF4J versions
 
 # text-serializer-gson

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,7 @@ sequenceOf(
   "nbt",
   "serializer-configurate3",
   "serializer-configurate4",
+  "text-logger-slf4j",
   "text-minimessage",
   "text-serializer-gson",
   "text-serializer-gson-legacy-impl",

--- a/text-logger-slf4j/build.gradle.kts
+++ b/text-logger-slf4j/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+  id("adventure.common-conventions")
+}
+
+dependencies {
+  api(projects.adventureApi)
+  api(libs.slf4j)
+  implementation(libs.slf4j.ext) {
+    exclude(group = "org.slf4j", module = "slf4j-api")
+  }
+  testImplementation(libs.slf4j.simple)
+}
+
+sourceSets.main {
+  multirelease {
+    alternateVersions(9)
+  }
+}

--- a/text-logger-slf4j/build.gradle.kts
+++ b/text-logger-slf4j/build.gradle.kts
@@ -5,14 +5,23 @@ plugins {
 dependencies {
   api(projects.adventureApi)
   api(libs.slf4j)
-  implementation(libs.slf4j.ext) {
-    exclude(group = "org.slf4j", module = "slf4j-api")
-  }
+  implementation(libs.slf4j.ext)
   testImplementation(libs.slf4j.simple)
 }
 
 sourceSets.main {
   multirelease {
     alternateVersions(9)
+  }
+}
+
+eclipse {
+  // Make sure slf4j doesn't end up on the module path until we are actually a module
+  classpath.file.whenMerged {
+    (this as org.gradle.plugins.ide.eclipse.model.Classpath).entries.forEach { entry ->
+      if (entry is org.gradle.plugins.ide.eclipse.model.Library) {
+        entry.entryAttributes["module"] = false
+      }
+    }
   }
 }

--- a/text-logger-slf4j/build.gradle.kts
+++ b/text-logger-slf4j/build.gradle.kts
@@ -6,10 +6,7 @@ dependencies {
   api(projects.adventureApi)
   api(libs.slf4j)
   implementation(libs.slf4j.ext)
-  testImplementation(libs.slf4j.simple)
-  testImplementation(libs.mockSlf4j)
-  testImplementation(libs.mockito)
-  testImplementation(libs.mockito.junit)
+  testImplementation(libs.slf4jtest)
 }
 
 sourceSets.main {

--- a/text-logger-slf4j/build.gradle.kts
+++ b/text-logger-slf4j/build.gradle.kts
@@ -7,6 +7,9 @@ dependencies {
   api(libs.slf4j)
   implementation(libs.slf4j.ext)
   testImplementation(libs.slf4j.simple)
+  testImplementation(libs.mockSlf4j)
+  testImplementation(libs.mockito)
+  testImplementation(libs.mockito.junit)
 }
 
 sourceSets.main {

--- a/text-logger-slf4j/build.gradle.kts
+++ b/text-logger-slf4j/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 dependencies {
   api(projects.adventureApi)
   api(libs.slf4j)
-  implementation(libs.slf4j.ext)
   testImplementation(libs.slf4jtest)
 }
 

--- a/text-logger-slf4j/build.gradle.kts
+++ b/text-logger-slf4j/build.gradle.kts
@@ -14,6 +14,8 @@ sourceSets.main {
   }
 }
 
+applyJarMetadata("net.kyori.adventure.text.logger.slf4j")
+
 eclipse {
   // Make sure slf4j doesn't end up on the module path until we are actually a module
   classpath.file.whenMerged {

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/CallerClassFinder.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/CallerClassFinder.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+// Java 8 version, see Java 9 version as well
+final class CallerClassFinder {
+  private CallerClassFinder() {
+  }
+
+  static String callingClassName() {
+    return callingClassName(2); // this, plus the calling method
+  }
+
+  static String callingClassName(final int elementsToSkip) { // elementsToSkip not counting this method
+    final StackTraceElement[] elements = Thread.currentThread().getStackTrace(); // includes call to getStackTrace()
+    if (elements.length <= elementsToSkip) {
+      throw new IllegalArgumentException("Not enough stack elements to skip " + elementsToSkip + " elements");
+    } else {
+      return elements[elementsToSkip + 2].getClassName();
+    }
+  }
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogger.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogger.java
@@ -1,0 +1,669 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+/**
+ * An extended type of Logger capable of logging formatted components to the console.
+ *
+ * <p>The methods in this logger interface are intended to exactly mirror those methods in {@link Logger} that take a format string, but instead accepting {@link Component}s.</p>
+ *
+ * <p>Any {@code arg}s may be passed as Components as well.</p>
+ *
+ * @since 4.11.0
+ */
+public interface ComponentLogger extends Logger {
+  /**
+   * Get a logger instance with the name of the calling class.
+   *
+   * <p>This logger is produced by implementations of the {@link ComponentLoggerProvider}.</p>
+   *
+   * @return a logger with the name of the calling class
+   * @since 4.11.0
+   */
+  static ComponentLogger logger() {
+    return logger(CallerClassFinder.callingClassName());
+  }
+
+  /**
+   * Get a logger instance with the provided name.
+   *
+   * <p>This logger is produced by implementations of the {@link ComponentLoggerProvider}.</p>
+   *
+   * @param name the name of the logger
+   * @return a logger with the provided name
+   * @since 4.11.0
+   */
+  static ComponentLogger logger(final String name) {
+    return Handler.logger(name);
+  }
+
+  /**
+   * Get a logger instance with the binary name of the provided class.
+   *
+   * <p>This logger is produced by implementations of the {@link ComponentLoggerProvider}.</p>
+   *
+   * @param clazz the class to use when naming the logger
+   * @return a logger with the name of the calling class
+   * @since 4.11.0
+   */
+  static ComponentLogger logger(final Class<?> clazz) {
+    return logger(clazz.getName());
+  }
+
+  /**
+   * Log a message at the TRACE level.
+   *
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Component msg);
+
+  /**
+   * Log a message at the TRACE level according to the specified format
+   * and argument.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the TRACE level. </p>
+   *
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * Log a message at the TRACE level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the TRACE level. </p>
+   *
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * Log a message at the TRACE level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the TRACE level. However, this variant incurs the hidden
+   * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
+   * even if this logger is disabled for TRACE. The variants taking {@link #trace(Component, Object) one} and
+   * {@link #trace(Component, Object, Object) two} arguments exist solely in order to avoid this hidden cost.</p>
+   *
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Component format, final @Nullable Object @NotNull... arguments);
+
+  /**
+   * Log an exception (throwable) at the TRACE level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Component msg, final @Nullable Throwable t);
+
+  /**
+   * Log a message with the specific Marker at the TRACE level.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Marker marker, final @NotNull Component msg);
+
+  /**
+   * This method is similar to {@link #trace(Component, Object)} method except that the
+   * marker data is also taken into consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * This method is similar to {@link #trace(Component, Object, Object)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * This method is similar to {@link #trace(Component, Object...)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param argArray an array of arguments
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray);
+
+  /**
+   * This method is similar to {@link #trace(Component, Throwable)} method except that the
+   * marker data is also taken into consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void trace(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t);
+
+  /**
+   * Log a message at the DEBUG level.
+   *
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Component msg);
+
+  /**
+   * Log a message at the DEBUG level according to the specified format
+   * and argument.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the DEBUG level. </p>
+   *
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * Log a message at the DEBUG level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the DEBUG level. </p>
+   *
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * Log a message at the DEBUG level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the DEBUG level. However, this variant incurs the hidden
+   * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
+   * even if this logger is disabled for DEBUG. The variants taking
+   * {@link #debug(Component, Object) one} and {@link #debug(Component, Object, Object) two}
+   * arguments exist solely in order to avoid this hidden cost.</p>
+   *
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Component format, final @Nullable Object @NotNull... arguments);
+
+  /**
+   * Log an exception (throwable) at the DEBUG level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Component msg, final @Nullable Throwable t);
+
+  /**
+   * Log a message with the specific Marker at the DEBUG level.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Marker marker, final @NotNull Component msg);
+
+  /**
+   * This method is similar to {@link #debug(Component, Object)} method except that the
+   * marker data is also taken into consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * This method is similar to {@link #debug(Component, Object, Object)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * This method is similar to {@link #debug(Component, Object...)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... arguments);
+
+  /**
+   * This method is similar to {@link #debug(Component, Throwable)} method except that the
+   * marker data is also taken into consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void debug(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t);
+
+  /**
+   * Log a message at the INFO level.
+   *
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void info(final @NotNull Component msg);
+
+  /**
+   * Log a message at the INFO level according to the specified format
+   * and argument.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the INFO level. </p>
+   *
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void info(final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * Log a message at the INFO level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the INFO level. </p>
+   *
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void info(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * Log a message at the INFO level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the INFO level. However, this variant incurs the hidden
+   * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
+   * even if this logger is disabled for INFO. The variants taking
+   * {@link #info(Component, Object) one} and {@link #info(Component, Object, Object) two}
+   * arguments exist solely in order to avoid this hidden cost.</p>
+   *
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void info(final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+
+  /**
+   * Log an exception (throwable) at the INFO level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void info(final @NotNull Component msg, final @Nullable Throwable t);
+
+  /**
+   * Log a message with the specific Marker at the INFO level.
+   *
+   * @param marker The marker specific to this log statement
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void info(final @NotNull Marker marker, final @NotNull Component msg);
+
+  /**
+   * This method is similar to {@link #info(Component, Object)} method except that the
+   * marker data is also taken into consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * This method is similar to {@link #info(Component, Object, Object)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * This method is similar to {@link #info(Component, Object...)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+
+  /**
+   * This method is similar to {@link #info(Component, Throwable)} method
+   * except that the marker data is also taken into consideration.
+   *
+   * @param marker the marker data for this log statement
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void info(final @NotNull Marker marker, final @NotNull Component msg, final @NotNull Throwable t);
+
+  /**
+   * Log a message at the WARN level.
+   *
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Component msg);
+
+  /**
+   * Log a message at the WARN level according to the specified format
+   * and argument.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the WARN level. </p>
+   *
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * Log a message at the WARN level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the WARN level. However, this variant incurs the hidden
+   * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
+   * even if this logger is disabled for WARN. The variants taking
+   * {@link #warn(Component, Object) one} and {@link #warn(Component, Object, Object) two}
+   * arguments exist solely in order to avoid this hidden cost.</p>
+   *
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+
+  /**
+   * Log a message at the WARN level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the WARN level. </p>
+   *
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * Log an exception (throwable) at the WARN level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Component msg, final @NotNull Throwable t);
+
+  /**
+   * Log a message with the specific final @NotNull Marker at the WARN level.
+   *
+   * @param marker The marker specific to this log statement
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Marker marker, final @NotNull Component msg);
+
+  /**
+   * This method is similar to {@link #warn(Component, Object)} method except that the
+   * marker data is also taken into consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * This method is similar to {@link #warn(Component, Object, Object)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * This method is similar to {@link #warn(Component, Object...)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+
+  /**
+   * This method is similar to {@link #warn(Component, Throwable)} method
+   * except that the marker data is also taken into consideration.
+   *
+   * @param marker the marker data for this log statement
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void warn(final @NotNull Marker marker, final @NotNull Component msg, final @NotNull Throwable t);
+
+  /**
+   * Log a message at the ERROR level.
+   *
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void error(final @NotNull Component msg);
+
+  /**
+   * Log a message at the ERROR level according to the specified format
+   * and argument.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the ERROR level.</p>
+   *
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void error(final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * Log a message at the ERROR level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the ERROR level.</p>
+   *
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void error(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * Log a message at the ERROR level according to the specified format
+   * and arguments.
+   *
+   * <p>This form avoids superfluous string concatenation when the logger
+   * is disabled for the ERROR level. However, this variant incurs the hidden
+   * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
+   * even if this logger is disabled for ERROR. The variants taking
+   * {@link #error(Component, Object) one} and {@link #error(Component, Object, Object) two}
+   * arguments exist solely in order to avoid this hidden cost.</p>
+   *
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void error(final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+
+  /**
+   * Log an exception (throwable) at the ERROR level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void error(final @NotNull Component msg, final @NotNull Throwable t);
+
+  /**
+   * Log a message with the specific final @NotNull Marker at the ERROR level.
+   *
+   * @param marker The marker specific to this log statement
+   * @param msg the message string to be logged
+   * @since 4.11.0
+   */
+  void error(final @NotNull Marker marker, final @NotNull Component msg);
+
+  /**
+   * This method is similar to {@link #error(Component, Object)} method except that the
+   * marker data is also taken into consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg the argument
+   * @since 4.11.0
+   */
+  void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+
+  /**
+   * This method is similar to {@link #error(Component, Object, Object)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arg1 the first argument
+   * @param arg2 the second argument
+   * @since 4.11.0
+   */
+  void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+
+  /**
+   * This method is similar to {@link #error(Component, Object...)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param format the format string
+   * @param arguments a list of 3 or more arguments
+   * @since 4.11.0
+   */
+  void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+
+  /**
+   * This method is similar to {@link #error(Component, Throwable)}
+   * method except that the marker data is also taken into
+   * consideration.
+   *
+   * @param marker the marker data specific to this log statement
+   * @param msg the message accompanying the exception
+   * @param t the exception (throwable) to log
+   * @since 4.11.0
+   */
+  void error(final @NotNull Marker marker, final @NotNull Component msg, final @NotNull Throwable t);
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogger.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogger.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * An extended type of Logger capable of logging formatted components to the console.
  *
@@ -42,12 +44,14 @@ public interface ComponentLogger extends Logger {
   /**
    * Get a logger instance with the name of the calling class.
    *
+   * <p>This method is caller-sensitive and should not be wrapped. See
+   *
    * <p>This logger is produced by implementations of the {@link ComponentLoggerProvider}.</p>
    *
    * @return a logger with the name of the calling class
    * @since 4.11.0
    */
-  static ComponentLogger logger() {
+  static @NotNull ComponentLogger logger() {
     return logger(CallerClassFinder.callingClassName());
   }
 
@@ -60,8 +64,8 @@ public interface ComponentLogger extends Logger {
    * @return a logger with the provided name
    * @since 4.11.0
    */
-  static ComponentLogger logger(final String name) {
-    return Handler.logger(name);
+  static @NotNull ComponentLogger logger(final @NotNull String name) {
+    return Handler.logger(requireNonNull(name, "name"));
   }
 
   /**
@@ -73,7 +77,7 @@ public interface ComponentLogger extends Logger {
    * @return a logger with the name of the calling class
    * @since 4.11.0
    */
-  static ComponentLogger logger(final Class<?> clazz) {
+  static @NotNull ComponentLogger logger(final @NotNull Class<?> clazz) {
     return logger(clazz.getName());
   }
 

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogger.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogger.java
@@ -44,7 +44,7 @@ public interface ComponentLogger extends Logger {
   /**
    * Get a logger instance with the name of the calling class.
    *
-   * <p>This method is caller-sensitive and should not be wrapped. See
+   * <p>This method is caller-sensitive and should not be wrapped.</p>
    *
    * <p>This logger is produced by implementations of the {@link ComponentLoggerProvider}.</p>
    *

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
@@ -59,7 +59,7 @@ public interface ComponentLoggerProvider {
      * @return a plain serializer
      * @since 4.11.0
      */
-    Function<Component, String> plainSerializer();
+    @NotNull Function<Component, String> plainSerializer();
 
     /**
      * Create a component logger based on one which delegates to an underlying plain {@link Logger} implementation.

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import java.util.function.Function;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+
+/**
+ * A service interface for platforms to provide their own component logger implementations.
+ *
+ * @since 4.11.0
+ */
+public interface ComponentLoggerProvider {
+  /**
+   * Create a component logger for the provided logger name.
+   *
+   * @param helper a source for common helper implementations when building a logger
+   * @param name the logger name
+   * @return a component logger with the provided name
+   * @since 4.11.0
+   */
+  @NotNull ComponentLogger logger(final @NotNull LoggerHelper helper, final @NotNull String name);
+
+  /**
+   * A factory for default implementations of component loggers.
+   *
+   * @since 4.11.0
+   */
+  @ApiStatus.NonExtendable
+  interface LoggerHelper {
+
+    /**
+     * Create a serializer function that will translate logged output into the system default locale, and then serialize it to plain text.
+     *
+     * @return a plain serializer
+     * @since 4.11.0
+     */
+    Function<Component, String> plainSerializer();
+
+    /**
+     * Create a component logger based on one which delegates to an underlying plain {@link Logger} implementation.
+     *
+     * <p>This sort of logger requires Components to be serialized to some sort of formatted {@link String} to match the SLF4J contract.</p>
+     *
+     * @param base the base logger
+     * @param serializer the serializer to translate and format a component in a log message.
+     * @return a new logger
+     * @since 4.11.0
+     */
+    @NotNull ComponentLogger delegating(final @NotNull Logger base, final @NotNull Function<Component, String> serializer);
+  }
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
  *
  * @since 4.11.0
  */
+@ApiStatus.Internal // SPI for platform use only
 public interface ComponentLoggerProvider {
   /**
    * Create a component logger for the provided logger name.

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import java.util.Locale;
+import java.util.function.Function;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.flattener.ComponentFlattener;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.kyori.adventure.util.Services;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility methods relating to creating component loggers.
+ */
+final class Handler {
+  private static final ComponentLoggerProvider PROVIDER = Services.service(ComponentLoggerProvider.class)
+    .orElse(LoggerFactory.getILoggerFactory() instanceof ComponentLoggerProvider ? (ComponentLoggerProvider) LoggerFactory.getILoggerFactory() : new DefaultProvider());
+
+  private Handler() {
+  }
+
+  static ComponentLogger logger(final String name) {
+    return PROVIDER.logger(LoggerHelperImpl.INSTANCE, name);
+  }
+
+  static final class DefaultProvider implements ComponentLoggerProvider {
+    @Override
+    public @NotNull ComponentLogger logger(final @NotNull LoggerHelper helper, final @NotNull String name) {
+      final Logger backing = LoggerFactory.getLogger(name);
+      return helper.delegating(backing, helper.plainSerializer());
+    }
+  }
+
+  static final class LoggerHelperImpl implements ComponentLoggerProvider.LoggerHelper {
+    static final LoggerHelperImpl INSTANCE = new LoggerHelperImpl();
+
+    private LoggerHelperImpl() {
+    }
+
+    @Override
+    public Function<Component, String> plainSerializer() {
+      return comp -> {
+        final Component translated = GlobalTranslator.render(comp, Locale.getDefault());
+        final StringBuilder contents = new StringBuilder();
+        ComponentFlattener.basic().flatten(translated, contents::append);
+        return contents.toString();
+      };
+    }
+
+    @Override
+    public @NotNull ComponentLogger delegating(@NotNull final Logger base, @NotNull final Function<Component, String> serializer) {
+      return new WrappingComponentLoggerImpl(base, serializer);
+    }
+  }
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
@@ -51,6 +51,7 @@ final class Handler {
 
   static final class DefaultProvider implements ComponentLoggerProvider {
     private final Map<String, ComponentLogger> loggers = new ConcurrentHashMap<>();
+
     @Override
     public @NotNull ComponentLogger logger(final @NotNull LoggerHelper helper, final @NotNull String name) {
       final ComponentLogger initial = this.loggers.get(name);
@@ -80,7 +81,7 @@ final class Handler {
     }
 
     @Override
-    public @NotNull ComponentLogger delegating(@NotNull final Logger base, @NotNull final Function<Component, String> serializer) {
+    public @NotNull ComponentLogger delegating(final @NotNull Logger base, final @NotNull Function<Component, String> serializer) {
       return new WrappingComponentLoggerImpl(base, serializer);
     }
   }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
@@ -67,7 +67,7 @@ final class Handler {
   static final class LoggerHelperImpl implements ComponentLoggerProvider.LoggerHelper {
     static final LoggerHelperImpl INSTANCE = new LoggerHelperImpl();
 
-    private LoggerHelperImpl() {
+    LoggerHelperImpl() {
     }
 
     @Override

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/UnpackedComponentThrowable.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/UnpackedComponentThrowable.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import java.util.function.Function;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.util.ComponentMessageThrowable;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A wrapper for exceptions that implement ComponentMessageThrowable.
+ */
+final class UnpackedComponentThrowable extends Throwable {
+  private static final long serialVersionUID = -1L;
+
+  private final Class<? extends Throwable> backingType;
+
+  static Throwable unpack(final Throwable maybeRich, final Function<Component, String> serializer) {
+    if (!(maybeRich instanceof ComponentMessageThrowable)) return maybeRich; // TODO: do we need to unwrap any nested exceptions?
+
+    final @Nullable Component message = ((ComponentMessageThrowable) maybeRich).componentMessage();
+    final Throwable cause = maybeRich.getCause() != null ? unpack(maybeRich.getCause(), serializer) : null;
+    final Throwable[] suppressed = maybeRich.getSuppressed();
+
+    final UnpackedComponentThrowable ret = new UnpackedComponentThrowable(maybeRich.getClass(), serializer.apply(message), cause);
+    ret.setStackTrace(maybeRich.getStackTrace());
+    if (suppressed.length > 0) {
+      for (int i = 0; i < suppressed.length; i++) {
+        ret.addSuppressed(unpack(suppressed[i], serializer));
+      }
+    }
+
+    return ret;
+  }
+
+  private UnpackedComponentThrowable(final Class<? extends Throwable> backingType, final String serializedMessage, final Throwable cause) {
+    super(serializedMessage, cause);
+    this.backingType = backingType;
+  }
+
+  @Override
+  public String toString() {
+    final String className = this.backingType.getName();
+    final String message = this.getMessage();
+    return message == null ? className : className + ":" + message;
+  }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return this;
+  }
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -1,0 +1,417 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import java.util.function.Function;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.ext.LoggerWrapper;
+
+final class WrappingComponentLoggerImpl extends LoggerWrapper implements ComponentLogger {
+  private static final String FQCN = WrappingComponentLoggerImpl.class.getName();
+
+  // TODO: maybe handle ComponentMessageThrowable logging somehow?
+
+  private final Function<Component, String> serializer;
+
+  WrappingComponentLoggerImpl(final Logger backing, final Function<Component, String> serializer) {
+    super(backing, FQCN);
+    this.serializer = serializer;
+  }
+
+  private String serialize(final Component input) {
+    return this.serializer.apply(input);
+  }
+
+  private Object maybeSerialize(final @Nullable Object input) {
+    if (input instanceof Component) {
+      return this.serialize((Component) input);
+    } else {
+      return input;
+    }
+  }
+
+  private Object[] maybeSerialize(final @Nullable Object@NotNull... args) {
+    for (int i = 0; i < args.length; i++) {
+      if (args[i] instanceof Component) {
+        args[i] = this.serialize((Component) args[i]);
+      }
+    }
+
+    return args;
+  }
+
+  @Override
+  public void trace(final @NotNull Component msg) {
+    if (!this.isTraceEnabled()) return;
+
+    this.trace(this.serialize(msg));
+  }
+
+  @Override
+  public void trace(final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isTraceEnabled()) return;
+
+    this.trace(this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void trace(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isTraceEnabled()) return;
+
+    this.trace(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void trace(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isTraceEnabled()) return;
+
+    this.trace(this.serialize(format), this.maybeSerialize(arguments));
+  }
+
+  @Override
+  public void trace(final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isTraceEnabled()) return;
+
+    this.trace(this.serialize(msg), t);
+  }
+
+  @Override
+  public void trace(final Marker marker, final @NotNull Component msg) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    this.trace(marker, this.serialize(msg));
+  }
+
+  @Override
+  public void trace(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    this.trace(marker, this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void trace(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    this.trace(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void trace(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    this.trace(marker, this.serialize(format), this.maybeSerialize(argArray));
+  }
+
+  @Override
+  public void trace(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    this.trace(marker, this.serialize(msg), t);
+  }
+
+  @Override
+  public void debug(final @NotNull Component msg) {
+    if (!this.isDebugEnabled()) return;
+
+    this.debug(this.serialize(msg));
+  }
+
+  @Override
+  public void debug(final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isDebugEnabled()) return;
+
+    this.debug(this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void debug(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isDebugEnabled()) return;
+
+    this.debug(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void debug(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isDebugEnabled()) return;
+
+    this.debug(this.serialize(format), this.maybeSerialize(arguments));
+  }
+
+  @Override
+  public void debug(final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isDebugEnabled()) return;
+
+    this.debug(this.serialize(msg), t);
+  }
+
+  @Override
+  public void debug(final Marker marker, final @NotNull Component msg) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    this.debug(marker, this.serialize(msg));
+  }
+
+  @Override
+  public void debug(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    this.debug(marker, this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void debug(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    this.debug(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void debug(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    this.debug(marker, this.serialize(format), this.maybeSerialize(argArray));
+  }
+
+  @Override
+  public void debug(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    this.debug(marker, this.serialize(msg), t);
+  }
+
+  @Override
+  public void info(final @NotNull Component msg) {
+    if (!this.isInfoEnabled()) return;
+
+    this.info(this.serialize(msg));
+  }
+
+  @Override
+  public void info(final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isInfoEnabled()) return;
+
+    this.info(this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void info(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isInfoEnabled()) return;
+
+    this.info(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void info(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isInfoEnabled()) return;
+
+    this.info(this.serialize(format), this.maybeSerialize(arguments));
+  }
+
+  @Override
+  public void info(final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isInfoEnabled()) return;
+
+    this.info(this.serialize(msg), t);
+  }
+
+  @Override
+  public void info(final Marker marker, final @NotNull Component msg) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    this.info(marker, this.serialize(msg));
+  }
+
+  @Override
+  public void info(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    this.info(marker, this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void info(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    this.info(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void info(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    this.info(marker, this.serialize(format), this.maybeSerialize(argArray));
+  }
+
+  @Override
+  public void info(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    this.info(marker, this.serialize(msg), t);
+  }
+
+  @Override
+  public void warn(final @NotNull Component msg) {
+    if (!this.isWarnEnabled()) return;
+
+    this.warn(this.serialize(msg));
+  }
+
+  @Override
+  public void warn(final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isWarnEnabled()) return;
+
+    this.warn(this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void warn(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isWarnEnabled()) return;
+
+    this.warn(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void warn(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isWarnEnabled()) return;
+
+    this.warn(this.serialize(format), this.maybeSerialize(arguments));
+  }
+
+  @Override
+  public void warn(final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isWarnEnabled()) return;
+
+    this.warn(this.serialize(msg), t);
+  }
+
+  @Override
+  public void warn(final Marker marker, final @NotNull Component msg) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    this.warn(marker, this.serialize(msg));
+  }
+
+  @Override
+  public void warn(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    this.warn(marker, this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void warn(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    this.warn(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void warn(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    this.warn(marker, this.serialize(format), this.maybeSerialize(argArray));
+  }
+
+  @Override
+  public void warn(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    this.warn(marker, this.serialize(msg), t);
+  }
+
+  @Override
+  public void error(final @NotNull Component msg) {
+    if (!this.isErrorEnabled()) return;
+
+    this.error(this.serialize(msg));
+  }
+
+  @Override
+  public void error(final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isErrorEnabled()) return;
+
+    this.error(this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void error(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isErrorEnabled()) return;
+
+    this.error(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void error(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isErrorEnabled()) return;
+
+    this.error(this.serialize(format), this.maybeSerialize(arguments));
+  }
+
+  @Override
+  public void error(final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isErrorEnabled()) return;
+
+    this.error(this.serialize(msg), t);
+  }
+
+  @Override
+  public void error(final Marker marker, final @NotNull Component msg) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    this.error(marker, this.serialize(msg));
+  }
+
+  @Override
+  public void error(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    this.error(marker, this.serialize(format), this.maybeSerialize(arg));
+  }
+
+  @Override
+  public void error(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    this.error(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+  }
+
+  @Override
+  public void error(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    this.error(marker, this.serialize(format), this.maybeSerialize(argArray));
+  }
+
+  @Override
+  public void error(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    this.error(marker, this.serialize(msg), t);
+  }
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.logger.slf4j;
 
+import java.util.Arrays;
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
@@ -60,17 +61,24 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   private Object[] maybeSerialize(final @Nullable Object@NotNull... args) {
-    for (int i = 0; i < args.length; i++) {
-      if (args[i] instanceof ComponentLike) {
-        args[i] = this.serialize(((ComponentLike) args[i]).asComponent());
+    Object[] writable = args;
+    for (int i = 0; i < writable.length; i++) {
+      if (writable[i] instanceof ComponentLike) {
+        if (writable == args) {
+          writable = Arrays.copyOf(args, args.length);
+        }
+        writable[i] = this.serialize(((ComponentLike) writable[i]).asComponent());
       }
     }
 
-    if (args.length > 0 && args[args.length - 1] instanceof Throwable) {
-      args[args.length - 1] = UnpackedComponentThrowable.unpack((Throwable) args[args.length - 1], this.serializer);
+    if (writable.length > 0 && writable[writable.length - 1] instanceof Throwable) {
+      if (writable == args) {
+        writable = Arrays.copyOf(args, args.length);
+      }
+      writable[writable.length - 1] = UnpackedComponentThrowable.unpack((Throwable) writable[writable.length - 1], this.serializer);
     }
 
-    return args;
+    return writable;
   }
 
   // Basic methods, plain delegation

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.logger.slf4j;
 
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -33,8 +34,6 @@ import org.slf4j.ext.LoggerWrapper;
 
 final class WrappingComponentLoggerImpl extends LoggerWrapper implements ComponentLogger {
   private static final String FQCN = WrappingComponentLoggerImpl.class.getName();
-
-  // TODO: maybe handle ComponentMessageThrowable logging somehow?
 
   private final Function<Component, String> serializer;
 
@@ -48,8 +47,8 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   }
 
   private Object maybeSerialize(final @Nullable Object input) {
-    if (input instanceof Component) {
-      return this.serialize((Component) input);
+    if (input instanceof ComponentLike) {
+      return this.serialize(((ComponentLike) input).asComponent());
     } else {
       return input;
     }
@@ -57,9 +56,13 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
 
   private Object[] maybeSerialize(final @Nullable Object@NotNull... args) {
     for (int i = 0; i < args.length; i++) {
-      if (args[i] instanceof Component) {
-        args[i] = this.serialize((Component) args[i]);
+      if (args[i] instanceof ComponentLike) {
+        args[i] = this.serialize(((ComponentLike) args[i]).asComponent());
       }
+    }
+
+    if (args.length > 0 && args[args.length - 1] instanceof Throwable) {
+      args[args.length - 1] = UnpackedComponentThrowable.unpack((Throwable) args[args.length - 1], this.serializer);
     }
 
     return args;
@@ -97,7 +100,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
-    this.trace(this.serialize(msg), t);
+    this.trace(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -132,7 +135,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.trace(marker, this.serialize(msg), t);
+    this.trace(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -167,7 +170,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
-    this.debug(this.serialize(msg), t);
+    this.debug(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -202,7 +205,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.debug(marker, this.serialize(msg), t);
+    this.debug(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -237,7 +240,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
-    this.info(this.serialize(msg), t);
+    this.info(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -272,7 +275,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.info(marker, this.serialize(msg), t);
+    this.info(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -307,7 +310,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
-    this.warn(this.serialize(msg), t);
+    this.warn(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -342,7 +345,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.warn(marker, this.serialize(msg), t);
+    this.warn(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -377,7 +380,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
-    this.error(this.serialize(msg), t);
+    this.error(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 
   @Override
@@ -412,6 +415,6 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.error(marker, this.serialize(msg), t);
+    this.error(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
   }
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.ext.LoggerWrapper;
+import org.slf4j.spi.LocationAwareLogger;
 
 final class WrappingComponentLoggerImpl extends LoggerWrapper implements ComponentLogger {
   private static final String FQCN = WrappingComponentLoggerImpl.class.getName();
@@ -38,11 +39,13 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   private final Function<Component, String> serializer;
 
   WrappingComponentLoggerImpl(final Logger backing, final Function<Component, String> serializer) {
-    super(backing, FQCN);
+    super(backing, LoggerWrapper.class.getName());
     this.serializer = serializer;
   }
 
   private String serialize(final Component input) {
+    if (input == null) return null;
+
     return this.serializer.apply(input);
   }
 
@@ -69,352 +72,902 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   }
 
   @Override
-  public void trace(final @NotNull Component msg) {
+  public void trace(final @NotNull Component format) {
     if (!this.isTraceEnabled()) return;
 
-    this.trace(this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(format),
+        null,
+        null
+      );
+    } else {
+      this.trace(this.serialize(format));
+    }
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled()) return;
 
-    this.trace(this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.trace(this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled()) return;
 
-    this.trace(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.trace(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isTraceEnabled()) return;
 
-    this.trace(this.serialize(format), this.maybeSerialize(arguments));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(format),
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.trace(this.serialize(format), this.maybeSerialize(arguments));
+    }
   }
 
   @Override
   public void trace(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
-    this.trace(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.trace(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void trace(final Marker marker, final @NotNull Component msg) {
+  public void trace(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.trace(marker, this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(msg),
+        null,
+        null
+      );
+    } else {
+      this.trace(marker, this.serialize(msg));
+    }
   }
 
   @Override
-  public void trace(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.trace(marker, this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.trace(marker, this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
-  public void trace(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.trace(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.trace(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
-  public void trace(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.trace(marker, this.serialize(format), this.maybeSerialize(argArray));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(format),
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.trace(marker, this.serialize(format), this.maybeSerialize(argArray));
+    }
   }
 
   @Override
-  public void trace(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void trace(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.trace(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.trace(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void debug(final @NotNull Component msg) {
+  public void debug(final @NotNull Component format) {
     if (!this.isDebugEnabled()) return;
 
-    this.debug(this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(format),
+        null,
+        null
+      );
+    } else {
+      this.debug(this.serialize(format));
+    }
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled()) return;
 
-    this.debug(this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.debug(this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled()) return;
 
-    this.debug(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.debug(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isDebugEnabled()) return;
 
-    this.debug(this.serialize(format), this.maybeSerialize(arguments));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(format),
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.debug(this.serialize(format), this.maybeSerialize(arguments));
+    }
   }
 
   @Override
   public void debug(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
-    this.debug(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.debug(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void debug(final Marker marker, final @NotNull Component msg) {
+  public void debug(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.debug(marker, this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(msg),
+        null,
+        null
+      );
+    } else {
+      this.debug(marker, this.serialize(msg));
+    }
   }
 
   @Override
-  public void debug(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.debug(marker, this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.debug(marker, this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
-  public void debug(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.debug(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.debug(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
-  public void debug(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.debug(marker, this.serialize(format), this.maybeSerialize(argArray));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(format),
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.debug(marker, this.serialize(format), this.maybeSerialize(argArray));
+    }
   }
 
   @Override
-  public void debug(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void debug(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.debug(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.debug(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void info(final @NotNull Component msg) {
+  public void info(final @NotNull Component format) {
     if (!this.isInfoEnabled()) return;
 
-    this.info(this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(format),
+        null,
+        null
+      );
+    } else {
+      this.info(this.serialize(format));
+    }
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled()) return;
 
-    this.info(this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.info(this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled()) return;
 
-    this.info(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.info(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isInfoEnabled()) return;
 
-    this.info(this.serialize(format), this.maybeSerialize(arguments));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(format),
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.info(this.serialize(format), this.maybeSerialize(arguments));
+    }
   }
 
   @Override
   public void info(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
-    this.info(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.info(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void info(final Marker marker, final @NotNull Component msg) {
+  public void info(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.info(marker, this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(msg),
+        null,
+        null
+      );
+    } else {
+      this.info(marker, this.serialize(msg));
+    }
   }
 
   @Override
-  public void info(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.info(marker, this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.info(marker, this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
-  public void info(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.info(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.info(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
-  public void info(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.info(marker, this.serialize(format), this.maybeSerialize(argArray));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(format),
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.info(marker, this.serialize(format), this.maybeSerialize(argArray));
+    }
   }
 
   @Override
-  public void info(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void info(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.info(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.info(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void warn(final @NotNull Component msg) {
+  public void warn(final @NotNull Component format) {
     if (!this.isWarnEnabled()) return;
 
-    this.warn(this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(format),
+        null,
+        null
+      );
+    } else {
+      this.warn(this.serialize(format));
+    }
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled()) return;
 
-    this.warn(this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.warn(this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled()) return;
 
-    this.warn(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.warn(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isWarnEnabled()) return;
 
-    this.warn(this.serialize(format), this.maybeSerialize(arguments));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(format),
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.warn(this.serialize(format), this.maybeSerialize(arguments));
+    }
   }
 
   @Override
   public void warn(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
-    this.warn(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.warn(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void warn(final Marker marker, final @NotNull Component msg) {
+  public void warn(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.warn(marker, this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(msg),
+        null,
+        null
+      );
+    } else {
+      this.warn(marker, this.serialize(msg));
+    }
   }
 
   @Override
-  public void warn(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.warn(marker, this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.warn(marker, this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
-  public void warn(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.warn(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.warn(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
-  public void warn(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.warn(marker, this.serialize(format), this.maybeSerialize(argArray));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(format),
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.warn(marker, this.serialize(format), this.maybeSerialize(argArray));
+    }
   }
 
   @Override
-  public void warn(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void warn(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.warn(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.warn(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void error(final @NotNull Component msg) {
+  public void error(final @NotNull Component format) {
     if (!this.isErrorEnabled()) return;
 
-    this.error(this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(format),
+        null,
+        null
+      );
+    } else {
+      this.error(this.serialize(format));
+    }
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled()) return;
 
-    this.error(this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.error(this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled()) return;
 
-    this.error(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.error(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isErrorEnabled()) return;
 
-    this.error(this.serialize(format), this.maybeSerialize(arguments));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(format),
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.error(this.serialize(format), this.maybeSerialize(arguments));
+    }
   }
 
   @Override
   public void error(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
-    this.error(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.error(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 
   @Override
-  public void error(final Marker marker, final @NotNull Component msg) {
+  public void error(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.error(marker, this.serialize(msg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(msg),
+        null,
+        null
+      );
+    } else {
+      this.error(marker, this.serialize(msg));
+    }
   }
 
   @Override
-  public void error(final Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.error(marker, this.serialize(format), this.maybeSerialize(arg));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.error(marker, this.serialize(format), this.maybeSerialize(arg));
+    }
   }
 
   @Override
-  public void error(final Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.error(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(format),
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.error(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
   }
 
   @Override
-  public void error(final Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.error(marker, this.serialize(format), this.maybeSerialize(argArray));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(format),
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.error(marker, this.serialize(format), this.maybeSerialize(argArray));
+    }
   }
 
   @Override
-  public void error(final Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void error(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.error(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    if (this.instanceofLAL) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        this.serialize(msg),
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.error(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
   }
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -30,17 +30,19 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
-import org.slf4j.ext.LoggerWrapper;
 import org.slf4j.spi.LocationAwareLogger;
 
-final class WrappingComponentLoggerImpl extends LoggerWrapper implements ComponentLogger {
+final class WrappingComponentLoggerImpl implements ComponentLogger {
   private static final String FQCN = WrappingComponentLoggerImpl.class.getName();
 
+  private final Logger logger;
+  private final boolean isLocationAware;
   private final Function<Component, String> serializer;
 
   WrappingComponentLoggerImpl(final Logger backing, final Function<Component, String> serializer) {
-    super(backing, LoggerWrapper.class.getName());
     this.serializer = serializer;
+    this.logger = backing;
+    this.isLocationAware = backing instanceof LocationAwareLogger;
   }
 
   private String serialize(final Component input) {
@@ -71,11 +73,972 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
     return args;
   }
 
+  // Basic methods, plain delegation
+
+  @Override
+  public String getName() {
+    return this.logger.getName();
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return this.logger.isTraceEnabled();
+  }
+
+  @Override
+  public boolean isTraceEnabled(final Marker marker) {
+    return this.logger.isTraceEnabled(marker);
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return this.logger.isDebugEnabled();
+  }
+
+  @Override
+  public boolean isDebugEnabled(final Marker marker) {
+    return this.logger.isDebugEnabled(marker);
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return this.logger.isInfoEnabled();
+  }
+
+  @Override
+  public boolean isInfoEnabled(final Marker marker) {
+    return this.logger.isInfoEnabled(marker);
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return this.logger.isWarnEnabled();
+  }
+
+  @Override
+  public boolean isWarnEnabled(final Marker marker) {
+    return this.logger.isWarnEnabled(marker);
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return this.logger.isErrorEnabled();
+  }
+
+  @Override
+  public boolean isErrorEnabled(final Marker marker) {
+    return this.logger.isErrorEnabled(marker);
+  }
+
+  // Standard string methods, to process potential Component arguments
+
+  @Override
+  public void trace(final @NotNull String format) {
+    if (!this.isTraceEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        format,
+        null,
+        null
+      );
+    } else {
+      this.logger.trace(format);
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isTraceEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.trace(format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isTraceEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.trace(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isTraceEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        format,
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.logger.trace(format, this.maybeSerialize(arguments));
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isTraceEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.trace(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull Marker marker, final @NotNull String msg) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        msg,
+        null,
+        null
+      );
+    } else {
+      this.logger.trace(marker, msg);
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.trace(marker, format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.trace(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        format,
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.logger.trace(marker, format, this.maybeSerialize(argArray));
+    }
+  }
+
+  @Override
+  public void trace(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isTraceEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.TRACE_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.trace(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull String format) {
+    if (!this.isDebugEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        format,
+        null,
+        null
+      );
+    } else {
+      this.logger.debug(format);
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isDebugEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.debug(format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isDebugEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.debug(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isDebugEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        format,
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.logger.debug(format, this.maybeSerialize(arguments));
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isDebugEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.debug(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull Marker marker, final @NotNull String msg) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        msg,
+        null,
+        null
+      );
+    } else {
+      this.logger.debug(marker, msg);
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.debug(marker, format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.debug(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        format,
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.logger.debug(marker, format, this.maybeSerialize(argArray));
+    }
+  }
+
+  @Override
+  public void debug(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isDebugEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.DEBUG_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.debug(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void info(final @NotNull String format) {
+    if (!this.isInfoEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        format,
+        null,
+        null
+      );
+    } else {
+      this.logger.info(format);
+    }
+  }
+
+  @Override
+  public void info(final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isInfoEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.info(format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void info(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isInfoEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.info(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void info(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isInfoEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        format,
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.logger.info(format, this.maybeSerialize(arguments));
+    }
+  }
+
+  @Override
+  public void info(final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isInfoEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.info(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void info(final @NotNull Marker marker, final @NotNull String msg) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        msg,
+        null,
+        null
+      );
+    } else {
+      this.logger.info(marker, msg);
+    }
+  }
+
+  @Override
+  public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.info(marker, format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.info(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        format,
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.logger.info(marker, format, this.maybeSerialize(argArray));
+    }
+  }
+
+  @Override
+  public void info(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isInfoEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.INFO_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.info(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull String format) {
+    if (!this.isWarnEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        format,
+        null,
+        null
+      );
+    } else {
+      this.logger.warn(format);
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isWarnEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.warn(format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isWarnEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.warn(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isWarnEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        format,
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.logger.warn(format, this.maybeSerialize(arguments));
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isWarnEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.warn(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull Marker marker, final @NotNull String msg) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        msg,
+        null,
+        null
+      );
+    } else {
+      this.logger.warn(marker, msg);
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.warn(marker, format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.warn(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        format,
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.logger.warn(marker, format, this.maybeSerialize(argArray));
+    }
+  }
+
+  @Override
+  public void warn(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isWarnEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.WARN_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.warn(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void error(final @NotNull String format) {
+    if (!this.isErrorEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        format,
+        null,
+        null
+      );
+    } else {
+      this.logger.error(format);
+    }
+  }
+
+  @Override
+  public void error(final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isErrorEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.error(format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void error(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isErrorEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.error(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void error(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+    if (!this.isErrorEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        format,
+        this.maybeSerialize(arguments),
+        null
+      );
+    } else {
+      this.logger.error(format, this.maybeSerialize(arguments));
+    }
+  }
+
+  @Override
+  public void error(final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isErrorEnabled()) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        null,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.error(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  @Override
+  public void error(final @NotNull Marker marker, final @NotNull String msg) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        msg,
+        null,
+        null
+      );
+    } else {
+      this.logger.error(marker, msg);
+    }
+  }
+
+  @Override
+  public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg)},
+        null
+      );
+    } else {
+      this.logger.error(marker, format, this.maybeSerialize(arg));
+    }
+  }
+
+  @Override
+  public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        format,
+        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+        null
+      );
+    } else {
+      this.logger.error(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+    }
+  }
+
+  @Override
+  public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        format,
+        this.maybeSerialize(argArray),
+        null
+      );
+    } else {
+      this.logger.error(marker, format, this.maybeSerialize(argArray));
+    }
+  }
+
+  @Override
+  public void error(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+    if (!this.isErrorEnabled(marker)) return;
+
+    if (this.isLocationAware) {
+      ((LocationAwareLogger) this.logger).log(
+        marker,
+        FQCN,
+        LocationAwareLogger.ERROR_INT,
+        msg,
+        null,
+        UnpackedComponentThrowable.unpack(t, this.serializer)
+      );
+    } else {
+      this.logger.error(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+    }
+  }
+
+  // Component-primary methods
+
   @Override
   public void trace(final @NotNull Component format) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -85,7 +1048,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.trace(this.serialize(format));
+      this.logger.trace(this.serialize(format));
     }
   }
 
@@ -93,7 +1056,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -103,7 +1066,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.trace(this.serialize(format), this.maybeSerialize(arg));
+      this.logger.trace(this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -111,7 +1074,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -121,7 +1084,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.trace(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.trace(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -129,7 +1092,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -139,7 +1102,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.trace(this.serialize(format), this.maybeSerialize(arguments));
+      this.logger.trace(this.serialize(format), this.maybeSerialize(arguments));
     }
   }
 
@@ -147,7 +1110,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -157,7 +1120,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.trace(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.trace(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -165,7 +1128,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -175,7 +1138,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.trace(marker, this.serialize(msg));
+      this.logger.trace(marker, this.serialize(msg));
     }
   }
 
@@ -183,7 +1146,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -193,7 +1156,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.trace(marker, this.serialize(format), this.maybeSerialize(arg));
+      this.logger.trace(marker, this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -201,7 +1164,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -211,7 +1174,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.trace(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.trace(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -219,7 +1182,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -229,7 +1192,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.trace(marker, this.serialize(format), this.maybeSerialize(argArray));
+      this.logger.trace(marker, this.serialize(format), this.maybeSerialize(argArray));
     }
   }
 
@@ -237,7 +1200,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void trace(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -247,7 +1210,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.trace(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.trace(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -255,7 +1218,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Component format) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -265,7 +1228,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.debug(this.serialize(format));
+      this.logger.debug(this.serialize(format));
     }
   }
 
@@ -273,7 +1236,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -283,7 +1246,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.debug(this.serialize(format), this.maybeSerialize(arg));
+      this.logger.debug(this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -291,7 +1254,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -301,7 +1264,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.debug(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.debug(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -309,7 +1272,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -319,7 +1282,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.debug(this.serialize(format), this.maybeSerialize(arguments));
+      this.logger.debug(this.serialize(format), this.maybeSerialize(arguments));
     }
   }
 
@@ -327,7 +1290,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -337,7 +1300,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.debug(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.debug(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -345,7 +1308,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -355,7 +1318,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.debug(marker, this.serialize(msg));
+      this.logger.debug(marker, this.serialize(msg));
     }
   }
 
@@ -363,7 +1326,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -373,7 +1336,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.debug(marker, this.serialize(format), this.maybeSerialize(arg));
+      this.logger.debug(marker, this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -381,7 +1344,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -391,7 +1354,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.debug(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.debug(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -399,7 +1362,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -409,7 +1372,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.debug(marker, this.serialize(format), this.maybeSerialize(argArray));
+      this.logger.debug(marker, this.serialize(format), this.maybeSerialize(argArray));
     }
   }
 
@@ -417,7 +1380,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void debug(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -427,7 +1390,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.debug(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.debug(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -435,7 +1398,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Component format) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -445,7 +1408,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.info(this.serialize(format));
+      this.logger.info(this.serialize(format));
     }
   }
 
@@ -453,7 +1416,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -463,7 +1426,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.info(this.serialize(format), this.maybeSerialize(arg));
+      this.logger.info(this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -471,7 +1434,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -481,7 +1444,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.info(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.info(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -489,7 +1452,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -499,7 +1462,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.info(this.serialize(format), this.maybeSerialize(arguments));
+      this.logger.info(this.serialize(format), this.maybeSerialize(arguments));
     }
   }
 
@@ -507,7 +1470,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -517,7 +1480,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.info(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.info(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -525,7 +1488,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -535,7 +1498,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.info(marker, this.serialize(msg));
+      this.logger.info(marker, this.serialize(msg));
     }
   }
 
@@ -543,7 +1506,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -553,7 +1516,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.info(marker, this.serialize(format), this.maybeSerialize(arg));
+      this.logger.info(marker, this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -561,7 +1524,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -571,7 +1534,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.info(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.info(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -579,7 +1542,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -589,7 +1552,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.info(marker, this.serialize(format), this.maybeSerialize(argArray));
+      this.logger.info(marker, this.serialize(format), this.maybeSerialize(argArray));
     }
   }
 
@@ -597,7 +1560,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void info(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -607,7 +1570,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.info(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.info(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -615,7 +1578,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Component format) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -625,7 +1588,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.warn(this.serialize(format));
+      this.logger.warn(this.serialize(format));
     }
   }
 
@@ -633,7 +1596,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -643,7 +1606,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.warn(this.serialize(format), this.maybeSerialize(arg));
+      this.logger.warn(this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -651,7 +1614,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -661,7 +1624,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.warn(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.warn(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -669,7 +1632,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -679,7 +1642,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.warn(this.serialize(format), this.maybeSerialize(arguments));
+      this.logger.warn(this.serialize(format), this.maybeSerialize(arguments));
     }
   }
 
@@ -687,7 +1650,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -697,7 +1660,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.warn(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.warn(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -705,7 +1668,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -715,7 +1678,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.warn(marker, this.serialize(msg));
+      this.logger.warn(marker, this.serialize(msg));
     }
   }
 
@@ -723,7 +1686,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -733,7 +1696,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.warn(marker, this.serialize(format), this.maybeSerialize(arg));
+      this.logger.warn(marker, this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -741,7 +1704,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -751,7 +1714,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.warn(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.warn(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -759,7 +1722,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -769,7 +1732,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.warn(marker, this.serialize(format), this.maybeSerialize(argArray));
+      this.logger.warn(marker, this.serialize(format), this.maybeSerialize(argArray));
     }
   }
 
@@ -777,7 +1740,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void warn(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -787,7 +1750,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.warn(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.warn(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -795,7 +1758,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Component format) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -805,7 +1768,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.error(this.serialize(format));
+      this.logger.error(this.serialize(format));
     }
   }
 
@@ -813,7 +1776,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -823,7 +1786,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.error(this.serialize(format), this.maybeSerialize(arg));
+      this.logger.error(this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -831,7 +1794,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -841,7 +1804,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.error(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.error(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -849,7 +1812,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -859,7 +1822,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.error(this.serialize(format), this.maybeSerialize(arguments));
+      this.logger.error(this.serialize(format), this.maybeSerialize(arguments));
     }
   }
 
@@ -867,7 +1830,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         null,
         FQCN,
@@ -877,7 +1840,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.error(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.error(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 
@@ -885,7 +1848,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -895,7 +1858,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.error(marker, this.serialize(msg));
+      this.logger.error(marker, this.serialize(msg));
     }
   }
 
@@ -903,7 +1866,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -913,7 +1876,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.error(marker, this.serialize(format), this.maybeSerialize(arg));
+      this.logger.error(marker, this.serialize(format), this.maybeSerialize(arg));
     }
   }
 
@@ -921,7 +1884,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -931,7 +1894,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.error(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      this.logger.error(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
     }
   }
 
@@ -939,7 +1902,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -949,7 +1912,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         null
       );
     } else {
-      this.error(marker, this.serialize(format), this.maybeSerialize(argArray));
+      this.logger.error(marker, this.serialize(format), this.maybeSerialize(argArray));
     }
   }
 
@@ -957,7 +1920,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
   public void error(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.instanceofLAL) {
+    if (this.isLocationAware) {
       ((LocationAwareLogger) this.logger).log(
         marker,
         FQCN,
@@ -967,7 +1930,7 @@ final class WrappingComponentLoggerImpl extends LoggerWrapper implements Compone
         UnpackedComponentThrowable.unpack(t, this.serializer)
       );
     } else {
-      this.error(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      this.logger.error(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
     }
   }
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/package-info.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * A wrapper around <a href="https://slf4j.org">SLF4J</a> providing methods for formatted logging of Components.
+ *
+ * <p>This wrapper supports the API provided in 1.7/1.8, but does not yet implement the fluent API present in the 2.0 betas.</p>
+ */
+package net.kyori.adventure.text.logger.slf4j;

--- a/text-logger-slf4j/src/main/java9/net/kyori/adventure/text/logger/slf4j/CallerClassFinder.java
+++ b/text-logger-slf4j/src/main/java9/net/kyori/adventure/text/logger/slf4j/CallerClassFinder.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+// Java 9+ version, see Java 8 version as well
+final class CallerClassFinder {
+  private CallerClassFinder() {
+  }
+
+  static String callingClassName() {
+    return callingClassName(2); // this, plus the calling method
+  }
+
+  static String callingClassName(final int elementsToSkip) { // elementsToSkip not counting this method
+    return StackWalker.getInstance().walk(stream -> stream.map(StackWalker.StackFrame::getClassName)
+      .skip(elementsToSkip + 1)
+      .findFirst())
+    .orElseThrow(() -> new IllegalArgumentException("Not enough stack elements to skip " + elementsToSkip + " elements"));
+  }
+}

--- a/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/CallerClassFinderTest.java
+++ b/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/CallerClassFinderTest.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CallerClassFinderTest {
+
+  @Test
+  void testCallerClass() {
+    assertEquals(CallerClassFinderTest.class.getName(), Holder.test());
+  }
+
+  static final class Holder {
+    static String test() {
+      return CallerClassFinder.callingClassName();
+    }
+  }
+}

--- a/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerTest.java
+++ b/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerTest.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.junit.jupiter.api.Test;
+
+public class ComponentLoggerTest {
+  @Test
+  void testLogSimple() {
+    final Component toLog = Component.text().content("Hello ").color(NamedTextColor.RED).append(Component.translatable("location.world")).build();
+
+    final ComponentLogger logger = ComponentLogger.logger();
+
+    logger.info(toLog);
+  }
+}

--- a/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerTest.java
+++ b/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerTest.java
@@ -147,4 +147,13 @@ public class ComponentLoggerTest {
       ImmutableList.of(LoggingEvent.info(MARKED, "meow :3"))
     );
   }
+
+  @Test
+  void testComponentAsArgToPlainLog() {
+    this.makeLogger().info("Hello {}", Component.text("friend"));
+    assertEquals(
+      LOGGER.getLoggingEvents(),
+      ImmutableList.of(LoggingEvent.info("Hello {}", "friend"))
+    );
+  }
 }

--- a/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerTest.java
+++ b/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerTest.java
@@ -25,15 +25,40 @@ package net.kyori.adventure.text.logger.slf4j;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 
+@ExtendWith(MockitoExtension.class)
 public class ComponentLoggerTest {
+  @Mock(name = "net.kyori.adventure.test.ComponentLoggerTest")
+  Logger backingLogger;
+
+  private final ComponentLoggerProvider.LoggerHelper helper = new Handler.LoggerHelperImpl();
+
+  ComponentLogger makeLogger() {
+    return new WrappingComponentLoggerImpl(this.backingLogger, this.helper.plainSerializer());
+  }
+
+  @BeforeEach
+  void enableLevels() {
+    Mockito.when(this.backingLogger.isInfoEnabled()).thenReturn(true);
+  }
+
   @Test
   void testLogSimple() {
     final Component toLog = Component.text().content("Hello ").color(NamedTextColor.RED).append(Component.translatable("location.world")).build();
 
-    final ComponentLogger logger = ComponentLogger.logger();
+    final ComponentLogger logger = this.makeLogger();
 
     logger.info(toLog);
+
+    Mockito.verify(this.backingLogger, Mockito.times(2)).isInfoEnabled();
+    Mockito.verify(this.backingLogger).info("Hello location.world");
+    Mockito.verifyNoMoreInteractions(this.backingLogger);
   }
 }


### PR DESCRIPTION
Fixes GH-731

TODOs:

- [x] make sure location information is passed through to logger implementations properly -- we might have to call LocationAwareLogger directly?
- [x] is our handling of argument arrays correct
- [x] test implemenations -- we should have prototypes for paper and fabric
- [x] does SLF4J have a test harness? or can we mockito up something?
- [x] is it worth doing something with `ComponentMessageThrowable`s as special handling for the throwable param?
- [x] Override all String logging methods to process component arguments/throwables passed