### PR TITLE
fix some issues with translatable component fallback

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -164,7 +164,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
       // of this component might need additional rendering
 
       final TranslatableComponent.Builder builder = Component.translatable()
-        .key(component.key());
+        .key(component.key()).fallback(component.fallback());
       if (!component.args().isEmpty()) {
         final List<Component> args = new ArrayList<>(component.args());
         for (int i = 0, size = args.size(); i < size; i++) {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
@@ -58,7 +58,6 @@ final class ComponentSerializerImpl extends TypeAdapter<Component> {
   static final String TRANSLATE = "translate";
   static final String TRANSLATE_FALLBACK = "fallback";
   static final String TRANSLATE_WITH = "with";
-  static final String FALLBACK = "fallback";
   static final String SCORE = "score";
   static final String SCORE_NAME = "name";
   static final String SCORE_OBJECTIVE = "objective";
@@ -274,10 +273,6 @@ final class ComponentSerializerImpl extends TypeAdapter<Component> {
       if (!translatable.args().isEmpty()) {
         out.name(TRANSLATE_WITH);
         this.gson.toJson(translatable.args(), COMPONENT_LIST_TYPE, out);
-      }
-      if (translatable.fallback() != null) {
-        out.name(FALLBACK);
-        out.value(translatable.fallback());
       }
     } else if (value instanceof ScoreComponent) {
       final ScoreComponent score = (ScoreComponent) value;


### PR DESCRIPTION
This PR fixes some issues with translatable component fallback.

commit 8b3cd4a:
- BEFORE
![image](https://user-images.githubusercontent.com/45729082/227402601-43c095f9-af6d-471b-a45c-ef83f7beb6b1.png)
- AFTER
![image](https://user-images.githubusercontent.com/45729082/227402801-2dfe506a-9954-41b5-9c03-4bb5cb661c9a.png)

commit e8105f4:
- BEFORE (same as above image)
- AFTER
![image](https://user-images.githubusercontent.com/45729082/227403195-ad11bd43-4d95-4564-b1a8-255dd141b373.png)
