### PR TITLE
Make DecorationMap$KeySet and $Values follow Collection::toArray() contract

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -247,7 +247,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
 
     @Override
     public Object @NotNull [] toArray() {
-      final TextDecoration.State[] states = new TextDecoration.State[MAP_SIZE];
+      final Object[] states = new Object[MAP_SIZE];
       for (int i = 0; i < MAP_SIZE; i++) {
         states[i] = DecorationMap.this.get(DECORATIONS[i]);
       }
@@ -292,7 +292,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
 
     @Override
     public Object @NotNull [] toArray() {
-      return DECORATIONS.clone();
+      return Arrays.copyOf(DECORATIONS, MAP_SIZE, Object[].class);
     }
 
     @Override


### PR DESCRIPTION
`Collection::toArray()` javadoc states that the array's runtime component type must be `Object`