### PR TITLE
Added legacy show achievements

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -210,6 +210,19 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
   }
 
   /**
+   * Creates a hover event that shows an achievement on hover.
+   *
+   * @param value the achievement value
+   * @return a hover event
+   * @since 4.13.1
+   * @deprecated Removed in Vanilla 1.12, but we keep it for backwards compat
+   */
+  @Deprecated
+  public static @NotNull HoverEvent<String> showAchievement(final @NotNull String value) {
+    return new HoverEvent<>(Action.SHOW_ACHIEVEMENT, value);
+  }
+
+  /**
    * Creates a hover event.
    *
    * @param action the action
@@ -699,13 +712,26 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
         return value.name(renderer.render(value.name, context));
       }
     });
+    /**
+     * Shows a {@link Component} when hovered over.
+     *
+     * @since 4.13.1
+     * @deprecated Removed in Vanilla 1.12, but we keep it for backwards compat
+     */
+    @Deprecated
+    public static final Action<String> SHOW_ACHIEVEMENT = new Action<>("show_achievement", String.class, true, new Renderer<String>() {
+      @Override
+      public <C> @NotNull String render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull String value) {
+        return value;
+      }
+    });
 
     /**
      * The name map.
      *
      * @since 4.0.0
      */
-    public static final Index<String, Action<?>> NAMES = Index.create(constant -> constant.name, SHOW_TEXT, SHOW_ITEM, SHOW_ENTITY);
+    public static final Index<String, Action<?>> NAMES = Index.create(constant -> constant.name, SHOW_TEXT, SHOW_ITEM, SHOW_ENTITY, SHOW_ACHIEVEMENT);
     private final String name;
     private final Class<V> type;
     /**

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -214,7 +214,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    *
    * @param value the achievement value
    * @return a hover event
-   * @since 4.13.1
+   * @since 4.14.0
    * @deprecated Removed in Vanilla 1.12, but we keep it for backwards compat
    */
   @Deprecated
@@ -715,7 +715,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     /**
      * Shows a {@link Component} when hovered over.
      *
-     * @since 4.13.1
+     * @since 4.14.0
      * @deprecated Removed in Vanilla 1.12, but we keep it for backwards compat
      */
     @Deprecated

--- a/api/src/test/java/net/kyori/adventure/text/event/HoverEventTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/event/HoverEventTest.java
@@ -95,6 +95,15 @@ class HoverEventTest {
   }
 
   @Test
