### PR TITLE
Promote decorationIfAbsent to StyleSetter and Public API

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -245,6 +245,17 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
 
   @Override
   @SuppressWarnings("unchecked")
+  public @NotNull B decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+    requireNonNull(state, "state");
+    final TextDecoration.@NotNull State thisState = this.buildStyle().decoration(decoration);
+    if (thisState == TextDecoration.State.NOT_SET) {
+      this.styleBuilder().decoration(decoration, state);
+    }
+    return (B) this;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
   public @NotNull B clickEvent(final @Nullable ClickEvent event) {
     this.styleBuilder().clickEvent(event);
     return (B) this;

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -246,11 +246,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   @Override
   @SuppressWarnings("unchecked")
   public @NotNull B decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
-    requireNonNull(state, "state");
-    final TextDecoration.@NotNull State thisState = this.buildStyle().decoration(decoration);
-    if (thisState == TextDecoration.State.NOT_SET) {
-      this.styleBuilder().decoration(decoration, state);
-    }
+    this.styleBuilder().decorationIfAbsent(decoration, state);
     return (B) this;
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2026,7 +2026,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Override
   default @NotNull Component decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state) {
     requireNonNull(state, "state");
-    //Not delegating this method prevents object creation if decoration is absent
+    //Not delegating this method prevents object creation if decoration is NOT absent
     final TextDecoration.@NotNull State thisState = this.decoration(decoration);
     if (thisState == TextDecoration.State.NOT_SET) {
       return this.style(this.style().decoration(decoration, state));

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2015,6 +2015,26 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Sets the state of a decoration on this component to {@code state} if the current state of
+   * the decoration is {@link TextDecoration.State#NOT_SET}.
+   *
+   * @param decoration the decoration
+   * @param state the state
+   * @return a component
+   * @since 4.12.0
+   */
+  @Override
+  default @NotNull Component decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state) {
+    requireNonNull(state, "state");
+    //Not delegating this method prevents object creation if decoration is absent
+    final TextDecoration.@NotNull State thisState = this.decoration(decoration);
+    if (thisState == TextDecoration.State.NOT_SET) {
+      return this.style(this.style().decoration(decoration, state));
+    }
+    return this;
+  }
+
+  /**
    * Gets the click event of this component.
    *
    * @return the click event

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1989,6 +1989,26 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Sets the state of a decoration on this component to {@code state} if the current state of
+   * the decoration is {@link TextDecoration.State#NOT_SET}.
+   *
+   * @param decoration the decoration
+   * @param state the state
+   * @return a component
+   * @since 4.12.0
+   */
+  @Override
+  default @NotNull Component decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state) {
+    requireNonNull(state, "state");
+    // Not delegating this method prevents object creation if decoration is NOT absent
+    final TextDecoration.@NotNull State oldState = this.decoration(decoration);
+    if (oldState == TextDecoration.State.NOT_SET) {
+      return this.style(this.style().decoration(decoration, state));
+    }
+    return this;
+  }
+
+  /**
    * Gets a set of decorations this component has.
    *
    * @return a set of decorations this component has
@@ -2012,26 +2032,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Override
   default @NotNull Component decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
     return this.style(this.style().decorations(decorations));
-  }
-
-  /**
-   * Sets the state of a decoration on this component to {@code state} if the current state of
-   * the decoration is {@link TextDecoration.State#NOT_SET}.
-   *
-   * @param decoration the decoration
-   * @param state the state
-   * @return a component
-   * @since 4.12.0
-   */
-  @Override
-  default @NotNull Component decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state) {
-    requireNonNull(state, "state");
-    //Not delegating this method prevents object creation if decoration is NOT absent
-    final TextDecoration.@NotNull State thisState = this.decoration(decoration);
-    if (thisState == TextDecoration.State.NOT_SET) {
-      return this.style(this.style().decoration(decoration, state));
-    }
-    return this;
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
@@ -309,6 +309,19 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
   @NotNull B decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
   /**
+   * Sets the state of a decoration on this component to {@code state} if the current state of
+   * the decoration is {@link TextDecoration.State#NOT_SET}.
+   *
+   * @param decoration the decoration
+   * @param state the state
+   * @return this builder
+   * @since 4.12.0
+   */
+  @Contract("_, _ -> this")
+  @Override
+  @NotNull B decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state);
+
+  /**
    * Sets the click event of this component.
    *
    * @param event the click event

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -365,6 +365,18 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
   @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations);
 
   /**
+   * Sets the state of a decoration on this style to {@code state} if the current state of
+   * the decoration is {@link TextDecoration.State#NOT_SET}.
+   *
+   * @param decoration the decoration
+   * @param state the state
+   * @return a style
+   * @since 4.12.0
+   */
+  @Override
+  @NotNull Style decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state);
+
+  /**
    * Gets the click event.
    *
    * @return the click event
@@ -760,6 +772,18 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
     @Override
     @Contract("_, _ -> this")
     @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+
+    /**
+     * Sets the state of a decoration on this style to {@code state} if the current state of the decoration is {@link TextDecoration.State#NOT_SET}.
+     *
+     * @param decoration the decoration
+     * @param state the state
+     * @return this builder
+     * @since 4.12.0
+     */
+    @Override
+    @Contract("_, _ -> this")
+    @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state);
 
     /**
      * Sets the click event.

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -342,6 +342,18 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
   @NotNull Style decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
   /**
+   * Sets the state of a decoration on this style to {@code state} if the current state of
+   * the decoration is {@link TextDecoration.State#NOT_SET}.
+   *
+   * @param decoration the decoration
+   * @param state the state
+   * @return a style
+   * @since 4.12.0
+   */
+  @Override
+  @NotNull Style decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state);
+
+  /**
    * Gets a map of decorations this style has.
    *
    * @return a set of decorations this style has
@@ -363,18 +375,6 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
    */
   @Override
   @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations);
