### PR TITLE
1.19.1 chat changes

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -179,6 +179,7 @@ public interface Audience extends Pointered {
     action.accept(this);
   }
 
+  /* Start: system messages */
   /**
    * Sends a system chat message to this {@link Audience}.
    *
@@ -194,36 +195,6 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Sends a player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
-   *
-   * @param source the source of the message
-   * @param message a message
-   * @see Component
-   * @since 4.0.0
-   * @deprecated since 4.12.0, the client errors on and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
-   */
-  @Deprecated
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull Identified source, final @NotNull ComponentLike message) {
-    this.sendMessage(source, message.asComponent());
-  }
-
-  /**
-   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
-   *
-   * @param source the identity of the source of the message
-   * @param message a message
-   * @see Component
-   * @since 4.0.0
-   * @deprecated since 4.12.0, the client errors on and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
-   */
-  @Deprecated
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull Identity source, final @NotNull ComponentLike message) {
-    this.sendMessage(source, message.asComponent());
-  }
-
-  /**
    * Sends a system chat message to this {@link Audience}.
    *
    * @param message a message
@@ -233,36 +204,6 @@ public interface Audience extends Pointered {
    * @since 4.1.0
    */
   default void sendMessage(final @NotNull Component message) {
-  }
-
-  /**
-   * Sends a player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
-   *
-   * @param source the source of the message
-   * @param message a message
-   * @see Component
-   * @since 4.0.0
-   * @deprecated since 4.12.0, the client errors on receiving and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, PlayerIdentified)} instead
-   */
-  @Deprecated
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull Identified source, final @NotNull Component message) {
-    this.sendMessage(source, message, MessageType.CHAT);
-  }
-
-  /**
-   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
-   *
-   * @param source the identity of the source of the message
-   * @param message a message
-   * @see Component
-   * @since 4.0.0
-   * @deprecated since 4.12.0, the client errors on receiving and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, PlayerIdentity)} instead
-   */
-  @Deprecated
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull Identity source, final @NotNull Component message) {
-    this.sendMessage(source, message, MessageType.CHAT);
   }
 
   /**
@@ -284,40 +225,6 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Sends a player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType} corresponding to the provided {@link MessageType}.
-   *
-   * @param source the source of the message
-   * @param message a message
-   * @param type the type
-   * @see Component
-   * @since 4.0.0
-   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
-   */
-  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
-  @Deprecated
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull Identified source, final @NotNull ComponentLike message, final @NotNull MessageType type) {
-    this.sendMessage(source, message.asComponent(), type);
-  }
-
-  /**
-   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience}.
-   *
-   * @param source the identity of the source of the message
-   * @param message a message
-   * @param type the type
-   * @see Component
-   * @since 4.0.0
-   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
-   */
-  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
-  @Deprecated
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull Identity source, final @NotNull ComponentLike message, final @NotNull MessageType type) {
-    this.sendMessage(source, message.asComponent(), type);
-  }
-
-  /**
    * Sends a system chat message to this {@link Audience} ignoring the provided {@link MessageType}.
    *
    * @param message a message
@@ -334,6 +241,102 @@ public interface Audience extends Pointered {
   default void sendMessage(final @NotNull Component message, final @NotNull MessageType type) {
     this.sendMessage(message);
   }
+  /* End: system messages */
+
+  /* Start: unsigned player messages */
+  /**
+   * Sends an unsigned player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
+   *
+   * @param source the source of the message
+   * @param message a message
+   * @see Component
+   * @since 4.0.0
+   * @deprecated since 4.12.0, the client errors on and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
+   */
+  @Deprecated
+  @ForwardingAudienceOverrideNotRequired
+  default void sendMessage(final @NotNull Identified source, final @NotNull ComponentLike message) {
+    this.sendMessage(source, message.asComponent());
+  }
+
+  /**
+   * Sends an unsigned player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
+   *
+   * @param source the identity of the source of the message
+   * @param message a message
+   * @see Component
+   * @since 4.0.0
+   * @deprecated since 4.12.0, the client errors on and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
+   */
+  @Deprecated
+  @ForwardingAudienceOverrideNotRequired
+  default void sendMessage(final @NotNull Identity source, final @NotNull ComponentLike message) {
+    this.sendMessage(source, message.asComponent());
+  }
+
+  /**
+   * Sends an unsigned player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
+   *
+   * @param source the source of the message
+   * @param message a message
+   * @see Component
+   * @since 4.0.0
+   * @deprecated since 4.12.0, the client errors on receiving and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, PlayerIdentified)} instead
+   */
+  @Deprecated
+  @ForwardingAudienceOverrideNotRequired
+  default void sendMessage(final @NotNull Identified source, final @NotNull Component message) {
+    this.sendMessage(source, message, MessageType.CHAT);
+  }
+
+  /**
+   * Sends an unsigned player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
+   *
+   * @param source the identity of the source of the message
+   * @param message a message
+   * @see Component
+   * @since 4.0.0
+   * @deprecated since 4.12.0, the client errors on receiving and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, PlayerIdentity)} instead
+   */
+  @Deprecated
+  @ForwardingAudienceOverrideNotRequired
+  default void sendMessage(final @NotNull Identity source, final @NotNull Component message) {
+    this.sendMessage(source, message, MessageType.CHAT);
+  }
+
+  /**
+   * Sends an unsigned player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType} corresponding to the provided {@link MessageType}.
+   *
+   * @param source the source of the message
+   * @param message a message
+   * @param type the type
+   * @see Component
+   * @since 4.0.0
+   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
+   */
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
+  @Deprecated
+  @ForwardingAudienceOverrideNotRequired
+  default void sendMessage(final @NotNull Identified source, final @NotNull ComponentLike message, final @NotNull MessageType type) {
+    this.sendMessage(source, message.asComponent(), type);
+  }
+
+  /**
+   * Sends an unsigned player chat message from the entity represented by the given {@link Identity} to this {@link Audience}.
+   *
+   * @param source the identity of the source of the message
+   * @param message a message
+   * @param type the type
+   * @see Component
+   * @since 4.0.0
+   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
+   */
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
+  @Deprecated
+  @ForwardingAudienceOverrideNotRequired
+  default void sendMessage(final @NotNull Identity source, final @NotNull ComponentLike message, final @NotNull MessageType type) {
+    this.sendMessage(source, message.asComponent(), type);
+  }
 
   /**
    * Sends a player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType} corresponding to the provided {@link MessageType}.
@@ -348,6 +351,9 @@ public interface Audience extends Pointered {
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
   default void sendMessage(final @NotNull Identified source, final @NotNull Component message, final @NotNull MessageType type) {
+    if (source.identity() == Identity.nil()) {
+      this.sendMessage(message);
+    }
   }
 
   /**
@@ -363,8 +369,13 @@ public interface Audience extends Pointered {
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
   default void sendMessage(final @NotNull Identity source, final @NotNull Component message, final @NotNull MessageType type) {
+    if (source == Identity.nil()) {
+      this.sendMessage(message);
+    }
   }
+  /* End: unsigned player messages */
 
