### PR TITLE
feat: allow custom colors in LegacyComponentSerializer

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -237,51 +237,7 @@ public final class NamedTextColor implements TextColor {
       return (NamedTextColor) any;
     }
 
-    return nearestColorTo(VALUES, any);
-  }
-
-  /**
-   *
-   * @param values
-   * @param any
-   * @param <C>
-   * @return
-   * @since 4.14.0
-   */
-  public static <C extends TextColor> @NotNull C nearestColorTo(final @NotNull List<C> values, final @NotNull TextColor any) {
-    requireNonNull(any, "color");
-
-    float matchedDistance = Float.MAX_VALUE;
-    C match = values.get(0);
-    for (int i = 0, length = values.size(); i < length; i++) {
-      final C potential = values.get(i);
-      final float distance = distance(any.asHSV(), potential.asHSV());
-      if (distance < matchedDistance) {
-        match = potential;
-        matchedDistance = distance;
-      }
-      if (distance == 0) {
-        break; // same colour! whoo!
-      }
-    }
-    return match;
-  }
-
-  /**
-   * Returns a distance metric to the other colour.
-   *
-   * <p>This value is unitless and should only be used to compare with other text colours.</p>
-   *
-   * @param self the base colour
-   * @param other colour to compare to
-   * @return distance metric
-   */
-  private static float distance(final @NotNull HSVLike self, final @NotNull HSVLike other) {
-    // weight hue more heavily than saturation and brightness. kind of magic numbers, but is fine for our use case of downsampling to a set of colors
-    final float hueDistance = 3 * Math.min(Math.abs(self.h() - other.h()), 1f - Math.abs(self.h() - other.h()));
-    final float saturationDiff = self.s() - other.s();
-    final float valueDiff = self.v() - other.v();
-    return hueDistance * hueDistance + saturationDiff * saturationDiff + valueDiff * valueDiff;
+    return TextColor.nearestColorTo(VALUES, any);
   }
 
   private final String name;

--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -34,8 +34,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * The named text colours in Minecraft: Java Edition.
  *

--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -237,12 +237,24 @@ public final class NamedTextColor implements TextColor {
       return (NamedTextColor) any;
     }
 