+  void testShowAchievementValue() {
+    final HoverEvent<String> sa0 = HoverEvent.showAchievement("achievement.bakeCake");
+    assertEquals("achievement.bakeCake", sa0.value());
+    final HoverEvent<String> sa1 = sa0.value("achievement.blazeRod");
+    assertEquals("achievement.bakeCake", sa0.value()); // original should be unmodified
+    assertEquals("achievement.blazeRod", sa1.value());
+  }
+
+  @Test
   void testEquality() {
     final UUID entity = UUID.randomUUID();
     new EqualsTester()

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/SerializerFactory.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/SerializerFactory.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.text.serializer.gson;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.BlockNBTComponent;
@@ -45,6 +46,7 @@ final class SerializerFactory implements TypeAdapterFactory {
   static final Class<HoverEvent.Action> HOVER_ACTION_TYPE = HoverEvent.Action.class;
   static final Class<HoverEvent.ShowItem> SHOW_ITEM_TYPE = HoverEvent.ShowItem.class;
   static final Class<HoverEvent.ShowEntity> SHOW_ENTITY_TYPE = HoverEvent.ShowEntity.class;
+  static final Class<String> STRING_TYPE = String.class;
   static final Class<TextColorWrapper> COLOR_WRAPPER_TYPE = TextColorWrapper.class;
   static final Class<TextColor> COLOR_TYPE = TextColor.class;
   static final Class<TextDecoration> TEXT_DECORATION_TYPE = TextDecoration.class;
@@ -78,6 +80,8 @@ final class SerializerFactory implements TypeAdapterFactory {
       return (TypeAdapter<T>) ShowItemSerializer.create(gson);
     } else if (SHOW_ENTITY_TYPE.isAssignableFrom(rawType)) {
       return (TypeAdapter<T>) ShowEntitySerializer.create(gson);
+    } else if (STRING_TYPE.isAssignableFrom(rawType)) {
+      return (TypeAdapter<T>) TypeAdapters.STRING;
     } else if (COLOR_WRAPPER_TYPE.isAssignableFrom(rawType)) {
       return (TypeAdapter<T>) TextColorWrapper.Serializer.INSTANCE;
     } else if (COLOR_TYPE.isAssignableFrom(rawType)) {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/SerializerFactory.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/SerializerFactory.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.serializer.gson;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.internal.bind.TypeAdapters;
 import com.google.gson.reflect.TypeToken;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.BlockNBTComponent;
@@ -80,8 +79,6 @@ final class SerializerFactory implements TypeAdapterFactory {
       return (TypeAdapter<T>) ShowItemSerializer.create(gson);
     } else if (SHOW_ENTITY_TYPE.isAssignableFrom(rawType)) {
       return (TypeAdapter<T>) ShowEntitySerializer.create(gson);
-    } else if (STRING_TYPE.isAssignableFrom(rawType)) {
-      return (TypeAdapter<T>) TypeAdapters.STRING;
     } else if (COLOR_WRAPPER_TYPE.isAssignableFrom(rawType)) {
       return (TypeAdapter<T>) TextColorWrapper.Serializer.INSTANCE;
     } else if (COLOR_TYPE.isAssignableFrom(rawType)) {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -274,17 +274,17 @@ final class StyleSerializer extends TypeAdapter<Style> {
       out.name(HOVER_EVENT_ACTION);
       final HoverEvent.Action<?> action = hoverEvent.action();
       this.gson.toJson(action, SerializerFactory.HOVER_ACTION_TYPE, out);
-      out.name(HOVER_EVENT_CONTENTS);
-      if (action == HoverEvent.Action.SHOW_ITEM) {
-        this.gson.toJson(hoverEvent.value(), SerializerFactory.SHOW_ITEM_TYPE, out);
-      } else if (action == HoverEvent.Action.SHOW_ENTITY) {
-        this.gson.toJson(hoverEvent.value(), SerializerFactory.SHOW_ENTITY_TYPE, out);
-      } else if (action == HoverEvent.Action.SHOW_TEXT) {
-        this.gson.toJson(hoverEvent.value(), SerializerFactory.COMPONENT_TYPE, out);
-      } else if (action == HoverEvent.Action.SHOW_ACHIEVEMENT) {
-        this.gson.toJson(hoverEvent.value(), SerializerFactory.STRING_TYPE, out);
-      } else {
-        throw new JsonParseException("Don't know how to serialize " + hoverEvent.value());
+      if (action != HoverEvent.Action.SHOW_ACHIEVEMENT) { // legacy action has no modern contents value
+        out.name(HOVER_EVENT_CONTENTS);
+        if (action == HoverEvent.Action.SHOW_ITEM) {
+          this.gson.toJson(hoverEvent.value(), SerializerFactory.SHOW_ITEM_TYPE, out);
+        } else if (action == HoverEvent.Action.SHOW_ENTITY) {
+          this.gson.toJson(hoverEvent.value(), SerializerFactory.SHOW_ENTITY_TYPE, out);
+        } else if (action == HoverEvent.Action.SHOW_TEXT) {
+          this.gson.toJson(hoverEvent.value(), SerializerFactory.COMPONENT_TYPE, out);
+        } else {
+          throw new JsonParseException("Don't know how to serialize " + hoverEvent.value());
+        }
       }
       if (this.emitLegacyHover) {
         out.name(HOVER_EVENT_VALUE);
@@ -306,6 +306,8 @@ final class StyleSerializer extends TypeAdapter<Style> {
   private void serializeLegacyHoverEvent(final HoverEvent<?> hoverEvent, final JsonWriter out) throws IOException {
     if (hoverEvent.action() == HoverEvent.Action.SHOW_TEXT) { // serialization is the same
       this.gson.toJson(hoverEvent.value(), SerializerFactory.COMPONENT_TYPE, out);
+    } else if (hoverEvent.action() == HoverEvent.Action.SHOW_ACHIEVEMENT) {
+      this.gson.toJson(hoverEvent.value(), String.class, out);
     } else if (this.legacyHover != null) { // for data formats that require knowledge of SNBT
       Component serialized = null;
       try {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -204,7 +204,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
   }
 
   private Object legacyHoverEventContents(final HoverEvent.Action<?> action, final Component rawValue) {
-    if (action == HoverEvent.Action.SHOW_TEXT || action == HoverEvent.Action.SHOW_ACHIEVEMENT) {
+    if (action == HoverEvent.Action.SHOW_TEXT) {
       return rawValue; // Passthrough -- no serialization needed
     } else if (this.legacyHover != null) {
       try {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -268,7 +268,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
     }
 
     final @Nullable HoverEvent<?> hoverEvent = value.hoverEvent();
-    if (hoverEvent != null) {
+    if (hoverEvent != null && (hoverEvent.action() != HoverEvent.Action.SHOW_ACHIEVEMENT || this.emitLegacyHover)) {
       out.name(HOVER_EVENT);
       out.beginObject();
       out.name(HOVER_EVENT_ACTION);

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -144,9 +144,9 @@ final class StyleSerializer extends TypeAdapter<Style> {
           final HoverEvent.Action<Object> action = this.gson.fromJson(serializedAction, SerializerFactory.HOVER_ACTION_TYPE);
           if (action.readable()) {
             final @Nullable Object value;
+            final Class<?> actionType = action.type();
             if (hoverEventObject.has(HOVER_EVENT_CONTENTS)) {
               final @Nullable JsonElement rawValue = hoverEventObject.get(HOVER_EVENT_CONTENTS);
-              final Class<?> actionType = action.type();
               if (isNullOrEmpty(rawValue)) {
                 value = null;
               } else if (SerializerFactory.COMPONENT_TYPE.isAssignableFrom(actionType)) {
@@ -162,9 +162,13 @@ final class StyleSerializer extends TypeAdapter<Style> {
               final JsonElement element = hoverEventObject.get(HOVER_EVENT_VALUE);
               if (isNullOrEmpty(element)) {
                 value = null;
-              } else {
+              } else if (SerializerFactory.COMPONENT_TYPE.isAssignableFrom(actionType)) {
                 final Component rawValue = this.gson.fromJson(element, SerializerFactory.COMPONENT_TYPE);
                 value = this.legacyHoverEventContents(action, rawValue);
+              } else if (SerializerFactory.STRING_TYPE.isAssignableFrom(actionType)) {
+                value = this.gson.fromJson(element, SerializerFactory.STRING_TYPE);
+              } else {
+                value = null;
               }
             } else {
               value = null;
@@ -200,7 +204,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
   }
 
   private Object legacyHoverEventContents(final HoverEvent.Action<?> action, final Component rawValue) {
-    if (action == HoverEvent.Action.SHOW_TEXT) {
+    if (action == HoverEvent.Action.SHOW_TEXT || action == HoverEvent.Action.SHOW_ACHIEVEMENT) {
       return rawValue; // Passthrough -- no serialization needed
     } else if (this.legacyHover != null) {
       try {
@@ -277,6 +281,8 @@ final class StyleSerializer extends TypeAdapter<Style> {
         this.gson.toJson(hoverEvent.value(), SerializerFactory.SHOW_ENTITY_TYPE, out);
       } else if (action == HoverEvent.Action.SHOW_TEXT) {
         this.gson.toJson(hoverEvent.value(), SerializerFactory.COMPONENT_TYPE, out);
+      } else if (action == HoverEvent.Action.SHOW_ACHIEVEMENT) {
+        this.gson.toJson(hoverEvent.value(), SerializerFactory.STRING_TYPE, out);
       } else {
         throw new JsonParseException("Don't know how to serialize " + hoverEvent.value());
       }
@@ -298,7 +304,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
   }
 
   private void serializeLegacyHoverEvent(final HoverEvent<?> hoverEvent, final JsonWriter out) throws IOException {
-    if (hoverEvent.action() == HoverEvent.Action.SHOW_TEXT) { // serialization is the same
+    if (hoverEvent.action() == HoverEvent.Action.SHOW_TEXT || hoverEvent.action() == HoverEvent.Action.SHOW_ACHIEVEMENT) { // serialization is the same
       this.gson.toJson(hoverEvent.value(), SerializerFactory.COMPONENT_TYPE, out);
     } else if (this.legacyHover != null) { // for data formats that require knowledge of SNBT
       Component serialized = null;

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -304,7 +304,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
   }
 
   private void serializeLegacyHoverEvent(final HoverEvent<?> hoverEvent, final JsonWriter out) throws IOException {
-    if (hoverEvent.action() == HoverEvent.Action.SHOW_TEXT || hoverEvent.action() == HoverEvent.Action.SHOW_ACHIEVEMENT) { // serialization is the same
+    if (hoverEvent.action() == HoverEvent.Action.SHOW_TEXT) { // serialization is the same
       this.gson.toJson(hoverEvent.value(), SerializerFactory.COMPONENT_TYPE, out);
     } else if (this.legacyHover != null) { // for data formats that require knowledge of SNBT
       Component serialized = null;


### PR DESCRIPTION
Before Minecraft 1.12, there is a hover event action called `show_achievement`.
Here's an example of it:
```json
{"action":"show_achievement","value":"achievement.bakeCake"}
```
This PR adds legacy support to it. 

Vanilla clients on or after 1.12 can silently ignore these hover events, so there should be no need to deliberately remove them if someone were to send them to modern clients.