-
-  /**
-   * Sets the state of a decoration on this style to {@code state} if the current state of
-   * the decoration is {@link TextDecoration.State#NOT_SET}.
-   *
-   * @param decoration the decoration
-   * @param state the state
-   * @return a style
-   * @since 4.12.0
-   */
-  @Override
-  @NotNull Style decorationIfAbsent(final @NotNull TextDecoration decoration, @NotNull final TextDecoration.State state);
 
   /**
    * Gets the click event.

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -123,6 +123,19 @@ final class StyleImpl implements Style {
   }
 
   @Override
+  public @NotNull Style decorationIfAbsent(final @NotNull TextDecoration decoration, final @NotNull TextDecoration.State state) {
+    requireNonNull(state, "state");
+    final TextDecoration.@Nullable State thisState = this.decorations.get(decoration);
+    if (thisState == TextDecoration.State.NOT_SET) {
+      return new StyleImpl(this.font, this.color, this.decorations.with(decoration, state), this.clickEvent, this.hoverEvent, this.insertion);
+    }
+    if (thisState != null) {
+      return this;
+    }
+    throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+  }
+
+  @Override
   public @Nullable ClickEvent clickEvent() {
     return this.clickEvent;
   }
@@ -280,8 +293,7 @@ final class StyleImpl implements Style {
       return this;
     }
 
-    // todo(kashike): promote to public api?
-    @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+    public @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
       final TextDecoration.@Nullable State thisState = this.decorations.get(decoration);
       if (thisState == TextDecoration.State.NOT_SET) {

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -113,6 +113,19 @@ final class StyleImpl implements Style {
   }
 
   @Override
+  public @NotNull Style decorationIfAbsent(final @NotNull TextDecoration decoration, final @NotNull TextDecoration.State state) {
+    requireNonNull(state, "state");
+    final TextDecoration.@Nullable State oldState = this.decorations.get(decoration);
+    if (oldState == TextDecoration.State.NOT_SET) {
+      return new StyleImpl(this.font, this.color, this.decorations.with(decoration, state), this.clickEvent, this.hoverEvent, this.insertion);
+    }
+    if (oldState != null) {
+      return this;
+    }
+    throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+  }
+
+  @Override
   public @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
     return this.decorations;
   }
@@ -120,19 +133,6 @@ final class StyleImpl implements Style {
   @Override
   public @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
     return new StyleImpl(this.font, this.color, DecorationMap.merge(decorations, this.decorations), this.clickEvent, this.hoverEvent, this.insertion);
-  }
-
-  @Override
-  public @NotNull Style decorationIfAbsent(final @NotNull TextDecoration decoration, final @NotNull TextDecoration.State state) {
-    requireNonNull(state, "state");
-    final TextDecoration.@Nullable State thisState = this.decorations.get(decoration);
-    if (thisState == TextDecoration.State.NOT_SET) {
-      return new StyleImpl(this.font, this.color, this.decorations.with(decoration, state), this.clickEvent, this.hoverEvent, this.insertion);
-    }
-    if (thisState != null) {
-      return this;
-    }
-    throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
   }
 
   @Override
@@ -293,13 +293,14 @@ final class StyleImpl implements Style {
       return this;
     }
 
+    @Override
     public @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
-      final TextDecoration.@Nullable State thisState = this.decorations.get(decoration);
-      if (thisState == TextDecoration.State.NOT_SET) {
+      final TextDecoration.@Nullable State oldState = this.decorations.get(decoration);
+      if (oldState == TextDecoration.State.NOT_SET) {
         this.decorations.put(decoration, state);
       }
-      if (thisState != null) {
+      if (oldState != null) {
         return this;
       }
       throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleSetter.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleSetter.java
@@ -150,6 +150,16 @@ public interface StyleSetter<T extends StyleSetter<?>> {
   }
 
   /**
+   * Sets the state of a decoration to {@code state} if the current state of the decoration is {@link TextDecoration.State#NOT_SET}.
+   *
+   * @param decoration the decoration
+   * @param state the state
+   * @return an object ({@code T})
+   * @since 4.12.0
+   */
+  @NotNull T decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+
+  /**
    * Sets the click event.
    *
    * @param event the click event

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleSetter.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleSetter.java
@@ -126,6 +126,16 @@ public interface StyleSetter<T extends StyleSetter<?>> {
   @NotNull T decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
   /**
+   * Sets the state of a decoration to {@code state} if the current state of the decoration is {@link TextDecoration.State#NOT_SET}.
+   *
+   * @param decoration the decoration
+   * @param state the state
+   * @return an object ({@code T})
+   * @since 4.12.0
+   */
+  @NotNull T decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+
+  /**
    * Sets decorations using the specified {@code decorations} map.
    *
    * <p>If a given decoration does not have a value explicitly set, the value of that particular decoration is not changed.</p>
@@ -148,16 +158,6 @@ public interface StyleSetter<T extends StyleSetter<?>> {
   default @NotNull T decorations(final @NotNull Set<TextDecoration> decorations, final boolean flag) {
     return this.decorations(decorations.stream().collect(Collectors.toMap(Function.identity(), decoration -> TextDecoration.State.byBoolean(flag))));
   }
-
-  /**
-   * Sets the state of a decoration to {@code state} if the current state of the decoration is {@link TextDecoration.State#NOT_SET}.
-   *
-   * @param decoration the decoration
-   * @param state the state
-   * @return an object ({@code T})
-   * @since 4.12.0
-   */
-  @NotNull T decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
   /**
    * Sets the click event.

--- a/api/src/test/java/net/kyori/adventure/text/ComponentDecorationTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentDecorationTest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import com.google.common.collect.ImmutableSet;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.TextAssertions.assertDecorations;
+
+public class ComponentDecorationTest {
+
+  @Test
+  void testDecorationIfAbsent() {
+    final Style s0 = Style.style(TextDecoration.BOLD);
+    final Component c0 = Component.text("tuba time", s0)
+      .decorationIfAbsent(TextDecoration.BOLD, TextDecoration.State.FALSE)
+      .decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE);
+    assertDecorations(c0.style(), ImmutableSet.of(TextDecoration.BOLD), ImmutableSet.of(TextDecoration.ITALIC));
+  }
+
+  @Test
+  void testDecorationIfAbsentWithBuilder() {
+    final Style s0 = Style.style(TextDecoration.BOLD);
+    final Component c0 = Component.text().style(s0).content("tuba time")
+      .decorationIfAbsent(TextDecoration.BOLD, TextDecoration.State.FALSE)
+      .decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+      .build();
+    assertDecorations(c0.style(), ImmutableSet.of(TextDecoration.BOLD), ImmutableSet.of(TextDecoration.ITALIC));
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/ComponentDecorationTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentDecorationTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.TextAssertions.assertDecorations;
 
-public class ComponentDecorationTest {
+class ComponentDecorationTest {
 
   @Test
   void testDecorationIfAbsent() {

--- a/api/src/test/java/net/kyori/adventure/text/format/StyleTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/StyleTest.java
@@ -155,6 +155,23 @@ class StyleTest {
   }
 
   @Test
+  void testDecorationIfAbsent() {
+    final Style s0 = Style.style(TextDecoration.BOLD)
+      .decorationIfAbsent(TextDecoration.BOLD, TextDecoration.State.FALSE)
+      .decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE);
+    assertDecorations(s0, ImmutableSet.of(TextDecoration.BOLD), ImmutableSet.of(TextDecoration.ITALIC));
+  }
+
+  @Test
+  void testDecorationIfAbsentWithBuilder() {
+    final Style s0 = Style.style().decoration(TextDecoration.BOLD, TextDecoration.State.TRUE)
+      .decorationIfAbsent(TextDecoration.BOLD, TextDecoration.State.FALSE)
+      .decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+      .build();
+    assertDecorations(s0, ImmutableSet.of(TextDecoration.BOLD), ImmutableSet.of(TextDecoration.ITALIC));
+  }
+
+  @Test
   void testOf_colorAndDecorations() {
     final Style s0 = Style.style(NamedTextColor.GREEN, TextDecoration.BOLD, TextDecoration.ITALIC);
     assertEquals(NamedTextColor.GREEN, s0.color());


### PR DESCRIPTION
Proposed implementation of #719 

The style stuff feels kinda messy rn because of the redundant definitions to keep binary compatibility, in my opinion a cleaning is necessary, but can be postponed to 5.0.0.

I've added redundant definitions in `Style, Style.Builder` and `ComponentBuilder`, is that necessary? Its only technically needed in `Component` in addition to `StyleSetter`

Also, is this maybe better for 4.13 instead of 4.12?

Closes #719 