### PR TITLE
feat(api): Expand the supported resource pack operations for 1.20.3

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -41,6 +41,7 @@ import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.resource.ResourcePackInfo;
 import net.kyori.adventure.resource.ResourcePackInfoLike;
 import net.kyori.adventure.resource.ResourcePackRequest;
+import net.kyori.adventure.resource.ResourcePackRequestLike;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
 import net.kyori.adventure.text.Component;
@@ -734,7 +735,33 @@ public interface Audience extends Pointered {
    * @see ResourcePackInfo
    * @since 4.15.0
    */
+  @ForwardingAudienceOverrideNotRequired
+  default void sendResourcePacks(final @NotNull ResourcePackRequestLike request) {
+    this.sendResourcePacks(request.asResourcePackRequest());
+  }
+
+  /**
+   * Sends a request to apply resource packs to this audience.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, all requests behave as if {@link ResourcePackRequest#replace()} is set to {@code true}.</p>
+   *
+   * @param request the resource pack request
+   * @see ResourcePackInfo
+   * @since 4.15.0
+   */
   default void sendResourcePacks(final @NotNull ResourcePackRequest request) {
+  }
+
+  /**
+   * Clear resource packs with the IDs used in the provided requests if they are present.
+   *
+   * @param request the request used to originally apply the packs
+   * @since 4.15.0
+   * @sinceMinecraft 1.20.3
+   */
+  @ForwardingAudienceOverrideNotRequired
+  default void removeResourcePacks(final @NotNull ResourcePackRequestLike request) {
+    this.removeResourcePacks(request.asResourcePackRequest());
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -721,12 +721,12 @@ public interface Audience extends Pointered {
    */
   @SuppressWarnings("checkstyle:MethodName")
   @ForwardingAudienceOverrideNotRequired
-  default void setResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  default void setResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
     final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
     for (int i = 0; i < others.length; i++) {
       otherReqs[i] = others[i].asResourcePackRequest();
     }
-    this.setResourcePack(request.asResourcePackRequest(), otherReqs);
+    this.setResourcePacks(request.asResourcePackRequest(), otherReqs);
   }
 
   /**
@@ -740,7 +740,7 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    */
   @SuppressWarnings("checkstyle:MethodName")
-  default void setResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  default void setResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
   }
 
   /**
@@ -756,12 +756,12 @@ public interface Audience extends Pointered {
    */
   @SuppressWarnings("checkstyle:MethodName")
   @ForwardingAudienceOverrideNotRequired
-  default void setResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  default void setResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
     final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
     for (int i = 0; i < others.length; i++) {
       otherReqs[i] = others[i].asResourcePackRequest();
     }
-    this.setResourcePack(cb, request.asResourcePackRequest(), otherReqs);
+    this.setResourcePacks(cb, request.asResourcePackRequest(), otherReqs);
   }
 
   /**
@@ -776,13 +776,13 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    */
   @SuppressWarnings("checkstyle:MethodName")
-  default void setResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  default void setResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
   }
 
   /**
    * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
    *
-   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequestLike, ResourcePackRequestLike...)}.</p>
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePacks(ResourcePackRequestLike, ResourcePackRequestLike...)}.</p>
    *
    * @param request the resource pack request
    * @param others other requests
@@ -790,31 +790,31 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  default void sendResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
     final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
     for (int i = 0; i < others.length; i++) {
       otherReqs[i] = others[i].asResourcePackRequest();
     }
-    this.sendResourcePack(request.asResourcePackRequest(), otherReqs);
+    this.sendResourcePacks(request.asResourcePackRequest(), otherReqs);
   }
 
   /**
    * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
    *
-   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequest, ResourcePackRequest...)}.</p>
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePacks(ResourcePackRequest, ResourcePackRequest...)}.</p>
    *
    * @param request the resource pack request
    * @param others other requests
    * @see ResourcePackRequest
    * @since 4.15.0
    */
-  default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  default void sendResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
   }
 
   /**
    * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
    *
-   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequestLike, ResourcePackRequestLike...)}.</p>
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePacks(ResourcePackRequestLike, ResourcePackRequestLike...)}.</p>
    *
    * @param cb a callback to be executed when resource pack events associated with this application are received
    * @param request the resource pack request
@@ -823,18 +823,18 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  default void sendResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
     final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
     for (int i = 0; i < others.length; i++) {
       otherReqs[i] = others[i].asResourcePackRequest();
     }
-    this.sendResourcePack(cb, request.asResourcePackRequest(), otherReqs);
+    this.sendResourcePacks(cb, request.asResourcePackRequest(), otherReqs);
   }
 
   /**
    * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
    *
-   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequest, ResourcePackRequest...)}.</p>
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePacks(ResourcePackRequest, ResourcePackRequest...)}.</p>
    *
    * @param cb a callback to be executed when resource pack events associated with this application are received
    * @param request the resource pack request
@@ -842,7 +842,7 @@ public interface Audience extends Pointered {
    * @see ResourcePackRequest
    * @since 4.15.0
    */
-  default void sendResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  default void sendResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
   }
 
   /**
@@ -854,12 +854,12 @@ public interface Audience extends Pointered {
    * @sinceMinecraft 1.20.3
    */
   @ForwardingAudienceOverrideNotRequired
-  default void removeResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  default void removeResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
     final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
     for (int i = 0; i < others.length; i++) {
       otherReqs[i] = others[i].asResourcePackRequest();
     }
-    this.removeResourcePack(request.asResourcePackRequest(), otherReqs);
+    this.removeResourcePacks(request.asResourcePackRequest(), otherReqs);
   }
 
   /**
@@ -872,12 +872,12 @@ public interface Audience extends Pointered {
    * @sinceMinecraft 1.20.3
    */
   @ForwardingAudienceOverrideNotRequired
-  default void removeResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  default void removeResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
     final UUID[] otherIds = new UUID[others.length];
     for (int i = 0; i < others.length; i++) {
       otherIds[i] = others[i].id();
     }
-    this.removeResourcePack(request.id(), otherIds);
+    this.removeResourcePacks(request.id(), otherIds);
   }
 
   /**
@@ -888,7 +888,7 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    * @sinceMinecraft 1.20.3
    */
-  default void removeResourcePack(final @NotNull UUID id, final @NotNull UUID@NotNull... others) {
+  default void removeResourcePacks(final @NotNull UUID id, final @NotNull UUID@NotNull... others) {
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -739,8 +739,10 @@ public interface Audience extends Pointered {
    * @see ResourcePackRequest
    * @since 4.15.0
    */
+  @ForwardingAudienceOverrideNotRequired
   @SuppressWarnings("checkstyle:MethodName")
   default void setResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+    this.setResourcePacks(ResourcePackCallback.noOp(), request, others);
   }
 
   /**
@@ -808,7 +810,9 @@ public interface Audience extends Pointered {
    * @see ResourcePackRequest
    * @since 4.15.0
    */
+  @ForwardingAudienceOverrideNotRequired
   default void sendResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+    this.sendResourcePacks(ResourcePackCallback.noOp(), request, others);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -37,6 +37,7 @@ import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.pointer.Pointered;
+import net.kyori.adventure.resource.ResourcePackCallback;
 import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.resource.ResourcePackRequestLike;
 import net.kyori.adventure.sound.Sound;
@@ -743,6 +744,42 @@ public interface Audience extends Pointered {
   }
 
   /**
+   * Sends resource pack requests to this audience, replacing any existing resource packs that might be present.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, only the first pack will be sent.</p>
+   *
+   * @param cb a callback to be executed when resource pack events associated with this application are received
+   * @param request the first resource pack request
+   * @param others other requests
+   * @see ResourcePackRequest
+   * @since 4.15.0
+   */
+  @SuppressWarnings("checkstyle:MethodName")
+  @ForwardingAudienceOverrideNotRequired
+  default void setResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+    final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
+    for (int i = 0; i < others.length; i++) {
+      otherReqs[i] = others[i].asResourcePackRequest();
+    }
+    this.setResourcePack(cb, request.asResourcePackRequest(), otherReqs);
+  }
+
+  /**
+   * Sends resource pack requests to this audience, replacing any resource packs that might be present.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, only the first pack will be sent.</p>
+   *
+   * @param cb a callback to be executed when resource pack events associated with this application are received
+   * @param request the resource pack request
+   * @param others other requests
+   * @see ResourcePackRequest
+   * @since 4.15.0
+   */
+  @SuppressWarnings("checkstyle:MethodName")
+  default void setResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  }
+
+  /**
    * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
    *
    * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequestLike, ResourcePackRequestLike...)}.</p>
@@ -772,6 +809,40 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    */
   default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  }