+  /* Start: signed player messages */
   /**
    * Sends a signed player chat message from the given {@link PlayerIdentified} to this {@link Audience} with the {@link ChatType#CHAT chat} chat type.
    *
@@ -398,6 +409,7 @@ public interface Audience extends Pointered {
    */
   default void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.Bound boundChatType) {
   }
+  /* End: signed player messages */
 
   /**
    * Sends a message on the action bar.

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -180,7 +180,7 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Sends a system chat message with to this {@link Audience} with the {@link ChatType#SYSTEM system} chat type.
+   * Sends a system chat message to this {@link Audience}.
    *
    * @param message a message
    * @see Component
@@ -190,17 +190,17 @@ public interface Audience extends Pointered {
    */
   @ForwardingAudienceOverrideNotRequired
   default void sendMessage(final @NotNull ComponentLike message) {
-    this.sendMessage(message, ChatType.SYSTEM);
+    this.sendMessage(message.asComponent());
   }
 
   /**
-   * Sends a player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType#SYSTEM system} chat type.
+   * Sends a player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
    *
    * @param source the source of the message
    * @param message a message
    * @see Component
    * @since 4.0.0
-   * @deprecated since 4.12.0, the client errors on and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(ComponentLike, SignedMessage, PlayerIdentified)} instead
+   * @deprecated since 4.12.0, the client errors on and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
    */
   @Deprecated
   @ForwardingAudienceOverrideNotRequired
@@ -209,13 +209,13 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#SYSTEM system} chat type.
+   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
    *
    * @param source the identity of the source of the message
    * @param message a message
    * @see Component
    * @since 4.0.0
-   * @deprecated since 4.12.0, the client errors on and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(ComponentLike, SignedMessage, PlayerIdentified)} instead
+   * @deprecated since 4.12.0, the client errors on and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
    */
   @Deprecated
   @ForwardingAudienceOverrideNotRequired
