### PR TITLE
feat(nbt): Implement nameless binary serialization

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
@@ -250,6 +250,8 @@ public final class BinaryTagIO {
      *
      * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #read(Path, Compression)}.</p>
      *
+     * <p>The root name field is discarded.</p>
+     *
      * @param path the path
      * @return a binary tag
      * @throws IOException if an exception was encountered while reading the tag
@@ -261,6 +263,8 @@ public final class BinaryTagIO {
 
     /**
      * Reads a binary tag from {@code path} with a {@code compression} type.
+     *
+     * <p>The root name field is discarded.</p>
      *
      * @param path the path
      * @param compression the compression type
@@ -275,6 +279,8 @@ public final class BinaryTagIO {
      *
      * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #read(InputStream, Compression)}.</p>
      *
+     * <p>The root name field is discarded.</p>
+     *
      * @param input the input stream
      * @return a binary tag
      * @throws IOException if an exception was encountered while reading the tag
@@ -287,6 +293,8 @@ public final class BinaryTagIO {
     /**
      * Reads a binary tag from {@code input} with a {@code compression} type.
      *
+     * <p>The root name field is discarded.</p>
+     *
      * @param input the input stream
      * @param compression the compression type
      * @return a binary tag
@@ -297,6 +305,8 @@ public final class BinaryTagIO {
 
     /**
      * Reads a binary tag from {@code input}.
+     *
+     * <p>The root name field is discarded.</p>
      *
      * @param input the input stream
      * @return a binary tag
@@ -310,12 +320,13 @@ public final class BinaryTagIO {
      *
      * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #read(Path, Compression)}.</p>
      *
-     * <p>Doesn't read a name from the {@link Path}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't read a root name from the {@link Path} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param path the path
      * @return a binary tag
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     default @NotNull CompoundBinaryTag readNameless(final @NotNull Path path) throws IOException {
       return this.readNameless(path, Compression.NONE);
@@ -324,13 +335,14 @@ public final class BinaryTagIO {
     /**
      * Reads a binary tag from {@code path} with a {@code compression} type.
      *
-     * <p>Doesn't read a name from the {@link Path}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't read a root name from the {@link Path} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param path the path
      * @param compression the compression type
      * @return a binary tag
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     @NotNull CompoundBinaryTag readNameless(final @NotNull Path path, final @NotNull Compression compression) throws IOException;
 
@@ -339,12 +351,13 @@ public final class BinaryTagIO {
      *
      * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #read(InputStream, Compression)}.</p>
      *
-     * <p>Doesn't read a name from the {@link InputStream}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't read a root name from the {@link InputStream} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param input the input stream
      * @return a binary tag
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     default @NotNull CompoundBinaryTag readNameless(final @NotNull InputStream input) throws IOException {
       return this.readNameless(input, Compression.NONE);
@@ -353,25 +366,27 @@ public final class BinaryTagIO {
     /**
      * Reads a binary tag from {@code input} with a {@code compression} type.
      *
-     * <p>Doesn't read a name from the {@link InputStream}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't read a root name from the {@link InputStream} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param input the input stream
      * @param compression the compression type
      * @return a binary tag
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     @NotNull CompoundBinaryTag readNameless(final @NotNull InputStream input, final @NotNull Compression compression) throws IOException;
 
     /**
      * Reads a binary tag from {@code input}.
      *
-     * <p>Doesn't read a name from the {@link DataInput}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't read a root name from the {@link DataInput} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param input the input stream
      * @return a binary tag
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     @NotNull CompoundBinaryTag readNameless(final @NotNull DataInput input) throws IOException;
 
@@ -447,6 +462,8 @@ public final class BinaryTagIO {
      *
      * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #write(CompoundBinaryTag, Path, Compression)}.</p>
      *
+     * <p>An empty root name is written.</p>
+     *
      * @param tag the tag to write
      * @param path the path
      * @throws IOException if an exception was encountered while reading the tag
@@ -458,6 +475,8 @@ public final class BinaryTagIO {
 
     /**
      * Writes a binary tag to {@code path} with a {@code compression} type.
+     *
+     * <p>An empty root name is written.</p>
      *
      * @param tag the tag to write
      * @param path the path
@@ -472,6 +491,8 @@ public final class BinaryTagIO {
      *
      * <p>This is the equivalent of passing {@link Compression#NONE} as the second parameter to {@link #write(CompoundBinaryTag, OutputStream, Compression)}.</p>
      *
+     * <p>An empty root name is written.</p>
+     *
      * @param tag the tag to write
      * @param output the output stream
      * @throws IOException if an exception was encountered while reading the tag
@@ -484,6 +505,8 @@ public final class BinaryTagIO {
     /**
      * Writes a binary tag to {@code output} with a {@code compression} type.
      *
+     * <p>An empty root name is written.</p>
+     *
      * @param tag the tag to write
      * @param output the output stream
      * @param compression the compression type
@@ -494,6 +517,8 @@ public final class BinaryTagIO {
 
     /**
      * Writes a binary tag to {@code output}.
+     *
+     * <p>An empty root name is written.</p>
      *
      * @param tag the tag to write
      * @param output the output
@@ -507,12 +532,13 @@ public final class BinaryTagIO {
      *
      * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #write(CompoundBinaryTag, Path, Compression)}.</p>
      *
-     * <p>Doesn't write a name to the {@link Path}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't write a root name to the {@link Path} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param tag the tag to write
      * @param path the path
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     default void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull Path path) throws IOException {
       this.writeNameless(tag, path, Compression.NONE);
@@ -521,13 +547,14 @@ public final class BinaryTagIO {
     /**
      * Writes a binary tag to {@code path} with a {@code compression} type.
      *
-     * <p>Doesn't write a name to the {@link Path}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't write a root name to the {@link Path} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param tag the tag to write
      * @param path the path
      * @param compression the compression type
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final @NotNull Compression compression) throws IOException;
 
@@ -536,12 +563,13 @@ public final class BinaryTagIO {
      *
      * <p>This is the equivalent of passing {@link Compression#NONE} as the second parameter to {@link #write(CompoundBinaryTag, OutputStream, Compression)}.</p>
      *
-     * <p>Doesn't write a name to the {@link OutputStream}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't write a root name to the {@link OutputStream} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param tag the tag to write
      * @param output the output stream
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     default void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output) throws IOException {
       this.writeNameless(tag, output, Compression.NONE);
@@ -550,25 +578,27 @@ public final class BinaryTagIO {
     /**
      * Writes a binary tag to {@code output} with a {@code compression} type.
      *
-     * <p>Doesn't write a name to the {@link OutputStream}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't write a root name to the {@link OutputStream} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param tag the tag to write
      * @param output the output stream
      * @param compression the compression type
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final @NotNull Compression compression) throws IOException;
 
     /**
      * Writes a binary tag to {@code output}.
      *
-     * <p>Doesn't write a name to the {@link DataOutput}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     * <p>Doesn't write a root name to the {@link DataOutput} at all, to match the wire protocol in modern game versions.</p>
      *
      * @param tag the tag to write
      * @param output the output
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.15.0
+     * @sinceMinecraft 1.20.2
      */
     void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
@@ -306,6 +306,76 @@ public final class BinaryTagIO {
     @NotNull CompoundBinaryTag read(final @NotNull DataInput input) throws IOException;
 
     /**
+     * Reads a binary tag from {@code path}.
+     *
+     * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #read(Path, Compression)}.</p>
+     *
+     * <p>Doesn't read a name from the {@link Path}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param path the path
+     * @return a binary tag
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    default @NotNull CompoundBinaryTag readNameless(final @NotNull Path path) throws IOException {
+      return this.readNameless(path, Compression.NONE);
+    }
+
+    /**
+     * Reads a binary tag from {@code path} with a {@code compression} type.
+     *
+     * <p>Doesn't read a name from the {@link Path}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param path the path
+     * @param compression the compression type
+     * @return a binary tag
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    @NotNull CompoundBinaryTag readNameless(final @NotNull Path path, final @NotNull Compression compression) throws IOException;
+
+    /**
+     * Reads a binary tag from {@code input}.
+     *
+     * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #read(InputStream, Compression)}.</p>
+     *
+     * <p>Doesn't read a name from the {@link InputStream}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param input the input stream
+     * @return a binary tag
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    default @NotNull CompoundBinaryTag readNameless(final @NotNull InputStream input) throws IOException {
+      return this.readNameless(input, Compression.NONE);
+    }
+
+    /**
+     * Reads a binary tag from {@code input} with a {@code compression} type.
+     *
+     * <p>Doesn't read a name from the {@link InputStream}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param input the input stream
+     * @param compression the compression type
+     * @return a binary tag
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    @NotNull CompoundBinaryTag readNameless(final @NotNull InputStream input, final @NotNull Compression compression) throws IOException;
+
+    /**
+     * Reads a binary tag from {@code input}.
+     *
+     * <p>Doesn't read a name from the {@link DataInput}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param input the input stream
+     * @return a binary tag
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    @NotNull CompoundBinaryTag readNameless(final @NotNull DataInput input) throws IOException;
+
+    /**
      * Reads a binary tag, with a name, from {@code path}.
      *
      * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #readNamed(Path, Compression)}.</p>
@@ -431,6 +501,76 @@ public final class BinaryTagIO {
      * @since 4.4.0
      */
     void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException;
+
+    /**
+     * Writes a binary tag to {@code path} with a {@code compression} type.
+     *
+     * <p>This is the equivalent of passing {@code Compression#NONE} as the second parameter to {@link #write(CompoundBinaryTag, Path, Compression)}.</p>
+     *
+     * <p>Doesn't write a name to the {@link Path}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param tag the tag to write
+     * @param path the path
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    default void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull Path path) throws IOException {
+      this.writeNameless(tag, path, Compression.NONE);
+    }
+
+    /**
+     * Writes a binary tag to {@code path} with a {@code compression} type.
+     *
+     * <p>Doesn't write a name to the {@link Path}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param tag the tag to write
+     * @param path the path
+     * @param compression the compression type
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final @NotNull Compression compression) throws IOException;
+
+    /**
+     * Writes a binary tag to {@code output}.
+     *
+     * <p>This is the equivalent of passing {@link Compression#NONE} as the second parameter to {@link #write(CompoundBinaryTag, OutputStream, Compression)}.</p>
+     *
+     * <p>Doesn't write a name to the {@link OutputStream}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param tag the tag to write
+     * @param output the output stream
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    default void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output) throws IOException {
+      this.writeNameless(tag, output, Compression.NONE);
+    }
+
+    /**
+     * Writes a binary tag to {@code output} with a {@code compression} type.
+     *
+     * <p>Doesn't write a name to the {@link OutputStream}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param tag the tag to write
+     * @param output the output stream
+     * @param compression the compression type
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final @NotNull Compression compression) throws IOException;
+
+    /**
+     * Writes a binary tag to {@code output}.
+     *
+     * <p>Doesn't write a name to the {@link DataOutput}, as changed by mojang in the network protocol since 23w31a (1.20.2 snapshot).</p>
+     *
+     * @param tag the tag to write
+     * @param output the output
+     * @throws IOException if an exception was encountered while reading the tag
+     * @since 4.15.0
+     */
+    void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException;
 
     /**
      * Writes a binary tag, with a name, to {@code path}.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
@@ -62,14 +62,39 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
 
   @Override
   public @NotNull CompoundBinaryTag read(@NotNull DataInput input) throws IOException {
+    return this.read(input, false);
+  }
+
+  private @NotNull CompoundBinaryTag read(@NotNull DataInput input, boolean nameless) throws IOException {
     if (!(input instanceof TrackingDataInput)) {
       input = new TrackingDataInput(input, this.maxBytes);
     }
 
     final BinaryTagType<? extends BinaryTag> type = BinaryTagType.binaryTagType(input.readByte());
     requireCompound(type);
-    input.skipBytes(input.readUnsignedShort()); // read empty name
+    if (!nameless) {
+      input.skipBytes(input.readUnsignedShort()); // read empty name
+    }
     return BinaryTagTypes.COMPOUND.read(input);
+  }
+
+  @Override
+  public @NotNull CompoundBinaryTag readNameless(final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+    try (final InputStream is = Files.newInputStream(path)) {
+      return this.readNameless(is, compression);
+    }
+  }
+
+  @Override
+  public @NotNull CompoundBinaryTag readNameless(final @NotNull InputStream input, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+    try (final DataInputStream dis = new DataInputStream(new BufferedInputStream(compression.decompress(closeShield(input))))) {
+      return this.readNameless((DataInput) dis);
+    }
+  }
+
+  @Override
+  public @NotNull CompoundBinaryTag readNameless(@NotNull DataInput input) throws IOException {
+    return this.read(input, true);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
@@ -62,17 +62,17 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
 
   @Override
   public @NotNull CompoundBinaryTag read(final @NotNull DataInput input) throws IOException {
-    return this.read(input, false);
+    return this.read(input, true);
   }
 
-  private @NotNull CompoundBinaryTag read(@NotNull DataInput input, final boolean nameless) throws IOException {
+  private @NotNull CompoundBinaryTag read(@NotNull DataInput input, final boolean named) throws IOException {
     if (!(input instanceof TrackingDataInput)) {
       input = new TrackingDataInput(input, this.maxBytes);
     }
 
     final BinaryTagType<? extends BinaryTag> type = BinaryTagType.binaryTagType(input.readByte());
     requireCompound(type);
-    if (!nameless) {
+    if (named) {
       input.skipBytes(input.readUnsignedShort()); // read empty name
     }
     return BinaryTagTypes.COMPOUND.read(input);
@@ -94,7 +94,7 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
 
   @Override
   public @NotNull CompoundBinaryTag readNameless(final @NotNull DataInput input) throws IOException {
-    return this.read(input, true);
+    return this.read(input, false);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
@@ -61,11 +61,11 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
   }
 
   @Override
-  public @NotNull CompoundBinaryTag read(@NotNull DataInput input) throws IOException {
+  public @NotNull CompoundBinaryTag read(final @NotNull DataInput input) throws IOException {
     return this.read(input, false);
   }
 
-  private @NotNull CompoundBinaryTag read(@NotNull DataInput input, boolean nameless) throws IOException {
+  private @NotNull CompoundBinaryTag read(@NotNull DataInput input, final boolean nameless) throws IOException {
     if (!(input instanceof TrackingDataInput)) {
       input = new TrackingDataInput(input, this.maxBytes);
     }
@@ -93,7 +93,7 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
   }
 
   @Override
-  public @NotNull CompoundBinaryTag readNameless(@NotNull DataInput input) throws IOException {
+  public @NotNull CompoundBinaryTag readNameless(final @NotNull DataInput input) throws IOException {
     return this.read(input, true);
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
@@ -54,12 +54,12 @@ final class BinaryTagWriterImpl implements BinaryTagIO.Writer {
 
   @Override
   public void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException {
-    this.write(tag, output, false);
+    this.write(tag, output, true);
   }
 
-  private void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output, final boolean nameless) throws IOException {
+  private void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output, final boolean named) throws IOException {
     output.writeByte(BinaryTagTypes.COMPOUND.id());
-    if (!nameless) {
+    if (named) {
       output.writeUTF(""); // write empty name
     }
     BinaryTagTypes.COMPOUND.write(tag, output);
@@ -81,7 +81,7 @@ final class BinaryTagWriterImpl implements BinaryTagIO.Writer {
 
   @Override
   public void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException {
-    this.write(tag, output, true);
+    this.write(tag, output, false);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
@@ -57,7 +57,7 @@ final class BinaryTagWriterImpl implements BinaryTagIO.Writer {
     this.write(tag, output, false);
   }
 
-  private void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output, boolean nameless) throws IOException {
+  private void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output, final boolean nameless) throws IOException {
     output.writeByte(BinaryTagTypes.COMPOUND.id());
     if (!nameless) {
       output.writeUTF(""); // write empty name

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
@@ -54,9 +54,34 @@ final class BinaryTagWriterImpl implements BinaryTagIO.Writer {
 
   @Override
   public void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException {
+    this.write(tag, output, false);
+  }
+
+  private void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output, boolean nameless) throws IOException {
     output.writeByte(BinaryTagTypes.COMPOUND.id());
-    output.writeUTF(""); // write empty name
+    if (!nameless) {
+      output.writeUTF(""); // write empty name
+    }
     BinaryTagTypes.COMPOUND.write(tag, output);
+  }
+
+  @Override
+  public void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+    try (final OutputStream os = Files.newOutputStream(path)) {
+      this.writeNameless(tag, os, compression);
+    }
+  }
+
+  @Override
+  public void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+    try (final DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(compression.compress(closeShield(output))))) {
+      this.writeNameless(tag, (DataOutput) dos);
+    }
+  }
+
+  @Override
+  public void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException {
+    this.write(tag, output, true);
   }
 
   @Override

--- a/nbt/src/test/java/net/kyori/adventure/nbt/BinaryTagIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/BinaryTagIOTest.java
@@ -60,4 +60,14 @@ class BinaryTagIOTest {
     BinaryTagIO.writer().write(tag, output, BinaryTagIO.Compression.ZLIB);
     assertEquals(tag, BinaryTagIO.reader().read(new ByteArrayInputStream(output.toByteArray()), BinaryTagIO.Compression.ZLIB));
   }
+
+  @Test
+  void testNamelessWriteAndReadNoCompression() throws IOException {
+    final CompoundBinaryTag tag = CompoundBinaryTag.builder()
+      .putString("name", "test")
+      .build();
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    BinaryTagIO.writer().writeNameless(tag, output);
+    assertEquals(tag, BinaryTagIO.reader().readNameless(new ByteArrayInputStream(output.toByteArray())));
+  }
 }


### PR DESCRIPTION
Implements serialization of nameless compound tags. Mojang has removed these already useless names in 23w31a (1.20.2 snapshot) and this adds API for reading/writing these "nameless" compound tags.

---

Not sure about how it is exposed, could also be solved by specifying a boolean for `read`/`write` methods