### PR TITLE
feat(api): replace text in ClickEvent value too

### DIFF
--- a/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextReplacementRendererTest.java
@@ -24,6 +24,8 @@
 package net.kyori.adventure.text;
 
 import java.util.regex.Pattern;
+
+import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -245,6 +247,19 @@ class TextReplacementRendererTest {
       )
       .build();
     assertEquals(expected, replaced);
+  }
+
+  @Test
+  void testClickEventReplacement() {
+    final Component original = Component.text("Click on me!")
+      .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/server <server>"));
+
+    final Component replaced = original.replaceText(c -> c.match("<server>").replacement("lobby"));
+
+    final Component expected = Component.text("Click on me!")
+      .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/server lobby"));
+
+    TextAssertions.assertEquals(expected, replaced);
   }
 
   // https://github.com/KyoriPowered/adventure/issues/387


### PR DESCRIPTION
Hi! 👋

While developing a plugin, it became necessary for me to replace the text in the ClickEvent value. The test provides a case of using this feature.

I also refactored the code a bit because the function turned out to be very complicated.