@@ -224,7 +224,7 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Sends a system chat message with to this {@link Audience} with the {@link ChatType#SYSTEM system} chat type.
+   * Sends a system chat message to this {@link Audience}.
    *
    * @param message a message
    * @see Component
@@ -232,43 +232,41 @@ public interface Audience extends Pointered {
    * @see #sendMessage(Identity, Component)
    * @since 4.1.0
    */
-  @ForwardingAudienceOverrideNotRequired
   default void sendMessage(final @NotNull Component message) {
-    this.sendMessage(message, ChatType.SYSTEM);
   }
 
   /**
-   * Sends a player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType#SYSTEM system} chat type.
+   * Sends a player chat message from the given {@link Identified} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
    *
    * @param source the source of the message
    * @param message a message
    * @see Component
    * @since 4.0.0
-   * @deprecated since 4.12.0, the client errors on receiving and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(Component, SignedMessage, PlayerIdentified)} instead
+   * @deprecated since 4.12.0, the client errors on receiving and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, PlayerIdentified)} instead
    */
   @Deprecated
   @ForwardingAudienceOverrideNotRequired
   default void sendMessage(final @NotNull Identified source, final @NotNull Component message) {
-    this.sendMessage(source, message, MessageType.SYSTEM);
+    this.sendMessage(source, message, MessageType.CHAT);
   }
 
   /**
-   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#SYSTEM system} chat type.
+   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#CHAT system} chat type.
    *
    * @param source the identity of the source of the message
    * @param message a message
    * @see Component
    * @since 4.0.0
-   * @deprecated since 4.12.0, the client errors on receiving and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(Component, SignedMessage, PlayerIdentity)} instead
+   * @deprecated since 4.12.0, the client errors on receiving and can reject identified messages without {@link SignedMessage} data, this may be unsupported in the future, use {@link #sendMessage(SignedMessage, PlayerIdentity)} instead
    */
   @Deprecated
   @ForwardingAudienceOverrideNotRequired
   default void sendMessage(final @NotNull Identity source, final @NotNull Component message) {
-    this.sendMessage(source, message, MessageType.SYSTEM);
+    this.sendMessage(source, message, MessageType.CHAT);
   }
 
   /**
-   * Sends a system chat message this {@link Audience} with the {@link ChatType} corresponding to the provided {@link MessageType}.
+   * Sends a system chat message to this {@link Audience} ignoring the provided {@link MessageType}.
    *
    * @param message a message
    * @param type the type
@@ -276,13 +274,13 @@ public interface Audience extends Pointered {
    * @see #sendMessage(Identified, ComponentLike, MessageType)
    * @see #sendMessage(Identity, ComponentLike, MessageType)
    * @since 4.1.0
-   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal, use {@link #sendMessage(ComponentLike, ChatType)}
+   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal, use {@link #sendMessage(ComponentLike)}
    */
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
   @ForwardingAudienceOverrideNotRequired
   default void sendMessage(final @NotNull ComponentLike message, final @NotNull MessageType type) {
-    this.sendMessage(message, (ChatType) type);
+    this.sendMessage(message);
   }
 
   /**
@@ -293,7 +291,7 @@ public interface Audience extends Pointered {
    * @param type the type
    * @see Component
    * @since 4.0.0
-   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(Component, SignedMessage, PlayerIdentified, ChatType)} instead
+   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
    */
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
@@ -303,14 +301,14 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience} with the {@link ChatType#SYSTEM system} chat type.
+   * Sends a player chat message from the entity represented by the given {@link Identity} to this {@link Audience}.
    *
    * @param source the identity of the source of the message
    * @param message a message
    * @param type the type
    * @see Component
    * @since 4.0.0
-   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(Component, SignedMessage, PlayerIdentity, ChatType)} instead
+   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
    */
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
@@ -320,7 +318,7 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Sends a system chat message to this {@link Audience} with the {@link ChatType} corresponding to the provided {@link MessageType}.
+   * Sends a system chat message to this {@link Audience} ignoring the provided {@link MessageType}.
    *
    * @param message a message
    * @param type the type
@@ -328,13 +326,13 @@ public interface Audience extends Pointered {
    * @see #sendMessage(Identified, Component, MessageType)
    * @see #sendMessage(Identity, Component, MessageType)
    * @since 4.1.0
-   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal, use {@link #sendMessage(Component, ChatType)} instead
+   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal, use {@link #sendMessage(Component)} instead
    */
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
   @ForwardingAudienceOverrideNotRequired
   default void sendMessage(final @NotNull Component message, final @NotNull MessageType type) {
-    this.sendMessage(message, (ChatType) type);
+    this.sendMessage(message);
   }
 
   /**
@@ -345,7 +343,7 @@ public interface Audience extends Pointered {
    * @param type the type
    * @see Component
    * @since 4.0.0
-   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data,  use {@link #sendMessage(Component, SignedMessage, PlayerIdentified, ChatType)} instead
+   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
    */
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
@@ -360,7 +358,7 @@ public interface Audience extends Pointered {
    * @param type the type
    * @see Component
    * @since 4.0.0
-   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use  use {@link #sendMessage(Component, SignedMessage, PlayerIdentity, ChatType)} instead
+   * @deprecated for removal since 4.12.0, {@link MessageType} is deprecated for removal and the client errors on receiving and can reject identified messages without {@link SignedMessage} data, use {@link #sendMessage(SignedMessage, ChatType.Bound)} instead
    */
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
@@ -368,129 +366,37 @@ public interface Audience extends Pointered {
   }
 
   /**
-   * Sends a system chat message to this {@link Audience} with the provided {@link ChatType}.
-   *
-   * @param message the message
-   * @param chatType the chat type
-   * @since 4.12.0
-   */
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull ComponentLike message, final @NotNull ChatType chatType) {
-    this.sendMessage(message.asComponent(), chatType);
-  }
-
-  /**
-   * Sends a system chat message to this {@link Audience} with the provided {@link ChatType}.
-   *
-   * @param message the message
-   * @param chatType the chat type
-   * @since 4.12.0
-   */
-  default void sendMessage(final @NotNull Component message, final @NotNull ChatType chatType) {
-  }
-
-  /**
    * Sends a signed player chat message from the given {@link PlayerIdentified} to this {@link Audience} with the {@link ChatType#CHAT chat} chat type.
    *
-   * @param message the message
    * @param signedMessage the signed message data
    * @param source the source of the message
    * @since 4.12.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull ComponentLike message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
-    this.sendMessage(message.asComponent(), signedMessage, source);
-  }
-
-  /**
-   * Sends a signed player chat message from the given {@link PlayerIdentified} to this {@link Audience} with the {@link ChatType#CHAT chat} chat type.
-   *
-   * @param message the message
-   * @param signedMessage the signed message data
-   * @param source the source of the message
-   * @since 4.12.0
-   */
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
-    this.sendMessage(message, signedMessage, source, ChatType.CHAT);
+  default void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
+    this.sendMessage(signedMessage, source.identity());
   }
 
   /**
    * Sends a signed player chat message from player identified by the provided {@link PlayerIdentity} to this {@link Audience} with the {@link ChatType#CHAT chat} chat type.
    *
-   * @param message the message
    * @param signedMessage the signed message data
    * @param source the identity of the source of the message
    * @since 4.12.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull ComponentLike message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source) {
-    this.sendMessage(message.asComponent(), signedMessage, source);
-  }
-
-  /**
-   * Sends a signed player chat message from player identified by the provided {@link PlayerIdentity} to this {@link Audience} with the {@link ChatType#CHAT chat} chat type.
-   *
-   * @param message the message
-   * @param signedMessage the signed message data
-   * @param source the identity of the source of the message
-   * @since 4.12.0
-   */
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source) {
-    this.sendMessage(message, signedMessage, source, ChatType.CHAT);
-  }
-
-  /**
-   * Sends a signed player chat message from the given {@link PlayerIdentified} to this {@link Audience} with the provided {@link ChatType}.
-   *
-   * @param message the message
-   * @param signedMessage the signed message data
-   * @param source the source of the message
-   * @param chatType the chat type
-   * @since 4.12.0
-   */
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull ComponentLike message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source, final @NotNull ChatType chatType) {
-    this.sendMessage(message.asComponent(), signedMessage, source, chatType);
+  default void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source) {
+    this.sendMessage(signedMessage, ChatType.CHAT.bind(source.name()));
   }
 
   /**
    * Sends a signed player chat message from the given {@link PlayerIdentified} to this {@link Audience} with the provided {@link ChatType} chat type.
    *
-   * @param message the message
    * @param signedMessage the signed message data
-   * @param source the source of the message
-   * @param chatType the chat type
+   * @param boundChatType the bound chat type
    * @since 4.12.0
    */
-  default void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source, final @NotNull ChatType chatType) {
-  }
-
-  /**
-   * Sends a signed player chat message from player identified by the provided {@link PlayerIdentity} to this {@link Audience} with the provided {@link ChatType}.
-   *
-   * @param message the message
-   * @param signedMessage the signed message data
-   * @param source the identity of the source of the message
-   * @param chatType the chat type
-   * @since 4.12.0
-   */
-  @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull ComponentLike message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source, final @NotNull ChatType chatType) {
-    this.sendMessage(message.asComponent(), signedMessage, source, chatType);
-  }
-
-  /**
-   * Sends a signed player chat message from player identified by the provided {@link PlayerIdentity} to this {@link Audience} with the provided {@link ChatType}.
-   *
-   * @param message the message
-   * @param signedMessage the signed message data
-   * @param source the identity of the source of the message
-   * @param chatType the chat type
-   * @since 4.12.0
-   */
-  default void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source, final @NotNull ChatType chatType) {
+  default void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.Bound boundChatType) {
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
@@ -79,27 +79,15 @@ final class EmptyAudience implements Audience {
   }
 
   @Override
-  public void sendMessage(final @NotNull ComponentLike message, final @NotNull ChatType chatType) {
+  public void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
   }
 
   @Override
-  public void sendMessage(final @NotNull ComponentLike message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
+  public void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source) {
   }
 
   @Override
-  public void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
-  }
-
-  @Override
-  public void sendMessage(final @NotNull ComponentLike message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source) {
-  }
-
-  @Override
-  public void sendMessage(final @NotNull ComponentLike message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source, final @NotNull ChatType chatType) {
-  }
-
-  @Override
-  public void sendMessage(final @NotNull ComponentLike message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source, final @NotNull ChatType chatType) {
+  public void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.Bound boundChatType) {
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -100,18 +100,18 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void sendMessage(final @NotNull Component message, final @NotNull ChatType chatType) {
-    for (final Audience audience : this.audiences()) audience.sendMessage(message, chatType);
+  default void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
+    for (final Audience audience : this.audiences()) audience.sendMessage(signedMessage, source);
   }
 
   @Override
-  default void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source, final @NotNull ChatType chatType) {
-    for (final Audience audience : this.audiences()) audience.sendMessage(message, signedMessage, source, chatType);
+  default void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source) {
+    for (final Audience audience : this.audiences()) audience.sendMessage(signedMessage, source);
   }
 
   @Override
