### PR TITLE
minimessage: Fix exception with single quote as tag part

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TagPart.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TagPart.java
@@ -106,6 +106,11 @@ public final class TagPart implements Tag.Argument {
       endIndex--;
     }
 
+    if (startIndex > endIndex) {
+      // We were given only a single quote that doesn't terminate, we can't unescape it
+      return text.substring(start, end);
+    }
+
     return TokenParser.unescape(text, startIndex, endIndex, i -> i == firstChar || i == TokenParser.ESCAPE);
   }
 

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -544,4 +544,13 @@ public class MiniMessageParserTest extends AbstractTest {
 
     this.assertParsedEquals(expected, input, alwaysMatchingResolver);
   }
+
+  // https://github.com/KyoriPowered/adventure/issues/1011
+  @Test
+  void testNonTerminatingQuoteArgument() {
+    final String input = "<hover:show_text_:\">";
+    final Component expected = Component.text(input);
+
+    this.assertParsedEquals(expected, input);
+  }
 }


### PR DESCRIPTION
The parser tries to un-quote tag parts surrounded by quotes, it does so by checking if the first character of the tag part is a quote and the last character is as well. However, things break if that first and last character are actually the same character! A StringIndexOutOfBoundsException is thrown later on.

This patch makes it so tag parts consisting of a single quote aren't tried to be un-quoted, they stay as is

Fixes https://github.com/KyoriPowered/adventure/issues/1011