### PR TITLE
feat(api): add support for translatable component fallbacks (#863)

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1393,6 +1393,164 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(key, fallback, Style.empty(), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and styling.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
+    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, fallback, requireNonNull(args, "args"));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and styling.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style, args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.0.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
+    return TranslatableComponentImpl.create(Collections.emptyList(), style, key, fallback, requireNonNull(args, "args"));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style, args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @param style the style
+   * @return a translatable component
+   * @since 4.0.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull List<StyleBuilderApplicable> style) {
+    return TranslatableComponentImpl.create(Collections.emptyList(), Style.style(style), key, fallback, requireNonNull(args, "args"));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @param style the style
+   * @return a translatable component
+   * @since 4.8.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull List<StyleBuilderApplicable> style) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args, style);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @param style the style
+   * @return a translatable component
+   * @since 4.0.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull StyleBuilderApplicable... style) {
+    return TranslatableComponentImpl.create(Collections.emptyList(), Style.style(style), key, fallback, requireNonNull(args, "args"));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @param style the style
+   * @return a translatable component
+   * @since 4.8.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull StyleBuilderApplicable... style) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args, style);
+  }
+
+  /**
    * Creates a translatable component with a translation key, and optional color.
    *
    * @param key the translation key

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1288,7 +1288,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style) {
-    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, Collections.emptyList());
+    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, null, Collections.emptyList());
   }
 
   /**
@@ -1423,7 +1423,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
-    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, requireNonNull(args, "args"));
+    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, null, requireNonNull(args, "args"));
   }
 
   /**
@@ -1508,7 +1508,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull List<? extends ComponentLike> args) {
-    return TranslatableComponentImpl.create(Collections.emptyList(), Style.empty(), key, requireNonNull(args, "args"));
+    return TranslatableComponentImpl.create(Collections.emptyList(), Style.empty(), key, null, requireNonNull(args, "args"));
   }
 
   /**
@@ -1535,7 +1535,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
-    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, requireNonNull(args, "args"));
+    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, null, requireNonNull(args, "args"));
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1285,6 +1285,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param fallback the fallback string
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback) {
@@ -1298,6 +1299,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param fallback the fallback string
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback) {
@@ -1338,6 +1340,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param style the style
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style) {
@@ -1352,6 +1355,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param style the style
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style) {
@@ -1392,6 +1396,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param color the color
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color) {
@@ -1406,6 +1411,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param color the color
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _ , _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color) {
@@ -1449,6 +1455,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param decorations the decorations
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
@@ -1464,6 +1471,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param decorations the decorations
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
@@ -1507,6 +1515,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param decorations the decorations
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
@@ -1522,6 +1531,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param decorations the decorations
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
@@ -1562,6 +1572,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
@@ -1576,6 +1587,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
@@ -1619,6 +1631,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
@@ -1634,6 +1647,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
@@ -1677,6 +1691,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
@@ -1692,6 +1707,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
@@ -1738,6 +1754,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
@@ -1754,6 +1771,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
@@ -1794,6 +1812,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.0.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args) {
@@ -1808,6 +1827,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.8.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args) {
@@ -1851,6 +1871,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
@@ -1866,6 +1887,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
@@ -1909,6 +1931,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
@@ -1924,6 +1947,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
@@ -1970,6 +1994,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
@@ -1986,6 +2011,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @param args the translation arguments
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1279,6 +1279,32 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key and an optional fallback string.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback) {
+    return translatable(key, fallback, Style.empty());
+  }
+
+  /**
+   * Creates a translatable component with a translation key and an optional fallback string.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, Style.empty());
+  }
+
+  /**
    * Creates a translatable component with a translation key and styling.
    *
    * @param key the translation key
@@ -1305,6 +1331,34 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key, optional fallback string, and styling.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param style the style
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style) {
+    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), fallback, key, Collections.emptyList());
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and styling.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param style the style
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style);
+  }
+
+  /**
    * Creates a translatable component with a translation key, and optional color.
    *
    * @param key the translation key
@@ -1328,6 +1382,34 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and optional color.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param color the color
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color) {
+    return translatable(key, fallback, Style.style(color));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and optional color.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param color the color
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _ , _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color);
   }
 
   /**
@@ -1359,6 +1441,36 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key, optional fallback string, and optional color and decorations.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param color the color
+   * @param decorations the decorations
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+    return translatable(key, fallback, Style.style(color, decorations));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and optional color and decorations.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param color the color
+   * @param decorations the decorations
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, decorations);
+  }
+
+  /**
    * Creates a translatable component with a translation key, and optional color and decorations.
    *
    * @param key the translation key
@@ -1387,6 +1499,36 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key, an optional fallback string, and optional color and decorations.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param color the color
+   * @param decorations the decorations
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+    return translatable(key, fallback, Style.style(color, decorations));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, an optional fallback string, and optional color and decorations.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param color the color
+   * @param decorations the decorations
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, decorations);
+  }
+
+  /**
    * Creates a translatable component with a translation key and arguments.
    *
    * @param key the translation key
@@ -1410,6 +1552,34 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull ComponentLike@NotNull... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(key, fallback, Style.empty(), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args);
   }
 
   /**
@@ -1441,6 +1611,36 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key, optional fallback string, and styling.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
+    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, fallback, requireNonNull(args, "args"));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and styling.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style, args);
+  }
+
+  /**
    * Creates a translatable component with a translation key, arguments, and optional color.
    *
    * @param key the translation key
@@ -1466,6 +1666,36 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param color the color
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(key, fallback, Style.style(color), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param color the color
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, args);
   }
 
   /**
@@ -1499,6 +1729,38 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color and decorations.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param color the color
+   * @param decorations the decorations
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(key, fallback, Style.style(color, decorations), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color and decorations.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param color the color
+   * @param decorations the decorations
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, decorations, args);
+  }
+
+  /**
    * Creates a translatable component with a translation key and arguments.
    *
    * @param key the translation key
@@ -1522,6 +1784,34 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.0.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args) {
+    return TranslatableComponentImpl.create(Collections.emptyList(), Style.empty(), key, fallback, requireNonNull(args, "args"));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and arguments.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.8.0
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args);
   }
 
   /**
@@ -1553,6 +1843,36 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
+   * Creates a translatable component with a translation key, an optional fallback string, and styling.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
+    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, fallback, requireNonNull(args, "args"));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, an optional fallback string, and styling.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param style the style
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style, args);
+  }
+
+  /**
    * Creates a translatable component with a translation key, arguments, and optional color.
    *
    * @param key the translation key
@@ -1578,6 +1898,36 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _ -> new", pure = true)
   static TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param color the color
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
+    return translatable(key, fallback, Style.style(color), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param color the color
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _ -> new", pure = true)
+  static TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, args);
   }
 
   /**
@@ -1608,6 +1958,38 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, decorations, args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color and decorations.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param color the color
+   * @param decorations the decorations
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
+    return translatable(key, fallback, Style.style(color, decorations), args);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color and decorations.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param color the color
+   * @param decorations the decorations
+   * @param args the translation arguments
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(value = "_, _, _, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, decorations, args);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1344,7 +1344,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style) {
-    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), fallback, key, Collections.emptyList());
+    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, fallback, Collections.emptyList());
   }
 
   /**
@@ -1360,6 +1360,36 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style);
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and styling.
+   *
+   * @param key the translation key
+   * @param fallback the fallback string
+   * @param style the style
+   * @return a translatable component
+   * @since 4.13.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull StyleBuilderApplicable... style) {
+    return translatable(requireNonNull(key, "key"), fallback, Style.style(style));
+  }
+
+  /**
+   * Creates a translatable component with a translation key, optional fallback string, and styling.
+   *
+   * @param translatable the translatable object to get the key from
+   * @param fallback the fallback string
+   * @param style the style
+   * @return a translatable component
+   * @since 4.13.0
+   * @sinceMinecraft 1.19.4
+   */
+  @Contract(value = "_, _, _ -> new", pure = true)
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<StyleBuilderApplicable> style) {
+    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, Style.style(style));
   }
 
   /**
@@ -1386,36 +1416,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, and optional color.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param color the color
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color) {
-    return translatable(key, fallback, Style.style(color));
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, and optional color.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param color the color
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _ , _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color);
   }
 
   /**
@@ -1447,38 +1447,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Creates a translatable component with a translation key, optional fallback string, and optional color and decorations.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param color the color
-   * @param decorations the decorations
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
-    return translatable(key, fallback, Style.style(color, decorations));
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, and optional color and decorations.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param color the color
-   * @param decorations the decorations
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, decorations);
-  }
-
-  /**
    * Creates a translatable component with a translation key, and optional color and decorations.
    *
    * @param key the translation key
@@ -1507,38 +1475,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Creates a translatable component with a translation key, an optional fallback string, and optional color and decorations.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param color the color
-   * @param decorations the decorations
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
-    return translatable(key, fallback, Style.style(color, decorations));
-  }
-
-  /**
-   * Creates a translatable component with a translation key, an optional fallback string, and optional color and decorations.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param color the color
-   * @param decorations the decorations
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, decorations);
-  }
-
-  /**
    * Creates a translatable component with a translation key and arguments.
    *
    * @param key the translation key
@@ -1562,36 +1498,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull ComponentLike@NotNull... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, and arguments.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
-    return translatable(key, fallback, Style.empty(), args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, and arguments.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args);
   }
 
   /**
@@ -1623,38 +1529,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Creates a translatable component with a translation key, optional fallback string, and styling.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param style the style
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
-    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, fallback, requireNonNull(args, "args"));
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, and styling.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param style the style
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style, args);
-  }
-
-  /**
    * Creates a translatable component with a translation key, arguments, and optional color.
    *
    * @param key the translation key
@@ -1680,38 +1554,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param color the color
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
-    return translatable(key, fallback, Style.style(color), args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param color the color
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, args);
   }
 
   /**
@@ -1745,40 +1587,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color and decorations.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param color the color
-   * @param decorations the decorations
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
-    return translatable(key, fallback, Style.style(color, decorations), args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color and decorations.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param color the color
-   * @param decorations the decorations
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, decorations, args);
-  }
-
-  /**
    * Creates a translatable component with a translation key and arguments.
    *
    * @param key the translation key
@@ -1802,36 +1610,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, and arguments.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.0.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args) {
-    return TranslatableComponentImpl.create(Collections.emptyList(), Style.empty(), key, fallback, requireNonNull(args, "args"));
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, and arguments.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.8.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args);
   }
 
   /**
@@ -1863,38 +1641,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   }
 
   /**
-   * Creates a translatable component with a translation key, an optional fallback string, and styling.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param style the style
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
-    return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, fallback, requireNonNull(args, "args"));
-  }
-
-  /**
-   * Creates a translatable component with a translation key, an optional fallback string, and styling.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param style the style
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style, args);
-  }
-
-  /**
    * Creates a translatable component with a translation key, arguments, and optional color.
    *
    * @param key the translation key
@@ -1920,38 +1666,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _ -> new", pure = true)
   static TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param color the color
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
-    return translatable(key, fallback, Style.style(color), args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param color the color
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _ -> new", pure = true)
-  static TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, args);
   }
 
   /**
@@ -1982,40 +1696,6 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(value = "_, _, _, _ -> new", pure = true)
   static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, decorations, args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color and decorations.
-   *
-   * @param key the translation key
-   * @param fallback the fallback string
-   * @param color the color
-   * @param decorations the decorations
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
-    return translatable(key, fallback, Style.style(color, decorations), args);
-  }
-
-  /**
-   * Creates a translatable component with a translation key, optional fallback string, arguments, and optional color and decorations.
-   *
-   * @param translatable the translatable object to get the key from
-   * @param fallback the fallback string
-   * @param color the color
-   * @param decorations the decorations
-   * @param args the translation arguments
-   * @return a translatable component
-   * @since 4.13.0
-   * @sinceMinecraft 1.19.4
-   */
-  @Contract(value = "_, _, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
-    return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, color, decorations, args);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -1388,7 +1388,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<StyleBuilderApplicable> style) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Iterable<StyleBuilderApplicable> style) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, Style.style(style));
   }
 
