### PR TITLE
fix(text-minimessage): Preserve non-text components in color changing tags

### DIFF
--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTagTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.event.HoverEvent.showText;
 import static net.kyori.adventure.text.format.NamedTextColor.BLACK;
 import static net.kyori.adventure.text.format.NamedTextColor.BLUE;
@@ -541,5 +542,19 @@ class GradientTagTest extends AbstractTest {
     );
 
     this.assertParsedEquals(expected, input, Placeholder.component("placeholder", placeholder));
+  }
+
+  // https://github.com/KyoriPowered/adventure/issues/827
+  @Test
+  void testLangTagInGradient() {
+    final String input = "<gradient:red:blue>ab<lang:block.minecraft.diamond_block>!</gradient>";
+    final Component expected = Component.textOfChildren(
+      text("a", RED),
+      text("b", color(0xd55580)),
+      translatable("block.minecraft.diamond_block", color(0xaa55aa))
+        .append(text("!", color(0x8055d5)))
+    );
+
+    this.assertParsedEquals(expected, input);
   }
 }


### PR DESCRIPTION
This output isn't really ideal:tm: since it doesn't make non-text components actually part of the gradient, but at least this way they're not plain white, or stripped altogether

Fixes GH-827