+
+  /**
+   * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequestLike, ResourcePackRequestLike...)}.</p>
+   *
+   * @param cb a callback to be executed when resource pack events associated with this application are received
+   * @param request the resource pack request
+   * @param others other requests
+   * @see ResourcePackRequest
+   * @since 4.15.0
+   */
+  @ForwardingAudienceOverrideNotRequired
+  default void sendResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+    final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
+    for (int i = 0; i < others.length; i++) {
+      otherReqs[i] = others[i].asResourcePackRequest();
+    }
+    this.sendResourcePack(cb, request.asResourcePackRequest(), otherReqs);
+  }
+
+  /**
+   * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequest, ResourcePackRequest...)}.</p>
+   *
+   * @param cb a callback to be executed when resource pack events associated with this application are received
+   * @param request the resource pack request
+   * @param others other requests
+   * @see ResourcePackRequest
+   * @since 4.15.0
+   */
+  default void sendResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.audience;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collector;
@@ -708,24 +709,122 @@ public interface Audience extends Pointered {
   // ------------------------
 
   /**
-   * Sends a resource pack request to this audience.
+   * Sends resource pack requests to this audience, replacing any existing resource packs that might be present.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, only the first pack will be sent.</p>
+   *
+   * @param request the first resource pack request
+   * @param others other requests
+   * @see ResourcePackRequest
+   * @since 4.15.0
+   */
+  @SuppressWarnings("checkstyle:MethodName")
+  @ForwardingAudienceOverrideNotRequired
+  default void setResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+    final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
+    for (int i = 0; i < others.length; i++) {
+      otherReqs[i] = others[i].asResourcePackRequest();
+    }
+    this.setResourcePack(request.asResourcePackRequest(), otherReqs);
+  }
+
+  /**
+   * Sends resource pack requests to this audience, replacing any resource packs that might be present.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, only the first pack will be sent.</p>
    *
    * @param request the resource pack request
+   * @param others other requests
+   * @see ResourcePackRequest
+   * @since 4.15.0
+   */
+  @SuppressWarnings("checkstyle:MethodName")
+  default void setResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  }
+
+  /**
+   * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequestLike, ResourcePackRequestLike...)}.</p>
+   *
+   * @param request the resource pack request
+   * @param others other requests
    * @see ResourcePackRequest
    * @since 4.15.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendResourcePack(final @NotNull ResourcePackRequestLike request) {
-    this.sendResourcePack(request.asResourcePackRequest());
+  default void sendResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+    final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
+    for (int i = 0; i < others.length; i++) {
+      otherReqs[i] = others[i].asResourcePackRequest();
+    }
+    this.sendResourcePack(request.asResourcePackRequest(), otherReqs);
   }
 
   /**
-   * Sends a resource pack request to this audience.
+   * Sends resource pack requests to this audience, adding to any existing resource packs that might be present.
+   *
+   * <p>Multiple resource packs are only supported since 1.20.3. On older versions, this behaves identically to {@link #setResourcePack(ResourcePackRequest, ResourcePackRequest...)}.</p>
    *
    * @param request the resource pack request
+   * @param others other requests
    * @see ResourcePackRequest
    * @since 4.15.0
    */
-  default void sendResourcePack(final @NotNull ResourcePackRequest request) {
+  default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+  }
+
+  /**
+   * Clear resource packs with the IDs used in the provided requests if they are present.
+   *
+   * @param request the first request used to originally apply the pack
+   * @param others requests for other packs that should be removed
+   * @since 4.15.0
+   * @sinceMinecraft 1.20.3
+   */
+  @ForwardingAudienceOverrideNotRequired
+  default void removeResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+    final ResourcePackRequest[] otherReqs = new ResourcePackRequest[others.length];
+    for (int i = 0; i < others.length; i++) {
+      otherReqs[i] = others[i].asResourcePackRequest();
+    }
+    this.removeResourcePack(request.asResourcePackRequest(), otherReqs);
+  }
+
+  /**
+   * Clear resource packs with the IDs used in the provided requests if they are present.
+   * Clear a resource pack with id {@code id} if it is present for a certain user.
+   *
+   * @param request the first request used to originally apply the pack
+   * @param others requests for other packs that should be removed
+   * @since 4.15.0
+   * @sinceMinecraft 1.20.3
+   */
+  @ForwardingAudienceOverrideNotRequired
+  default void removeResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+    final UUID[] otherIds = new UUID[others.length];
+    for (int i = 0; i < others.length; i++) {
+      otherIds[i] = others[i].id();
+    }
+    this.removeResourcePack(request.id(), otherIds);
+  }
+
+  /**
+   * Clear resource packs with the provided ids if they are present.
+   *
+   * @param id the id
+   * @param others the ids of any additional resource packs
+   * @since 4.15.0
+   * @sinceMinecraft 1.20.3
+   */
+  default void removeResourcePack(final @NotNull UUID id, final @NotNull UUID@NotNull... others) {
+  }
+
+  /**
+   * Clear all server-provided resource packs that have been sent to this user.
+   *
+   * @since 4.15.0
+   */
+  default void clearResourcePacks() {
   }
 }

--- a/api/src/main/java/net/kyori/adventure/audience/Audiences.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audiences.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.function.Consumer;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import net.kyori.adventure.resource.ResourcePackCallback;
 import net.kyori.adventure.text.ComponentLike;
 import org.jetbrains.annotations.NotNull;
 
@@ -54,5 +55,13 @@ public final class Audiences {
    */
   public static @NotNull Consumer<? super Audience> sendingMessage(final @NotNull ComponentLike message) {
     return audience -> audience.sendMessage(message);
+  }
+
+  static @NotNull ResourcePackCallback unwrapCallback(final Audience forwarding, final Audience dest, final @NotNull ResourcePackCallback cb) {
+    if (cb == ResourcePackCallback.noOp()) return cb;
+
+    return (uuid, status, audience) -> {
+      cb.packEventReceived(uuid, status, audience == dest ? forwarding : audience);
+    };
   }
 }

--- a/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
@@ -33,8 +33,8 @@ import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.pointer.Pointer;
+import net.kyori.adventure.resource.ResourcePackInfoLike;
 import net.kyori.adventure.resource.ResourcePackRequest;
-import net.kyori.adventure.resource.ResourcePackRequestLike;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import org.jetbrains.annotations.Contract;
@@ -121,19 +121,15 @@ final class EmptyAudience implements Audience {
   }
 
   @Override
-  public void sendResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  public void sendResourcePacks(final @NotNull ResourcePackInfoLike request, final @NotNull ResourcePackInfoLike@NotNull... others) {
   }
 
   @Override