@@ -1498,7 +1498,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull List<StyleBuilderApplicable> style) {
+  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull Iterable<StyleBuilderApplicable> style) {
     return TranslatableComponentImpl.create(Collections.emptyList(), Style.style(style), key, fallback, requireNonNull(args, "args"));
   }
 
@@ -1514,7 +1514,7 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull List<StyleBuilderApplicable> style) {
+  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull Iterable<StyleBuilderApplicable> style) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args, style);
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -127,6 +127,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    *
    * @return the fallback string
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Nullable String fallback();
 
@@ -138,6 +139,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @param fallback the fallback string
    * @return a translatable component
    * @since 4.13.0
+   * @sinceMinecraft 1.19.4
    */
   @Contract(pure = true)
   @NotNull TranslatableComponent fallback(final @NotNull String fallback);
@@ -241,6 +243,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      * @param fallback the fallback string
      * @return this builder
      * @since 4.13.0
+     * @sinceMinecraft 1.19.4
      */
     @Contract("_ -> this")
     @NotNull Builder fallback(final @Nullable String fallback);

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -142,7 +142,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * @sinceMinecraft 1.19.4
    */
   @Contract(pure = true)
-  @NotNull TranslatableComponent fallback(final @NotNull String fallback);
+  @NotNull TranslatableComponent fallback(final @Nullable String fallback);
 
   @Override
   default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -93,24 +93,6 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
   @NotNull TranslatableComponent key(final @NotNull String key);
 
   /**
-   * Gets the fallback string.
-   *
-   * @return the fallback string
-   * @since 4.13.0
-   */
-  @Nullable String fallback();
-
-  /**
-   * Sets the fallback string.
-   *
-   * @param fallback the fallback string
-   * @return a translatable component
-   * @since 4.13.0
-   */
-  @Contract(pure = true)
-  @NotNull TranslatableComponent fallback(final @Nullable String fallback);
-
-  /**
    * Gets the unmodifiable list of translation arguments.
    *
    * @return the unmodifiable list of translation arguments
@@ -138,12 +120,35 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
   @Contract(pure = true)
   @NotNull TranslatableComponent args(final @NotNull List<? extends ComponentLike> args);
 
+  /**
+   * Gets the translation fallback text for this component.
+   * The fallback text will be shown when the client doesn't know the
+   * translation key used in the translatable component.
+   *
+   * @return the fallback string
+   * @since 4.13.0
+   */
+  @Nullable String fallback();
+
+  /**
+   * Sets the translation fallback text for this component.
+   * The fallback text will be shown when the client doesn't know the
+   * translation key used in the translatable component.
+   *
+   * @param fallback the fallback string
+   * @return this builder
+   * @since 4.13.0
+   */
+  @Contract(pure = true)
+  @NotNull TranslatableComponent fallback(final @NotNull String fallback);
+
   @Override
   default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("key", this.key()),
