### PR TITLE
feat(mini-message): #791 add mini-message audience

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/audience/MiniMessageAudience.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/audience/MiniMessageAudience.java
@@ -23,9 +23,7 @@
  */
 package net.kyori.adventure.text.minimessage.audience;
 
-import java.util.Collections;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.chat.ChatType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -34,19 +32,11 @@ import net.kyori.adventure.title.TitlePart;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Implementation of {@link ForwardingAudience} that provides additional methods for sending MiniMessage strings.
+ * Implementation of {@link Audience} that provides additional methods for sending MiniMessage strings.
  *
  * @since 4.13.0
  */
-public final class MiniMessageAudience implements ForwardingAudience {
-
-  private final @NotNull Iterable<Audience> delegate;
-  private final @NotNull MiniMessage mini;
-
-  private MiniMessageAudience(final @NotNull Audience delegate, final @NotNull MiniMessage mini) {
-    this.delegate = Collections.singleton(delegate);
-    this.mini = mini;
-  }
+public interface MiniMessageAudience extends Audience {
 
   /**
    * Creates a new {@link MiniMessageAudience} that forwards to the provided {@link Audience}.
@@ -56,8 +46,8 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @return a new MiniMessageAudience
    * @since 4.13.0
    */
-  public static @NotNull MiniMessageAudience audience(final @NotNull Audience audience) {
-    return new MiniMessageAudience(audience, MiniMessage.miniMessage());
+  static @NotNull MiniMessageAudience audience(final @NotNull Audience audience) {
+    return audience(audience, MiniMessage.miniMessage());
   }
 
   /**
@@ -68,8 +58,8 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @return a new MiniMessageAudience
    * @since 4.13.0
    */
-  public static @NotNull MiniMessageAudience audience(final @NotNull Audience audience, final @NotNull MiniMessage mini) {
-    return new MiniMessageAudience(audience, mini);
+  static @NotNull MiniMessageAudience audience(final @NotNull Audience audience, final @NotNull MiniMessage mini) {
+    return new MiniMessageAudienceImpl(audience, mini);
   }
 
   /**
@@ -78,9 +68,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param message the message with MiniMessage strings to send
    * @since 4.13.0
    */
-  public void sendMessage(final @NotNull String message) {
-    this.sendMessage(this.mini.deserialize(message));
-  }
+  void sendMessage(final @NotNull String message);
 
   /**
    * Sends a MiniMessage string to this audience.
@@ -89,9 +77,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolver the tag resolver to parse additional tags
    * @since 4.13.0
    */
-  public void sendMessage(final @NotNull String message, final @NotNull TagResolver tagResolver) {
-    this.sendMessage(this.mini.deserialize(message, tagResolver));
-  }
+  void sendMessage(final @NotNull String message, final @NotNull TagResolver tagResolver);
 
   /**
    * Sends a MiniMessage string to this audience.
@@ -100,9 +86,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolvers the tag resolvers to parse additional tags
    * @since 4.13.0
    */
-  public void sendMessage(final @NotNull String message, final @NotNull TagResolver @NotNull... tagResolvers) {
-    this.sendMessage(this.mini.deserialize(message, tagResolvers));
-  }
+  void sendMessage(final @NotNull String message, final @NotNull TagResolver @NotNull ... tagResolvers);
 
   /**
    * Sends a MiniMessage string to this audience.
@@ -111,9 +95,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param bound the bound chat type
    * @since 4.13.0
    */
-  public void sendMessage(final @NotNull String message, final ChatType.@NotNull Bound bound) {
-    this.sendMessage(this.mini.deserialize(message), bound);
-  }
+  void sendMessage(final @NotNull String message, ChatType.@NotNull Bound bound);
 
   /**
    * Sends a MiniMessage string to this audience as action bar.
@@ -121,9 +103,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param message the action bar with MiniMessage strings to send
    * @since 4.13.0
    */
-  public void sendActionBar(final @NotNull String message) {
-    this.sendActionBar(this.mini.deserialize(message));
-  }
+  void sendActionBar(final @NotNull String message);
 
   /**
    * Sends a MiniMessage string to this audience as action bar.
@@ -132,9 +112,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolver the tag resolver to parse additional tags
    * @since 4.13.0
    */
-  public void sendActionBar(final @NotNull String message, final @NotNull TagResolver tagResolver) {
-    this.sendActionBar(this.mini.deserialize(message, tagResolver));
-  }
+  void sendActionBar(final @NotNull String message, final @NotNull TagResolver tagResolver);
 
   /**
    * Sends a MiniMessage string to this audience as action bar.
@@ -143,9 +121,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolvers the tag resolvers to parse additional tags
    * @since 4.13.0
    */
-  public void sendActionBar(final @NotNull String message, final @NotNull TagResolver @NotNull... tagResolvers) {
-    this.sendActionBar(this.mini.deserialize(message, tagResolvers));
-  }
+  void sendActionBar(final @NotNull String message, final @NotNull TagResolver @NotNull ... tagResolvers);
 
   /**
    * Sends a MiniMessage string to this audience as player list header.
@@ -153,9 +129,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param header the title header with MiniMessage strings to send
    * @since 4.13.0
    */
-  public void sendPlayerListHeader(final @NotNull String header) {
-    this.sendPlayerListHeader(this.mini.deserialize(header));
-  }
+  void sendPlayerListHeader(final @NotNull String header);
 
   /**
    * Sends a MiniMessage string to this audience as player list header.
@@ -164,9 +138,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolver the tag resolver to parse additional tags
    * @since 4.13.0
    */
-  public void sendPlayerListHeader(final @NotNull String header, final @NotNull TagResolver tagResolver) {
-    this.sendPlayerListHeader(this.mini.deserialize(header, tagResolver));
-  }
+  void sendPlayerListHeader(final @NotNull String header, final @NotNull TagResolver tagResolver);
 
   /**
    * Sends a MiniMessage string to this audience as player list header.
@@ -175,9 +147,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolvers the tag resolvers to parse additional tags
    * @since 4.13.0
    */
-  public void sendPlayerListHeader(final @NotNull String header, final @NotNull TagResolver @NotNull... tagResolvers) {
-    this.sendPlayerListHeader(this.mini.deserialize(header, tagResolvers));
-  }
+  void sendPlayerListHeader(final @NotNull String header, final @NotNull TagResolver @NotNull ... tagResolvers);
 
   /**
    * Sends a MiniMessage string to this audience as player list footer.
@@ -185,9 +155,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param footer the title footer with MiniMessage strings to send
    * @since 4.13.0
    */
-  public void sendPlayerListFooter(final @NotNull String footer) {
-    this.sendPlayerListFooter(this.mini.deserialize(footer));
-  }
+  void sendPlayerListFooter(final @NotNull String footer);
 
   /**
    * Sends a MiniMessage string to this audience as player list footer.
@@ -196,9 +164,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolver the tag resolver to parse additional tags
    * @since 4.13.0
    */
-  public void sendPlayerListFooter(final @NotNull String footer, final @NotNull TagResolver tagResolver) {
-    this.sendPlayerListFooter(this.mini.deserialize(footer, tagResolver));
-  }
+  void sendPlayerListFooter(final @NotNull String footer, final @NotNull TagResolver tagResolver);
 
   /**
    * Sends a MiniMessage string to this audience as player list footer.
@@ -207,9 +173,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolvers the tag resolvers to parse additional tags
    * @since 4.13.0
    */
-  public void sendPlayerListFooter(final @NotNull String footer, final @NotNull TagResolver @NotNull... tagResolvers) {
-    this.sendPlayerListFooter(this.mini.deserialize(footer, tagResolvers));
-  }
+  void sendPlayerListFooter(final @NotNull String footer, final @NotNull TagResolver @NotNull ... tagResolvers);
 
   /**
    * Sends two MiniMessage strings to this audience as player list header and footer respectively.
@@ -218,9 +182,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param footer the title footer with MiniMessage strings to send
    * @since 4.13.0
    */
-  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer) {
-    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header), this.mini.deserialize(footer));
-  }
+  void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer);
 
   /**
    * Sends two MiniMessage strings to this audience as player list header and footer respectively.
@@ -230,9 +192,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolver the tag resolver to parse additional tags
    * @since 4.13.0
    */
