### PR TITLE
feature: Add a new standard join configuration for spaces

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/JoinConfiguration.java
+++ b/api/src/main/java/net/kyori/adventure/text/JoinConfiguration.java
@@ -125,7 +125,7 @@ public interface JoinConfiguration extends Buildable<JoinConfiguration, JoinConf
    * creating the following output: 'hello there'.</p>
    *
    * @return the join configuration
-   * @since 4.14.0
+   * @since 4.15.0
    */
   static @NotNull JoinConfiguration spaces() {
     return JoinConfigurationImpl.STANDARD_SPACES;

--- a/api/src/main/java/net/kyori/adventure/text/JoinConfiguration.java
+++ b/api/src/main/java/net/kyori/adventure/text/JoinConfiguration.java
@@ -119,6 +119,19 @@ public interface JoinConfiguration extends Buildable<JoinConfiguration, JoinConf
   }
 
   /**
+   * Provides a join configuration with no prefix or suffix that simply joins the components together using the {@link Component#space()} component.
+   *
+   * <p>A purely text based example of this syntax, without introducing the concepts of components, would join the two strings 'hello' and 'there' together,
+   * creating the following output: 'hello there'.</p>
+   *
+   * @return the join configuration
+   * @since 4.14.0
+   */
+  static @NotNull JoinConfiguration spaces() {
+    return JoinConfigurationImpl.STANDARD_SPACES;
+  }
+
+  /**
    * Provides a join configuration with no prefix or suffix that simply joins the components together using a single comma, matching a CSV like layout.
    *
    * <p>A purely text based example of this syntax, without introducing the concepts of components, would join the two strings 'hello' and 'there' together,

--- a/api/src/main/java/net/kyori/adventure/text/JoinConfigurationImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/JoinConfigurationImpl.java
@@ -41,6 +41,7 @@ final class JoinConfigurationImpl implements JoinConfiguration {
   static final JoinConfigurationImpl NULL = new JoinConfigurationImpl();
 
   static final JoinConfiguration STANDARD_NEW_LINES = JoinConfiguration.separator(Component.newline());
+  static final JoinConfiguration STANDARD_SPACES = JoinConfiguration.separator(Component.space());
   static final JoinConfiguration STANDARD_COMMA_SEPARATED = JoinConfiguration.separator(Component.text(","));
   static final JoinConfiguration STANDARD_COMMA_SPACE_SEPARATED = JoinConfiguration.separator(Component.text(", "));
   static final JoinConfiguration STANDARD_ARRAY_LIKE = JoinConfiguration.builder()

--- a/api/src/test/java/net/kyori/adventure/text/JoinTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/JoinTest.java
@@ -277,6 +277,21 @@ class JoinTest {
   }
 
   @Test
+  final void testStandardJoinConfigurationsSpaces() {
+    final Component result = Component.join(JoinConfiguration.spaces(), Component.text("line 1"), Component.text("line 2"), Component.text("line 3"));
+    assertEquals(
+      Component.text()
+        .append(Component.text("line 1"))
+        .append(Component.space())
+        .append(Component.text("line 2"))
+        .append(Component.space())
+        .append(Component.text("line 3"))
+        .build(),
+      result
+    );
+  }
+
+  @Test
   final void testStandardJoinConfigurationsCommas() {
     final Component result = Component.join(JoinConfiguration.commas(false), Component.text("line 1"), Component.text("line 2"), Component.text("line 3"));
     assertEquals(


### PR DESCRIPTION
Adds `JoinConfiguration.spaces()`, which is equivalent to `JoinConfiguration.separator(Component.space())`. Unit tests and docs are both provided.