-        ExaminableProperty.of("args", this.args())
+        ExaminableProperty.of("args", this.args()),
+        ExaminableProperty.of("fallback", this.fallback())
       ),
       BuildableComponent.super.examinableProperties()
     );
@@ -176,16 +181,6 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      */
     @Contract("_ -> this")
     @NotNull Builder key(final @NotNull String key);
-
-    /**
-     * Sets the fallback string.
-     *
-     * @param fallback the fallback string
-     * @return this builder
-     * @since 4.13.0
-     */
-    @Contract("_ -> this")
-    @NotNull Builder fallback(final @NotNull String fallback);
 
     /**
      * Sets the translation args.
@@ -237,5 +232,17 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      */
     @Contract("_ -> this")
     @NotNull Builder args(final @NotNull List<? extends ComponentLike> args);
+
+    /**
+     * Sets the translation fallback text.
+     * The fallback text will be shown when the client doesn't know the
+     * translation key used in the translatable component.
+     *
+     * @param fallback the fallback string
+     * @return this builder
+     * @since 4.13.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder fallback(final @Nullable String fallback);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -136,7 +136,7 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    * translation key used in the translatable component.
    *
    * @param fallback the fallback string
-   * @return this builder
+   * @return a translatable component
    * @since 4.13.0
    */
   @Contract(pure = true)

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -34,6 +34,7 @@ import net.kyori.adventure.translation.TranslationRegistry;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A component that can display translated text.
@@ -90,6 +91,24 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
    */
   @Contract(pure = true)
   @NotNull TranslatableComponent key(final @NotNull String key);