-  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer, final @NotNull TagResolver tagResolver) {
-    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header, tagResolver), this.mini.deserialize(footer, tagResolver));
-  }
+  void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer, final @NotNull TagResolver tagResolver);
 
   /**
    * Sends two MiniMessage strings to this audience as player list header and footer respectively.
@@ -242,9 +202,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolvers the tag resolvers to parse additional tags
    * @since 4.13.0
    */
-  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer, final @NotNull TagResolver @NotNull... tagResolvers) {
-    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header, tagResolvers), this.mini.deserialize(footer, tagResolvers));
-  }
+  void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer, final @NotNull TagResolver @NotNull ... tagResolvers);
 
   /**
    * Sends a MiniMessage string to this audience as title part.
@@ -253,9 +211,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param message the content of the title part with MiniMessage strings to send
    * @since 4.13.0
    */
-  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message) {
-    this.sendTitlePart(part, this.mini.deserialize(message));
-  }
+  void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message);
 
   /**
    * Sends a MiniMessage string to this audience as title part.
@@ -265,9 +221,7 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolver the tag resolver to parse additional tags
    * @since 4.13.0
    */
-  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message, final @NotNull TagResolver tagResolver) {
-    this.sendTitlePart(part, this.mini.deserialize(message, tagResolver));
-  }
+  void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message, final @NotNull TagResolver tagResolver);
 
   /**
    * Sends a MiniMessage string to this audience as title part.
@@ -277,12 +231,6 @@ public final class MiniMessageAudience implements ForwardingAudience {
    * @param tagResolvers the tag resolvers to parse additional tags
    * @since 4.13.0
    */
