### PR TITLE
feat(api): allow Translators to create their own Components

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -73,6 +73,13 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
       protected @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale context) {
         return source.translate(key, context);
       }
+
+      @Override
+      protected @NotNull Component renderTranslatable(final @NotNull TranslatableComponent component, final @NotNull Locale context) {
+        final @Nullable Component translated = source.translate(component, context);
+        if (translated != null) return translated;
+        return super.renderTranslatable(component, context);
+      }
     };
   }
 

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -62,6 +62,9 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   /**
    * Creates a {@link TranslatableComponentRenderer} using the {@link Translator} to translate.
    *
+   * <p>Alongside the standard {@link MessageFormat} translation, this will also allow the {@link Translator} to
+   * create a {@link Component} {@link Translator#translate(TranslatableComponent, Locale) directly}.</p>
+   *
    * @param source the translation source
    * @return the renderer
    * @since 4.0.0

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -62,8 +62,8 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   /**
    * Creates a {@link TranslatableComponentRenderer} using the {@link Translator} to translate.
    *
-   * <p>Alongside the standard {@link MessageFormat} translation, this will also allow the {@link Translator} to
-   * create a {@link Component} {@link Translator#translate(TranslatableComponent, Locale) directly}.</p>
+   * <p>Alongside the standard {@link MessageFormat}-based translation, this will also allow the {@link Translator}
+   * to create a {@link Component} {@link Translator#translate(TranslatableComponent, Locale) directly}.</p>
    *
    * @param source the translation source
    * @return the renderer

--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.NotNull;
@@ -75,6 +77,17 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
     requireNonNull(locale, "locale");
     for (final Translator source : this.sources) {
       final MessageFormat translation = source.translate(key, locale);
+      if (translation != null) return translation;
+    }
+    return null;
+  }
+
+  @Override
+  public @Nullable Component translate(final @NotNull TranslatableComponent component, final @NotNull Locale locale) {
+    requireNonNull(component, "component");
+    requireNonNull(locale, "locale");
+    for (final Translator source : this.sources) {
+      final Component translation = source.translate(component, locale);
       if (translation != null) return translation;
     }
     return null;

--- a/api/src/main/java/net/kyori/adventure/translation/Translator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translator.java
@@ -37,6 +37,9 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>To see how to create a {@link Translator} with a {@link ResourceBundle}
  * see {@link TranslationRegistry#registerAll(Locale, ResourceBundle, boolean)}</p>
+ * 
+ * <p>To bypass vanilla's {@link MessageFormat}-based translation system,
+ * see {@link #translate(TranslatableComponent, Locale)}</p>
  *
  * <p>After creating a {@link Translator} you can add it to the {@link GlobalTranslator}
  * to enable automatic translations by the platforms.</p>
@@ -77,6 +80,8 @@ public interface Translator {
 
   /**
    * Gets a message format from a key and locale.
+   *
+   * <p>This method is called only if {@link #translate(TranslatableComponent, Locale)} returns {@code null}.</p>
    *
    * @param locale a locale
    * @param key a translation key

--- a/api/src/main/java/net/kyori/adventure/translation/Translator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translator.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>To see how to create a {@link Translator} with a {@link ResourceBundle}
  * see {@link TranslationRegistry#registerAll(Locale, ResourceBundle, boolean)}</p>
- * 
+ *
  * <p>To bypass vanilla's {@link MessageFormat}-based translation system,
  * see {@link #translate(TranslatableComponent, Locale)}</p>
  *

--- a/api/src/main/java/net/kyori/adventure/translation/Translator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translator.java
@@ -81,7 +81,8 @@ public interface Translator {
   /**
    * Gets a message format from a key and locale.
    *
-   * <p>This method is called only if {@link #translate(TranslatableComponent, Locale)} returns {@code null}.</p>
+   * <p>When used in the {@link GlobalTranslator}, this method is called only if
+   * {@link #translate(TranslatableComponent, Locale)} returns {@code null}.</p>
    *
    * @param locale a locale
    * @param key a translation key

--- a/api/src/main/java/net/kyori/adventure/translation/Translator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translator.java
@@ -27,11 +27,13 @@ import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A message format translator.
+ * A message translator.
  *
  * <p>To see how to create a {@link Translator} with a {@link ResourceBundle}
  * see {@link TranslationRegistry#registerAll(Locale, ResourceBundle, boolean)}</p>
@@ -82,4 +84,16 @@ public interface Translator {
    * @since 4.0.0
    */
   @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale);
+
+  /**
+   * Gets a translated component from a translatable component and locale.
+   *
+   * @param locale a locale
+   * @param component a translatable component
+   * @return a translated component or {@code null} to use {@link #translate(String, Locale)} instead (if available)
+   * @since 4.13.0
+   */
+  default @Nullable Component translate(final @NotNull TranslatableComponent component, final @NotNull Locale locale) {
+    return null;
+  }
 }


### PR DESCRIPTION
Allows Translators to bypass the loading and parsing of MessageFormat in favor of providing their own rendered Components. Use cases may include using MiniMessage in i18n files (instead of §) or even raw JSON strings/objects.

Was kinda surprised to see GlobalTranslator worked exclusively with MessageFormat (seems very implementation-specific to how vanilla does it) so I whipped this up… tried to keep the PR simple but I could also see it being desirable to have a dedicated class/interface for a ComponentTranslator. Open to feedback/suggestions/etc 🙂 