### PR TITLE
feat(api): Add split method to Component

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2642,6 +2642,19 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
     return this.replaceText(b -> b.match(pattern).replacement(replacement).condition(fn));
   }
 
+  /**
+   * Split an existing Component into multiple Components based on a separator.
+   *
+   * <p>This will return a list of Components</p>
+   *
+   * @param separator a separator
+   * @return a list of components
+   * @since 4.15.0
+   */
+  default @NotNull List<Component> split(final @NotNull Component separator) {
+    return ComponentSplit.split(this, separator);
+  }
+
   @Override
   default void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component) {
     component.append(this);

--- a/api/src/main/java/net/kyori/adventure/text/ComponentSplit.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentSplit.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.kyori.adventure.text.format.Style;
+import org.jetbrains.annotations.NotNull;
+
+final class ComponentSplit {
+  private ComponentSplit() {
+  }
+
+  static @NotNull List<Component> split(final @NotNull Component self, final @NotNull Component separator) {
+    if (self.children().size() == 0) {
+      return Collections.singletonList(self);
+    }
+
+    final List<Component> result = new ArrayList<>();
+    final Component root = self.children(Collections.emptyList());
+    TextComponent.Builder build = Component.text();
+    build.append(root.style(Style.empty()));
+    for (final Component child : self.children()) {
+      if (child.equals(separator)) {
+        result.add(build.build().applyFallbackStyle(root.style()));
+        build = Component.text();
+      } else {
+        build.append(child);
+      }
+    }
+    result.add(build.build().applyFallbackStyle(root.style()));
+    return result;
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/ComponentSplitTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentSplitTest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import java.util.Arrays;
+import java.util.List;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentSplitTest {
+  @Test
+  public void testSimple() {
+    final Component example = Component.text("first", NamedTextColor.RED).appendNewline().append(Component.text("second"));
+    final List<Component> expected = Arrays.asList(
+      Component.empty().color(NamedTextColor.RED).append(Component.text("first")),
+      Component.empty().color(NamedTextColor.RED).append(Component.text("second"))
+    );
+
+    assertEquals(expected, example.split(Component.newline()));
+  }
+
+  @Test
+  public void testAdvanced() {
+    final Component example = Component.text("first", NamedTextColor.RED).appendNewline().append(Component.text("second", NamedTextColor.BLUE));
+    final List<Component> expected = Arrays.asList(
+      Component.empty().color(NamedTextColor.RED).append(Component.text("first")),
+      Component.empty().color(NamedTextColor.RED).append(Component.text("second", NamedTextColor.BLUE))
+    );
+
+    assertEquals(expected, example.split(Component.newline()));
+  }
+}


### PR DESCRIPTION
Add a method to Component to split it into a List.

This can be used to split a Component into a List for a Lore:
```java
MiniMessage.miniMessage().deserialize("<red>Hello world, this is<br>my lore").split(Component.newline());
```

# How Components in the list are formatted

The style of the root component is applied as fallback style to each Component in the list.
```java
    final Component example = Component.text("first", NamedTextColor.RED).appendNewline().append(Component.text("second"));
```
will translate to the following List:
```
[TextComponentImpl{
  content="", style=StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=NamedTextColor{name="red", value="#ff5555"}, clickEvent=null, hoverEvent=null, insertion=null, font=null}, 
    children=[
      TextComponentImpl{content="first", style=StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=null, clickEvent=null, hoverEvent=null, insertion=null, font=null}, children=[]}
    ]
  }, 
TextComponentImpl{
  content="", style=StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=NamedTextColor{name="red", value="#ff5555"}, clickEvent=null, hoverEvent=null, insertion=null, font=null}, 
    children=[
      TextComponentImpl{content="second", style=StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=null, clickEvent=null, hoverEvent=null, insertion=null, font=null}, children=[]}
    ]
  }
]
```

This is still a proof of concept. I'm happy on every optimization.

Currently it's not possible to split the Component by some text. E.g. `Component.text("mydummytext").split(Component.text("dummy"))` will not be split to `Component.text("my")` and `Component.text("text")`

However this works fine to split newlines.