### PR TITLE
Finish adding MM tags for all Vanilla component types

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/ParsingExceptionImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/ParsingExceptionImpl.java
@@ -139,7 +139,9 @@ public class ParsingExceptionImpl extends ParsingException {
     for (final Token t : ts) {
       Arrays.fill(chars, i, t.startIndex(), ' ');
       chars[t.startIndex()] = '^';
-      Arrays.fill(chars, t.startIndex() + 1, t.endIndex() - 1, '~');
+      if (Math.abs(t.startIndex() - t.endIndex()) > 1) {
+        Arrays.fill(chars, t.startIndex() + 1, t.endIndex() - 1, '~');
+      }
       chars[t.endIndex() - 1] = '^';
       i = t.endIndex();
     }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NbtTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NbtTag.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.BlockNBTComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.EntityNBTComponent;
+import net.kyori.adventure.text.NBTComponent;
+import net.kyori.adventure.text.NBTComponentBuilder;
+import net.kyori.adventure.text.StorageNBTComponent;
+import net.kyori.adventure.text.minimessage.Context;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.internal.serializer.Emitable;
+import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * One tag for all NBT components.
+ *
+ * @since 4.13.0
+ */
+final class NbtTag {
+  private static final String NBT = "nbt";
+  private static final String DATA = "data";
+
+  private static final String BLOCK = "block";
+  private static final String ENTITY = "entity";
+  private static final String STORAGE = "storage";
+  private static final String INTERPRET = "interpret";
+
+  static final TagResolver RESOLVER = SerializableResolver.claimingComponent(
+    StandardTags.names(NBT, DATA),
+    NbtTag::resolve,
+    NbtTag::emit
+  );
+
+  private NbtTag() {
+  }
+
+  // syntax intended to match the /data command in vanilla MC
+  static Tag resolve(final ArgumentQueue args, final Context ctx) throws ParsingException {
+    final String type = args.popOr("a type of block, entity, or storage is required").lowerValue();
+    final NBTComponentBuilder<?, ?> builder;
+    if (BLOCK.equals(type)) {
+      final String pos = args.popOr("A position is required").value();
+      try {
+        builder = Component.blockNBT()
+          .pos(BlockNBTComponent.Pos.fromString(pos));
+      } catch (final IllegalArgumentException ex) {
+        throw ctx.newException(ex.getMessage(), args);
+      }
+    } else if (ENTITY.equals(type)) {
+      builder = Component.entityNBT()
+        .selector(args.popOr("A selector is required").value());
+    } else if (STORAGE.equals(type)) {
+      builder = Component.storageNBT()
+        .storage(Key.key(args.popOr("A storage key is required").value()));
+    } else {
+      throw ctx.newException("Unknown nbt tag type '" + type + "'", args);
+    }
+
+    builder.nbtPath(args.popOr("An NBT path is required").value());
+
+    if (args.hasNext()) {
+      final String popped = args.pop().value();
+
+      if (INTERPRET.equalsIgnoreCase(popped)) {
+        builder.interpret(true);
+      } else {
+        builder.separator(ctx.deserialize(popped));
+
+        if (args.hasNext() && args.pop().value().equalsIgnoreCase(INTERPRET)) {
+          builder.interpret(true);
+        }
+      }
+    }
+
+    return Tag.inserting(builder.build());
+  }
+
+  static @Nullable Emitable emit(final Component comp) {
+    final String type;
+    final String id;
+    if (comp instanceof BlockNBTComponent) {
+      type = BLOCK;
+      id = ((BlockNBTComponent) comp).pos().asString();
+    } else if (comp instanceof EntityNBTComponent) {
+      type = ENTITY;
+      id = ((EntityNBTComponent) comp).selector();
+    } else if (comp instanceof StorageNBTComponent) {
+      type = STORAGE;
+      id = ((StorageNBTComponent) comp).storage().asString();
+    } else {
+      return null;
+    }
+
+    return out -> {
+      final NBTComponent<?, ?> nbt = (NBTComponent<?, ?>) comp;
+      out.tag(NBT)
+        .argument(type)
+        .argument(id)
+        .argument(nbt.nbtPath());
+
+      if (nbt.separator() != null) {
+        out.argument(nbt.separator());
+      }
+
+      if (nbt.interpret()) {
+        out.argument(INTERPRET);
+      }
+    };
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ScoreTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ScoreTag.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ScoreComponent;
+import net.kyori.adventure.text.minimessage.Context;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.internal.serializer.Emitable;
+import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.jetbrains.annotations.Nullable;
+
+final class ScoreTag {
+  public static final String SCORE = "score";
+
+  static final TagResolver RESOLVER = SerializableResolver.claimingComponent(ScoreTag.SCORE, ScoreTag::create, ScoreTag::emit);
+
+  private ScoreTag() {
+  }
+
+  static Tag create(final ArgumentQueue args, final Context ctx) throws ParsingException {
+    final String name = args.popOr("A scoreboard member name is required").value();
+    final String objective = args.popOr("An objective name is required").value();
+    return Tag.inserting(Component.score(name, objective));
+  }
+
+  static @Nullable Emitable emit(final Component component) {
+    if (!(component instanceof ScoreComponent)) return null;
+
+    final ScoreComponent score = (ScoreComponent) component;
+
+    return emit -> emit.tag(SCORE)
+      .argument(score.name())
+      .argument(score.objective());
+  }
+
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -60,7 +60,8 @@ public final class StandardTags {
         ResetTag.RESOLVER,
         NewlineTag.RESOLVER,
         TransitionTag.RESOLVER,
-        SelectorTag.RESOLVER
+        SelectorTag.RESOLVER,
+        ScoreTag.RESOLVER
       )
       .build();
 
@@ -225,6 +226,16 @@ public final class StandardTags {
    */
   public static @NotNull TagResolver selector() {
     return SelectorTag.RESOLVER;
+  }
+
+  /**
+   * Get a resolver for the {@value ScoreTag#SCORE} tag.
+   *
+   * @return a resolver for the {@value ScoreTag#SCORE} tag
+   * @since 4.13.0
+   */
+  public static @NotNull TagResolver score() {
+    return ScoreTag.RESOLVER;
   }
 
   /**

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -61,7 +61,8 @@ public final class StandardTags {
         NewlineTag.RESOLVER,
         TransitionTag.RESOLVER,
         SelectorTag.RESOLVER,
-        ScoreTag.RESOLVER
+        ScoreTag.RESOLVER,
+        NbtTag.RESOLVER
       )
       .build();
 
@@ -236,6 +237,18 @@ public final class StandardTags {
    */
   public static @NotNull TagResolver score() {
     return ScoreTag.RESOLVER;
+  }
+
+  /**
+   * Get a resolver for the {@value NbtTag#NBT} tag.
+   *
+   * <p>This tag also responds to {@value NbtTag#DATA}.</p>
+   *
+   * @return a resolver for the {@value NbtTag#NBT} tag.
+   * @since 4.13.0
+   */
+  public static @NotNull TagResolver nbt() {
+    return NbtTag.RESOLVER;
   }
 
   /**

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/NbtTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/NbtTagTest.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.BlockNBTComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class NbtTagTest extends AbstractTest {
+  @Test
+  void testParseBlockNbt() {
+    final String input = "That block has <nbt:block:^0 ^0 ^0:Items[0].display.Name/> in its first slot";
+
+    final Component expected = Component.text()
+      .content("That block has ")
+      .append(Component.blockNBT("Items[0].display.Name", BlockNBTComponent.LocalPos.localPos(0, 0, 0)))
+      .append(Component.text(" in its first slot"))
+      .build();
+
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testSerializeBlockNbt() {
+    final String expected = "That block has <nbt:block:'^0.0 ^0.0 ^0.0':Items[0].display.Name/> in its first slot";
+
+    final Component input = Component.text()
+      .content("That block has ")
+      .append(Component.blockNBT("Items[0].display.Name", BlockNBTComponent.LocalPos.localPos(0, 0, 0)))
+      .append(Component.text(" in its first slot"))
+      .build();
+
+    this.assertSerializedEquals(expected, input);
+  }
+
+  @Test
+  void testParseInvalidPos() {
+    final String input = "<nbt:block:abc:Data.Value/>";
+    final Component expected = Component.text(input);
+
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testParseEntityNbt() {
+    final String input = "<nbt:entity:@s:Health/>";
+    final Component expected = Component.entityNBT("Health", "@s");
+
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testSerializeEntityNbt() {
+    final Component input = Component.entityNBT("Health", "@s");
+    final String expected = "<nbt:entity:@s:Health>";
+
+    this.assertSerializedEquals(expected, input);
+  }
+
+  @Test
+  void testParseStorageNbt() {
+    final String input = "<nbt:storage:'adventure:persist':'Users{cat: true}'/>";
+    final Component expected = Component.storageNBT("Users{cat: true}", Key.key("adventure", "persist"));
+
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testParseInvalidKey() {
+    final String input = "<nbt:storage:'adventure:pe rsist':'Users{cat: true}'/>";
+    final Component expected = Component.text(input);
+
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testSerializeStorageNbt() {
+    final String expected = "<nbt:storage:'adventure:persist':'Users{cat: true}'>";
+    final Component input = Component.storageNBT("Users{cat: true}", Key.key("adventure", "persist"));
+
+    this.assertSerializedEquals(expected, input);
+  }
+
+  @Test
+  void testParseInterpret() {
+    final String input = "<nbt:entity:@s:sth:interpret/>";
+    final Component expected = Component.entityNBT()
+      .selector("@s")
+      .nbtPath("sth")
+      .interpret(true)
+      .build();
+
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testSerializeInterpret() {
+    final Component input = Component.entityNBT()
+      .selector("@s")
+      .nbtPath("sth")
+      .separator(Component.text("! ", NamedTextColor.BLUE))
+      .interpret(true)
+      .build();
+    final String expected = "<nbt:entity:@s:sth:'<blue>! ':interpret>";
+
+    this.assertSerializedEquals(expected, input);
+  }
+
+  @Test
+  void testParseSeparator() {
+    final String input = "<nbt:entity:@s:sth:'<blue>! '/>";
+    final Component expected = Component.entityNBT()
+      .selector("@s")
+      .nbtPath("sth")
+      .separator(Component.text("! ", NamedTextColor.BLUE))
+      .build();
+
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testSerializeSeparator() {
+    final Component input = Component.entityNBT()
+      .selector("@s")
+      .nbtPath("sth")
+      .separator(Component.text("! ", NamedTextColor.BLUE))
+      .build();
+    final String expected = "<nbt:entity:@s:sth:'<blue>! '>";
+
+    this.assertSerializedEquals(expected, input);
+  }
+}

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/ScoreTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/ScoreTagTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class ScoreTagTest extends AbstractTest {
+  @Test
+  void testSerializeScore() {
+    final String expected = "You have won <score:rymiel:gamesWon/> games!";
+
+    final Component input = Component.text()
+      .content("You have won ")
+      .append(Component.score("rymiel", "gamesWon"))
+      .append(Component.text(" games!"))
+      .build();
+
+    this.assertSerializedEquals(expected, input);
+  }
+
+  @Test
+  void testParseScore() {
+    final String input = "You have won <score:rymiel:gamesWon/> games!";
+
+    final Component expected = Component.text()
+      .content("You have won ")
+      .append(Component.score("rymiel", "gamesWon"))
+      .append(Component.text(" games!"))
+      .build();
+
+    this.assertParsedEquals(expected, input);
+  }
+}


### PR DESCRIPTION
These are definitely less used, but this allows MiniMessage to have more complete coverage of any possible component.

Closes GH-678

[Docs PR](https://github.com/KyoriPowered/adventure-docs/pull/106)