### PR TITLE
feat(text-minimessage): Show ANSI rendering of parsed components in tests

### DIFF
--- a/text-minimessage/build.gradle.kts
+++ b/text-minimessage/build.gradle.kts
@@ -7,7 +7,8 @@ description = "A string-based, user-friendly format for representing Minecraft: 
 
 dependencies {
   api(projects.adventureApi)
-  testImplementation(project(":adventure-text-serializer-plain"))
+  testImplementation(projects.adventureTextSerializerPlain)
+  testImplementation(projects.adventureTextSerializerAnsi)
   annotationProcessor(projects.adventureAnnotationProcessors)
 }
 

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/AbstractTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/AbstractTest.java
@@ -31,6 +31,8 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializer;
+import net.kyori.ansi.ColorLevel;
 import net.kyori.examination.string.MultiLineStringExaminer;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,6 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class AbstractTest {
   protected static final MiniMessage PARSER = MiniMessage.builder().debug(System.out::print).build();
+  protected static final ANSIComponentSerializer ANSI = ANSIComponentSerializer.builder()
+    .colorLevel(ColorLevel.TRUE_COLOR)
+    .build();
 
   protected void assertSerializedEquals(final @NotNull String expected, final @NotNull ComponentLike input) {
     final String string = PARSER.serialize(input.asComponent());
@@ -52,16 +57,14 @@ public abstract class AbstractTest {
     this.assertParsedEquals(PARSER, expected, input, args);
   }
 
-  protected void assertParsedEquals(final MiniMessage miniMessage, final Component expected, final String input) {
-    final String expectedSerialized = this.prettyPrint(expected.compact());
-    final String actual = this.prettyPrint(miniMessage.deserialize(input).compact());
-    assertEquals(expectedSerialized, actual);
-  }
-
   protected void assertParsedEquals(final MiniMessage miniMessage, final Component expected, final String input, final @NotNull TagResolver... args) {
-    final String expectedSerialized = this.prettyPrint(expected.compact());
-    final String actual = this.prettyPrint(miniMessage.deserialize(input, TagResolver.resolver(args)).compact());
-    assertEquals(expectedSerialized, actual);
+    final Component expectedCompacted = expected.compact();
+    final String expectedSerialized = this.prettyPrint(expectedCompacted);
+    final Component actualCompacted = miniMessage.deserialize(input, TagResolver.resolver(args)).compact();
+    final String actual = this.prettyPrint(actualCompacted);
+    assertEquals(expectedSerialized, actual, () -> "Expected parsed value did not match actual:\n"
+      + "  Expected: " + ANSI.serialize(expectedCompacted) + '\n'
+      + "  Actual:   " + ANSI.serialize(actualCompacted));
   }
 
   protected final String prettyPrint(final Component component) {


### PR DESCRIPTION
<img width="368" alt="image" src="https://github.com/KyoriPowered/adventure/assets/629092/5c04c67f-9f9a-4ccd-9878-53ddea45ab77">

this makes things look a little better for some things