### PR TITLE
text-minimessage: Add a shortcut for styling tags

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.java
@@ -93,7 +93,7 @@ public final class Placeholder {
    * @return the placeholder
    * @since 4.13.0
    */
-  public static TagResolver.@NotNull Single style(final @NotNull String key, final @NotNull StyleBuilderApplicable style) {
+  public static TagResolver.@NotNull Single style(final @NotNull String key, final @NotNull StyleBuilderApplicable@NotNull... style) {
     return TagResolver.resolver(key, Tag.styling(style));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.minimessage.tag.resolver;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.format.StyleBuilderApplicable;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import org.jetbrains.annotations.NotNull;
 
@@ -80,5 +81,19 @@ public final class Placeholder {
    */
   public static TagResolver.@NotNull Single component(final @NotNull String key, final @NotNull ComponentLike value) {
     return TagResolver.resolver(key, Tag.selfClosingInserting(value));
+  }
+
+  /**
+   * Creates a style tag which will modify the style of the component.
+   *
+   * <p>This style can be used like other styles.</p>
+   *
+   * @param key the key
+   * @param style the style
+   * @return the placeholder
+   * @since 4.13.0
+   */
+  public static TagResolver.@NotNull Single style(final @NotNull String key, final @NotNull StyleBuilderApplicable style) {
+    return TagResolver.resolver(key, Tag.styling(style));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.java
@@ -93,7 +93,7 @@ public final class Placeholder {
    * @return the placeholder
    * @since 4.13.0
    */
-  public static TagResolver.@NotNull Single style(final @NotNull String key, final @NotNull StyleBuilderApplicable@NotNull... style) {
+  public static TagResolver.@NotNull Single styling(final @NotNull String key, final @NotNull StyleBuilderApplicable@NotNull... style) {
     return TagResolver.resolver(key, Tag.styling(style));
   }
 }


### PR DESCRIPTION
Add a new TagResolver type for styling.

This will provide a shortcut:
```java
TagResolver.resolver("test", Tag.styling(ClickEvent.runCommand("/test"));
TagResolver.resolver("mycolor", Tag.styling(NamedTextColor.RED));
// to
Placeholder.styling("test", ClickEvent.runCommand("/test"));
Placeholder.styling("mycolor", NamedTextColor.RED);
```