### PR TITLE
fix(serializer-gson): Ignore empty hover event values

### DIFF
--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -147,7 +147,9 @@ final class StyleSerializer extends TypeAdapter<Style> {
             if (hoverEventObject.has(HOVER_EVENT_CONTENTS)) {
               final @Nullable JsonElement rawValue = hoverEventObject.get(HOVER_EVENT_CONTENTS);
               final Class<?> actionType = action.type();
-              if (SerializerFactory.COMPONENT_TYPE.isAssignableFrom(actionType)) {
+              if (rawValue.isJsonNull() || (rawValue.isJsonArray() && rawValue.getAsJsonArray().size() == 0) || (rawValue.isJsonObject() && rawValue.getAsJsonObject().size() == 0)) {
+                value = null;
+              } else if (SerializerFactory.COMPONENT_TYPE.isAssignableFrom(actionType)) {
                 value = this.gson.fromJson(rawValue, SerializerFactory.COMPONENT_TYPE);
               } else if (SerializerFactory.SHOW_ITEM_TYPE.isAssignableFrom(actionType)) {
                 value = this.gson.fromJson(rawValue, SerializerFactory.SHOW_ITEM_TYPE);
@@ -157,8 +159,13 @@ final class StyleSerializer extends TypeAdapter<Style> {
                 value = null;
               }
             } else if (hoverEventObject.has(HOVER_EVENT_VALUE)) {
-              final Component rawValue = this.gson.fromJson(hoverEventObject.get(HOVER_EVENT_VALUE), SerializerFactory.COMPONENT_TYPE);
-              value = this.legacyHoverEventContents(action, rawValue);
+              final JsonElement element = hoverEventObject.get(HOVER_EVENT_VALUE);
+              if (element.isJsonNull() || (element.isJsonArray() && element.getAsJsonArray().size() == 0) || (element.isJsonObject() && element.getAsJsonObject().size() == 0)) {
+                value = null;
+              } else {
+                final Component rawValue = this.gson.fromJson(element, SerializerFactory.COMPONENT_TYPE);
+                value = this.legacyHoverEventContents(action, rawValue);
+              }
             } else {
               value = null;
             }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -147,7 +147,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
             if (hoverEventObject.has(HOVER_EVENT_CONTENTS)) {
               final @Nullable JsonElement rawValue = hoverEventObject.get(HOVER_EVENT_CONTENTS);
               final Class<?> actionType = action.type();
-              if (rawValue.isJsonNull() || (rawValue.isJsonArray() && rawValue.getAsJsonArray().size() == 0) || (rawValue.isJsonObject() && rawValue.getAsJsonObject().size() == 0)) {
+              if (isNullOrEmpty(rawValue)) {
                 value = null;
               } else if (SerializerFactory.COMPONENT_TYPE.isAssignableFrom(actionType)) {
                 value = this.gson.fromJson(rawValue, SerializerFactory.COMPONENT_TYPE);
@@ -160,7 +160,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
               }
             } else if (hoverEventObject.has(HOVER_EVENT_VALUE)) {
               final JsonElement element = hoverEventObject.get(HOVER_EVENT_VALUE);
-              if (element.isJsonNull() || (element.isJsonArray() && element.getAsJsonArray().size() == 0) || (element.isJsonObject() && element.getAsJsonObject().size() == 0)) {
+              if (isNullOrEmpty(element)) {
                 value = null;
               } else {
                 final Component rawValue = this.gson.fromJson(element, SerializerFactory.COMPONENT_TYPE);
@@ -182,6 +182,10 @@ final class StyleSerializer extends TypeAdapter<Style> {
 
     in.endObject();
     return style.build();
+  }
+
+  private static boolean isNullOrEmpty(final @Nullable JsonElement element) {
+    return element == null || element.isJsonNull() || (element.isJsonArray() && element.getAsJsonArray().size() == 0) || (element.isJsonObject() && element.getAsJsonObject().size() == 0);
   }
 
   private boolean readBoolean(final JsonReader in) throws IOException {

--- a/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerTest.java
+++ b/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerTest.java
@@ -90,6 +90,14 @@ class GsonComponentSerializerTest {
     assertEquals("Don't know how to turn null into a Component", ex.getMessage());
   }
 
+  // https://github.com/KyoriPowered/adventure/issues/414
+  @Test
+  void testSkipInvalidHoverEvent() {
+    final String input = "{\"text\": \"hello\", \"hoverEvent\":{\"action\":\"show_text\",\"value\":[]}}";
+    final Component expected = Component.text("hello");
+    assertEquals(expected, GsonComponentSerializer.gson().deserialize(input));
+  }
+
   private static String name(final NamedTextColor color) {
     return NamedTextColor.NAMES.key(color);
   }


### PR DESCRIPTION
Fixes GH-414

I'm not sure if this is something we want to do, or maybe lock behind a 'lenient' mode? but this does resolve the case from the original issue.