-  default void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source, final @NotNull ChatType chatType) {
-    for (final Audience audience : this.audiences()) audience.sendMessage(message, signedMessage, source, chatType);
+  default void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.Bound boundChatType) {
+    for (final Audience audience : this.audiences()) audience.sendMessage(signedMessage, boundChatType);
   }
 
   @Override
@@ -256,18 +256,18 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void sendMessage(final @NotNull Component message, final @NotNull ChatType chatType) {
-      this.audience().sendMessage(message, chatType);
+    default void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
+      this.audience().sendMessage(signedMessage, source);
     }
 
     @Override
-    default void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source, final @NotNull ChatType chatType) {
-      this.audience().sendMessage(message, signedMessage, source, chatType);
+    default void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source) {
+      this.audience().sendMessage(signedMessage, source);
     }
 
     @Override
-    default void sendMessage(final @NotNull Component message, final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentity source, final @NotNull ChatType chatType) {
-      this.audience().sendMessage(message, signedMessage, source, chatType);
+    default void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.Bound boundChatType) {
+      this.audience().sendMessage(signedMessage, boundChatType);
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -100,6 +100,11 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
+  default void sendMessage(final @NotNull Component message) {
+    for (final Audience audience : this.audiences()) audience.sendMessage(message);
+  }
+
+  @Override
   default void sendMessage(final @NotNull SignedMessage signedMessage, final @NotNull PlayerIdentified source) {
     for (final Audience audience : this.audiences()) audience.sendMessage(signedMessage, source);
   }
@@ -253,6 +258,11 @@ public interface ForwardingAudience extends Audience {
     @Override
     default @NotNull Pointers pointers() {
       return this.audience().pointers();
+    }
+
+    @Override
+    default void sendMessage(final @NotNull Component message) {
+      this.audience().sendMessage(message);
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/audience/MessageType.java
+++ b/api/src/main/java/net/kyori/adventure/audience/MessageType.java
@@ -24,9 +24,7 @@
 package net.kyori.adventure.audience;
 
 import net.kyori.adventure.chat.ChatType;
-import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Message types.

--- a/api/src/main/java/net/kyori/adventure/audience/MessageType.java
+++ b/api/src/main/java/net/kyori/adventure/audience/MessageType.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.NotNull;
  */
 @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
 @Deprecated
-public enum MessageType implements ChatType {
+public enum MessageType {
   /**
    * Chat message type.
    *
@@ -45,25 +45,14 @@ public enum MessageType implements ChatType {
    */
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
-  CHAT(ChatType.CHAT),
+  CHAT,
   /**
    * System message type.
    *
    * @since 4.0.0
-   * @deprecated for removal since 4.12.0, use {@link ChatType#SYSTEM} instead
+   * @deprecated for removal since 4.12.0
    */
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   @Deprecated
-  SYSTEM(ChatType.SYSTEM);
-
-  private final ChatType chatType;
-
-  MessageType(final @NotNull ChatType chatType) {
-    this.chatType = chatType;
-  }
-
-  @Override
-  public final @NotNull Key key() {
-    return this.chatType.key();
-  }
+  SYSTEM;
 }

--- a/api/src/main/java/net/kyori/adventure/chat/ChatType.java
+++ b/api/src/main/java/net/kyori/adventure/chat/ChatType.java
@@ -125,7 +125,7 @@ public interface ChatType extends Examinable, Keyed {
   interface Bound extends Examinable {
 
     @Contract(pure = true)
-    @NotNull ChatType chatType();
+    @NotNull ChatType type();
 
     @Contract(pure = true)
     @NotNull Component sender();
@@ -137,7 +137,7 @@ public interface ChatType extends Examinable, Keyed {
     @NotNull
     default Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
-        ExaminableProperty.of("chatType", this.chatType()),
+        ExaminableProperty.of("type", this.type()),
         ExaminableProperty.of("sender", this.sender()),
         ExaminableProperty.of("target", this.target())
       );

--- a/api/src/main/java/net/kyori/adventure/chat/ChatType.java
+++ b/api/src/main/java/net/kyori/adventure/chat/ChatType.java
@@ -27,9 +27,12 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
+import net.kyori.adventure.text.Component;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A type of chat.
@@ -47,20 +50,20 @@ public interface ChatType extends Examinable, Keyed {
   ChatType CHAT = new ChatTypeImpl(Key.key("chat"));
 
   /**
-   * A chat message from the "system" or server.
+   * A message send as a result of using the {@code /say} command.
    *
    * @since 4.12.0
    * @sinceMinecraft 1.19
    */
-  ChatType SYSTEM = new ChatTypeImpl(Key.key("system"));
+  ChatType SAY_COMMAND = new ChatTypeImpl(Key.key("say_command"));
 
   /**
-   * A game information message, displaying in the action bar.
+   * A message received as a result of using the {@code /msg} command.
    *
    * @since 4.12.0
    * @sinceMinecraft 1.19
    */
-  ChatType GAME_INFO = new ChatTypeImpl(Key.key("game_info"));
+  ChatType MSG_COMMAND_INCOMING = new ChatTypeImpl(Key.key("msg_command_incoming"));
 
   /**
    * A message sent as a result of using the {@code /msg} command.
@@ -68,7 +71,15 @@ public interface ChatType extends Examinable, Keyed {
    * @since 4.12.0
    * @sinceMinecraft 1.19
    */
-  ChatType MSG_COMMAND = new ChatTypeImpl(Key.key("say_command"));
+  ChatType MSG_COMMAND_OUTGOING = new ChatTypeImpl(Key.key("msg_command_outgoing"));
+
+  /**
+   * A message received as a result of using the {@code /teammsg} command.
+   *
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
+  ChatType TEAM_MSG_COMMAND_INCOMING = new ChatTypeImpl(Key.key("team_msg_command_incoming"));
 
   /**
    * A message sent as a result of using the {@code /teammsg} command.
@@ -76,7 +87,7 @@ public interface ChatType extends Examinable, Keyed {
    * @since 4.12.0
    * @sinceMinecraft 1.19
    */
-  ChatType TEAM_MSG_COMMAND = new ChatTypeImpl(Key.key("team_msg_command"));
+  ChatType TEAM_MSG_COMMAND_OUTGOING = new ChatTypeImpl(Key.key("team_msg_command_outgoing"));
 
   /**
    * A message sent as a result of using the {@code /me} command.
@@ -85,14 +96,6 @@ public interface ChatType extends Examinable, Keyed {
    * @sinceMinecraft 1.19
    */
   ChatType EMOTE_COMMAND = new ChatTypeImpl(Key.key("emote_command"));
-
-  /**
-   * A message sent as a result of using the {@code /tellraw} command.
-   *
-   * @since 4.12.0
-   * @sinceMinecraft 1.19
-   */
-  ChatType TELL_RAW_COMMAND = new ChatTypeImpl(Key.key("tellraw_command"));
 
   /**
    * Creates a new chat type with a given key.
@@ -105,8 +108,39 @@ public interface ChatType extends Examinable, Keyed {
     return new ChatTypeImpl(Objects.requireNonNull(key, "key"));
   }
 
+  default ChatType.Bound bind(@NotNull final Component sender) {
+    return this.bind(sender, null);
+  }
+
+  default ChatType.Bound bind(@NotNull final Component sender, final @Nullable Component target) {
+    return new ChatTypeImpl.BoundImpl(this, sender, target);
+  }
+
+
   @Override
   default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("key", this.key()));
+  }
+
+  interface Bound extends Examinable {
+
+    @Contract(pure = true)
+    @NotNull ChatType chatType();
+
+    @Contract(pure = true)
+    @NotNull Component sender();
+
+    @Contract(pure = true)
+    @Nullable Component target();
+
+    @Override
+    @NotNull
+    default Stream<? extends ExaminableProperty> examinableProperties() {
+      return Stream.of(
+        ExaminableProperty.of("chatType", this.chatType()),
+        ExaminableProperty.of("sender", this.sender()),
+        ExaminableProperty.of("target", this.target())
+      );
+    }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/chat/ChatType.java
+++ b/api/src/main/java/net/kyori/adventure/chat/ChatType.java
@@ -108,28 +108,73 @@ public interface ChatType extends Examinable, Keyed {
     return new ChatTypeImpl(Objects.requireNonNull(key, "key"));
   }
 
-  default ChatType.Bound bind(@NotNull final Component sender) {
+  /**
+   * Creates a bound chat type with a sender {@link Component}.
+   *
+   * @param sender the sender component
+   * @return a new bound chat type
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
+  @Contract(value = "_ -> new", pure = true)
+  default @NotNull ChatType.Bound bind(@NotNull final Component sender) {
     return this.bind(sender, null);
   }
 
-  default ChatType.Bound bind(@NotNull final Component sender, final @Nullable Component target) {
+  /**
+   * Creates a bound chat type with a sender and target {@link Component}.
+   *
+   * @param sender the sender component
+   * @param target the optional target component
+   * @return a new bound chat type
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  default @NotNull ChatType.Bound bind(@NotNull final Component sender, final @Nullable Component target) {
     return new ChatTypeImpl.BoundImpl(this, sender, target);
   }
-
 
   @Override
   default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("key", this.key()));
   }
 
+  /**
+   * A bound {@link ChatType}.
+   *
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
   interface Bound extends Examinable {
 
+    /**
+     * Gets the chat type.
+     *
+     * @return the chat type
+     * @since 4.12.0
+     * @sinceMinecraft 1.19
+     */
     @Contract(pure = true)
     @NotNull ChatType type();
 
+    /**
+     * Get the sender component.
+     *
+     * @return the sender component
+     * @since 4.12.0
+     * @sinceMinecraft 1.19
+     */
     @Contract(pure = true)
     @NotNull Component sender();
 
+    /**
+     * Get the target component.
+     *
+     * @return the target component or null
+     * @since 4.12.0
+     * @sinceMinecraft 1.19
+     */
     @Contract(pure = true)
     @Nullable Component target();
 

--- a/api/src/main/java/net/kyori/adventure/chat/ChatTypeImpl.java
+++ b/api/src/main/java/net/kyori/adventure/chat/ChatTypeImpl.java
@@ -25,7 +25,9 @@ package net.kyori.adventure.chat;
 
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class ChatTypeImpl implements ChatType {
   private final Key key;
@@ -42,5 +44,37 @@ final class ChatTypeImpl implements ChatType {
   @Override
   public String toString() {
     return Internals.toString(this);
+  }
+
+  static final class BoundImpl implements ChatType.Bound {
+    private final ChatType chatType;
+    private final Component sender;
+    private final @Nullable Component target;
+
+    BoundImpl(final ChatType chatType, final Component sender, final @Nullable Component target) {
+      this.chatType = chatType;
+      this.sender = sender;
+      this.target = target;
+    }
+
+    @Override
+    public @NotNull ChatType chatType() {
+      return this.chatType;
+    }
+
+    @Override
+    public @NotNull Component sender() {
+      return this.sender;
+    }
+
+    @Override
+    public @Nullable Component target() {
+      return this.target;
+    }
+
+    @Override
+    public String toString() {
+      return Internals.toString(this);
+    }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/chat/ChatTypeImpl.java
+++ b/api/src/main/java/net/kyori/adventure/chat/ChatTypeImpl.java
@@ -58,7 +58,7 @@ final class ChatTypeImpl implements ChatType {
     }
 
     @Override
-    public @NotNull ChatType chatType() {
+    public @NotNull ChatType type() {
       return this.chatType;
     }
 

--- a/api/src/main/java/net/kyori/adventure/chat/SignedMessage.java
+++ b/api/src/main/java/net/kyori/adventure/chat/SignedMessage.java
@@ -141,6 +141,12 @@ public interface SignedMessage extends Identified, ComponentLike {
   @Contract(pure = true)
   @NotNull String plain();
 
+  /**
+   * A signature wrapper type.
+   *
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
   final class Signature {
 
     final byte[] signature;

--- a/api/src/main/java/net/kyori/adventure/chat/SignedMessage.java
+++ b/api/src/main/java/net/kyori/adventure/chat/SignedMessage.java
@@ -24,10 +24,14 @@
 package net.kyori.adventure.chat;
 
 import java.time.Instant;
-import net.kyori.adventure.identity.PlayerIdentified;
+import net.kyori.adventure.identity.Identified;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A signed chat message.
@@ -36,7 +40,51 @@ import org.jetbrains.annotations.NotNull;
  * @sinceMinecraft 1.19
  */
 @ApiStatus.NonExtendable
-public interface SignedMessage extends PlayerIdentified {
+public interface SignedMessage extends Identified, ComponentLike {
+
+  /**
+   * Creates a signature wrapper.
+   *
+   * @param signature the signature
+   * @return a new signature
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
+  @Contract(value = "_ -> new", pure = true)
+  static @NotNull Signature signature(final byte[] signature) {
+    return new Signature(signature);
+  }
+
+  /**
+   * Creates an unsigned {@link SignedMessage} for an {@link Identity}.
+   *
+   * @param component the message component
+   * @param plain the plain text message
+   * @param identity the identity for the signed message header
+   * @return a new unsigned {@link SignedMessage}
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull SignedMessage unsigned(final @NotNull Component component, final @NotNull String plain, final @NotNull Identity identity) {
+    return new UnsignedSignedMessageImpl(component, plain, identity);
+  }
+
+  /**
+   * Creates an unsigned {@link SignedMessage} for an {@link Identity}.
+   *
+   * @param component the message component
+   * @param plain the plain text message
+   * @param identified the identity for the signed message header
+   * @return a new unsigned {@link SignedMessage}
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull SignedMessage unsigned(final @NotNull Component component, final @NotNull String plain, final @NotNull Identified identified) {
+    return new UnsignedSignedMessageImpl(component, plain, identified.identity());
+  }
+
   /**
    * The time that the message was sent.
    *
@@ -65,5 +113,52 @@ public interface SignedMessage extends PlayerIdentified {
    * @sinceMinecraft 1.19
    */
   @Contract(pure = true)
-  byte[] signature();
+  @Nullable Signature signature();
+
+  /**
+   * The signed component.
+   *
+   * @return the component
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
+  @Contract(pure = true)
+  @NotNull Component message();
+
+  @Override
+  @NotNull
+  default Component asComponent() {
+    return this.message();
+  }
+
+  /**
+   * The plain string message.
+   *
+   * @return the plain string message
+   * @since 4.12.0
+   * @sinceMinecraft 1.19
+   */
+  @Contract(pure = true)
+  @NotNull String plain();
+
+  final class Signature {
+
+    final byte[] signature;
+
+    private Signature(final byte[] signature) {
+      this.signature = signature;
+    }
+
+    /**
+     * Gets the bytes for this signature.
+     *
+     * @return the bytes
+     * @since 4.12.0
+     * @sinceMinecraft 1.19
+     */
+    @Contract(pure = true)
+    public byte[] bytes() {
+      return this.signature;
+    }
+  }
 }

--- a/api/src/main/java/net/kyori/adventure/chat/UnsignedSignedMessageImpl.java
+++ b/api/src/main/java/net/kyori/adventure/chat/UnsignedSignedMessageImpl.java
@@ -1,0 +1,55 @@
+package net.kyori.adventure.chat;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+final class UnsignedSignedMessageImpl implements SignedMessage {
+  static final SecureRandom RANDOM = new SecureRandom();
+
+  private final Instant instant;
+  private final long salt;
+  private final Component message;
+  private final String plain;
+  private final Identity identity;
+
+  UnsignedSignedMessageImpl(final Component message, final String plain, final Identity identity) {
+    this.instant = Instant.now();
+    this.salt = RANDOM.nextLong();
+    this.message = message;
+    this.plain = plain;
+    this.identity = identity;
+  }
+
+  @Override
+  public @NotNull Instant timeStamp() {
+    return this.instant;
+  }
+
+  @Override
+  public long salt() {
+    return this.salt;
+  }
+
+  @Override
+  public Signature signature() {
+    return null;
+  }
+
+  @Override
+  public @NotNull Component message() {
+    return this.message;
+  }
+
+  @Override
+  public @NotNull String plain() {
+    return this.plain;
+  }
+
+  @Override
+  public @NotNull Identity identity() {
+    return this.identity;
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/chat/UnsignedSignedMessageImpl.java
+++ b/api/src/main/java/net/kyori/adventure/chat/UnsignedSignedMessageImpl.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package net.kyori.adventure.chat;
 
 import java.security.SecureRandom;


### PR DESCRIPTION
Updating for changes made in 1.19.1

There is no more "SYSTEM" chat type. If a message is a system message, it uses its own packet, and is just a raw component message.

SignedMessage should not extend PlayerIdentified, just Identified. The only player-related stuff in a SignedMessage is the UUID of the signer, so just Identified works.

Its possible the PlayerIdentified/PlayerIdentity interfaces should just be removed. I opted to kind of mirror how vanilla handles chat types, creating `ChatType$Bound` which holds the chat type, the sender component, and the nullable target component.


I don't know the exact policy on removing implementation of `Audience#sendMessage(Component)`. That is now for only system messages, but since there is no system chat type, it can't call another method without using deprecated types (`MessageType`).

I updated the default `ChatType`s that exist in vanilla 1.19.1.

I created an `UnsignedSignedMessageImpl` type so the api can create unsigned messages. All other `SignedMessage` impulse should come from platforms that use the adventure api. 