### PR TITLE
Add Context#preProcess to resolve all preProcess tags

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -70,6 +70,15 @@ public interface Context {
   @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers);
 
   /**
+   * Resolve PreProcess tags and insert them in the String. This has a recursion limit of 10.
+   *
+   * @param message the message to replace tags
+   * @return the message with replaced {@link net.kyori.adventure.text.minimessage.tag.PreProcess} tags
+   * @since 4.10.2
+   */
+  @NotNull String preProcess(final @NotNull String message);
+
+  /**
    * Create a new parsing exception.
    *
    * @param message a detail message describing the error

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -74,7 +74,7 @@ public interface Context {
    *
    * @param message the message to replace tags
    * @return the message with replaced {@link net.kyori.adventure.text.minimessage.tag.PreProcess} tags
-   * @since 4.10.2
+   * @since 4.11.0
    */
   @NotNull String preProcess(final @NotNull String message);
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -131,6 +131,10 @@ final class MiniMessageImpl implements MiniMessage {
     return this.parser.stripTokens(input, this.newContext(input, tagResolver));
   }
 
+  @NotNull String preProcessTags(final @NotNull String input, final @NotNull ContextImpl context) {
+    return this.parser.parsePreProcessTags(input, context);
+  }
+
   private @NotNull ContextImpl newContext(final @NotNull String input, final @Nullable TagResolver resolver) {
     requireNonNull(input, "input");
     if (resolver == null) {


### PR DESCRIPTION
This PR adds a new method to Context. With this method you can resolve preProcess tags in your own TagResolver.

This should be handy for TagResolvers which do not directly insert components and want to have some sort of recursive resolvers.

I added a recursion limit to throw an exception once the TagResolvers tried 10 times to preProcess those tags.