### PR TITLE
fix(api): Flatten ScoreComponent to empty string if score value is null

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattenerImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattenerImpl.java
@@ -47,7 +47,11 @@ final class ComponentFlattenerImpl implements ComponentFlattener {
   @SuppressWarnings("deprecation")
   static final ComponentFlattener BASIC = new BuilderImpl()
     .mapper(KeybindComponent.class, component -> component.keybind()) // IntelliJ is wrong here, this is fine
-    .mapper(ScoreComponent.class, ScoreComponent::value) // Removed in Vanilla 1.16, but we keep it for backwards compat
+    .mapper(ScoreComponent.class, component -> {
+      // Removed in Vanilla 1.16, but we keep it for backwards compat
+      final @Nullable String value = component.value();
+      return value != null ? value : "";
+    })
     .mapper(SelectorComponent.class, SelectorComponent::pattern)
     .mapper(TextComponent.class, TextComponent::content)
     .mapper(TranslatableComponent.class, component -> {


### PR DESCRIPTION
The ScoreComponent value is nullable. When the value is null (which it always should be for 1.16+) two problems occur:
- `FlattenerListener#component(@NotNull String text)` implemented by the LegacyTextSerializer rightfully throws an NPE.
- PlainTextSerializer serializes the ScoreComponent as a string literal `null`, unlike the vanilla client.

This attempts to resemble client behaviour more closely:
- `<1.16`: Display the score value, otherwise empty text.
- `1.16+`: Always display empty text. This PR does not match that, as it will still display the value regardless of game version.


Closes #953