### PR TITLE
feat: abstract legacy code conversion

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -156,7 +156,10 @@ public final class NamedTextColor implements TextColor {
    */
   public static final NamedTextColor WHITE = new NamedTextColor("white", WHITE_VALUE);
 
-  private static final List<NamedTextColor> VALUES = Collections.unmodifiableList(Arrays.asList(BLACK, DARK_BLUE, DARK_GREEN, DARK_AQUA, DARK_RED, DARK_PURPLE, GOLD, GRAY, DARK_GRAY, BLUE, GREEN, AQUA, RED, LIGHT_PURPLE, YELLOW, WHITE));
+  /**
+   * @since 4.14.0
+   */
+  public static final List<NamedTextColor> VALUES = Collections.unmodifiableList(Arrays.asList(BLACK, DARK_BLUE, DARK_GREEN, DARK_AQUA, DARK_RED, DARK_PURPLE, GOLD, GRAY, DARK_GRAY, BLUE, GREEN, AQUA, RED, LIGHT_PURPLE, YELLOW, WHITE));
   /**
    * An index of name to color.
    *

--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -156,10 +156,7 @@ public final class NamedTextColor implements TextColor {
    */
   public static final NamedTextColor WHITE = new NamedTextColor("white", WHITE_VALUE);
 
-  /**
-   * @since 4.14.0
-   */
-  public static final List<NamedTextColor> VALUES = Collections.unmodifiableList(Arrays.asList(BLACK, DARK_BLUE, DARK_GREEN, DARK_AQUA, DARK_RED, DARK_PURPLE, GOLD, GRAY, DARK_GRAY, BLUE, GREEN, AQUA, RED, LIGHT_PURPLE, YELLOW, WHITE));
+  private static final List<NamedTextColor> VALUES = Collections.unmodifiableList(Arrays.asList(BLACK, DARK_BLUE, DARK_GREEN, DARK_AQUA, DARK_RED, DARK_PURPLE, GOLD, GRAY, DARK_GRAY, BLUE, GREEN, AQUA, RED, LIGHT_PURPLE, YELLOW, WHITE));
   /**
    * An index of name to color.
    *
@@ -240,12 +237,16 @@ public final class NamedTextColor implements TextColor {
       return (NamedTextColor) any;
     }
 
+    return nearestColorTo(VALUES, any);
+  }
+
+  public static <C extends TextColor> @NotNull C nearestColorTo(final @NotNull List<C> values, final @NotNull TextColor any) {
     requireNonNull(any, "color");
 
     float matchedDistance = Float.MAX_VALUE;
-    NamedTextColor match = VALUES.get(0);
-    for (int i = 0, length = VALUES.size(); i < length; i++) {
-      final NamedTextColor potential = VALUES.get(i);
+    C match = values.get(0);
+    for (int i = 0, length = values.size(); i < length; i++) {
+      final C potential = values.get(i);
       final float distance = distance(any.asHSV(), potential.asHSV());
       if (distance < matchedDistance) {
         match = potential;

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -1,0 +1,27 @@
+package net.kyori.adventure.text.serializer.legacy;
+
+import net.kyori.adventure.text.format.TextFormat;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A pair containing a text format and its legacy character equivalent.
+ * @since 4.14.0
+ */
+public final class CharacterAndFormat {
+  private final char character;
+  private final @NotNull TextFormat format;
+
+  public CharacterAndFormat(final char character, final @NotNull TextFormat format) {
+    this.character = character;
+    this.format = format;
+  }
+
+  public char getCharacter() {
+    return character;
+  }
+
+  @NotNull
+  public TextFormat getFormat() {
+    return format;
+  }
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/DecodedFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/DecodedFormat.java
@@ -1,0 +1,16 @@
+package net.kyori.adventure.text.serializer.legacy;
+
+import net.kyori.adventure.text.format.TextFormat;
+
+final class DecodedFormat {
+  final FormatCodeType encodedFormat;
+  final TextFormat format;
+
+  DecodedFormat(final FormatCodeType encodedFormat, final TextFormat format) {
+    if (format == null) {
+      throw new IllegalStateException("No format found");
+    }
+    this.encodedFormat = encodedFormat;
+    this.format = format;
+  }
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/FormatCodeType.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/FormatCodeType.java
@@ -1,0 +1,7 @@
+package net.kyori.adventure.text.serializer.legacy;
+
+enum FormatCodeType {
+  MOJANG_LEGACY,
+  KYORI_HEX,
+  BUNGEECORD_UNUSUAL_HEX;
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyCodeConverter.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyCodeConverter.java
@@ -1,0 +1,171 @@
+package net.kyori.adventure.text.serializer.legacy;
+
+import java.util.List;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextFormat;
+import net.kyori.adventure.util.HSVLike;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class LegacyCodeConverter {
+  protected static final char LEGACY_BUNGEE_HEX_CHAR = 'x';
+
+  protected final char character;
+  protected final char hexCharacter;
+  protected final boolean hexColours;
+  protected final boolean useTerriblyStupidHexFormat; // (╯°□°)╯︵ ┻━┻
+
+  protected LegacyCodeConverter(final char character, final char hexCharacter, final boolean hexColours, final boolean useTerriblyStupidHexFormat) {
+    this.character = character;
+    this.hexCharacter = hexCharacter;
+    this.hexColours = hexColours;
+    this.useTerriblyStupidHexFormat = useTerriblyStupidHexFormat;
+  }
+
+  @NotNull abstract List<TextFormat> getFormats();
+
+  @NotNull abstract String getAllLegacyChars();
+
+  @NotNull abstract List<? extends TextColor> getLegacyColors();
+
+  @NotNull abstract LegacyCodeConverterSupplier createSupplier();
+
+  private @Nullable FormatCodeType determineFormatType(final char legacy, final String input, final int pos) {
+    if (pos >= 14) {
+      // The BungeeCord RGB color format uses a repeating sequence of RGB values, each character formatted
+      // as their own color format string, and to make things interesting, all the colors are also valid
+      // Mojang colors. To differentiate this, we do a lookback check for &x (or equivalent) for its position
+      // in the string if it is indeed a BungeeCord-style RGB color.
+      final int expectedCharacterPosition = pos - 14;
+      final int expectedIndicatorPosition = pos - 13;
+      if (input.charAt(expectedCharacterPosition) == this.character && input.charAt(expectedIndicatorPosition) == LEGACY_BUNGEE_HEX_CHAR) {
+        return FormatCodeType.BUNGEECORD_UNUSUAL_HEX;
+      }
+    }
+    if (legacy == this.hexCharacter && input.length() - pos >= 6) {
+      return FormatCodeType.KYORI_HEX;
+    } else if (getAllLegacyChars().indexOf(legacy) != -1) {
+      return FormatCodeType.MOJANG_LEGACY;
+    }
+    return null;
+  }
+
+  @Nullable DecodedFormat decodeTextFormat(final char legacy, final String input, final int pos) {
+    final FormatCodeType foundFormat = this.determineFormatType(legacy, input, pos);
+    if (foundFormat == null) {
+      return null;
+    }
+    if (foundFormat == FormatCodeType.KYORI_HEX) {
+      final @Nullable TextColor parsed = tryParseHexColor(input.substring(pos, pos + 6));
+      if (parsed != null) {
+        return new DecodedFormat(foundFormat, parsed);
+      }
+    } else if (foundFormat == FormatCodeType.MOJANG_LEGACY) {
+      return new DecodedFormat(foundFormat, getFormats().get(getAllLegacyChars().indexOf(legacy)));
+    } else if (foundFormat == FormatCodeType.BUNGEECORD_UNUSUAL_HEX) {
+      final StringBuilder foundHex = new StringBuilder(6);
+      for (int i = pos - 1; i >= pos - 11; i -= 2) {
+        foundHex.append(input.charAt(i));
+      }
+      final @Nullable TextColor parsed = tryParseHexColor(foundHex.reverse().toString());
+      if (parsed != null) {
+        return new DecodedFormat(foundFormat, parsed);
+      }
+    }
+    return null;
+  }
+
+  private static @Nullable TextColor tryParseHexColor(final String hexDigits) {
+    try {
+      final int color = Integer.parseInt(hexDigits, 16);
+      return TextColor.color(color);
+    } catch (final NumberFormatException ex) {
+      return null;
+    }
+  }
+
+  private static boolean isHexTextColor(final TextFormat format) {
+    return format instanceof TextColor && !(format instanceof NamedTextColor);
+  }
+
+  String toLegacyCode(TextFormat format) {
+    if (isHexTextColor(format)) {
+      final TextColor color = (TextColor) format;
+      if (this.hexColours) {
+        final String hex = String.format("%06x", color.value());
+        if (this.useTerriblyStupidHexFormat) {
+          // ah yes, wonderful. A 14 digit long completely unreadable string.
+          final StringBuilder legacy = new StringBuilder(String.valueOf(LEGACY_BUNGEE_HEX_CHAR));
+          for (int i = 0, length = hex.length(); i < length; i++) {
+            legacy.append(this.character).append(hex.charAt(i));
+          }
+          return legacy.toString();
+        } else {
+          // this is a bit nicer, hey?
+          return this.hexCharacter + hex;
+        }
+      } else {
+        // if we are not using hex colours, then convert the hex colour
+        // to the "nearest" possible named/standard text colour
+        format = nearestColorTo(color);
+      }
+    }
+    final int index = getFormats().indexOf(format);
+    return Character.toString(getAllLegacyChars().charAt(index));
+  }
+
+  /**
+   * Find the named colour nearest to the provided colour.
+   *
+   * @param any colour to match
+   * @return nearest named colour. will always return a value
+   * @since 4.14.0
+   */
+  public @NotNull TextColor nearestColorTo(final @NotNull TextColor any) {
+    if (any instanceof NamedTextColor) {
+      return any;
+    }
+
+    requireNonNull(any, "color");
+
+    float matchedDistance = Float.MAX_VALUE;
+    final List<? extends TextColor> values = getLegacyColors();
+    TextColor match = values.get(0);
+    for (int i = 0, length = values.size(); i < length; i++) {
+      final TextColor potential = values.get(i);
+      final float distance = distance(any.asHSV(), potential.asHSV());
+      if (distance < matchedDistance) {
+        match = potential;
+        matchedDistance = distance;
+      }
+      if (distance == 0) {
+        break; // same colour! whoo!
+      }
+    }
+    return match;
+  }
+
+  /**
+   * Returns a distance metric to the other colour.
+   *
+   * <p>This value is unitless and should only be used to compare with other text colours.</p>
+   *
+   * @param self the base colour
+   * @param other colour to compare to
+   * @return distance metric
+   */
+  protected static float distance(final @NotNull HSVLike self, final @NotNull HSVLike other) {
+    // weight hue more heavily than saturation and brightness. kind of magic numbers, but is fine for our use case of downsampling to a set of colors
+    final float hueDistance = 3 * Math.min(Math.abs(self.h() - other.h()), 1f - Math.abs(self.h() - other.h()));
+    final float saturationDiff = self.s() - other.s();
+    final float valueDiff = self.v() - other.v();
+    return hueDistance * hueDistance + saturationDiff * saturationDiff + valueDiff * valueDiff;
+  }
+
+  protected enum Reset implements TextFormat {
+    INSTANCE
+  }
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyCodeConverterImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyCodeConverterImpl.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -14,56 +15,56 @@ import org.jetbrains.annotations.Nullable;
 
 final class LegacyCodeConverterImpl extends LegacyCodeConverter {
 
-  private static final List<TextFormat> FORMATS;
+  private static final List<CharacterAndFormat> FORMATS;
   private static final String LEGACY_CHARS;
 
   static {
     // Enumeration order may change - manually
 
-    final Map<TextFormat, String> formats = new LinkedHashMap<>(16 + 5 + 1); // colours + decorations + reset
+    final List<CharacterAndFormat> formats = new ArrayList<>(16 + 5 + 1); // colours + decorations + reset
 
-    formats.put(NamedTextColor.BLACK, "0");
-    formats.put(NamedTextColor.DARK_BLUE, "1");
-    formats.put(NamedTextColor.DARK_GREEN, "2");
-    formats.put(NamedTextColor.DARK_AQUA, "3");
-    formats.put(NamedTextColor.DARK_RED, "4");
-    formats.put(NamedTextColor.DARK_PURPLE, "5");
-    formats.put(NamedTextColor.GOLD, "6");
-    formats.put(NamedTextColor.GRAY, "7");
-    formats.put(NamedTextColor.DARK_GRAY, "8");
-    formats.put(NamedTextColor.BLUE, "9");
-    formats.put(NamedTextColor.GREEN, "a");
-    formats.put(NamedTextColor.AQUA, "b");
-    formats.put(NamedTextColor.RED, "c");
-    formats.put(NamedTextColor.LIGHT_PURPLE, "d");
-    formats.put(NamedTextColor.YELLOW, "e");
-    formats.put(NamedTextColor.WHITE, "f");
+    formats.add(new CharacterAndFormat('0', NamedTextColor.BLACK));
+    formats.add(new CharacterAndFormat('1', NamedTextColor.DARK_BLUE));
+    formats.add(new CharacterAndFormat('2', NamedTextColor.DARK_GREEN));
+    formats.add(new CharacterAndFormat('3', NamedTextColor.DARK_AQUA));
+    formats.add(new CharacterAndFormat('4', NamedTextColor.DARK_RED));
+    formats.add(new CharacterAndFormat('5', NamedTextColor.DARK_PURPLE));
+    formats.add(new CharacterAndFormat('6', NamedTextColor.GOLD));
+    formats.add(new CharacterAndFormat('7', NamedTextColor.GRAY));
+    formats.add(new CharacterAndFormat('8', NamedTextColor.DARK_GRAY));
+    formats.add(new CharacterAndFormat('9', NamedTextColor.BLUE));
+    formats.add(new CharacterAndFormat('a', NamedTextColor.GREEN));
+    formats.add(new CharacterAndFormat('b', NamedTextColor.AQUA));
+    formats.add(new CharacterAndFormat('c', NamedTextColor.RED));
+    formats.add(new CharacterAndFormat('d', NamedTextColor.LIGHT_PURPLE));
+    formats.add(new CharacterAndFormat('e', NamedTextColor.YELLOW));
+    formats.add(new CharacterAndFormat('f', NamedTextColor.WHITE));
 
-    formats.put(TextDecoration.OBFUSCATED, "k");
-    formats.put(TextDecoration.BOLD, "l");
-    formats.put(TextDecoration.STRIKETHROUGH, "m");
-    formats.put(TextDecoration.UNDERLINED, "n");
-    formats.put(TextDecoration.ITALIC, "o");
+    formats.add(new CharacterAndFormat('k', TextDecoration.OBFUSCATED));
+    formats.add(new CharacterAndFormat('l', TextDecoration.BOLD));
+    formats.add(new CharacterAndFormat('m', TextDecoration.STRIKETHROUGH));
+    formats.add(new CharacterAndFormat('n', TextDecoration.UNDERLINED));
+    formats.add(new CharacterAndFormat('o', TextDecoration.ITALIC));
 
-    formats.put(LegacyCodeConverter.Reset.INSTANCE, "r");
+    formats.add(new CharacterAndFormat('r', LegacyCodeConverter.Reset.INSTANCE));
 
-    FORMATS = Collections.unmodifiableList(new ArrayList<>(formats.keySet()));
-    LEGACY_CHARS = String.join("", formats.values());
-
-    // assert same length
-    if (FORMATS.size() != LEGACY_CHARS.length()) {
-      throw new IllegalStateException("FORMATS length differs from LEGACY_CHARS length");
+    StringBuilder legacyChars = new StringBuilder(formats.size());
+    FORMATS = Collections.unmodifiableList(formats);
+    for (int i = 0; i < FORMATS.size(); i++) {
+      legacyChars.append(FORMATS.get(i).getCharacter());
     }
+    LEGACY_CHARS = legacyChars.toString();
   }
 
   LegacyCodeConverterImpl(final char character, final char hexCharacter, final boolean hexColours, final boolean useTerriblyStupidHexFormat) {
-    super(character, hexCharacter, hexColours, useTerriblyStupidHexFormat);
+    super(FORMATS, character, hexCharacter, hexColours, useTerriblyStupidHexFormat);
   }
 
   static @Nullable LegacyFormat legacyFormat(final char character) {
     final int index = LEGACY_CHARS.indexOf(character);
     if (index != -1) {
-      final TextFormat format = FORMATS.get(index);
+      final CharacterAndFormat characterAndFormat = FORMATS.get(index);
+      final TextFormat format = characterAndFormat.getFormat();
       if (format instanceof TextColor) {
         return new LegacyFormat((TextColor) format);
       } else if (format instanceof TextDecoration) {
@@ -73,26 +74,6 @@ final class LegacyCodeConverterImpl extends LegacyCodeConverter {
       }
     }
     return null;
-  }
-
-  @Override
-  public @NotNull NamedTextColor nearestColorTo(final @NotNull TextColor color) {
-    return NamedTextColor.nearestTo(color);
-  }
-
-  @Override
-  @NotNull List<TextFormat> getFormats() {
-    return FORMATS;
-  }
-
-  @Override
-  @NotNull String getAllLegacyChars() {
-    return LEGACY_CHARS;
-  }
-
-  @Override
-  @NotNull List<? extends TextColor> getLegacyColors() {
-    return NamedTextColor.VALUES;
   }
 
   @Override

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyCodeConverterImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyCodeConverterImpl.java
@@ -1,0 +1,102 @@
+package net.kyori.adventure.text.serializer.legacy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.format.TextFormat;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class LegacyCodeConverterImpl extends LegacyCodeConverter {
+
+  private static final List<TextFormat> FORMATS;
+  private static final String LEGACY_CHARS;
+
+  static {
+    // Enumeration order may change - manually
+
+    final Map<TextFormat, String> formats = new LinkedHashMap<>(16 + 5 + 1); // colours + decorations + reset
+
+    formats.put(NamedTextColor.BLACK, "0");
+    formats.put(NamedTextColor.DARK_BLUE, "1");
+    formats.put(NamedTextColor.DARK_GREEN, "2");
+    formats.put(NamedTextColor.DARK_AQUA, "3");
+    formats.put(NamedTextColor.DARK_RED, "4");
+    formats.put(NamedTextColor.DARK_PURPLE, "5");
+    formats.put(NamedTextColor.GOLD, "6");
+    formats.put(NamedTextColor.GRAY, "7");
+    formats.put(NamedTextColor.DARK_GRAY, "8");
+    formats.put(NamedTextColor.BLUE, "9");
+    formats.put(NamedTextColor.GREEN, "a");
+    formats.put(NamedTextColor.AQUA, "b");
+    formats.put(NamedTextColor.RED, "c");
+    formats.put(NamedTextColor.LIGHT_PURPLE, "d");
+    formats.put(NamedTextColor.YELLOW, "e");
+    formats.put(NamedTextColor.WHITE, "f");
+
+    formats.put(TextDecoration.OBFUSCATED, "k");
+    formats.put(TextDecoration.BOLD, "l");
+    formats.put(TextDecoration.STRIKETHROUGH, "m");
+    formats.put(TextDecoration.UNDERLINED, "n");
+    formats.put(TextDecoration.ITALIC, "o");
+
+    formats.put(LegacyCodeConverter.Reset.INSTANCE, "r");
+
+    FORMATS = Collections.unmodifiableList(new ArrayList<>(formats.keySet()));
+    LEGACY_CHARS = String.join("", formats.values());
+
+    // assert same length
+    if (FORMATS.size() != LEGACY_CHARS.length()) {
+      throw new IllegalStateException("FORMATS length differs from LEGACY_CHARS length");
+    }
+  }
+
+  LegacyCodeConverterImpl(final char character, final char hexCharacter, final boolean hexColours, final boolean useTerriblyStupidHexFormat) {
+    super(character, hexCharacter, hexColours, useTerriblyStupidHexFormat);
+  }
+
+  static @Nullable LegacyFormat legacyFormat(final char character) {
+    final int index = LEGACY_CHARS.indexOf(character);
+    if (index != -1) {
+      final TextFormat format = FORMATS.get(index);
+      if (format instanceof TextColor) {
+        return new LegacyFormat((TextColor) format);
+      } else if (format instanceof TextDecoration) {
+        return new LegacyFormat((TextDecoration) format);
+      } else if (format instanceof LegacyCodeConverter.Reset) {
+        return LegacyFormat.RESET;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public @NotNull NamedTextColor nearestColorTo(final @NotNull TextColor color) {
+    return NamedTextColor.nearestTo(color);
+  }
+
+  @Override
+  @NotNull List<TextFormat> getFormats() {
+    return FORMATS;
+  }
+
+  @Override
+  @NotNull String getAllLegacyChars() {
+    return LEGACY_CHARS;
+  }
+
+  @Override
+  @NotNull List<? extends TextColor> getLegacyColors() {
+    return NamedTextColor.VALUES;
+  }
+
+  @Override
+  @NotNull LegacyCodeConverterSupplier createSupplier() {
+    return LegacyCodeConverterImpl::new;
+  }
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyCodeConverterSupplier.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyCodeConverterSupplier.java
@@ -1,0 +1,14 @@
+package net.kyori.adventure.text.serializer.legacy;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @since 4.14.0
+ */
+@FunctionalInterface
+public interface LegacyCodeConverterSupplier {
+  /**
+   * @since 4.14.0
+   */
+  @NotNull LegacyCodeConverter create(final char character, final char hexCharacter, final boolean hexColours, final boolean useTerriblyStupidHexFormat);
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -102,7 +102,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @since 4.0.0
    */
   static @Nullable LegacyFormat parseChar(final char character) {
-    return LegacyComponentSerializerImpl.legacyFormat(character);
+    return LegacyCodeConverterImpl.legacyFormat(character);
   }
 
   /**
@@ -257,6 +257,14 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @since 4.7.0
      */
     @NotNull Builder flattener(final @NotNull ComponentFlattener flattener);
+
+    /**
+     * Insert Javadocs here.
+     *
+     * @param supplier
+     * @return
+     */
+    @NotNull Builder legacyCodeConverterSupplier(final @NotNull LegacyCodeConverterSupplier supplier);
 
     /**
      * Builds the serializer.

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.serializer.legacy;
 
 import java.util.Objects;
 import java.util.stream.Stream;
-import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.examination.Examinable;
@@ -44,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class LegacyFormat implements Examinable {
   static final LegacyFormat RESET = new LegacyFormat(true);
-  private final @Nullable NamedTextColor color;
+  private final @Nullable TextColor color;
   private final @Nullable TextDecoration decoration;
   private final boolean reset;
 
@@ -52,7 +51,7 @@ public final class LegacyFormat implements Examinable {
    * Separate constructors to ensure a format can never be more than one thing.
    */
 
-  LegacyFormat(final @Nullable NamedTextColor color) {
+  LegacyFormat(final @Nullable TextColor color) {
     this.color = color;
     this.decoration = null;
     this.reset = false;


### PR DESCRIPTION
Bedrock already has one new "legacy" color code, "Minecoin gold". In 1.19.80, there will be a handful of new legacy color codes. The primary goal of this PR is to allow LegacyComponentSerializer usages to take advantage of these new color codes for hex color downsampling. While designing this PR, I also wanted to allow other non-color codes to be modified, since Bedrock doesn't have underscore and obfuscation. We already work around this, however, so this feature is not important to the PR.

For now, I only request feedback on the general structure of the PR. There are several Javadoc and checkstyle errors that I have yet to address until it is agreed upon that the implementation presented here is acceptable. Also, this PR has not yet been tested, for the same reason.