+
+  /**
+   * Gets the fallback string.
+   *
+   * @return the fallback string
+   * @since 4.13.0
+   */
+  @Nullable String fallback();
+
+  /**
+   * Sets the fallback string.
+   *
+   * @param fallback the fallback string
+   * @return a translatable component
+   * @since 4.13.0
+   */
+  @Contract(pure = true)
+  @NotNull TranslatableComponent fallback(final @Nullable String fallback);
 
   /**
    * Gets the unmodifiable list of translation arguments.
@@ -157,6 +176,16 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
      */
     @Contract("_ -> this")
     @NotNull Builder key(final @NotNull String key);
+
+    /**
+     * Sets the fallback string.
+     *
+     * @param fallback the fallback string
+     * @return this builder
+     * @since 4.13.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder fallback(final @NotNull String fallback);
 
     /**
      * Sets the translation args.

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
@@ -75,16 +75,6 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   }
 
   @Override
-  public @Nullable String fallback() {
-    return this.fallback;
-  }
-
-  @Override
-  public @NotNull TranslatableComponent fallback(final @Nullable String fallback) {
-    return create(this.children, this.style, this.key, fallback, this.args);
-  }
-
-  @Override
   public @NotNull List<Component> args() {
     return this.args;
   }
@@ -97,6 +87,16 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   @Override
   public @NotNull TranslatableComponent args(final @NotNull List<? extends ComponentLike> args) {
     return create(this.children, this.style, this.key, this.fallback, args);
+  }
+
+  @Override
+  public @Nullable String fallback() {
+    return this.fallback;
+  }
+
+  @Override
+  public @NotNull TranslatableComponent fallback(final @Nullable String fallback) {
+    return create(this.children, this.style, this.key, fallback, this.args);
   }
 
   @Override
@@ -149,17 +149,12 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
       super(component);
       this.key = component.key();
       this.args = component.args();
+      this.fallback = component.fallback();
     }
 
     @Override
     public @NotNull Builder key(final @NotNull String key) {
       this.key = key;
-      return this;
-    }
-
-    @Override
-    public @NotNull Builder fallback(final @Nullable String fallback) {
-      this.fallback = fallback;
       return this;
     }
 
@@ -191,6 +186,12 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
     @Override
     public @NotNull Builder args(final @NotNull List<? extends ComponentLike> args) {
       this.args = ComponentLike.asComponents(requireNonNull(args, "args"));
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder fallback(final @Nullable String fallback) {
+      this.fallback = fallback;
       return this;
     }
 

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
@@ -55,7 +55,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   static final String TEXT = "text";
   static final String TRANSLATE = "translate";
   static final String TRANSLATE_WITH = "with";
-  static final String FALLBACK = "fallback";
+  static final String TRANSLATE_FALLBACK = "fallback";
   static final String SCORE = "score";
   static final String SCORE_NAME = "name";
   static final String SCORE_OBJECTIVE = "objective";
@@ -120,17 +120,22 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
     if (children.containsKey(TEXT)) {
       component = Component.text().content(children.get(TEXT).getString());
     } else if (children.containsKey(TRANSLATE)) {
+      final TranslatableComponent.Builder builder;
       final String key = children.get(TRANSLATE).getString();
       if (!children.containsKey(TRANSLATE_WITH)) {
-        component = Component.translatable().key(key);
+        builder = Component.translatable().key(key);
       } else {
         final ConfigurationNode with = children.get(TRANSLATE_WITH);
         if (!with.isList()) {
           throw new ObjectMappingException("Expected " + TRANSLATE_WITH + " to be a list");
         }
         final List<Component> args = with.getValue(LIST_TYPE);
-        component = Component.translatable().key(key).args(args);
+        builder = Component.translatable().key(key).args(args);
       }
+      if (children.containsKey(TRANSLATE_FALLBACK)) {
+        builder.fallback(children.get(TRANSLATE_FALLBACK).getString());
+      }
+      component = builder;
     } else if (children.containsKey(SCORE)) {
       final ConfigurationNode score = children.get(SCORE);
       final ConfigurationNode name = score.getNode(SCORE_NAME);
@@ -208,7 +213,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
           with.appendListNode().setValue(TYPE, arg);
         }
       }
-      value.getNode(FALLBACK).setValue(tc.fallback());
+      value.getNode(TRANSLATE_FALLBACK).setValue(tc.fallback());
     } else if (src instanceof ScoreComponent) {
       final ScoreComponent sc = (ScoreComponent) src;
       final ConfigurationNode score = value.getNode(SCORE);

--- a/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
+++ b/serializer-configurate3/src/main/java/net/kyori/adventure/serializer/configurate3/ComponentTypeSerializer.java
@@ -55,6 +55,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   static final String TEXT = "text";
   static final String TRANSLATE = "translate";
   static final String TRANSLATE_WITH = "with";
+  static final String FALLBACK = "fallback";
   static final String SCORE = "score";
   static final String SCORE_NAME = "name";
   static final String SCORE_OBJECTIVE = "objective";
@@ -207,6 +208,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
           with.appendListNode().setValue(TYPE, arg);
         }
       }
+      value.getNode(FALLBACK).setValue(tc.fallback());
     } else if (src instanceof ScoreComponent) {
       final ScoreComponent sc = (ScoreComponent) src;
       final ConfigurationNode score = value.getNode(SCORE);

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
@@ -53,7 +53,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   static final String TEXT = "text";
   static final String TRANSLATE = "translate";
   static final String TRANSLATE_WITH = "with";
-  static final String FALLBACK = "fallback";
+  static final String TRANSLATE_FALLBACK = "fallback";
   static final String SCORE = "score";
   static final String SCORE_NAME = "name";
   static final String SCORE_OBJECTIVE = "objective";
@@ -118,17 +118,22 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
     if (children.containsKey(TEXT)) {
       component = Component.text().content(children.get(TEXT).getString());
     } else if (children.containsKey(TRANSLATE)) {
-      final String key = children.get(TRANSLATE).getString();
-      if (!children.containsKey(TRANSLATE_WITH)) {
-        component = Component.translatable().key(key);
-      } else {
+      final TranslatableComponent.Builder builder = Component.translatable()
+        .key(children.get(TRANSLATE).getString());
+
+      if (children.containsKey(TRANSLATE_WITH)) {
         final ConfigurationNode with = children.get(TRANSLATE_WITH);
         if (!with.isList()) {
           throw new SerializationException("Expected " + TRANSLATE_WITH + " to be a list");
         }
         final List<Component> args = with.get(LIST_TYPE);
-        component = Component.translatable().key(key).args(args);
+        builder.args(args);
       }
+
+      if (children.containsKey(TRANSLATE_FALLBACK)) {
+        builder.fallback(children.get(TRANSLATE_FALLBACK).getString());
+      }
+      component = builder;
     } else if (children.containsKey(SCORE)) {
       final ConfigurationNode score = children.get(SCORE);
       final ConfigurationNode name = score.node(SCORE_NAME);
@@ -206,7 +211,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
           with.appendListNode().set(Component.class, arg);
         }
       }
-      value.node(FALLBACK).set(tc.fallback());
+      value.node(TRANSLATE_FALLBACK).set(tc.fallback());
     } else if (src instanceof ScoreComponent) {
       final ScoreComponent sc = (ScoreComponent) src;
       final ConfigurationNode score = value.node(SCORE);

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
@@ -53,6 +53,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   static final String TEXT = "text";
   static final String TRANSLATE = "translate";
   static final String TRANSLATE_WITH = "with";
+  static final String FALLBACK = "fallback";
   static final String SCORE = "score";
   static final String SCORE_NAME = "name";
   static final String SCORE_OBJECTIVE = "objective";
@@ -205,6 +206,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
           with.appendListNode().set(Component.class, arg);
         }
       }
+      value.node(FALLBACK).set(tc.fallback());
     } else if (src instanceof ScoreComponent) {
       final ScoreComponent sc = (ScoreComponent) src;
       final ConfigurationNode score = value.node(SCORE);

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -152,7 +152,7 @@ public final class StandardTags {
    * <p>This tag also responds to {@value TranslatableFallbackTag#LANG_OR} and {@value TranslatableFallbackTag#TR_OR}.</p>
    *
    * @return a resolver for the {@value TranslatableFallbackTag#TRANSLATE_OR} tag
-   * @since 4.10.0
+   * @since 4.13.0
    */
   public static @NotNull TagResolver translatableFallback() {
     return TranslatableFallbackTag.RESOLVER;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -52,6 +52,7 @@ public final class StandardTags {
         ColorTagResolver.INSTANCE,
         KeybindTag.RESOLVER,
         TranslatableTag.RESOLVER,
+        TranslatableFallbackTag.RESOLVER,
         InsertionTag.RESOLVER,
         FontTag.RESOLVER,
         DecorationTag.RESOLVER,
@@ -143,6 +144,18 @@ public final class StandardTags {
    */
   public static @NotNull TagResolver translatable() {
     return TranslatableTag.RESOLVER;
+  }
+
+  /**
+   * Get a resolver for the {@value TranslatableFallbackTag#TRANSLATE_OR} tag.
+   *
+   * <p>This tag also responds to {@value TranslatableFallbackTag#LANG_OR} and {@value TranslatableFallbackTag#TR_OR}.</p>
+   *
+   * @return a resolver for the {@value TranslatableFallbackTag#TRANSLATE_OR} tag
+   * @since 4.10.0
+   */
+  public static @NotNull TagResolver translatableFallback() {
+    return TranslatableFallbackTag.RESOLVER;
   }
 
   /**

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTag.java
@@ -23,6 +23,9 @@
  */
 package net.kyori.adventure.text.minimessage.tag.standard;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.minimessage.Context;
@@ -33,10 +36,6 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Insert a translation component into the result, with a fallback string.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTag.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.minimessage.Context;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.internal.serializer.Emitable;
+import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Insert a translation component into the result, with a fallback string.
+ *
+ * @since 4.13.0
+ */
+final class TranslatableFallbackTag {
+  private static final String TR_OR = "tr_or";
+  private static final String TRANSLATE_OR = "translate_or";
+  private static final String LANG_OR = "lang_or";
+
+  static final TagResolver RESOLVER = SerializableResolver.claimingComponent(
+    StandardTags.names(LANG_OR, TRANSLATE_OR, TR_OR),
+    TranslatableFallbackTag::create,
+    TranslatableFallbackTag::claim
+  );
+
+  private TranslatableFallbackTag() {
+  }
+
+  static Tag create(final ArgumentQueue args, final Context ctx) throws ParsingException {
+    final String key = args.popOr("A translation key is required").value();
+    final String fallback = args.popOr("A fallback messages is required").value();
+    final List<Component> with;
+    if (args.hasNext()) {
+      with = new ArrayList<>();
+      while (args.hasNext()) {
+        with.add(ctx.deserialize(args.pop().value()));
+      }
+    } else {
+      with = Collections.emptyList();
+    }
+
+    return Tag.inserting(Component.translatable(key, fallback, with));
+  }
+
+  static @Nullable Emitable claim(final Component input) {
+    if (!(input instanceof TranslatableComponent) || ((TranslatableComponent) input).fallback() == null) return null;
+
+    final TranslatableComponent tr = (TranslatableComponent) input;
+    return emit -> {
+      emit.tag(LANG_OR);
+      emit.argument(tr.key());
+      emit.argument(tr.fallback());
+      for (final Component with : tr.args()) {
+        emit.argument(with);
+      }
+    };
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTag.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.Nullable;
  * Insert a translation component into the result, with a fallback string.
  *
  * @since 4.13.0
+ * @sinceMinecraft 1.19.4
  */
 final class TranslatableFallbackTag {
   private static final String TR_OR = "tr_or";

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableTag.java
@@ -72,7 +72,7 @@ final class TranslatableTag {
   }
 
   static @Nullable Emitable claim(final Component input) {
-    if (!(input instanceof TranslatableComponent)) return null;
+    if (!(input instanceof TranslatableComponent) || ((TranslatableComponent) input).fallback() != null) return null;
 
     final TranslatableComponent tr = (TranslatableComponent) input;
     return emit -> {

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTagTest.java
@@ -31,9 +31,6 @@ import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.Component.translatable;
-import static net.kyori.adventure.text.event.HoverEvent.showText;
-import static net.kyori.adventure.text.format.NamedTextColor.BLUE;
-import static net.kyori.adventure.text.format.NamedTextColor.RED;
 
 class TranslatableFallbackTagTest extends AbstractTest {
   @Test

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTagTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.Component.translatable;
+import static net.kyori.adventure.text.event.HoverEvent.showText;
+import static net.kyori.adventure.text.format.NamedTextColor.BLUE;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+
+class TranslatableFallbackTagTest extends AbstractTest {
+  @Test
+  void testSerializeTranslatable() {
+    final String expected = "You should get a <lang_or:block.minecraft.diamond_block:'Fallback :('/>!";
+
+    final TextComponent.Builder builder = Component.text()
+      .content("You should get a ")
+      .append(Component.translatable("block.minecraft.diamond_block").fallback("Fallback :("))
+      .append(Component.text("!"));
+
+    this.assertSerializedEquals(expected, builder);
+  }
+
+  @Test
+  void testSerializeTranslatableWithArgs() {
+    final String expected = "<lang_or:some_key:fallback:\"<red>:arg' 1\":'<blue>arg 2'>";
+
+    final Component translatable = Component.translatable()
+      .key("some_key")
+      .fallback("fallback")
+      .args(text(":arg' 1", NamedTextColor.RED), text("arg 2", NamedTextColor.BLUE))
+      .build();
+
+    this.assertSerializedEquals(expected, translatable);
+  }
+
+  @Test
+  void testTranslatable() {
+    final String input = "You should get a <lang_or:block.minecraft.diamond_block:'Diamond Block'>!";
+    final Component expected = text("You should get a ")
+      .append(translatable("block.minecraft.diamond_block").fallback("Diamond Block")
+        .append(text("!")));
+
+    this.assertParsedEquals(expected, input);
+  }
+}

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
@@ -58,6 +58,7 @@ final class ComponentSerializerImpl extends TypeAdapter<Component> {
   static final String TRANSLATE = "translate";
   static final String TRANSLATE_FALLBACK = "fallback";
   static final String TRANSLATE_WITH = "with";
+  static final String FALLBACK = "fallback";
   static final String SCORE = "score";
   static final String SCORE_NAME = "name";
   static final String SCORE_OBJECTIVE = "objective";
@@ -273,6 +274,10 @@ final class ComponentSerializerImpl extends TypeAdapter<Component> {
       if (!translatable.args().isEmpty()) {
         out.name(TRANSLATE_WITH);
         this.gson.toJson(translatable.args(), COMPONENT_LIST_TYPE, out);
+      }
+      if (translatable.fallback() != null) {
+        out.name(FALLBACK);
+        out.value(translatable.fallback());
       }
     } else if (value instanceof ScoreComponent) {
       final ScoreComponent score = (ScoreComponent) value;

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
@@ -56,6 +56,7 @@ import org.jetbrains.annotations.Nullable;
 final class ComponentSerializerImpl extends TypeAdapter<Component> {
   static final String TEXT = "text";
   static final String TRANSLATE = "translate";
+  static final String TRANSLATE_FALLBACK = "fallback";
   static final String TRANSLATE_WITH = "with";
   static final String SCORE = "score";
   static final String SCORE_NAME = "name";
@@ -115,6 +116,7 @@ final class ComponentSerializerImpl extends TypeAdapter<Component> {
     // type specific
     String text = null;
     String translate = null;
+    String translateFallback = null;
     List<Component> translateWith = null;
     String scoreName = null;
     String scoreObjective = null;
@@ -135,6 +137,8 @@ final class ComponentSerializerImpl extends TypeAdapter<Component> {
         text = readString(in);
       } else if (fieldName.equals(TRANSLATE)) {
         translate = in.nextString();
+      } else if (fieldName.equals(TRANSLATE_FALLBACK)) {
+        translateFallback = in.nextString();
       } else if (fieldName.equals(TRANSLATE_WITH)) {
         translateWith = this.gson.fromJson(in, COMPONENT_LIST_TYPE);
       } else if (fieldName.equals(SCORE)) {
@@ -183,9 +187,9 @@ final class ComponentSerializerImpl extends TypeAdapter<Component> {
       builder = Component.text().content(text);
     } else if (translate != null) {
       if (translateWith != null) {
-        builder = Component.translatable().key(translate).args(translateWith);
+        builder = Component.translatable().key(translate).fallback(translateFallback).args(translateWith);
       } else {
-        builder = Component.translatable().key(translate);
+        builder = Component.translatable().key(translate).fallback(translateFallback);
       }
     } else if (scoreName != null && scoreObjective != null) {
       if (scoreValue == null) {
@@ -261,6 +265,11 @@ final class ComponentSerializerImpl extends TypeAdapter<Component> {
       final TranslatableComponent translatable = (TranslatableComponent) value;
       out.name(TRANSLATE);
       out.value(translatable.key());
+      final @Nullable String fallback = translatable.fallback();
+      if (fallback != null) {
+        out.name(TRANSLATE_FALLBACK);
+        out.value(fallback);
+      }
       if (!translatable.args().isEmpty()) {
         out.name(TRANSLATE_WITH);
         this.gson.toJson(translatable.args(), COMPONENT_LIST_TYPE, out);

--- a/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/TranslatableComponentTest.java
+++ b/text-serializer-gson/src/test/java/net/kyori/adventure/text/serializer/gson/TranslatableComponentTest.java
@@ -42,6 +42,20 @@ class TranslatableComponentTest extends ComponentTest {
   }
 
   @Test
+  void testFallback() {
+    this.test(
+      Component.translatable()
+        .key("thisIsA")
+        .fallback("This is a test.")
+        .build(),
+      object(json -> {
+        json.addProperty(ComponentSerializerImpl.TRANSLATE, "thisIsA");
+        json.addProperty(ComponentSerializerImpl.TRANSLATE_FALLBACK, "This is a test.");
+      })
+    );
+  }
+
+  @Test
   void testSingleArgWithEvents() {
     final UUID id = UUID.fromString("eb121687-8b1a-4944-bd4d-e0a818d9dfe2");
     final String name = "kashike";


### PR DESCRIPTION
Adds support for the new translatable component fallbacks, as requested in #863.

Wasn't sure what to do for MiniMessage, since adding the fallback string in front would break existing configs, and at the end isn't possible because the tag allows for infinite arguments.

adding the fallback to all the static methods was a pain lol