### PR TITLE
text-minimessage: Add a TagResolver for boolean values

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -118,4 +118,24 @@ public final class Formatter {
       return Tag.inserting(context.deserialize(choiceFormat.format(number)));
     });
   }
+
+  /**
+   * Creates a choice tag. This will use the first argument when true, otherwise the second argument.
+   *
+   * <p>This tag expects two formats as attributes.</p>
+   *
+   * <p>This replacement is auto-closing, so its style will not influence the style of following components.</p>
+   *
+   * @param key the key
+   * @param value the value
+   * @return the placeholder
+   * @since 4.12.0
+   */
+  public static TagResolver booleanChoice(final @NotNull String key, final boolean value) {
+    return TagResolver.resolver(key, (argumentQueue, context) -> {
+      final String trueCase = argumentQueue.popOr("True format expected.").value();
+      final String falseCase = argumentQueue.popOr("Talse format expected.").value();
+      return Tag.inserting(context.deserialize(value ? trueCase : falseCase));
+    });
+  }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -129,7 +129,7 @@ public final class Formatter {
    * @param key the key
    * @param value the value
    * @return the placeholder
-   * @since 4.12.0
+   * @since 4.13.0
    */
   public static TagResolver booleanChoice(final @NotNull String key, final boolean value) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -134,7 +134,7 @@ public final class Formatter {
   public static TagResolver booleanChoice(final @NotNull String key, final boolean value) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final String trueCase = argumentQueue.popOr("True format expected.").value();
-      final String falseCase = argumentQueue.popOr("Talse format expected.").value();
+      final String falseCase = argumentQueue.popOr("False format expected.").value();
       return Tag.inserting(context.deserialize(value ? trueCase : falseCase));
     });
   }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/FormatterTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/FormatterTest.java
@@ -31,6 +31,7 @@ import net.kyori.adventure.text.minimessage.AbstractTest;
 import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.booleanChoice;
 import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.choice;
 import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.date;
 import static net.kyori.adventure.text.minimessage.tag.resolver.Formatter.number;
@@ -116,5 +117,12 @@ public class FormatterTest extends AbstractTest {
     this.assertParsedEquals(zero, input, choice("choice", 0));
     this.assertParsedEquals(one, input, choice("choice", 1));
     this.assertParsedEquals(bigResult, input, choice("choice", 2));
+  }
+
+  @Test
+  void testBooleanChoice() {
+    final String input = "<first:'<second:\\'<third:\"bah\":\"\">\\':\\'\\'>':''>";
+    final Component expected = text("bah");
+    this.assertParsedEquals(expected, input, booleanChoice("first", true), booleanChoice("second", true), booleanChoice("third", true));
   }
 }


### PR DESCRIPTION
This will add a new TagResolver for boolean values.

Instead of passing number values or timestamps you want to display some text when a condition is met.

E.g. the text `The issuer is a player` for players and `The issuer is a console` for consoles. Currently that's not easily possible.

With the new tag you can use:
```java
MiniMessage.miniMessage().deserialize("The issuer is a <isplayer:player:console>.", 
    Formatter.booleanChoice("isPlayer", isPlayer)
);
```