### PR TITLE
minimessage: Parsing corner cases with quotes

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
@@ -248,7 +248,7 @@ public final class TokenParser {
             case '"':
               currentStringChar = (char) codePoint;
               // Look ahead if the quote being opened is ever closed
-              if (message.substring(i + 1).indexOf(codePoint) != -1) {
+              if (message.indexOf(codePoint, i + 1) != -1) {
                 state = FirstPassState.STRING;
               }
               break;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
@@ -246,8 +246,11 @@ public final class TokenParser {
               break;
             case '\'':
             case '"':
-              state = FirstPassState.STRING;
               currentStringChar = (char) codePoint;
+              // Look ahead if the quote being opened is ever closed
+              if (message.substring(i + 1).indexOf(codePoint) != -1) {
+                state = FirstPassState.STRING;
+              }
               break;
           }
           break;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
@@ -260,6 +260,14 @@ public final class TokenParser {
           }
           break;
       }
+
+      if (i == (length - 1) && state == FirstPassState.TAG) {
+        // We've reached the end of the input with an open `<`, but it was never matched to a closing `>`.
+        // Anything which was inside of quotes needs to be parsed again, as it may contain additional tags.
+        // Rewind back to directly after the `<`, but in the NORMAL state, instead of TAG.
+        i = marker;
+        state = FirstPassState.NORMAL;
+      }
     }
 
     // anything left over is plain text

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -284,10 +284,20 @@ public class MiniMessageParserTest extends AbstractTest {
   void testNonTerminatingQuote() {
     final Component expected = empty().append(text("Remember the<3\"").color(RED)).append(text(" bug"));
     final Component expected1 = empty().append(text("Remember the<3'").color(RED)).append(text(" bug"));
+    final Component expected2 = empty().append(text("Remember the<h:\"").color(RED)).append(text(" bug"));
+    final Component expected3 = empty().append(text("Remember the<h:\"").color(RED)).append(text(" \"bug"));
+    // This one is an actually valid use of quotes
+    final Component expected4 = empty().append(text("Remember the<h:\"</red> \">bug").color(RED));
     final String input = "<red>Remember the<3\"</red> bug";
     final String input1 = "<red>Remember the<3'</red> bug";
+    final String input2 = "<red>Remember the<h:\"</red> bug";
+    final String input3 = "<red>Remember the<h:\"</red> \"bug";
+    final String input4 = "<red>Remember the<h:\"</red> \">bug";
     this.assertParsedEquals(expected, input);
     this.assertParsedEquals(expected1, input1);
+    this.assertParsedEquals(expected2, input2);
+    this.assertParsedEquals(expected3, input3);
+    this.assertParsedEquals(expected4, input4);
   }
 
   // GH-68, GH-93

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -280,6 +280,16 @@ public class MiniMessageParserTest extends AbstractTest {
     this.assertParsedEquals(expected3, input3);
   }
 
+  @Test
+  void testNonTerminatingQuote() {
+    final Component expected = empty().append(text("Remember the<3\"").color(RED)).append(text(" bug"));
+    final Component expected1 = empty().append(text("Remember the<3'").color(RED)).append(text(" bug"));
+    final String input = "<red>Remember the<3\"</red> bug";
+    final String input1 = "<red>Remember the<3'</red> bug";
+    this.assertParsedEquals(expected, input);
+    this.assertParsedEquals(expected1, input1);
+  }
+
   // GH-68, GH-93
   @Test
   void testAngleBracketsShit() {


### PR DESCRIPTION
Don't enter string parsing mode during the first pass when encountering a quote, but no matching quote exists later on in the message.

Note that this doesn't catch every case of invalid tags causing other valid tags to be ignored, in this case there could simply be an unrelated quote elsewhere in the message and the bug would still occur.

The parser could:

  * Only allow quotes after specific characters, such as the colon `:`, which is currently the only place where quotes are really valid. However, even then, the buggy payload could just include a colon before the quote

  * Only allow quotes when inside of a valid tag, as in the test. (`<3` isn't a valid introducer for a tag). However, even then, the buggy payload could use a character valid for tag. Additionally, checking the validity of a tag isn't done by the first parse stage

  * Backtrack when a quote-delimited section doesn't end up being inside of a valid tag. That would (presumably) require some pretty complicated checks in the first phase, but checking for it in the second phase is probably too late, because it'd have to reparse something it has already passed by