+    return nearestColorTo(VALUES, any);
+  }
+
+  /**
+   *
+   * @param values
+   * @param any
+   * @param <C>
+   * @return
+   * @since 4.14.0
+   */
+  public static <C extends TextColor> @NotNull C nearestColorTo(final @NotNull List<C> values, final @NotNull TextColor any) {
     requireNonNull(any, "color");
 
     float matchedDistance = Float.MAX_VALUE;
-    NamedTextColor match = VALUES.get(0);
-    for (int i = 0, length = VALUES.size(); i < length; i++) {
-      final NamedTextColor potential = VALUES.get(i);
+    C match = values.get(0);
+    for (int i = 0, length = values.size(); i < length; i++) {
+      final C potential = values.get(i);
       final float distance = distance(any.asHSV(), potential.asHSV());
       if (distance < matchedDistance) {
         match = potential;

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.format;
 
+import java.util.List;
 import java.util.stream.Stream;
 import net.kyori.adventure.util.HSVLike;
 import net.kyori.adventure.util.RGBLike;
@@ -31,6 +32,8 @@ import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A color which may be applied to a {@link Style}.
@@ -259,6 +262,34 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
       Math.round(ag + clampedT * (bg - ag)),
       Math.round(ab + clampedT * (bb - ab))
     );
+  }
+
+  /**
+   * Find the colour nearest to the provided colour.
+   *
+   * @param values the colours for matching
+   * @param any colour to match
+   * @param <C> the color type
+   * @return nearest named colour. will always return a value
+   * @since 4.14.0
+   */
+  static <C extends TextColor> @NotNull C nearestColorTo(final @NotNull List<C> values, final @NotNull TextColor any) {
+    requireNonNull(any, "color");
+
+    float matchedDistance = Float.MAX_VALUE;
+    C match = values.get(0);
+    for (int i = 0, length = values.size(); i < length; i++) {
+      final C potential = values.get(i);
+      final float distance = TextColorImpl.distance(any.asHSV(), potential.asHSV());
+      if (distance < matchedDistance) {
+        match = potential;
+        matchedDistance = distance;
+      }
+      if (distance == 0) {
+        break; // same colour! whoo!
+      }
+    }
+    return match;
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
@@ -23,7 +23,9 @@
  */
 package net.kyori.adventure.text.format;
 
+import net.kyori.adventure.util.HSVLike;
 import org.jetbrains.annotations.Debug;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Debug.Renderer(text = "asHexString()")
@@ -55,5 +57,22 @@ final class TextColorImpl implements TextColor {
   @Override
   public String toString() {
     return this.asHexString();
+  }
+
+  /**
+   * Returns a distance metric to the other colour.
+   *
+   * <p>This value is unitless and should only be used to compare with other text colours.</p>
+   *
+   * @param self the base colour
+   * @param other colour to compare to
+   * @return distance metric
+   */
+  static float distance(final @NotNull HSVLike self, final @NotNull HSVLike other) {
+    // weight hue more heavily than saturation and brightness. kind of magic numbers, but is fine for our use case of downsampling to a set of colors
+    final float hueDistance = 3 * Math.min(Math.abs(self.h() - other.h()), 1f - Math.abs(self.h() - other.h()));
+    final float saturationDiff = self.s() - other.s();
+    final float valueDiff = self.v() - other.v();
+    return hueDistance * hueDistance + saturationDiff * saturationDiff + valueDiff * valueDiff;
   }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -1,0 +1,33 @@
+package net.kyori.adventure.text.serializer.legacy;
+
+import net.kyori.adventure.text.format.TextFormat;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class CharacterAndFormat {
+  private final char character;
+  private final @Nullable TextFormat format;
+
+  private CharacterAndFormat(final char character) {
+    this.character = character;
+    this.format = null;
+  }
+
+  public CharacterAndFormat(final char character, final @NotNull TextFormat format) {
+    this.character = character;
+    this.format = format;
+  }
+
+  public char getCharacter() {
+    return character;
+  }
+
+  @Nullable
+  public TextFormat getFormat() {
+    return format;
+  }
+
+  public static CharacterAndFormat ofReset(char character) {
+    return new CharacterAndFormat(character);
+  }
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -30,6 +30,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.format.TextFormat;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -246,5 +247,29 @@ public final class CharacterAndFormat {
    */
   public @NotNull TextFormat format() {
     return this.format;
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if (this == other) return true;
+    if (!(other instanceof CharacterAndFormat)) return false;
+    final CharacterAndFormat that = (CharacterAndFormat) other;
+    return this.character == that.character
+      && this.format.equals(that.format);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = this.character;
+    result = 31 * result + this.format.hashCode();
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "CharacterAndFormat{" +
+      "character=" + this.character +
+      ", format=" + this.format +
+      '}';
   }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -23,210 +23,170 @@
  */
 package net.kyori.adventure.text.serializer.legacy;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.format.TextFormat;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * A combination of a {@code character} and a {@link TextFormat}.
  *
  * @since 4.14.0
  */
-public final class CharacterAndFormat {
+public interface CharacterAndFormat {
   /**
    * Character and format pair representing {@link NamedTextColor#BLACK}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat BLACK = new CharacterAndFormat('0', NamedTextColor.BLACK);
+  CharacterAndFormat BLACK = characterAndFormat('0', NamedTextColor.BLACK);
   /**
    * Character and format pair representing {@link NamedTextColor#DARK_BLUE}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat DARK_BLUE = new CharacterAndFormat('1', NamedTextColor.DARK_BLUE);
+  CharacterAndFormat DARK_BLUE = characterAndFormat('1', NamedTextColor.DARK_BLUE);
   /**
    * Character and format pair representing {@link NamedTextColor#DARK_GREEN}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat DARK_GREEN = new CharacterAndFormat('2', NamedTextColor.DARK_GREEN);
+  CharacterAndFormat DARK_GREEN = characterAndFormat('2', NamedTextColor.DARK_GREEN);
   /**
    * Character and format pair representing {@link NamedTextColor#DARK_AQUA}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat DARK_AQUA = new CharacterAndFormat('3', NamedTextColor.DARK_AQUA);
+  CharacterAndFormat DARK_AQUA = characterAndFormat('3', NamedTextColor.DARK_AQUA);
   /**
    * Character and format pair representing {@link NamedTextColor#DARK_RED}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat DARK_RED = new CharacterAndFormat('4', NamedTextColor.DARK_RED);
+  CharacterAndFormat DARK_RED = characterAndFormat('4', NamedTextColor.DARK_RED);
   /**
    * Character and format pair representing {@link NamedTextColor#DARK_PURPLE}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat DARK_PURPLE = new CharacterAndFormat('5', NamedTextColor.DARK_PURPLE);
+  CharacterAndFormat DARK_PURPLE = characterAndFormat('5', NamedTextColor.DARK_PURPLE);
   /**
    * Character and format pair representing {@link NamedTextColor#GOLD}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat GOLD = new CharacterAndFormat('6', NamedTextColor.GOLD);
+  CharacterAndFormat GOLD = characterAndFormat('6', NamedTextColor.GOLD);
   /**
    * Character and format pair representing {@link NamedTextColor#GRAY}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat GRAY = new CharacterAndFormat('7', NamedTextColor.GRAY);
+  CharacterAndFormat GRAY = characterAndFormat('7', NamedTextColor.GRAY);
   /**
    * Character and format pair representing {@link NamedTextColor#DARK_GRAY}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat DARK_GRAY = new CharacterAndFormat('8', NamedTextColor.DARK_GRAY);
+  CharacterAndFormat DARK_GRAY = characterAndFormat('8', NamedTextColor.DARK_GRAY);
   /**
    * Character and format pair representing {@link NamedTextColor#BLUE}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat BLUE = new CharacterAndFormat('9', NamedTextColor.BLUE);
+  CharacterAndFormat BLUE = characterAndFormat('9', NamedTextColor.BLUE);
   /**
    * Character and format pair representing {@link NamedTextColor#GREEN}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat GREEN = new CharacterAndFormat('a', NamedTextColor.GREEN);
+  CharacterAndFormat GREEN = characterAndFormat('a', NamedTextColor.GREEN);
   /**
    * Character and format pair representing {@link NamedTextColor#AQUA}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat AQUA = new CharacterAndFormat('b', NamedTextColor.AQUA);
+  CharacterAndFormat AQUA = characterAndFormat('b', NamedTextColor.AQUA);
   /**
    * Character and format pair representing {@link NamedTextColor#RED}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat RED = new CharacterAndFormat('c', NamedTextColor.RED);
+  CharacterAndFormat RED = characterAndFormat('c', NamedTextColor.RED);
   /**
    * Character and format pair representing {@link NamedTextColor#LIGHT_PURPLE}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat LIGHT_PURPLE = new CharacterAndFormat('d', NamedTextColor.LIGHT_PURPLE);
+  CharacterAndFormat LIGHT_PURPLE = characterAndFormat('d', NamedTextColor.LIGHT_PURPLE);
   /**
    * Character and format pair representing {@link NamedTextColor#YELLOW}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat YELLOW = new CharacterAndFormat('e', NamedTextColor.YELLOW);
+  CharacterAndFormat YELLOW = characterAndFormat('e', NamedTextColor.YELLOW);
   /**
    * Character and format pair representing {@link NamedTextColor#WHITE}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat WHITE = new CharacterAndFormat('f', NamedTextColor.WHITE);
+  CharacterAndFormat WHITE = characterAndFormat('f', NamedTextColor.WHITE);
 
   /**
    * Character and format pair representing {@link TextDecoration#OBFUSCATED}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat OBFUSCATED = new CharacterAndFormat('k', TextDecoration.OBFUSCATED);
+  CharacterAndFormat OBFUSCATED = characterAndFormat('k', TextDecoration.OBFUSCATED);
   /**
    * Character and format pair representing {@link TextDecoration#BOLD}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat BOLD = new CharacterAndFormat('l', TextDecoration.BOLD);
+  CharacterAndFormat BOLD = characterAndFormat('l', TextDecoration.BOLD);
   /**
    * Character and format pair representing {@link TextDecoration#STRIKETHROUGH}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat STRIKETHROUGH = new CharacterAndFormat('m', TextDecoration.STRIKETHROUGH);
+  CharacterAndFormat STRIKETHROUGH = characterAndFormat('m', TextDecoration.STRIKETHROUGH);
   /**
    * Character and format pair representing {@link TextDecoration#UNDERLINED}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat UNDERLINED = new CharacterAndFormat('n', TextDecoration.UNDERLINED);
+  CharacterAndFormat UNDERLINED = characterAndFormat('n', TextDecoration.UNDERLINED);
   /**
    * Character and format pair representing {@link TextDecoration#ITALIC}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat ITALIC = new CharacterAndFormat('o', TextDecoration.ITALIC);
+  CharacterAndFormat ITALIC = characterAndFormat('o', TextDecoration.ITALIC);
 
   /**
    * Character and format pair representing {@link Reset#INSTANCE}.
    *
    * @since 4.14.0
    */
-  public static final CharacterAndFormat RESET = new CharacterAndFormat('r', Reset.INSTANCE);
+  CharacterAndFormat RESET = characterAndFormat('r', Reset.INSTANCE);
 
   /**
    * A list of character and format pairs containing all default vanilla formats.
    *
    * @since 4.14.0
    */
-  public static final List<CharacterAndFormat> DEFAULTS = createDefault();
-
-  private final char character;
-  private final TextFormat format;
-
-  @SuppressWarnings("DuplicatedCode")
-  private static List<CharacterAndFormat> createDefault() {
-    final List<CharacterAndFormat> formats = new ArrayList<>(16 + 5 + 1); // colours + decorations + reset
-
-    formats.add(BLACK);
-    formats.add(DARK_BLUE);
-    formats.add(DARK_GREEN);
-    formats.add(DARK_AQUA);
-    formats.add(DARK_RED);
-    formats.add(DARK_PURPLE);
-    formats.add(GOLD);
-    formats.add(GRAY);
-    formats.add(DARK_GRAY);
-    formats.add(BLUE);
-    formats.add(GREEN);
-    formats.add(AQUA);
-    formats.add(RED);
-    formats.add(LIGHT_PURPLE);
-    formats.add(YELLOW);
-    formats.add(WHITE);
-
-    formats.add(OBFUSCATED);
-    formats.add(BOLD);
-    formats.add(STRIKETHROUGH);
-    formats.add(UNDERLINED);
-    formats.add(ITALIC);
-
-    formats.add(RESET);
-
-    return Collections.unmodifiableList(formats);
-  }
+  List<CharacterAndFormat> DEFAULTS = CharacterAndFormatImpl.createDefault();
 
   /**
    * Creates a new combination of a {@code character} and a {@link TextFormat}.
    *
    * @param character the character
    * @param format the format
+   * @return a new character and format pair.
    * @since 4.14.0
    */
-  public CharacterAndFormat(final char character, final @NotNull TextFormat format) {
-    this.character = character;
-    this.format = requireNonNull(format, "format");
+  static CharacterAndFormat characterAndFormat(final char character, final @NotNull TextFormat format) {
+    return new CharacterAndFormatImpl(character, format);
   }
 
   /**
@@ -235,9 +195,7 @@ public final class CharacterAndFormat {
    * @return the character
    * @since 4.14.0
    */
-  public char character() {
-    return this.character;
-  }
+  char character();
 
   /**
    * Gets the format.
@@ -245,31 +203,5 @@ public final class CharacterAndFormat {
    * @return the format
    * @since 4.14.0
    */
-  public @NotNull TextFormat format() {
-    return this.format;
-  }
-
-  @Override
-  public boolean equals(final @Nullable Object other) {
-    if (this == other) return true;
-    if (!(other instanceof CharacterAndFormat)) return false;
-    final CharacterAndFormat that = (CharacterAndFormat) other;
-    return this.character == that.character
-      && this.format.equals(that.format);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = this.character;
-    result = 31 * result + this.format.hashCode();
-    return result;
-  }
-
-  @Override
-  public @NotNull String toString() {
-    return "CharacterAndFormat{" +
-      "character=" + this.character +
-      ", format=" + this.format +
-      '}';
-  }
+  @NotNull TextFormat format();
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -40,41 +40,178 @@ import static java.util.Objects.requireNonNull;
  */
 public final class CharacterAndFormat {
   /**
-   * A list of vanilla default formats.
+   * Character and format pair representing {@link NamedTextColor#BLACK}.
    *
    * @since 4.14.0
    */
-  public static final List<CharacterAndFormat> DEFAULT = createDefault();
+  public static final CharacterAndFormat BLACK = new CharacterAndFormat('0', NamedTextColor.BLACK);
+  /**
+   * Character and format pair representing {@link NamedTextColor#DARK_BLUE}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat DARK_BLUE = new CharacterAndFormat('1', NamedTextColor.DARK_BLUE);
+  /**
+   * Character and format pair representing {@link NamedTextColor#DARK_GREEN}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat DARK_GREEN = new CharacterAndFormat('2', NamedTextColor.DARK_GREEN);
+  /**
+   * Character and format pair representing {@link NamedTextColor#DARK_AQUA}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat DARK_AQUA = new CharacterAndFormat('3', NamedTextColor.DARK_AQUA);
+  /**
+   * Character and format pair representing {@link NamedTextColor#DARK_RED}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat DARK_RED = new CharacterAndFormat('4', NamedTextColor.DARK_RED);
+  /**
+   * Character and format pair representing {@link NamedTextColor#DARK_PURPLE}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat DARK_PURPLE = new CharacterAndFormat('5', NamedTextColor.DARK_PURPLE);
+  /**
+   * Character and format pair representing {@link NamedTextColor#GOLD}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat GOLD = new CharacterAndFormat('6', NamedTextColor.GOLD);
+  /**
+   * Character and format pair representing {@link NamedTextColor#GRAY}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat GRAY = new CharacterAndFormat('7', NamedTextColor.GRAY);
+  /**
+   * Character and format pair representing {@link NamedTextColor#DARK_GRAY}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat DARK_GRAY = new CharacterAndFormat('8', NamedTextColor.DARK_GRAY);
+  /**
+   * Character and format pair representing {@link NamedTextColor#BLUE}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat BLUE = new CharacterAndFormat('9', NamedTextColor.BLUE);
+  /**
+   * Character and format pair representing {@link NamedTextColor#GREEN}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat GREEN = new CharacterAndFormat('a', NamedTextColor.GREEN);
+  /**
+   * Character and format pair representing {@link NamedTextColor#AQUA}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat AQUA = new CharacterAndFormat('b', NamedTextColor.AQUA);
+  /**
+   * Character and format pair representing {@link NamedTextColor#RED}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat RED = new CharacterAndFormat('c', NamedTextColor.RED);
+  /**
+   * Character and format pair representing {@link NamedTextColor#LIGHT_PURPLE}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat LIGHT_PURPLE = new CharacterAndFormat('d', NamedTextColor.LIGHT_PURPLE);
+  /**
+   * Character and format pair representing {@link NamedTextColor#YELLOW}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat YELLOW = new CharacterAndFormat('e', NamedTextColor.YELLOW);
+  /**
+   * Character and format pair representing {@link NamedTextColor#WHITE}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat WHITE = new CharacterAndFormat('f', NamedTextColor.WHITE);
+
+  /**
+   * Character and format pair representing {@link TextDecoration#OBFUSCATED}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat OBFUSCATED = new CharacterAndFormat('k', TextDecoration.OBFUSCATED);
+  /**
+   * Character and format pair representing {@link TextDecoration#BOLD}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat BOLD = new CharacterAndFormat('l', TextDecoration.BOLD);
+  /**
+   * Character and format pair representing {@link TextDecoration#STRIKETHROUGH}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat STRIKETHROUGH = new CharacterAndFormat('m', TextDecoration.STRIKETHROUGH);
+  /**
+   * Character and format pair representing {@link TextDecoration#UNDERLINED}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat UNDERLINED = new CharacterAndFormat('n', TextDecoration.UNDERLINED);
+  /**
+   * Character and format pair representing {@link TextDecoration#ITALIC}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat ITALIC = new CharacterAndFormat('o', TextDecoration.ITALIC);
+
+  /**
+   * Character and format pair representing {@link Reset#INSTANCE}.
+   *
+   * @since 4.14.0
+   */
+  public static final CharacterAndFormat RESET = new CharacterAndFormat('r', Reset.INSTANCE);
+
+  /**
+   * A list of character and format pairs containing all default vanilla formats.
+   *
+   * @since 4.14.0
+   */
+  public static final List<CharacterAndFormat> DEFAULTS = createDefault();
+
   private final char character;
   private final TextFormat format;
 
+  @SuppressWarnings("DuplicatedCode")
   private static List<CharacterAndFormat> createDefault() {
     final List<CharacterAndFormat> formats = new ArrayList<>(16 + 5 + 1); // colours + decorations + reset
 
-    formats.add(new CharacterAndFormat('0', NamedTextColor.BLACK));
-    formats.add(new CharacterAndFormat('1', NamedTextColor.DARK_BLUE));
-    formats.add(new CharacterAndFormat('2', NamedTextColor.DARK_GREEN));
-    formats.add(new CharacterAndFormat('3', NamedTextColor.DARK_AQUA));
-    formats.add(new CharacterAndFormat('4', NamedTextColor.DARK_RED));
-    formats.add(new CharacterAndFormat('5', NamedTextColor.DARK_PURPLE));
-    formats.add(new CharacterAndFormat('6', NamedTextColor.GOLD));
-    formats.add(new CharacterAndFormat('7', NamedTextColor.GRAY));
-    formats.add(new CharacterAndFormat('8', NamedTextColor.DARK_GRAY));
-    formats.add(new CharacterAndFormat('9', NamedTextColor.BLUE));
-    formats.add(new CharacterAndFormat('a', NamedTextColor.GREEN));
-    formats.add(new CharacterAndFormat('b', NamedTextColor.AQUA));
-    formats.add(new CharacterAndFormat('c', NamedTextColor.RED));
-    formats.add(new CharacterAndFormat('d', NamedTextColor.LIGHT_PURPLE));
-    formats.add(new CharacterAndFormat('e', NamedTextColor.YELLOW));
-    formats.add(new CharacterAndFormat('f', NamedTextColor.WHITE));
+    formats.add(BLACK);
+    formats.add(DARK_BLUE);
+    formats.add(DARK_GREEN);
+    formats.add(DARK_AQUA);
+    formats.add(DARK_RED);
+    formats.add(DARK_PURPLE);
+    formats.add(GOLD);
+    formats.add(GRAY);
+    formats.add(DARK_GRAY);
+    formats.add(BLUE);
+    formats.add(GREEN);
+    formats.add(AQUA);
+    formats.add(RED);
+    formats.add(LIGHT_PURPLE);
+    formats.add(YELLOW);
+    formats.add(WHITE);
 
-    formats.add(new CharacterAndFormat('k', TextDecoration.OBFUSCATED));
-    formats.add(new CharacterAndFormat('l', TextDecoration.BOLD));
-    formats.add(new CharacterAndFormat('m', TextDecoration.STRIKETHROUGH));
-    formats.add(new CharacterAndFormat('n', TextDecoration.UNDERLINED));
-    formats.add(new CharacterAndFormat('o', TextDecoration.ITALIC));
+    formats.add(OBFUSCATED);
+    formats.add(BOLD);
+    formats.add(STRIKETHROUGH);
+    formats.add(UNDERLINED);
+    formats.add(ITALIC);
 
-    formats.add(new CharacterAndFormat('r', Reset.INSTANCE));
+    formats.add(RESET);
 
     return Collections.unmodifiableList(formats);
   }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -24,17 +24,23 @@
 package net.kyori.adventure.text.serializer.legacy;
 
 import java.util.List;
+import java.util.stream.Stream;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.format.TextFormat;
+import net.kyori.examination.Examinable;
+import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * A combination of a {@code character} and a {@link TextFormat}.
  *
  * @since 4.14.0
  */
-public interface CharacterAndFormat {
+@ApiStatus.NonExtendable
+public interface CharacterAndFormat extends Examinable {
   /**
    * Character and format pair representing {@link NamedTextColor#BLACK}.
    *
@@ -171,13 +177,6 @@ public interface CharacterAndFormat {
   CharacterAndFormat RESET = characterAndFormat('r', Reset.INSTANCE);
 
   /**
-   * A list of character and format pairs containing all default vanilla formats.
-   *
-   * @since 4.14.0
-   */
-  List<CharacterAndFormat> DEFAULTS = CharacterAndFormatImpl.createDefault();
-
-  /**
    * Creates a new combination of a {@code character} and a {@link TextFormat}.
    *
    * @param character the character
@@ -185,8 +184,19 @@ public interface CharacterAndFormat {
    * @return a new character and format pair.
    * @since 4.14.0
    */
-  static CharacterAndFormat characterAndFormat(final char character, final @NotNull TextFormat format) {
+  static @NotNull CharacterAndFormat characterAndFormat(final char character, final @NotNull TextFormat format) {
     return new CharacterAndFormatImpl(character, format);
+  }
+
+  /**
+   * Gets an unmodifiable list of character and format pairs containing all default vanilla formats.
+   *
+   * @return am unmodifiable list of character and format pairs containing all default vanilla formats
+   * @since 4.14.0
+   */
+  @Unmodifiable
+  static @NotNull List<CharacterAndFormat> defaults() {
+    return CharacterAndFormatImpl.Defaults.DEFAULTS;
   }
 
   /**
@@ -204,4 +214,12 @@ public interface CharacterAndFormat {
    * @since 4.14.0
    */
   @NotNull TextFormat format();
+
+  @Override
+  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("character", this.character()),
+      ExaminableProperty.of("format", this.format())
+    );
+  }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -39,7 +39,12 @@ import static java.util.Objects.requireNonNull;
  * @since 4.14.0
  */
 public final class CharacterAndFormat {
-  static final List<CharacterAndFormat> DEFAULT = createDefault();
+  /**
+   * A list of vanilla default formats.
+   *
+   * @since 4.14.0
+   */
+  public static final List<CharacterAndFormat> DEFAULT = createDefault();
   private final char character;
   private final TextFormat format;
 

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -1,33 +1,108 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package net.kyori.adventure.text.serializer.legacy;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.format.TextFormat;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A combination of a {@code character} and a {@link TextFormat}.
+ *
+ * @since 4.14.0
+ */
 public final class CharacterAndFormat {
+  static final List<CharacterAndFormat> DEFAULT = createDefault();
   private final char character;
-  private final @Nullable TextFormat format;
+  private final TextFormat format;
 
-  private CharacterAndFormat(final char character) {
-    this.character = character;
-    this.format = null;
+  private static List<CharacterAndFormat> createDefault() {
+    final List<CharacterAndFormat> formats = new ArrayList<>(16 + 5 + 1); // colours + decorations + reset
+
+    formats.add(new CharacterAndFormat('0', NamedTextColor.BLACK));
+    formats.add(new CharacterAndFormat('1', NamedTextColor.DARK_BLUE));
+    formats.add(new CharacterAndFormat('2', NamedTextColor.DARK_GREEN));
+    formats.add(new CharacterAndFormat('3', NamedTextColor.DARK_AQUA));
+    formats.add(new CharacterAndFormat('4', NamedTextColor.DARK_RED));
+    formats.add(new CharacterAndFormat('5', NamedTextColor.DARK_PURPLE));
+    formats.add(new CharacterAndFormat('6', NamedTextColor.GOLD));
+    formats.add(new CharacterAndFormat('7', NamedTextColor.GRAY));
+    formats.add(new CharacterAndFormat('8', NamedTextColor.DARK_GRAY));
+    formats.add(new CharacterAndFormat('9', NamedTextColor.BLUE));
+    formats.add(new CharacterAndFormat('a', NamedTextColor.GREEN));
+    formats.add(new CharacterAndFormat('b', NamedTextColor.AQUA));
+    formats.add(new CharacterAndFormat('c', NamedTextColor.RED));
+    formats.add(new CharacterAndFormat('d', NamedTextColor.LIGHT_PURPLE));
+    formats.add(new CharacterAndFormat('e', NamedTextColor.YELLOW));
+    formats.add(new CharacterAndFormat('f', NamedTextColor.WHITE));
+
+    formats.add(new CharacterAndFormat('k', TextDecoration.OBFUSCATED));
+    formats.add(new CharacterAndFormat('l', TextDecoration.BOLD));
+    formats.add(new CharacterAndFormat('m', TextDecoration.STRIKETHROUGH));
+    formats.add(new CharacterAndFormat('n', TextDecoration.UNDERLINED));
+    formats.add(new CharacterAndFormat('o', TextDecoration.ITALIC));
+
+    formats.add(new CharacterAndFormat('r', Reset.INSTANCE));
+
+    return Collections.unmodifiableList(formats);
   }
 
+  /**
+   * Creates a new combination of a {@code character} and a {@link TextFormat}.
+   *
+   * @param character the character
+   * @param format the format
+   * @since 4.14.0
+   */
   public CharacterAndFormat(final char character, final @NotNull TextFormat format) {
     this.character = character;
-    this.format = format;
+    this.format = requireNonNull(format, "format");
   }
 
-  public char getCharacter() {
-    return character;
+  /**
+   * Gets the character.
+   *
+   * @return the character
+   * @since 4.14.0
+   */
+  public char character() {
+    return this.character;
   }
 
-  @Nullable
-  public TextFormat getFormat() {
-    return format;
-  }
-
-  public static CharacterAndFormat ofReset(char character) {
-    return new CharacterAndFormat(character);
+  /**
+   * Gets the format.
+   *
+   * @return the format
+   * @since 4.14.0
+   */
+  public @NotNull TextFormat format() {
+    return this.format;
   }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatImpl.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.legacy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.kyori.adventure.text.format.TextFormat;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+final class CharacterAndFormatImpl implements CharacterAndFormat {
+  private final char character;
+  private final TextFormat format;
+
+  CharacterAndFormatImpl(final char character, final @NotNull TextFormat format) {
+    this.character = character;
+    this.format = requireNonNull(format, "format");
+  }
+
+  @SuppressWarnings("DuplicatedCode")
+  static List<CharacterAndFormat> createDefault() {
+    final List<CharacterAndFormat> formats = new ArrayList<>(16 + 5 + 1); // colours + decorations + reset
+
+    formats.add(BLACK);
+    formats.add(DARK_BLUE);
+    formats.add(DARK_GREEN);
+    formats.add(DARK_AQUA);
+    formats.add(DARK_RED);
+    formats.add(DARK_PURPLE);
+    formats.add(GOLD);
+    formats.add(GRAY);
+    formats.add(DARK_GRAY);
+    formats.add(BLUE);
+    formats.add(GREEN);
+    formats.add(AQUA);
+    formats.add(RED);
+    formats.add(LIGHT_PURPLE);
+    formats.add(YELLOW);
+    formats.add(WHITE);
+
+    formats.add(OBFUSCATED);
+    formats.add(BOLD);
+    formats.add(STRIKETHROUGH);
+    formats.add(UNDERLINED);
+    formats.add(ITALIC);
+
+    formats.add(RESET);
+
+    return Collections.unmodifiableList(formats);
+  }
+
+  @Override
+  public char character() {
+    return this.character;
+  }
+
+  @Override
+  public @NotNull TextFormat format() {
+    return this.format;
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if (this == other) return true;
+    if (!(other instanceof CharacterAndFormatImpl)) return false;
+    final CharacterAndFormatImpl that = (CharacterAndFormatImpl) other;
+    return this.character == that.character
+      && this.format.equals(that.format);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = this.character;
+    result = 31 * result + this.format.hashCode();
+    return result;
+  }
+
+  @Override
+  public @NotNull String toString() {
+    return "CharacterAndFormat{" +
+      "character=" + this.character +
+      ", format=" + this.format +
+      '}';
+  }
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatImpl.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.text.serializer.legacy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.TextFormat;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,38 +40,6 @@ final class CharacterAndFormatImpl implements CharacterAndFormat {
   CharacterAndFormatImpl(final char character, final @NotNull TextFormat format) {
     this.character = character;
     this.format = requireNonNull(format, "format");
-  }
-
-  @SuppressWarnings("DuplicatedCode")
-  static List<CharacterAndFormat> createDefault() {
-    final List<CharacterAndFormat> formats = new ArrayList<>(16 + 5 + 1); // colours + decorations + reset
-
-    formats.add(BLACK);
-    formats.add(DARK_BLUE);
-    formats.add(DARK_GREEN);
-    formats.add(DARK_AQUA);
-    formats.add(DARK_RED);
-    formats.add(DARK_PURPLE);
-    formats.add(GOLD);
-    formats.add(GRAY);
-    formats.add(DARK_GRAY);
-    formats.add(BLUE);
-    formats.add(GREEN);
-    formats.add(AQUA);
-    formats.add(RED);
-    formats.add(LIGHT_PURPLE);
-    formats.add(YELLOW);
-    formats.add(WHITE);
-
-    formats.add(OBFUSCATED);
-    formats.add(BOLD);
-    formats.add(STRIKETHROUGH);
-    formats.add(UNDERLINED);
-    formats.add(ITALIC);
-
-    formats.add(RESET);
-
-    return Collections.unmodifiableList(formats);
   }
 
   @Override
@@ -101,9 +70,45 @@ final class CharacterAndFormatImpl implements CharacterAndFormat {
 
   @Override
   public @NotNull String toString() {
-    return "CharacterAndFormat{" +
-      "character=" + this.character +
-      ", format=" + this.format +
-      '}';
+    return Internals.toString(this);
+  }
+
+  static final class Defaults {
+    static final List<CharacterAndFormat> DEFAULTS = createDefaults();
+
+    private Defaults() {
+    }
+
+    @SuppressWarnings("DuplicatedCode")
+    static List<CharacterAndFormat> createDefaults() {
+      final List<CharacterAndFormat> formats = new ArrayList<>(16 + 5 + 1); // colours + decorations + reset
+
+      formats.add(BLACK);
+      formats.add(DARK_BLUE);
+      formats.add(DARK_GREEN);
+      formats.add(DARK_AQUA);
+      formats.add(DARK_RED);
+      formats.add(DARK_PURPLE);
+      formats.add(GOLD);
+      formats.add(GRAY);
+      formats.add(DARK_GRAY);
+      formats.add(BLUE);
+      formats.add(GREEN);
+      formats.add(AQUA);
+      formats.add(RED);
+      formats.add(LIGHT_PURPLE);
+      formats.add(YELLOW);
+      formats.add(WHITE);
+
+      formats.add(OBFUSCATED);
+      formats.add(BOLD);
+      formats.add(STRIKETHROUGH);
+      formats.add(UNDERLINED);
+      formats.add(ITALIC);
+
+      formats.add(RESET);
+
+      return Collections.unmodifiableList(formats);
+    }
   }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatSet.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatSet.java
@@ -30,7 +30,7 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextFormat;
 
 final class CharacterAndFormatSet {
-  static final CharacterAndFormatSet DEFAULT = of(CharacterAndFormat.DEFAULTS);
+  static final CharacterAndFormatSet DEFAULT = of(CharacterAndFormat.defaults());
   final List<TextFormat> formats;
   final List<TextColor> colors;
   final String characters;

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatSet.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatSet.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.legacy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextFormat;
+
+final class CharacterAndFormatSet {
+  static final CharacterAndFormatSet DEFAULT = of(CharacterAndFormat.DEFAULT);
+  final List<TextFormat> formats;
+  final List<TextColor> colors;
+  final String characters;
+
+  static CharacterAndFormatSet of(final List<CharacterAndFormat> pairs) {
+    final int size = pairs.size();
+    final List<TextColor> colors = new ArrayList<>();
+    final List<TextFormat> formats = new ArrayList<>(size);
+    final StringBuilder characters = new StringBuilder(size);
+    for (int i = 0; i < size; i++) {
+      final CharacterAndFormat pair = pairs.get(i);
+      characters.append(pair.character());
+      final TextFormat format = pair.format();
+      formats.add(format);
+      if (format instanceof TextColor) {
+        colors.add((TextColor) format);
+      }
+    }
+    if (formats.size() != characters.length()) {
+      throw new IllegalStateException("formats length differs from characters length");
+    }
+    return new CharacterAndFormatSet(Collections.unmodifiableList(formats), Collections.unmodifiableList(colors), characters.toString());
+  }
+
+  CharacterAndFormatSet(final List<TextFormat> formats, final List<TextColor> colors, final String characters) {
+    this.formats = formats;
+    this.colors = colors;
+    this.characters = characters;
+  }
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatSet.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatSet.java
@@ -30,7 +30,7 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextFormat;
 
 final class CharacterAndFormatSet {
-  static final CharacterAndFormatSet DEFAULT = of(CharacterAndFormat.DEFAULT);
+  static final CharacterAndFormatSet DEFAULT = of(CharacterAndFormat.DEFAULTS);
   final List<TextFormat> formats;
   final List<TextColor> colors;
   final String characters;

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -260,12 +260,13 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
     @NotNull Builder flattener(final @NotNull ComponentFlattener flattener);
 
     /**
+     * Sets the formats to use.
      *
-     * @param characterAndFormats
-     * @return
+     * @param formats the formats
+     * @return this builder
      * @since 4.14.0
      */
-    @NotNull Builder characterAndFormats(final @NotNull List<CharacterAndFormat> characterAndFormats);
+    @NotNull Builder formats(final @NotNull List<CharacterAndFormat> formats);
 
     /**
      * Builds the serializer.

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.serializer.legacy;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import net.kyori.adventure.builder.AbstractBuilder;
@@ -257,6 +258,14 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @since 4.7.0
      */
     @NotNull Builder flattener(final @NotNull ComponentFlattener flattener);
+
+    /**
+     *
+     * @param characterAndFormats
+     * @return
+     * @since 4.14.0
+     */
+    @NotNull Builder characterAndFormats(final @NotNull List<CharacterAndFormat> characterAndFormats);
 
     /**
      * Builds the serializer.

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -163,7 +163,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     return format instanceof TextColor && !(format instanceof NamedTextColor);
   }
 
-  private String toLegacyCode(TextFormat format) {
+  private @Nullable String toLegacyCode(TextFormat format) {
     if (isHexTextColor(format)) {
       final TextColor color = (TextColor) format;
       if (this.hexColours) {
@@ -186,6 +186,10 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
       }
     }
     final int index = this.formats.formats.indexOf(format);
+    if (index == -1) {
+      // this format was removed from the formats list
+      return null;
+    }
     return Character.toString(this.formats.characters.charAt(index));
   }
 
@@ -334,7 +338,11 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
 
     void append(final @NotNull TextFormat format) {
       if (this.lastWritten != format) {
-        this.sb.append(LegacyComponentSerializerImpl.this.character).append(LegacyComponentSerializerImpl.this.toLegacyCode(format));
+        final String legacyCode = LegacyComponentSerializerImpl.this.toLegacyCode(format);
+        if (legacyCode == null) {
+          return;
+        }
+        this.sb.append(LegacyComponentSerializerImpl.this.character).append(legacyCode);
       }
       this.lastWritten = format;
     }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -180,9 +180,11 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
           return this.hexCharacter + hex;
         }
       } else {
-        // if we are not using hex colours, then convert the hex colour
-        // to the "nearest" possible named/standard text colour
-        format = TextColor.nearestColorTo(this.formats.colors, color);
+        if (!(color instanceof NamedTextColor)) {
+          // if we are not using hex colours, then convert the hex colour
+          // to the "nearest" possible named/standard text colour
+          format = TextColor.nearestColorTo(this.formats.colors, color);
+        }
       }
     }
     final int index = this.formats.formats.indexOf(format);

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/Reset.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/Reset.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.legacy;
+
+import net.kyori.adventure.text.format.TextFormat;
+
+/**
+ * The reset directive.
+ *
+ * @since 4.14.0
+ */
+public enum Reset implements TextFormat {
+  INSTANCE;
+}

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -323,7 +323,7 @@ class LegacyComponentSerializerTest {
 
   @Test
   void testNullTextFormat() {
-    final List<CharacterAndFormat> formats = new ArrayList<>(CharacterAndFormat.DEFAULTS);
+    final List<CharacterAndFormat> formats = new ArrayList<>(CharacterAndFormat.defaults());
     formats.remove(CharacterAndFormat.STRIKETHROUGH);
     final LegacyComponentSerializer serializer = LegacyComponentSerializer.legacySection().toBuilder().formats(formats).build();
 

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -324,7 +324,7 @@ class LegacyComponentSerializerTest {
   @Test
   void testNullTextFormat() {
     final List<CharacterAndFormat> formats = new ArrayList<>(CharacterAndFormat.DEFAULTS);
-    formats.removeIf(format -> format.character() == 'm');
+    formats.remove(CharacterAndFormat.STRIKETHROUGH);
     final LegacyComponentSerializer serializer = LegacyComponentSerializer.legacySection().toBuilder().formats(formats).build();
 
     final Component strikethough = Component.text("Hello World", Style.style(TextDecoration.STRIKETHROUGH));

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -23,6 +23,8 @@
  */
 package net.kyori.adventure.text.serializer.legacy;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -317,5 +319,16 @@ class LegacyComponentSerializerTest {
     final Component deserialized = LegacyComponentSerializer.legacyAmpersand().deserialize(text);
 
     assertEquals(Component.text(text), deserialized);
+  }
+
+  @Test
+  void testNullTextFormat() {
+    final List<CharacterAndFormat> formats = new ArrayList<>(CharacterAndFormat.DEFAULT);
+    formats.removeIf(format -> format.character() == 'm');
+    final LegacyComponentSerializer serializer = LegacyComponentSerializer.legacySection().toBuilder().formats(formats).build();
+
+    final Component strikethough = Component.text("Hello World", Style.style(TextDecoration.STRIKETHROUGH));
+    final String serialized = serializer.serialize(strikethough);
+    assertEquals(serialized, "Hello World");
   }
 }

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -323,7 +323,7 @@ class LegacyComponentSerializerTest {
 
   @Test
   void testNullTextFormat() {
-    final List<CharacterAndFormat> formats = new ArrayList<>(CharacterAndFormat.DEFAULT);
+    final List<CharacterAndFormat> formats = new ArrayList<>(CharacterAndFormat.DEFAULTS);
     formats.removeIf(format -> format.character() == 'm');
     final LegacyComponentSerializer serializer = LegacyComponentSerializer.legacySection().toBuilder().formats(formats).build();
 


### PR DESCRIPTION
Supersedes #903 

Bedrock already has one new "legacy" color code, "Minecoin gold". In 1.19.80, there will be a handful of new legacy color codes. The primary goal of this PR is to allow LegacyComponentSerializer usages to take advantage of these new color codes for hex color downsampling. While designing this PR, I also wanted to allow other non-color codes to be modified, since Bedrock doesn't have underscore and obfuscation. We already work around this, however, so this feature is not important to the PR.