-  public void setResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike @NotNull ... others) {
+  public void removeResourcePacks(final @NotNull ResourcePackRequest request) {
   }
 
   @Override
-  public void removeResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
-  }
-
-  @Override
-  public void removeResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
+  public void removeResourcePacks(final @NotNull ResourcePackInfoLike request, final @NotNull ResourcePackInfoLike@NotNull... others) {
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
@@ -33,6 +33,7 @@ import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.pointer.Pointer;
+import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.resource.ResourcePackRequestLike;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
@@ -120,7 +121,19 @@ final class EmptyAudience implements Audience {
   }
 
   @Override
-  public void sendResourcePack(final @NotNull ResourcePackRequestLike request) {
+  public void sendResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  }
+
+  @Override
+  public void setResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike @NotNull ... others) {
+  }
+
+  @Override
+  public void removeResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  }
+
+  @Override
+  public void removeResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
@@ -121,19 +121,19 @@ final class EmptyAudience implements Audience {
   }
 
   @Override
-  public void sendResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  public void sendResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
   }
 
   @Override
-  public void setResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike @NotNull ... others) {
+  public void setResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike @NotNull ... others) {
   }
 
   @Override
-  public void removeResourcePack(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
+  public void removeResourcePacks(final @NotNull ResourcePackRequestLike request, final @NotNull ResourcePackRequestLike@NotNull... others) {
   }
 
   @Override
-  public void removeResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
+  public void removeResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -201,8 +202,23 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void sendResourcePack(final @NotNull ResourcePackRequest request) {
-    for (final Audience audience : this.audiences()) audience.sendResourcePack(request);
+  default void setResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest... others) {
+    for (final Audience audience : this.audiences()) audience.setResourcePack(request, others);
+  }
+
+  @Override
+  default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+    for (final Audience audience : this.audiences()) audience.sendResourcePack(request, others);
+  }
+
+  @Override
+  default void removeResourcePack(final @NotNull UUID id, final @NotNull UUID @NotNull ... others) {
+    for (final Audience audience : this.audiences()) audience.removeResourcePack(id, others);
+  }
+
+  @Override
+  default void clearResourcePacks() {
+    for (final Audience audience : this.audiences()) audience.clearResourcePacks();
   }
 
   /**
@@ -369,8 +385,23 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void sendResourcePack(final @NotNull ResourcePackRequest request) {
-      this.audience().sendResourcePack(request);
+    default void setResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest... others) {
+      this.audience().setResourcePack(request, others);
+    }
+
+    @Override
+    default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+      this.audience().sendResourcePack(request, others);
+    }
+
+    @Override
+    default void removeResourcePack(final @NotNull UUID id, final @NotNull UUID @NotNull ... others) {
+      this.audience().removeResourcePack(id, others);
+    }
+
+    @Override
+    default void clearResourcePacks() {
+      this.audience().clearResourcePacks();
     }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -39,7 +39,6 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.pointer.Pointers;
-import net.kyori.adventure.resource.ResourcePackCallback;
 import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
@@ -203,13 +202,8 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void setResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
-    for (final Audience audience : this.audiences()) audience.setResourcePacks(cb, request, others);
-  }
-
-  @Override
-  default void sendResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull ... others) {
-    for (final Audience audience : this.audiences()) audience.sendResourcePacks(cb, request, others);
+  default void sendResourcePacks(final @NotNull ResourcePackRequest request) {
+    for (final Audience audience : this.audiences()) audience.sendResourcePacks(request);
   }
 
   @Override
@@ -386,13 +380,8 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void setResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
-      this.audience().setResourcePacks(Audiences.unwrapCallback(this, this.audience(), cb), request, others);
-    }
-
-    @Override
-    default void sendResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
-      this.audience().sendResourcePacks(Audiences.unwrapCallback(this, this.audience(), cb), request, others);
+    default void sendResourcePacks(final @NotNull ResourcePackRequest request) {
+      this.audience().sendResourcePacks(request.callback(Audiences.unwrapCallback(this, this.audience(), request.callback())));
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -203,28 +203,28 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void setResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
-    for (final Audience audience : this.audiences()) audience.setResourcePack(request, others);
+  default void setResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+    for (final Audience audience : this.audiences()) audience.setResourcePacks(request, others);
   }
 
   @Override
-  default void setResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
-    for (final Audience audience : this.audiences()) audience.setResourcePack(cb, request, others);
+  default void setResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
+    for (final Audience audience : this.audiences()) audience.setResourcePacks(cb, request, others);
   }
 
   @Override
-  default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
-    for (final Audience audience : this.audiences()) audience.sendResourcePack(request, others);
+  default void sendResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+    for (final Audience audience : this.audiences()) audience.sendResourcePacks(request, others);
   }
 
   @Override
-  default void sendResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull ... others) {
-    for (final Audience audience : this.audiences()) audience.sendResourcePack(cb, request, others);
+  default void sendResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull ... others) {
+    for (final Audience audience : this.audiences()) audience.sendResourcePacks(cb, request, others);
   }
 
   @Override
-  default void removeResourcePack(final @NotNull UUID id, final @NotNull UUID @NotNull ... others) {
-    for (final Audience audience : this.audiences()) audience.removeResourcePack(id, others);
+  default void removeResourcePacks(final @NotNull UUID id, final @NotNull UUID @NotNull ... others) {
+    for (final Audience audience : this.audiences()) audience.removeResourcePacks(id, others);
   }
 
   @Override
@@ -396,28 +396,28 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void setResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest... others) {
-      this.audience().setResourcePack(request, others);
+    default void setResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest... others) {
+      this.audience().setResourcePacks(request, others);
     }
 
     @Override
-    default void setResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
-      this.audience().setResourcePack((uuid, status, audience) -> cb.packEventReceived(uuid, status, this), request, others);
+    default void setResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
+      this.audience().setResourcePacks((uuid, status, audience) -> cb.packEventReceived(uuid, status, this), request, others);
     }
 
     @Override
-    default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
-      this.audience().sendResourcePack(request, others);
+    default void sendResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
+      this.audience().sendResourcePacks(request, others);
     }
 
     @Override
-    default void sendResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
-      this.audience().sendResourcePack((uuid, status, audience) -> cb.packEventReceived(uuid, status, this), request, others);
+    default void sendResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
+      this.audience().sendResourcePacks((uuid, status, audience) -> cb.packEventReceived(uuid, status, this), request, others);
     }
 
     @Override
-    default void removeResourcePack(final @NotNull UUID id, final @NotNull UUID @NotNull ... others) {
-      this.audience().removeResourcePack(id, others);
+    default void removeResourcePacks(final @NotNull UUID id, final @NotNull UUID @NotNull ... others) {
+      this.audience().removeResourcePacks(id, others);
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -203,18 +203,8 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void setResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
-    for (final Audience audience : this.audiences()) audience.setResourcePacks(request, others);
-  }
-
-  @Override
   default void setResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
     for (final Audience audience : this.audiences()) audience.setResourcePacks(cb, request, others);
-  }
-
-  @Override
-  default void sendResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
-    for (final Audience audience : this.audiences()) audience.sendResourcePacks(request, others);
   }
 
   @Override
@@ -396,23 +386,13 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void setResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest... others) {
-      this.audience().setResourcePacks(request, others);
-    }
-
-    @Override
     default void setResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
-      this.audience().setResourcePacks((uuid, status, audience) -> cb.packEventReceived(uuid, status, this), request, others);
-    }
-
-    @Override
-    default void sendResourcePacks(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
-      this.audience().sendResourcePacks(request, others);
+      this.audience().setResourcePacks(Audiences.unwrapCallback(this, this.audience(), cb), request, others);
     }
 
     @Override
     default void sendResourcePacks(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
-      this.audience().sendResourcePacks((uuid, status, audience) -> cb.packEventReceived(uuid, status, this), request, others);
+      this.audience().sendResourcePacks(Audiences.unwrapCallback(this, this.audience(), cb), request, others);
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -39,6 +39,7 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.pointer.Pointers;
+import net.kyori.adventure.resource.ResourcePackCallback;
 import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
@@ -202,13 +203,23 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void setResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest... others) {
+  default void setResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
     for (final Audience audience : this.audiences()) audience.setResourcePack(request, others);
+  }
+
+  @Override
+  default void setResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
+    for (final Audience audience : this.audiences()) audience.setResourcePack(cb, request, others);
   }
 
   @Override
   default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
     for (final Audience audience : this.audiences()) audience.sendResourcePack(request, others);
+  }
+
+  @Override
+  default void sendResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull ... others) {
+    for (final Audience audience : this.audiences()) audience.sendResourcePack(cb, request, others);
   }
 
   @Override
@@ -390,8 +401,18 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
+    default void setResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
+      this.audience().setResourcePack((uuid, status, audience) -> cb.packEventReceived(uuid, status, this), request, others);
+    }
+
+    @Override
     default void sendResourcePack(final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest@NotNull... others) {
       this.audience().sendResourcePack(request, others);
+    }
+
+    @Override
+    default void sendResourcePack(final @NotNull ResourcePackCallback cb, final @NotNull ResourcePackRequest request, final @NotNull ResourcePackRequest @NotNull ... others) {
+      this.audience().sendResourcePack((uuid, status, audience) -> cb.packEventReceived(uuid, status, this), request, others);
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackCallback.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackCallback.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.resource;
+
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import net.kyori.adventure.audience.Audience;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A callback for a resource pack application operation.
+ *
+ * @since 4.15.0
+ */
+@FunctionalInterface
+public interface ResourcePackCallback {
+  /**
+   * Create a pack callback that will only execute the provided functions when the pack application has completed, discarding all intermediate events.
+   *
+   * @param success the success callback
+   * @param failure the failure callback
+   * @return the created callback
+   * @since 4.15.0
+   */
+  static @NotNull ResourcePackCallback onTerminal(final @NotNull BiConsumer<UUID, Audience> success, final @NotNull BiConsumer<UUID, Audience> failure) {
+    return (uuid, status, audience) -> {
+      if (status == ResourcePackStatus.SUCCESSFULLY_LOADED) {
+        success.accept(uuid, audience);
+      } else if (!status.intermediate()) {
+        failure.accept(uuid, audience);
+      }
+    };
+  }
+
+  /**
+   * Called when a pack event has been received.
+   *
+   * <p>If the pack apply action was executed on a group audience, {@code audience} will referer to the
+   * individual member audiences the action is executed on. Forwarding audiences may wrap callbacks to ensure they receive the appropriate wrapped audience.</p>
+   *
+   * @param uuid the uuid of the pack that has been applied.
+   * @param status the current pack status
+   * @param audience the audience the pack is being applied to
+   * @since 4.15.0
+   */
+  void packEventReceived(final @NotNull UUID uuid, final @NotNull ResourcePackStatus status, final @NotNull Audience audience);
+}

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackCallback.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackCallback.java
@@ -36,6 +36,18 @@ import org.jetbrains.annotations.NotNull;
 @FunctionalInterface
 public interface ResourcePackCallback {
   /**
+   * Create a pack callback that performs no operation.
+   *
+   * <p>Multiple calls to this method are guaranteed to return callback functions with equal identity.</p>
+   *
+   * @return the no-op callback
+   * @since 4.15.0
+   */
+  static @NotNull ResourcePackCallback noOp() {
+    return ResourcePackCallbacks.NO_OP;
+  }
+
+  /**
    * Create a pack callback that will only execute the provided functions when the pack application has completed, discarding all intermediate events.
    *
    * @param success the success callback

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackCallbacks.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackCallbacks.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.resource;
+
+final class ResourcePackCallbacks {
+  private ResourcePackCallbacks() {
+  }
+
+  static final ResourcePackCallback NO_OP = (uuid, status, audience) -> {};
+}

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
@@ -30,11 +30,9 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.builder.AbstractBuilder;
-import net.kyori.adventure.text.Component;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents information about a resource pack that can be sent to players.
@@ -50,27 +48,11 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
    * @param id the id
    * @param uri the uri
    * @param hash the sha-1 hash
-   * @param required whether the resource pack is required or not
    * @return the resource pack request
    * @since 4.15.0
    */
-  static @NotNull ResourcePackInfo resourcePackInfo(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required) {
-    return resourcePackInfo(id, uri, hash, required, null);
-  }
-
-  /**
-   * Creates information about a resource pack.
-   *
-   * @param id the id
-   * @param uri the uri
-   * @param hash the sha-1 hash
-   * @param required whether the resource pack is required or not
-   * @param prompt the prompt
-   * @return the resource pack request
-   * @since 4.15.0
-   */
-  static @NotNull ResourcePackInfo resourcePackInfo(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required, final @Nullable Component prompt) {
-    return new ResourcePackInfoImpl(id, uri, hash, required, prompt);
+  static @NotNull ResourcePackInfo resourcePackInfo(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash) {
+    return new ResourcePackInfoImpl(id, uri, hash);
   }
 
   /**
@@ -106,24 +88,6 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
    * @since 4.15.0
    */
   @NotNull String hash();
-
-  /**
-   * Gets whether the resource pack is required
-   * or not.
-   *
-   * @return True if the resource pack is required,
-   *     false otherwise
-   * @since 4.15.0
-   */
-  boolean required();
-
-  /**
-   * Gets the prompt.
-   *
-   * @return the prompt
-   * @since 4.15.0
-   */
-  @Nullable Component prompt();
 
   @Override
   default @NotNull ResourcePackInfo asResourcePackInfo() {
@@ -171,26 +135,6 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
     @NotNull Builder hash(final @NotNull String hash);
 
     /**
-     * Sets whether the resource pack is required or not.
-     *
-     * @param required whether the resource pack is required or not
-     * @return this builder
-     * @since 4.15.0
-     */
-    @Contract("_ -> this")
-    @NotNull Builder required(final boolean required);
-
-    /**
-     * Sets the prompt.
-     *
-     * @param prompt the prompt
-     * @return this builder
-     * @since 4.15.0
-     */
-    @Contract("_ -> this")
-    @NotNull Builder prompt(final @Nullable Component prompt);
-
-    /**
      * Builds.
      *
      * @return a new resource pack request
@@ -202,7 +146,7 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
     /**
      * Builds, computing a hash based on the provided URL.
      *
-     * <p>The hash computation will perform a network request asynchronously, exposing the built request via the returned future.</p>
+     * <p>The hash computation will perform a network request asynchronously, exposing the completed info via the returned future.</p>
      *
      * @return a future providing the new resource pack request
      * @since 4.15.0
@@ -214,7 +158,7 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
     /**
      * Builds, computing a hash based on the provided URL.
      *
-     * <p>The hash computation will perform a network request asynchronously, exposing the built request via the returned future.</p>
+     * <p>The hash computation will perform a network request asynchronously, exposing the completed info via the returned future.</p>
      *
      * @param executor the executor to perform the hash computation on
      * @return a future providing the new resource pack request

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
@@ -37,14 +37,15 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents a resource pack request that can be sent to players.
+ * Represents information about a resource pack that can be sent to players.
  *
+ * @see ResourcePackRequest
  * @see Audience#sendResourcePacks(ResourcePackInfoLike, ResourcePackInfoLike...)
  * @since 4.15.0
  */
 public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
   /**
-   * Creates a resource pack request.
+   * Creates information about a resource pack.
    *
    * @param id the id
    * @param uri the uri
@@ -53,12 +54,12 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
    * @return the resource pack request
    * @since 4.15.0
    */
-  static @NotNull ResourcePackInfo resourcePackRequest(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required) {
-    return resourcePackRequest(id, uri, hash, required, null);
+  static @NotNull ResourcePackInfo resourcePackInfo(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required) {
+    return resourcePackInfo(id, uri, hash, required, null);
   }
 
   /**
-   * Creates a resource pack request.
+   * Creates information about a resource pack.
    *
    * @param id the id
    * @param uri the uri
@@ -68,7 +69,7 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
    * @return the resource pack request
    * @since 4.15.0
    */
-  static @NotNull ResourcePackInfo resourcePackRequest(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required, final @Nullable Component prompt) {
+  static @NotNull ResourcePackInfo resourcePackInfo(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required, final @Nullable Component prompt) {
     return new ResourcePackInfoImpl(id, uri, hash, required, prompt);
   }
 
@@ -78,7 +79,7 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
    * @return a builder
    * @since 4.15.0
    */
-  static @NotNull Builder resourcePackRequest() {
+  static @NotNull Builder resourcePackInfo() {
     return new ResourcePackInfoImpl.BuilderImpl();
   }
 
@@ -99,7 +100,7 @@ public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
   @NotNull URI uri();
 
   /**
-   * Gets the hash.
+   * Gets the SHA-1 hash.
    *
    * @return the hash
    * @since 4.15.0

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
@@ -1,0 +1,229 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.resource;
+
+import java.net.URI;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.builder.AbstractBuilder;
+import net.kyori.adventure.text.Component;
+import net.kyori.examination.Examinable;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a resource pack request that can be sent to players.
+ *
+ * @see Audience#sendResourcePacks(ResourcePackInfo, ResourcePackInfo...)
+ * @since 4.15.0
+ */
+public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {
+  /**
+   * Creates a resource pack request.
+   *
+   * @param id the id
+   * @param uri the uri
+   * @param hash the sha-1 hash
+   * @param required whether the resource pack is required or not
+   * @return the resource pack request
+   * @since 4.15.0
+   */
+  static @NotNull ResourcePackInfo resourcePackRequest(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required) {
+    return resourcePackRequest(id, uri, hash, required, null);
+  }
+
+  /**
+   * Creates a resource pack request.
+   *
+   * @param id the id
+   * @param uri the uri
+   * @param hash the sha-1 hash
+   * @param required whether the resource pack is required or not
+   * @param prompt the prompt
+   * @return the resource pack request
+   * @since 4.15.0
+   */
+  static @NotNull ResourcePackInfo resourcePackRequest(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required, final @Nullable Component prompt) {
+    return new ResourcePackInfoImpl(id, uri, hash, required, prompt);
+  }
+
+  /**
+   * Create a new builder that will create a {@link ResourcePackInfo}.
+   *
+   * @return a builder
+   * @since 4.15.0
+   */
+  static @NotNull Builder resourcePackRequest() {
+    return new ResourcePackInfoImpl.BuilderImpl();
+  }
+
+  /**
+   * Gets the id.
+   *
+   * @return the id
+   * @since 4.15.0
+   */
+  @NotNull UUID id();
+
+  /**
+   * Gets the uri.
+   *
+   * @return the uri
+   * @since 4.15.0
+   */
+  @NotNull URI uri();
+
+  /**
+   * Gets the hash.
+   *
+   * @return the hash
+   * @since 4.15.0
+   */
+  @NotNull String hash();
+
+  /**
+   * Gets whether the resource pack is required
+   * or not.
+   *
+   * @return True if the resource pack is required,
+   *     false otherwise
+   * @since 4.15.0
+   */
+  boolean required();
+
+  /**
+   * Gets the prompt.
+   *
+   * @return the prompt
+   * @since 4.15.0
+   */
+  @Nullable Component prompt();
+
+  @Override
+  default @NotNull ResourcePackInfo asResourcePackInfo() {
+    return this;
+  }
+
+  /**
+   * A builder for resource pack requests.
+   *
+   * @since 4.15.0
+   */
+  interface Builder extends AbstractBuilder<ResourcePackInfo>, ResourcePackInfoLike {
+    /**
+     * Sets the id.
+     *
+     * @param id the id
+     * @return this builder
+     * @since 4.15.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder id(final @NotNull UUID id);
+
+    /**
+     * Sets the uri.
+     *
+     * <p>If no UUID has been provided, setting a URL will set the ID to one based on the URL.</p>
+     *
+     * <p>This parameter is required.</p>
+     *
+     * @param uri the uri
+     * @return this builder
+     * @since 4.15.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder uri(final @NotNull URI uri);
+
+    /**
+     * Sets the hash.
+     *
+     * @param hash the hash
+     * @return this builder
+     * @since 4.15.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder hash(final @NotNull String hash);
+
+    /**
+     * Sets whether the resource pack is required or not.
+     *
+     * @param required whether the resource pack is required or not
+     * @return this builder
+     * @since 4.15.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder required(final boolean required);
+
+    /**
+     * Sets the prompt.
+     *
+     * @param prompt the prompt
+     * @return this builder
+     * @since 4.15.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder prompt(final @Nullable Component prompt);
+
+    /**
+     * Builds.
+     *
+     * @return a new resource pack request
+     * @since 4.15.0
+     */
+    @Override
+    @NotNull ResourcePackInfo build();
+
+    /**
+     * Builds, computing a hash based on the provided URL.
+     *
+     * <p>The hash computation will perform a network request asynchronously, exposing the built request via the returned future.</p>
+     *
+     * @return a future providing the new resource pack request
+     * @since 4.15.0
+     */
+    default @NotNull CompletableFuture<ResourcePackInfo> computeHashAndBuild() {
+      return this.computeHashAndBuild(ForkJoinPool.commonPool());
+    }
+
+    /**
+     * Builds, computing a hash based on the provided URL.
+     *
+     * <p>The hash computation will perform a network request asynchronously, exposing the built request via the returned future.</p>
+     *
+     * @param executor the executor to perform the hash computation on
+     * @return a future providing the new resource pack request
+     * @since 4.15.0
+     */
+    @NotNull CompletableFuture<ResourcePackInfo> computeHashAndBuild(final @NotNull Executor executor);
+
+    @Override
+    default @NotNull ResourcePackInfo asResourcePackInfo() {
+      return this.build();
+    }
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Represents a resource pack request that can be sent to players.
  *
- * @see Audience#sendResourcePacks(ResourcePackInfo, ResourcePackInfo...)
+ * @see Audience#sendResourcePacks(ResourcePackInfoLike, ResourcePackInfoLike...)
  * @since 4.15.0
  */
 public interface ResourcePackInfo extends Examinable, ResourcePackInfoLike {

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoImpl.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoImpl.java
@@ -1,0 +1,218 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Formatter;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Stream;
+import net.kyori.adventure.internal.Internals;
+import net.kyori.adventure.text.Component;
+import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+final class ResourcePackInfoImpl implements ResourcePackInfo {
+  private final UUID id;
+  private final URI uri;
+  private final String hash;
+  private final boolean required;
+  private final Component prompt;
+
+  ResourcePackInfoImpl(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required, final @Nullable Component prompt) {
+    this.id = requireNonNull(id, "id");
+    this.uri = requireNonNull(uri, "uri");
+    this.hash = requireNonNull(hash, "hash");
+    this.required = required;
+    this.prompt = prompt;
+  }
+
+  @Override
+  public @NotNull UUID id() {
+    return this.id;
+  }
+
+  @Override
+  public @NotNull URI uri() {
+    return this.uri;
+  }
+
+  @Override
+  public @NotNull String hash() {
+    return this.hash;
+  }
+
+  @Override
+  public boolean required() {
+    return this.required;
+  }
+
+  @Override
+  public @Nullable Component prompt() {
+    return this.prompt;
+  }
+
+  @Override
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("id", this.id),
+      ExaminableProperty.of("uri", this.uri),
+      ExaminableProperty.of("hash", this.hash),
+      ExaminableProperty.of("required", this.required),
+      ExaminableProperty.of("prompt", this.prompt)
+    );
+  }
+
+  @Override
+  public String toString() {
+    return Internals.toString(this);
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if (this == other) return true;
+    if (!(other instanceof ResourcePackInfoImpl)) return false;
+    final ResourcePackInfoImpl that = (ResourcePackInfoImpl) other;
+    return this.id.equals(that.id) &&
+           this.uri.equals(that.uri) &&
+           this.hash.equals(that.hash) &&
+           this.required == that.required &&
+           Objects.equals(this.prompt, that.prompt);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = this.id.hashCode();
+    result = 31 * result + this.uri.hashCode();
+    result = 31 * result + this.hash.hashCode();
+    result = 31 * result + (this.required ? 1 : 0);
+    result = 31 * result + (this.prompt != null ? this.prompt.hashCode() : 0);
+    return result;
+  }
+
+  static final class BuilderImpl implements Builder {
+    private UUID id;
+    private URI uri;
+    private String hash;
+    private boolean required;
+    private Component prompt;
+
+    BuilderImpl() {
+    }
+
+    @Override
+    public @NotNull Builder id(final @NotNull UUID id) {
+      this.id = requireNonNull(id, "id");
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder uri(final @NotNull URI uri) {
+      this.uri = requireNonNull(uri, "uri");
+      if (this.id == null) {
+        this.id = UUID.nameUUIDFromBytes(uri.toString().getBytes(StandardCharsets.UTF_8));
+      }
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder hash(final @NotNull String hash) {
+      this.hash = requireNonNull(hash, "hash");
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder required(final boolean required) {
+      this.required = required;
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder prompt(final @Nullable Component prompt) {
+      this.prompt = prompt;
+      return this;
+    }
+
+    @Override
+    public @NotNull ResourcePackInfo build() {
+      return new ResourcePackInfoImpl(this.id, this.uri, this.hash, this.required, this.prompt);
+    }
+
+    @Override
+    public @NotNull CompletableFuture<ResourcePackInfo> computeHashAndBuild(final @NotNull Executor executor) {
+      return computeHash(requireNonNull(this.uri, "uri"), executor)
+        .thenApply(hash -> {
+          this.hash(hash);
+          return this.build();
+        });
+    }
+  }
+
+  static CompletableFuture<String> computeHash(final URI uri, final Executor exec) {
+    final CompletableFuture<String> result = new CompletableFuture<>();
+
+    exec.execute(() -> {
+      try {
+        final URL url = uri.toURL();
+        final URLConnection conn = url.openConnection();
+        conn.addRequestProperty("User-Agent", "adventure/" + ResourcePackInfoImpl.class.getPackage().getSpecificationVersion() + " (pack-fetcher)");
+        try (final InputStream is = conn.getInputStream()) {
+          final MessageDigest digest = MessageDigest.getInstance("SHA-1");
+          final byte[] buf = new byte[8192];
+          int read;
+          while ((read = is.read(buf)) != -1) {
+            digest.update(buf, 0, read);
+          }
+          result.complete(bytesToString(digest.digest()));
+        }
+      } catch (final IOException | NoSuchAlgorithmException ex) {
+        result.completeExceptionally(ex);
+      }
+    });
+
+    return result;
+  }
+
+  static String bytesToString(final byte[] arr) {
+    final StringBuilder builder = new StringBuilder(arr.length * 2);
+    final Formatter fmt = new Formatter(builder, Locale.ROOT);
+    for (int i = 0; i < arr.length; i++) {
+      fmt.format("%02x", arr[i] & 0xff);
+    }
+    return builder.toString();
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoImpl.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoImpl.java
@@ -33,13 +33,11 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Formatter;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
-import net.kyori.adventure.text.Component;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -50,15 +48,11 @@ final class ResourcePackInfoImpl implements ResourcePackInfo {
   private final UUID id;
   private final URI uri;
   private final String hash;
-  private final boolean required;
-  private final Component prompt;
 
-  ResourcePackInfoImpl(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash, final boolean required, final @Nullable Component prompt) {
+  ResourcePackInfoImpl(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash) {
     this.id = requireNonNull(id, "id");
     this.uri = requireNonNull(uri, "uri");
     this.hash = requireNonNull(hash, "hash");
-    this.required = required;
-    this.prompt = prompt;
   }
 
   @Override
@@ -77,23 +71,11 @@ final class ResourcePackInfoImpl implements ResourcePackInfo {
   }
 
   @Override
-  public boolean required() {
-    return this.required;
-  }
-
-  @Override
-  public @Nullable Component prompt() {
-    return this.prompt;
-  }
-
-  @Override
   public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("id", this.id),
       ExaminableProperty.of("uri", this.uri),
-      ExaminableProperty.of("hash", this.hash),
-      ExaminableProperty.of("required", this.required),
-      ExaminableProperty.of("prompt", this.prompt)
+      ExaminableProperty.of("hash", this.hash)
     );
   }
 
@@ -109,9 +91,7 @@ final class ResourcePackInfoImpl implements ResourcePackInfo {
     final ResourcePackInfoImpl that = (ResourcePackInfoImpl) other;
     return this.id.equals(that.id) &&
            this.uri.equals(that.uri) &&
-           this.hash.equals(that.hash) &&
-           this.required == that.required &&
-           Objects.equals(this.prompt, that.prompt);
+           this.hash.equals(that.hash);
   }
 
   @Override
@@ -119,8 +99,6 @@ final class ResourcePackInfoImpl implements ResourcePackInfo {
     int result = this.id.hashCode();
     result = 31 * result + this.uri.hashCode();
     result = 31 * result + this.hash.hashCode();
-    result = 31 * result + (this.required ? 1 : 0);
-    result = 31 * result + (this.prompt != null ? this.prompt.hashCode() : 0);
     return result;
   }
 
@@ -128,8 +106,6 @@ final class ResourcePackInfoImpl implements ResourcePackInfo {
     private UUID id;
     private URI uri;
     private String hash;
-    private boolean required;
-    private Component prompt;
 
     BuilderImpl() {
     }
@@ -156,20 +132,8 @@ final class ResourcePackInfoImpl implements ResourcePackInfo {
     }
 
     @Override
-    public @NotNull Builder required(final boolean required) {
-      this.required = required;
-      return this;
-    }
-
-    @Override
-    public @NotNull Builder prompt(final @Nullable Component prompt) {
-      this.prompt = prompt;
-      return this;
-    }
-
-    @Override
     public @NotNull ResourcePackInfo build() {
-      return new ResourcePackInfoImpl(this.id, this.uri, this.hash, this.required, this.prompt);
+      return new ResourcePackInfoImpl(this.id, this.uri, this.hash);
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoLike.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoLike.java
@@ -26,16 +26,16 @@ package net.kyori.adventure.resource;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Something that can be represented as a {@link ResourcePackRequest}.
+ * Something that can be represented as a {@link ResourcePackInfo}.
  *
  * @since 4.15.0
  */
-public interface ResourcePackRequestLike {
+public interface ResourcePackInfoLike {
   /**
-   * Gets a {@link ResourcePackRequest} representation.
+   * Gets a {@link ResourcePackInfo} representation.
    *
    * @return a component
    * @since 4.15.0
    */
-  @NotNull ResourcePackRequest asResourcePackRequest();
+  @NotNull ResourcePackInfo asResourcePackInfo();
 }

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Represents a resource pack request that can be sent to players.
  *
- * @see Audience#sendResourcePack(ResourcePackRequest, ResourcePackRequest...)
+ * @see Audience#sendResourcePacks(ResourcePackRequest, ResourcePackRequest...)
  * @since 4.15.0
  */
 public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike {

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.resource;
 
 import java.net.URI;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.adventure.text.Component;
@@ -145,6 +146,10 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
     /**
      * Sets the uri.
      *
+     * <p>If no UUID has been provided, setting a URL will set the ID to one based on the URL.</p>
+     *
+     * <p>This parameter is required.</p>
+     *
      * @param uri the uri
      * @return this builder
      * @since 4.15.0
@@ -190,6 +195,16 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
      */
     @Override
     @NotNull ResourcePackRequest build();
+
+    /**
+     * Builds, computing a hash based on the provided URL.
+     *
+     * <p>The hash computation will perform a network request asynchronously, exposing the built request via the returned future.</p>
+     *
+     * @return a future providing the new resource pack request
+     * @since 4.15.0
+     */
+    @NotNull CompletableFuture<ResourcePackRequest> computeHashAndBuild();
 
     @Override
     default @NotNull ResourcePackRequest asResourcePackRequest() {

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 4.15.0
  */
-public interface ResourcePackRequest extends Examinable {
+public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike {
   /**
    * Create a basic request to apply the provided resource packs.
    *
@@ -125,12 +125,17 @@ public interface ResourcePackRequest extends Examinable {
    */
   @NotNull ResourcePackRequest replace(final boolean replace);
 
+  @Override
+  default @NotNull ResourcePackRequest asResourcePackRequest() {
+    return this;
+  }
+
   /**
    * A builder for resource pack requests.
    *
    * @since 4.15.0
    */
-  interface Builder extends AbstractBuilder<ResourcePackRequest> {
+  interface Builder extends AbstractBuilder<ResourcePackRequest>, ResourcePackRequestLike {
     /**
      * Set the resource packs to apply.
      *
@@ -167,5 +172,10 @@ public interface ResourcePackRequest extends Examinable {
      * @since 4.15.0
      */
     @NotNull Builder replace(final boolean replace);
+
+    @Override
+    default @NotNull ResourcePackRequest asResourcePackRequest() {
+      return this.build();
+    }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
@@ -25,8 +25,11 @@ package net.kyori.adventure.resource;
 
 import java.util.List;
 import net.kyori.adventure.builder.AbstractBuilder;
+import net.kyori.adventure.text.Component;
 import net.kyori.examination.Examinable;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -125,6 +128,23 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
    */
   @NotNull ResourcePackRequest replace(final boolean replace);
 
+  /**
+   * Gets whether the resource packs in this request are required.
+   *
+   * @return True if the resource pack is required,
+   *     false otherwise
+   * @since 4.15.0
+   */
+  boolean required();
+
+  /**
+   * Gets the prompt that will be provided when requesting these packs.
+   *
+   * @return the prompt
+   * @since 4.15.0
+   */
+  @Nullable Component prompt();
+
   @Override
   default @NotNull ResourcePackRequest asResourcePackRequest() {
     return this;
@@ -144,6 +164,7 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
      * @return this builder
      * @since 4.15.0
      */
+    @Contract("_, _ -> this")
     @NotNull Builder packs(final @NotNull ResourcePackInfoLike first, final @NotNull ResourcePackInfoLike@NotNull... others);
 
     /**
@@ -153,6 +174,7 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
      * @return this builder
      * @since 4.15.0
      */
+    @Contract("_ -> this")
     @NotNull Builder packs(final @NotNull Iterable<? extends ResourcePackInfoLike> packs);
 
     /**
@@ -162,6 +184,7 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
      * @return this builder
      * @since 4.15.0
      */
+    @Contract("_ -> this")
     @NotNull Builder callback(final @NotNull ResourcePackCallback cb);
 
     /**
@@ -171,7 +194,28 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
      * @return this builder
      * @since 4.15.0
      */
+    @Contract("_ -> this")
     @NotNull Builder replace(final boolean replace);
+
+    /**
+     * Sets whether the resource pack is required or not.
+     *
+     * @param required whether the resource pack is required or not
+     * @return this builder
+     * @since 4.15.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder required(final boolean required);
+
+    /**
+     * Sets the prompt.
+     *
+     * @param prompt the prompt
+     * @return this builder
+     * @since 4.15.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder prompt(final @Nullable Component prompt);
 
     @Override
     default @NotNull ResourcePackRequest asResourcePackRequest() {

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
@@ -26,6 +26,8 @@ package net.kyori.adventure.resource;
 import java.net.URI;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.adventure.text.Component;
@@ -204,7 +206,20 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
      * @return a future providing the new resource pack request
      * @since 4.15.0
      */
-    @NotNull CompletableFuture<ResourcePackRequest> computeHashAndBuild();
+    default @NotNull CompletableFuture<ResourcePackRequest> computeHashAndBuild() {
+      return this.computeHashAndBuild(ForkJoinPool.commonPool());
+    }
+
+    /**
+     * Builds, computing a hash based on the provided URL.
+     *
+     * <p>The hash computation will perform a network request asynchronously, exposing the built request via the returned future.</p>
+     *
+     * @param executor the executor to perform the hash computation on
+     * @return a future providing the new resource pack request
+     * @since 4.15.0
+     */
+    @NotNull CompletableFuture<ResourcePackRequest> computeHashAndBuild(final @NotNull Executor executor);
 
     @Override
     default @NotNull ResourcePackRequest asResourcePackRequest() {

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
@@ -131,6 +131,11 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
   /**
    * Gets whether the resource packs in this request are required.
    *
+   * <p>Vanilla clients will disconnect themselves if their player
+   * rejects a required pack, but implementations will not necessarily
+   * perform any additional serverside validation. The {@link #callback()}
+   * can provide more information about the client's reaction.</p>
+   *
    * @return True if the resource pack is required,
    *     false otherwise
    * @since 4.15.0
@@ -199,6 +204,11 @@ public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike
 
     /**
      * Sets whether the resource pack is required or not.
+     *
+     * <p>Vanilla clients will disconnect themselves if their player
+     * rejects a required pack, but implementations will not necessarily
+     * perform any additional serverside validation. The {@link #callback()}
+     * can provide more information about the client's reaction.</p>
      *
      * @param required whether the resource pack is required or not
      * @return this builder

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Represents a resource pack request that can be sent to players.
  *
- * @see Audience#sendResourcePack(ResourcePackRequest)
+ * @see Audience#sendResourcePack(ResourcePackRequest, ResourcePackRequest...)
  * @since 4.15.0
  */
 public interface ResourcePackRequest extends Examinable, ResourcePackRequestLike {

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequestImpl.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequestImpl.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.Component;
@@ -174,8 +173,8 @@ final class ResourcePackRequestImpl implements ResourcePackRequest {
     }
 
     @Override
-    public @NotNull CompletableFuture<ResourcePackRequest> computeHashAndBuild() {
-      return computeHash(requireNonNull(this.uri, "uri"), ForkJoinPool.commonPool())
+    public @NotNull CompletableFuture<ResourcePackRequest> computeHashAndBuild(final @NotNull Executor executor) {
+      return computeHash(requireNonNull(this.uri, "uri"), executor)
         .thenApply(hash -> {
           this.hash(hash);
           return this.build();

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequestLike.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequestLike.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.resource;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Something that can be represented as a {@link ResourcePackRequest}.
+ *
+ * @since 4.15.0
+ */
+public interface ResourcePackRequestLike {
+  /**
+   * Get the pack request representation.
+   *
+   * @return the pack request representation of this object
+   * @since 4.15.0
+   */
+  @NotNull ResourcePackRequest asResourcePackRequest();
+}

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackStatus.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackStatus.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.resource;
+
+/**
+ * Resource pack application state.
+ *
+ * <p>Each status is a phase in the status state machine.
+ * The client provides this information back to servers as it attempts to download and apply resource packs.</p>
+ *
+ * <p>Initial states are {@link #ACCEPTED}, {@link #DECLINED}, or {@link #INVALID_URL}.</p>
+ *
+ * @since 4.15.0
+ */
+public enum ResourcePackStatus {
+  /**
+   * Indicates that the user has accepted download.
+   *
+   * <p>Next states: {@link #FAILED_DOWNLOAD}, {@link #DOWNLOADED}</p>
+   *
+   * @since 4.15.0
+   */
+  ACCEPTED(true),
+  /**
+   * Indicates that the user has declined a pack.
+   *
+   * <p>Terminal state.</p>
+   *
+   * @since 4.15.0
+   */
+  DECLINED(false),
+  /**
+   * Indicates that the provided pack URL could not be parsed.
+   *
+   * <p>Terminal state.</p>
+   *
+   * @since 4.15.0
+   * @sinceMinecraft 1.20.3
+   */
+  INVALID_URL(false),
+  /**
+   * Indicates that the download failed for some other reason.
+   *
+   * <p>Terminal state.</p>
+   *
+   * @since 4.15.0
+   */
+  FAILED_DOWNLOAD(false),
+  /**
+   * Indicates that the resource pack has been successfully downloaded.
+   *
+   * <p>Next states: {@link #FAILED_RELOAD}, {@link #DISCARDED}, or {@link #SUCCESSFULLY_LOADED}</p>
+   *
+   * @since 4.15.0
+   * @sinceMinecraft 1.20.3
+   */
+  DOWNLOADED(true),
+  /**
+   * Indicates that the client's resource manager reload failed.
+   *
+   * <p>Terminal state.</p>
+   *
+   * @since 4.15.0
+   * @sinceMinecraft 1.20.3
+   */
+  FAILED_RELOAD(false),
+  /**
+   * Indicates that this resource pack did not have issues, but was not applied due to a failure in another server resource pack.
+   *
+   * <p>Terminal state.</p>
+   *
+   * @since 4.15.0
+   * @sinceMinecraft 1.20.3
+   */
+  DISCARDED(false),
+
+  /**
+   * Indicates that the pack has successfully loaded and resource reloading is complete.
+   *
+   * <p>Terminal state.</p>
+   *
+   * @since 4.15.0
+   */
+  SUCCESSFULLY_LOADED(false);
+
+  private final boolean intermediate;
+
+  ResourcePackStatus(final boolean intermediate) {
+    this.intermediate = intermediate;
+  }
+
+  /**
+   * Whether, after receiving this status, further status events might occur.
+   *
+   * @return the intermediate status
+   * @since 4.15.0
+   */
+  public boolean intermediate() {
+    return this.intermediate;
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/util/MonkeyBars.java
+++ b/api/src/main/java/net/kyori/adventure/util/MonkeyBars.java
@@ -29,7 +29,10 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * {@link Collection} related utilities.
@@ -74,5 +77,48 @@ public final class MonkeyBars {
     newList.addAll(oldList);
     newList.add(newElement);
     return Collections.unmodifiableList(newList);
+  }
+
+  /**
+   * Create a list based on a first element plus array of additional elements.
+   *
+   * <p>All elements must be non-null before and after mapping.</p>
+   *
+   * @param mapper a mapper to convert objects
+   * @param first the first element
+   * @param others any other elements
+   * @param <I> the input type
+   * @param <O> the output type
+   * @return an unmodifiable list based on the provided elements
+   * @since 4.15.0
+   */
+  @SafeVarargs
+  public static <I, O> @NotNull List<O> nonEmptyArrayToList(final @NotNull Function<I, O> mapper, final @NotNull I first, final @NotNull I@NotNull... others) {
+    final List<O> ret = new ArrayList<>(others.length + 1);
+    ret.add(mapper.apply(first));
+    for (final I other : others) {
+      ret.add(requireNonNull(mapper.apply(requireNonNull(other, "source[?]")), "mapper(source[?])"));
+    }
+    return Collections.unmodifiableList(ret);
+  }
+
+  /**
+   * Create a list eagerly mapping the source elements through the {@code mapper function}.
+   *
+   * <p>All elements must be non-null before and after mapping.</p>
+   *
+   * @param <I>    the input type
+   * @param <O>    the output type
+   * @param mapper element mapper
+   * @param source input elements
+   * @return a mapped list
+   * @since 4.15.0
+   */
+  public static <I, O> @NotNull List<O> toUnmodifiableList(final @NotNull Function<I, O> mapper, final @NotNull Iterable<? extends I> source) {
+    final ArrayList<O> ret = source instanceof Collection<?> ? new ArrayList<>(((Collection<?>) source).size()) : new ArrayList<>();
+    for (final I el : source) {
+      ret.add(requireNonNull(mapper.apply(requireNonNull(el, "source[?]")), "mapper(source[?])"));
+    }
+    return Collections.unmodifiableList(ret);
   }
 }

--- a/api/src/test/java/net/kyori/adventure/resource/ResourcePackInfoImplTest.java
+++ b/api/src/test/java/net/kyori/adventure/resource/ResourcePackInfoImplTest.java
@@ -30,14 +30,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class ResourcePackRequestImplTest {
+class ResourcePackInfoImplTest {
   @Test
   void testHashComputation() throws NoSuchAlgorithmException {
     final MessageDigest md = MessageDigest.getInstance("SHA-1");
     final byte[] digest = md.digest("hello world\n".getBytes(StandardCharsets.UTF_8));
     assertEquals(
       "22596363b3de40b06f981fb85d82312e8c0ed511",
-      ResourcePackRequestImpl.bytesToString(digest)
+      ResourcePackInfoImpl.bytesToString(digest)
     );
   }
 }

--- a/api/src/test/java/net/kyori/adventure/resource/ResourcePackRequestImplTest.java
+++ b/api/src/test/java/net/kyori/adventure/resource/ResourcePackRequestImplTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2023 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.resource;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResourcePackRequestImplTest {
+  @Test
+  void testHashComputation() throws NoSuchAlgorithmException {
+    final MessageDigest md = MessageDigest.getInstance("SHA-1");
+    final byte[] digest = md.digest("hello world\n".getBytes(StandardCharsets.UTF_8));
+    assertEquals(
+      "22596363b3de40b06f981fb85d82312e8c0ed511",
+      ResourcePackRequestImpl.bytesToString(digest)
+    );
+  }
+}


### PR DESCRIPTION
This PR makes it easy to handle multiple resource packs, and adds a callback system to track pack application.

(note, this does change some API used in snapshots so it'd be a binary break for any current testers)