-  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message, final @NotNull TagResolver @NotNull... tagResolvers) {
-    this.sendTitlePart(part, this.mini.deserialize(message, tagResolvers));
-  }
+  void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message, final @NotNull TagResolver @NotNull ... tagResolvers);
 
-  @Override
-  public @NotNull Iterable<? extends Audience> audiences() {
-    return this.delegate;
-  }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/audience/MiniMessageAudience.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/audience/MiniMessageAudience.java
@@ -1,0 +1,288 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.audience;
+
+import java.util.Collections;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.ForwardingAudience;
+import net.kyori.adventure.chat.ChatType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.title.TitlePart;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Implementation of {@link ForwardingAudience} that provides additional methods for sending MiniMessage strings.
+ *
+ * @since 4.13.0
+ */
+public final class MiniMessageAudience implements ForwardingAudience {
+
+  private final @NotNull Iterable<Audience> delegate;
+  private final @NotNull MiniMessage mini;
+
+  private MiniMessageAudience(final @NotNull Audience delegate, final @NotNull MiniMessage mini) {
+    this.delegate = Collections.singleton(delegate);
+    this.mini = mini;
+  }
+
+  /**
+   * Creates a new {@link MiniMessageAudience} that forwards to the provided {@link Audience}.
+   * Uses the {@link MiniMessage} instance provided by {@link MiniMessage#miniMessage()}.
+   *
+   * @param audience the audience to forward to
+   * @return a new MiniMessageAudience
+   * @since 4.13.0
+   */
+  public static @NotNull MiniMessageAudience audience(final @NotNull Audience audience) {
+    return new MiniMessageAudience(audience, MiniMessage.miniMessage());
+  }
+
+  /**
+   * Creates a new {@link MiniMessageAudience} that forwards to the provided {@link Audience}.
+   *
+   * @param audience the audience to forward to
+   * @param mini the MiniMessage instance to use
+   * @return a new MiniMessageAudience
+   * @since 4.13.0
+   */
+  public static @NotNull MiniMessageAudience audience(final @NotNull Audience audience, final @NotNull MiniMessage mini) {
+    return new MiniMessageAudience(audience, mini);
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience.
+   *
+   * @param message the message with MiniMessage strings to send
+   * @since 4.13.0
+   */
+  public void sendMessage(final @NotNull String message) {
+    this.sendMessage(this.mini.deserialize(message));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience.
+   *
+   * @param message the message with MiniMessage strings to send
+   * @param tagResolver the tag resolver to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendMessage(final @NotNull String message, final @NotNull TagResolver tagResolver) {
+    this.sendMessage(this.mini.deserialize(message, tagResolver));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience.
+   *
+   * @param message the message with MiniMessage strings to send
+   * @param tagResolvers the tag resolvers to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendMessage(final @NotNull String message, final @NotNull TagResolver @NotNull... tagResolvers) {
+    this.sendMessage(this.mini.deserialize(message, tagResolvers));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience.
+   *
+   * @param message the message with MiniMessage strings to send
+   * @param bound the bound chat type
+   * @since 4.13.0
+   */
+  public void sendMessage(final @NotNull String message, final ChatType.@NotNull Bound bound) {
+    this.sendMessage(this.mini.deserialize(message), bound);
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as action bar.
+   *
+   * @param message the action bar with MiniMessage strings to send
+   * @since 4.13.0
+   */
+  public void sendActionBar(final @NotNull String message) {
+    this.sendActionBar(this.mini.deserialize(message));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as action bar.
+   *
+   * @param message the action bar with MiniMessage strings to send
+   * @param tagResolver the tag resolver to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendActionBar(final @NotNull String message, final @NotNull TagResolver tagResolver) {
+    this.sendActionBar(this.mini.deserialize(message, tagResolver));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as action bar.
+   *
+   * @param message the action bar with MiniMessage strings to send
+   * @param tagResolvers the tag resolvers to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendActionBar(final @NotNull String message, final @NotNull TagResolver @NotNull... tagResolvers) {
+    this.sendActionBar(this.mini.deserialize(message, tagResolvers));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as player list header.
+   *
+   * @param header the title header with MiniMessage strings to send
+   * @since 4.13.0
+   */
+  public void sendPlayerListHeader(final @NotNull String header) {
+    this.sendPlayerListHeader(this.mini.deserialize(header));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as player list header.
+   *
+   * @param header the title header with MiniMessage strings to send
+   * @param tagResolver the tag resolver to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendPlayerListHeader(final @NotNull String header, final @NotNull TagResolver tagResolver) {
+    this.sendPlayerListHeader(this.mini.deserialize(header, tagResolver));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as player list header.
+   *
+   * @param header the title header with MiniMessage strings to send
+   * @param tagResolvers the tag resolvers to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendPlayerListHeader(final @NotNull String header, final @NotNull TagResolver @NotNull... tagResolvers) {
+    this.sendPlayerListHeader(this.mini.deserialize(header, tagResolvers));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as player list footer.
+   *
+   * @param footer the title footer with MiniMessage strings to send
+   * @since 4.13.0
+   */
+  public void sendPlayerListFooter(final @NotNull String footer) {
+    this.sendPlayerListFooter(this.mini.deserialize(footer));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as player list footer.
+   *
+   * @param footer the title footer with MiniMessage strings to send
+   * @param tagResolver the tag resolver to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendPlayerListFooter(final @NotNull String footer, final @NotNull TagResolver tagResolver) {
+    this.sendPlayerListFooter(this.mini.deserialize(footer, tagResolver));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as player list footer.
+   *
+   * @param footer the title footer with MiniMessage strings to send
+   * @param tagResolvers the tag resolvers to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendPlayerListFooter(final @NotNull String footer, final @NotNull TagResolver @NotNull... tagResolvers) {
+    this.sendPlayerListFooter(this.mini.deserialize(footer, tagResolvers));
+  }
+
+  /**
+   * Sends two MiniMessage strings to this audience as player list header and footer respectively.
+   *
+   * @param header the title header with MiniMessage strings to send
+   * @param footer the title footer with MiniMessage strings to send
+   * @since 4.13.0
+   */
+  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer) {
+    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header), this.mini.deserialize(footer));
+  }
+
+  /**
+   * Sends two MiniMessage strings to this audience as player list header and footer respectively.
+   *
+   * @param header the title header with MiniMessage strings to send
+   * @param footer the title footer with MiniMessage strings to send
+   * @param tagResolver the tag resolver to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer, final @NotNull TagResolver tagResolver) {
+    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header, tagResolver), this.mini.deserialize(footer, tagResolver));
+  }
+
+  /**
+   * Sends two MiniMessage strings to this audience as player list header and footer respectively.
+   *
+   * @param header the title header with MiniMessage strings to send
+   * @param footer the title footer with MiniMessage strings to send
+   * @param tagResolvers the tag resolvers to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer, final @NotNull TagResolver @NotNull... tagResolvers) {
+    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header, tagResolvers), this.mini.deserialize(footer, tagResolvers));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as title part.
+   *
+   * @param part the part of the title to send
+   * @param message the content of the title part with MiniMessage strings to send
+   * @since 4.13.0
+   */
+  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message) {
+    this.sendTitlePart(part, this.mini.deserialize(message));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as title part.
+   *
+   * @param part the part of the title to send
+   * @param message the content of the title part with MiniMessage strings to send
+   * @param tagResolver the tag resolver to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message, final @NotNull TagResolver tagResolver) {
+    this.sendTitlePart(part, this.mini.deserialize(message, tagResolver));
+  }
+
+  /**
+   * Sends a MiniMessage string to this audience as title part.
+   *
+   * @param part the part of the title to send
+   * @param message the content of the title part with MiniMessage strings to send
+   * @param tagResolvers the tag resolvers to parse additional tags
+   * @since 4.13.0
+   */
+  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message, final @NotNull TagResolver @NotNull... tagResolvers) {
+    this.sendTitlePart(part, this.mini.deserialize(message, tagResolvers));
+  }
+
+  @Override
+  public @NotNull Iterable<? extends Audience> audiences() {
+    return this.delegate;
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/audience/MiniMessageAudienceImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/audience/MiniMessageAudienceImpl.java
@@ -1,0 +1,219 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.audience;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.chat.ChatType;
+import net.kyori.adventure.chat.SignedMessage;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.inventory.Book;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.SoundStop;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.title.TitlePart;
+import org.jetbrains.annotations.NotNull;
+
+final class MiniMessageAudienceImpl implements MiniMessageAudience {
+
+  private final @NotNull Audience delegate;
+  private final @NotNull MiniMessage mini;
+
+  MiniMessageAudienceImpl(final @NotNull Audience delegate, final @NotNull MiniMessage mini) {
+    this.delegate = delegate;
+    this.mini = mini;
+  }
+
+  @Override
+  public void sendMessage(final @NotNull String message) {
+    this.sendMessage(this.mini.deserialize(message));
+  }
+
+  @Override
+  public void sendMessage(final @NotNull String message, final @NotNull TagResolver tagResolver) {
+    this.sendMessage(this.mini.deserialize(message, tagResolver));
+  }
+
+  @Override
+  public void sendMessage(final @NotNull String message, final @NotNull TagResolver @NotNull ... tagResolvers) {
+    this.sendMessage(this.mini.deserialize(message, tagResolvers));
+  }
+
+  @Override
+  public void sendMessage(final @NotNull String message, final ChatType.@NotNull Bound bound) {
+    this.sendMessage(this.mini.deserialize(message), bound);
+  }
+
+  @Override
+  public void sendActionBar(final @NotNull String message) {
+    this.sendActionBar(this.mini.deserialize(message));
+  }
+
+  @Override
+  public void sendActionBar(final @NotNull String message, final @NotNull TagResolver tagResolver) {
+    this.sendActionBar(this.mini.deserialize(message, tagResolver));
+  }
+
+  @Override
+  public void sendActionBar(final @NotNull String message, final @NotNull TagResolver @NotNull ... tagResolvers) {
+    this.sendActionBar(this.mini.deserialize(message, tagResolvers));
+  }
+
+  @Override
+  public void sendPlayerListHeader(final @NotNull String header) {
+    this.sendPlayerListHeader(this.mini.deserialize(header));
+  }
+
+  @Override
+  public void sendPlayerListHeader(final @NotNull String header, final @NotNull TagResolver tagResolver) {
+    this.sendPlayerListHeader(this.mini.deserialize(header, tagResolver));
+  }
+
+  @Override
+  public void sendPlayerListHeader(final @NotNull String header, final @NotNull TagResolver @NotNull ... tagResolvers) {
+    this.sendPlayerListHeader(this.mini.deserialize(header, tagResolvers));
+  }
+
+  @Override
+  public void sendPlayerListFooter(final @NotNull String footer) {
+    this.sendPlayerListFooter(this.mini.deserialize(footer));
+  }
+
+  @Override
+  public void sendPlayerListFooter(final @NotNull String footer, final @NotNull TagResolver tagResolver) {
+    this.sendPlayerListFooter(this.mini.deserialize(footer, tagResolver));
+  }
+
+  @Override
+  public void sendPlayerListFooter(final @NotNull String footer, final @NotNull TagResolver @NotNull ... tagResolvers) {
+    this.sendPlayerListFooter(this.mini.deserialize(footer, tagResolvers));
+  }
+
+  @Override
+  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer) {
+    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header), this.mini.deserialize(footer));
+  }
+
+  @Override
+  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer, final @NotNull TagResolver tagResolver) {
+    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header, tagResolver), this.mini.deserialize(footer, tagResolver));
+  }
+
+  @Override
+  public void sendPlayerListHeaderAndFooter(final @NotNull String header, final @NotNull String footer, final @NotNull TagResolver @NotNull ... tagResolvers) {
+    this.sendPlayerListHeaderAndFooter(this.mini.deserialize(header, tagResolvers), this.mini.deserialize(footer, tagResolvers));
+  }
+
+  @Override
+  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message) {
+    this.sendTitlePart(part, this.mini.deserialize(message));
+  }
+
+  @Override
+  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message, final @NotNull TagResolver tagResolver) {
+    this.sendTitlePart(part, this.mini.deserialize(message, tagResolver));
+  }
+
+  @Override
+  public void sendTitlePart(final @NotNull TitlePart<Component> part, final @NotNull String message, final @NotNull TagResolver @NotNull ... tagResolvers) {
+    this.sendTitlePart(part, this.mini.deserialize(message, tagResolvers));
+  }
+
+  //delegate methods
+
+  @Override
+  @Deprecated
+  public void sendMessage(final @NotNull Identity source, final @NotNull Component message, final @NotNull MessageType type) {
+    this.delegate.sendMessage(source, message, type);
+  }
+
+  @Override
+  public void deleteMessage(final SignedMessage.@NotNull Signature signature) {
+    this.delegate.deleteMessage(signature);
+  }
+
+  @Override
+  public void sendActionBar(final @NotNull Component message) {
+    this.delegate.sendActionBar(message);
+  }
+
+  @Override
+  public void sendPlayerListHeaderAndFooter(final @NotNull Component header, final @NotNull Component footer) {
+    this.delegate.sendPlayerListHeaderAndFooter(header, footer);
+  }
+
+  @Override
+  public <T> void sendTitlePart(final @NotNull TitlePart<T> part, final @NotNull T value) {
+    this.delegate.sendTitlePart(part, value);
+  }
+
+  @Override
+  public void clearTitle() {
+    this.delegate.clearTitle();
+  }
+
+  @Override
+  public void resetTitle() {
+    this.delegate.resetTitle();
+  }
+
+  @Override
+  public void showBossBar(final @NotNull BossBar bar) {
+    this.delegate.showBossBar(bar);
+  }
+
+  @Override
+  public void hideBossBar(final @NotNull BossBar bar) {
+    this.delegate.hideBossBar(bar);
+  }
+
+  @Override
+  public void playSound(final @NotNull Sound sound) {
+    this.delegate.playSound(sound);
+  }
+
+  @Override
+  public void playSound(final @NotNull Sound sound, final double x, final double y, final double z) {
+    this.delegate.playSound(sound, x, y, z);
+  }
+
+  @Override
+  public void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {
+    this.delegate.playSound(sound, emitter);
+  }
+
+  @Override
+  public void stopSound(final @NotNull SoundStop stop) {
+    this.delegate.stopSound(stop);
+  }
+
+  @Override
+  public void openBook(final @NotNull Book book) {
+    this.delegate.openBook(book);
+  }
+
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/audience/package-info.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/audience/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2022 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Classes to help with sending messages with MiniMessage strings to players.
+ */
+package net.kyori.adventure.text.minimessage.audience;


### PR DESCRIPTION
Adds shorthand methods to send messages with mini-message strings in them easily. The current approach utilizes the delegation provided by `ForwardingAudience` and allows users to use a custom `MiniMessage` instance for each audience instead of just the default one.

TODO:

- [x] Shorthand method for chat messages/action bars/title parts/tab list header and footer
- [ ] Unit tests for MiniMessageAudience

Closes #791