### PR TITLE
ComponentEncoder

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/serializer/ComponentEncoder.java
+++ b/api/src/main/java/net/kyori/adventure/text/serializer/ComponentEncoder.java
@@ -24,85 +24,27 @@
 package net.kyori.adventure.text.serializer;
 
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A {@link Component} serializer and deserializer.
+ * A {@link Component} encoder, which provides serialization, but without deserialization.
+ *
+ * <p>For both serialization and deserialization, use {@link ComponentSerializer}</p>
  *
  * @param <I> the input component type
- * @param <O> the output component type
  * @param <R> the serialized type
- * @since 4.0.0
+ * @since 4.14.0
  */
-public interface ComponentSerializer<I extends Component, O extends Component, R> extends ComponentEncoder<I, R> {
-  /**
-   * Deserialize a component from input of type {@code R}.
-   *
-   * @param input the input
-   * @return the component
-   * @since 4.0.0
-   */
-  @NotNull O deserialize(final @NotNull R input);
-
-  /**
-   * Deserialize a component from input of type {@code R}.
-   *
-   * <p>If {@code input} is {@code null}, then {@code null} will be returned.</p>
-   *
-   * @param input the input
-   * @return the component if {@code input} is non-null, otherwise {@code null}
-   * @since 4.7.0
-   * @deprecated for removal since 4.8.0, use {@link #deserializeOrNull(Object)} instead.
-   */
-  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
-  @Contract(value = "!null -> !null; null -> null", pure = true)
-  @Deprecated
-  default @Nullable O deseializeOrNull(final @Nullable R input) {
-    return this.deserializeOrNull(input);
-  }
-
-  /**
-   * Deserialize a component from input of type {@code R}.
-   *
-   * <p>If {@code input} is {@code null}, then {@code null} will be returned.</p>
-   *
-   * @param input the input
-   * @return the component if {@code input} is non-null, otherwise {@code null}
-   * @since 4.8.0
-   */
-  @Contract(value = "!null -> !null; null -> null", pure = true)
-  default @Nullable O deserializeOrNull(final @Nullable R input) {
-    return this.deserializeOr(input, null);
-  }
-
-  /**
-   * Deserialize a component from input of type {@code R}.
-   *
-   * <p>If {@code input} is {@code null}, then {@code fallback} will be returned.</p>
-   *
-   * @param input the input
-   * @param fallback the fallback value
-   * @return the component if {@code input} is non-null, otherwise {@code fallback}
-   * @since 4.7.0
-   */
-  @Contract(value = "!null, _ -> !null; null, _ -> param2", pure = true)
-  default @Nullable O deserializeOr(final @Nullable R input, final @Nullable O fallback) {
-    if (input == null) return fallback;
-
-    return this.deserialize(input);
-  }
-
+public interface ComponentEncoder<I extends Component, R> {
   /**
    * Serializes a component into an output of type {@code R}.
    *
    * @param component the component
    * @return the output
-   * @since 4.0.0
+   * @since 4.14.0
    */
-  @Override
   @NotNull R serialize(final @NotNull I component);
 
   /**
@@ -112,9 +54,8 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    *
    * @param component the component
    * @return the output if {@code component} is non-null, otherwise {@code null}
-   * @since 4.7.0
+   * @since 4.14.0
    */
-  @Override
   @Contract(value = "!null -> !null; null -> null", pure = true)
   default @Nullable R serializeOrNull(final @Nullable I component) {
     return this.serializeOr(component, null);
@@ -128,9 +69,8 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @param component the component
    * @param fallback the fallback value
    * @return the output if {@code component} is non-null, otherwise {@code fallback}
-   * @since 4.7.0
+   * @since 4.14.0
    */
-  @Override
   @Contract(value = "!null, _ -> !null; null, _ -> param2", pure = true)
   default @Nullable R serializeOr(final @Nullable I component, final @Nullable R fallback) {
     if (component == null) return fallback;


### PR DESCRIPTION
ComponentEncoder is akin to ComponentSerializer, except it doesn't provide deserialization. This is intended to be used in #898.

ComponentSerializer now extends ComponentEncoder, but still overrides the methods with exact copies, to keep the javadocs more clear. These originals also retain their old `@since` tags.