### PR TITLE
Improve compaction of empty/blank TextComponents

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -221,6 +221,7 @@ final class ComponentCompaction {
     
     builder.color(null);
     builder.decoration(TextDecoration.ITALIC, TextDecoration.State.NOT_SET);
+    builder.decoration(TextDecoration.OBFUSCATED, TextDecoration.State.NOT_SET);
     
     return builder.build();
   }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -222,7 +222,7 @@ final class ComponentCompaction {
     // TextColor doesn't affect spaces
     builder.color(null);
 
-    // ITALIC/OBFUSCATED don't affect spaces, as these styles only affect glyph rendering
+    // ITALIC/OBFUSCATED don't affect spaces (in modern versions), as these styles only affect glyph rendering
     builder.decoration(TextDecoration.ITALIC, TextDecoration.State.NOT_SET);
     builder.decoration(TextDecoration.OBFUSCATED, TextDecoration.State.NOT_SET);
 

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -218,10 +218,18 @@ final class ComponentCompaction {
   */
   private static @NotNull Style simplifyStyleForBlank(final @NotNull Style style) {
     final Style.Builder builder = style.toBuilder();
-    
+
+    // TextColor doesn't affect spaces
     builder.color(null);
+
+    // ITALIC/OBFUSCATED don't affect spaces, as these styles only affect glyph rendering
     builder.decoration(TextDecoration.ITALIC, TextDecoration.State.NOT_SET);
     builder.decoration(TextDecoration.OBFUSCATED, TextDecoration.State.NOT_SET);
+
+    // UNDERLINE/STRIKETHROUGH affects spaces because the line renders on top
+    // BOLD affects spaces because it increments the character advance by 1
+
+    // font affects spaces in 1.19+ (since 22w11a), due to the font glyph provider for spaces
     
     return builder.build();
   }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -49,8 +49,8 @@ final class ComponentCompaction {
 
     if (childrenSize == 0) {
       // no children, style can be further simplified if self is blank
-      if (isBlank(self)) {
-        optimized = optimized.style(simplifyStyleForBlank(self.style()));
+      if (isBlank(optimized)) {
+        optimized = optimized.style(simplifyStyleForBlank(optimized.style()));
       }
 
       // leaf nodes do not need to be further optimized - there is no point
@@ -58,8 +58,8 @@ final class ComponentCompaction {
     }
 
     // if there is only one child, check if self a useless empty component
-    if (childrenSize == 1 && self instanceof TextComponent) {
-      final TextComponent textComponent = (TextComponent) self;
+    if (childrenSize == 1 && optimized instanceof TextComponent) {
+      final TextComponent textComponent = (TextComponent) optimized;
 
       if (textComponent.content().isEmpty()) {
         final Component child = children.get(0);
@@ -140,8 +140,8 @@ final class ComponentCompaction {
     }
 
     // no children, style can be further simplified if self is blank
-    if (childrenToAppend.isEmpty() && isBlank(self)) {
-      optimized = optimized.style(simplifyStyleForBlank(self.style()));
+    if (childrenToAppend.isEmpty() && isBlank(optimized)) {
+      optimized = optimized.style(simplifyStyleForBlank(optimized.style()));
     }
 
     return optimized.children(childrenToAppend);
@@ -191,18 +191,19 @@ final class ComponentCompaction {
   }
 
   /**
-  * Checks whether the Component is blank (a TextComponent containing only space characters)
+  * Checks whether the Component is blank (a TextComponent containing only space characters).
   *
   * @param component the component to check
   * @return true if the provided component is blank, false otherwise
   */
-  private static boolean isBlank(Component component) {
+  private static boolean isBlank(final Component component) {
     if (component instanceof TextComponent) {
       final TextComponent textComponent = (TextComponent) component;
 
-      String content = textComponent.content();
+      final String content = textComponent.content();
+
       for (int i = 0; i < content.length(); i++) {
-        char c = content.charAt(i);
+        final char c = content.charAt(i);
         if (c != ' ') return false;
       }
       
@@ -213,7 +214,7 @@ final class ComponentCompaction {
   
   /**
   * Simplify the provided style to remove any information that is redundant,
-  * given that the content is blank
+  * given that the content is blank.
   *
   * @param style style to simplify
   * @return a new, simplified style

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -199,8 +199,10 @@ final class ComponentCompaction {
   private static boolean isBlank(Component component) {
     if (component instanceof TextComponent) {
       final TextComponent textComponent = (TextComponent) component;
-      
-      for (char c : textComponent.content().toCharArray()) {
+
+      String content = textComponent.content();
+      for (int i = 0; i < content.length(); i++) {
+        char c = content.charAt(i);
         if (c != ' ') return false;
       }
       

--- a/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
@@ -24,8 +24,10 @@
 package net.kyori.adventure.text;
 
 import java.util.stream.Stream;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
@@ -314,4 +316,84 @@ class ComponentCompactingTest {
 
     assertEquals(expectedCompact, notCompact.compact());
   }
+
+  @Test
+  void testBlankStyleRemoval() {
+    final String blank = "   ";
+
+    final Component expectedCompact = text(blank);
+    final Component notCompact = text(blank, NamedTextColor.RED);
+
+    assertEquals(expectedCompact, notCompact.compact());
+  }
+
+  @Test
+  void testBlankCompactionWithRemovableStyle() {
+    final String blank = "   ";
+
+    final Component expectedCompact = text(blank);
+    final Component notCompact = text().append(
+      text(blank, NamedTextColor.RED)
+    ).build();
+
+    assertEquals(expectedCompact, notCompact.compact());
+  }
+
+  @Test
+  void testBlankCompactionWithManyStyle() {
+    final String blank = "   ";
+
+    final Component expectedCompact = text(blank + blank + blank + blank);
+    final Component notCompact = text().append(
+      text(blank, NamedTextColor.RED)
+        .append(text(blank).decorate(TextDecoration.ITALIC))
+    ).append(
+      text(blank).decorate(TextDecoration.OBFUSCATED)
+        .append(text(blank, TextColor.color(0xDEADB33F)))
+    ).build();
+
+    assertEquals(expectedCompact, notCompact.compact());
+  }
+
+  @Test
+  void testBlankCompactionWithNonRemovableStyle() {
+    final String blank = "   ";
+
+    final Component expectedCompact = text(blank).decorate(TextDecoration.STRIKETHROUGH);
+    final Component notCompact = text().append(
+      text(blank).decorate(TextDecoration.STRIKETHROUGH)
+    ).build();
+
+    assertEquals(expectedCompact, notCompact.compact());
+  }
+
+  @Test
+  void testBlankCompactionWithManyNonRemovableStyle() {
+    final String blank = "   ";
+
+    final Component notCompact = text().append(
+      text(blank).decorate(TextDecoration.STRIKETHROUGH)
+        .append(text(blank).decorate(TextDecoration.BOLD))
+    ).append(
+      text(blank).decorate(TextDecoration.UNDERLINED)
+        .append(text(blank).font(Key.key("kyori:meow")))
+    ).build();
+
+    assertEquals(notCompact, notCompact.compact());
+  }
+
+  @Test
+  void testEmptyCompactionWithManyNonRemovableStyle() {
+    final Component expectedCompact = text("meow");
+    final Component notCompact = text().content("meow").append(
+      empty().decorate(TextDecoration.STRIKETHROUGH)
+        .append(empty().decorate(TextDecoration.BOLD))
+    ).append(
+      empty().decorate(TextDecoration.UNDERLINED)
+        .append(empty().font(Key.key("kyori:meow")))
+    ).build();
+
+    assertEquals(expectedCompact, notCompact.compact());
+  }
+
 }


### PR DESCRIPTION
## Improve compaction of empty/blank TextComponents

I believe that for a TextComponent comprised of only space characters (" "), TextColor and ITALIC stylings are redundant.
We can take advantage of this in order to further compact components.

Font and BOLD stylings also seem like candidates for removal, but afaik BOLD affects the advance of space character and in 1.19 Font will do so too.

## Some examples
### Removal of useless styling on blank components
Input: `{"text":"   ","color":"red"}`
Before: `{"text":"   ","color":"red"}`
After: `{"text":"   "}`

### Compaction of blank components (side effect of previous)
Input: `{"text":"Hello ","extra":[{"color":"red","text":"   "}]}`
Before: `{"text":"Hello ","extra":[{"color":"red","text":"   "}]}`
After: `{"text":"Hello    "}`

## #Removal of empty children, regardless of style
Input: `{"text":"Hello ","color":"red","extra":[{"strikethrough":true,"text":""}]}`
Before: `{"text":"Hello ","color":"red","extra":[{"strikethrough":true,"text":""}]}`
After: `{"text":"Hello ","color":"red"}`

