### PR TITLE
feat(api): item data components

### DIFF
--- a/annotation-processors/build.gradle.kts
+++ b/annotation-processors/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  annotationProcessor(libs.autoService.processor)
+  annotationProcessor(libs.autoService)
   compileOnlyApi(libs.autoService.annotations)
   api(libs.jetbrainsAnnotations)
 }

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
   compileOnlyApi(libs.jetbrainsAnnotations)
   testImplementation(libs.guava)
   annotationProcessor(projects.adventureAnnotationProcessors)
+  testCompileOnly(libs.autoService.annotations)
+  testAnnotationProcessor(libs.autoService)
 }
 
 applyJarMetadata("net.kyori.adventure")

--- a/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolder.java
+++ b/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolder.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.nbt.api;
 
+import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.adventure.util.Codec;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +38,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @since 4.0.0
  */
-public interface BinaryTagHolder {
+public interface BinaryTagHolder extends DataComponentValue.TagSerializable {
   /**
    * Encodes {@code nbt} using {@code codec}.
    *
@@ -85,6 +86,11 @@ public interface BinaryTagHolder {
    * @since 4.0.0
    */
   @NotNull String string();
+
+  @Override
+  default @NotNull BinaryTagHolder asBinaryTag() {
+    return this;
+  }
 
   /**
    * Gets the held value as a binary tag.

--- a/api/src/main/java/net/kyori/adventure/text/event/DataComponentValue.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/DataComponentValue.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.event;
+
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.examination.Examinable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A holder for the value of an item's data component.
+ *
+ * <p>The exact value is platform-specific. Serializers may provide their
+ * own implementations as well, and any logic to serialize or deserialize
+ * should be done per-serializer.</p>
+ *
+ * @since 4.17.0
+ * @sinceMinecraft 1.20.5
+ */
+public interface DataComponentValue extends Examinable {
+  /**
+   * Get a marker value to indicate that a data component's value should be removed.
+   *
+   * @return the removed holder
+   * @since 4.17.0
+   * @sinceMinecraft 1.20.5
+   */
+  static DataComponentValue.@NotNull Removed removed() {
+    return RemovedDataComponentValueImpl.REMOVED;
+  }
+
+  /**
+   * Represent an {@link DataComponentValue} that can be represented as a binary tag.
+   *
+   * @since 4.17.0
+   * @sinceMinecraft 1.20.5
+   */
+  interface TagSerializable extends DataComponentValue {
+
+    /**
+     * Convert this value into a binary tag value.
+     *
+     * @return the binary tag value
+     * @since 4.17.0
+     * @sinceMinecraft 1.20.5
+     */
+    @NotNull BinaryTagHolder asBinaryTag();
+  }
+
+  /**
+   * Only valid in a patch-style usage, indicating that the data component with a certain key should be removed.
+   *
+   * @since 4.17.0
+   * @sinceMinecraft 1.20.5
+   */
+  @ApiStatus.NonExtendable
+  interface Removed extends DataComponentValue {
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConversionImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConversionImpl.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.event;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import net.kyori.adventure.internal.Internals;
+import net.kyori.adventure.key.Key;
+import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+final class DataComponentValueConversionImpl<I, O> implements DataComponentValueConverterRegistry.Conversion<I, O> {
+  private final Class<I> source;
+  private final Class<O> destination;
+  private final BiFunction<Key, I, O> conversion;
+
+  DataComponentValueConversionImpl(final @NotNull Class<I> source, final @NotNull Class<O> destination, final @NotNull BiFunction<Key, I, O> conversion) {
+    this.source = source;
+    this.destination = destination;
+    this.conversion = conversion;
+  }
+
+  @Override
+  public @NotNull Class<I> source() {
+    return this.source;
+  }
+
+  @Override
+  public @NotNull Class<O> destination() {
+    return this.destination;
+  }
+
+  @Override
+  public @NotNull O convert(final @NotNull Key key, final @NotNull I input) {
+    return this.conversion.apply(requireNonNull(key, "key"), requireNonNull(input, "input"));
+  }
+
+  @Override
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("source", this.source),
+      ExaminableProperty.of("destination", this.destination),
+      ExaminableProperty.of("conversion", this.conversion)
+    );
+  }
+
+  @Override
+  public String toString() {
+    return Internals.toString(this);
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) return true;
+    if (other == null || getClass() != other.getClass()) return false;
+    final DataComponentValueConversionImpl<?, ?> that = (DataComponentValueConversionImpl<?, ?>) other;
+    return Objects.equals(this.source, that.source)
+      && Objects.equals(this.destination, that.destination)
+      && Objects.equals(this.conversion, that.conversion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.source, this.destination, this.conversion);
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistry.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistry.java
@@ -46,7 +46,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A registry for conversions between different data component value holder classes.
  *
- * <p>Conversions are discovered by {@link ServiceLoader} lookup of implementations of the {@link Provider} interface (using the loading thread's context classloader).</p>
+ * <p>Conversions are discovered by {@link ServiceLoader} lookup of implementations of the {@link Provider} interface (on the classloader which loaded Adventure).</p>
  *
  * @since 4.17.0
  */

--- a/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistry.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistry.java
@@ -27,16 +27,14 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.util.Services;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -53,20 +51,7 @@ import static java.util.Objects.requireNonNull;
  * @since 4.17.0
  */
 public final class DataComponentValueConverterRegistry {
-  private static final Set<Provider> PROVIDERS;
-
-  static {
-    final ServiceLoader<Provider> providerLoader = ServiceLoader.load(Provider.class);
-    final Set<Provider> providers = new HashSet<>();
-    for (final Iterator<Provider> it = providerLoader.iterator(); it.hasNext();) {
-      try {
-        providers.add(it.next());
-      } catch (final ServiceConfigurationError ex) {
-        throw new RuntimeException("Failed to load data holder service provider: " + ex);
-      }
-    }
-    PROVIDERS = Collections.unmodifiableSet(providers);
-  }
+  private static final Set<Provider> PROVIDERS = Services.services(Provider.class);
 
   private DataComponentValueConverterRegistry() {
   }
@@ -100,7 +85,7 @@ public final class DataComponentValueConverterRegistry {
    *
    * @since 4.17.0
    */
-  interface Provider {
+  public interface Provider {
     /**
      * An identifier for this provider.
      *
@@ -128,7 +113,7 @@ public final class DataComponentValueConverterRegistry {
    * @since 4.17.0
    */
   @ApiStatus.NonExtendable
-  interface Conversion<I, O> extends Examinable {
+  public interface Conversion<I, O> extends Examinable {
     /**
      * Create a new conversion.
      *

--- a/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistry.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistry.java
@@ -1,0 +1,259 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.event;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import net.kyori.adventure.key.Key;
+import net.kyori.examination.Examinable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A registry for conversions between different data component value holder classes.
+ *
+ * <p>Conversions are discovered by {@link ServiceLoader} lookup of implementations of the {@link Provider} interface (using the loading thread's context classloader).</p>
+ *
+ * @since 4.17.0
+ */
+public final class DataComponentValueConverterRegistry {
+  private static final Set<Provider> PROVIDERS;
+
+  static {
+    final ServiceLoader<Provider> providerLoader = ServiceLoader.load(Provider.class);
+    final Set<Provider> providers = new HashSet<>();
+    for (final Iterator<Provider> it = providerLoader.iterator(); it.hasNext();) {
+      try {
+        providers.add(it.next());
+      } catch (final ServiceConfigurationError ex) {
+        throw new RuntimeException("Failed to load data holder service provider: " + ex);
+      }
+    }
+    PROVIDERS = Collections.unmodifiableSet(providers);
+  }
+
+  private DataComponentValueConverterRegistry() {
+  }
+
+  /**
+   * Try to convert the data component value {@code in} to the provided output type.
+   *
+   * @param target the target type
+   * @param key the key this value is for
+   * @param in the input value
+   * @param <O> the output type
+   * @return a value of target type
+   * @since 4.17.0
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static <O extends DataComponentValue> @NotNull O convert(final @NotNull Class<O> target, final @NotNull Key key, final @NotNull DataComponentValue in) {
+    if (target.isInstance(in)) {
+      return target.cast(in);
+    }
+
+    final @Nullable Conversion<?, ? extends O> converter = ConversionCache.converter(in.getClass(), target);
+    if (converter == null) {
+      throw new IllegalArgumentException("There is no data holder converter registered to convert from a " + in.getClass() + " instance to a " + target + " (on field " + key + ")");
+    }
+
+    return (O) ((Conversion) converter).convert(key, in);
+  }
+
+  /**
+   * A provider for data component value converters.
+   *
+   * @since 4.17.0
+   */
+  interface Provider {
+    /**
+     * An identifier for this provider.
+     *
+     * @return the provider id
+     * @since 4.17.0
+     */
+    @NotNull Key id();
+
+    /**
+     * Return conversions available from this provider.
+     *
+     * <p>Conversions may only be queried once at application initialization, so changes to the result of this method may not have any effect.</p>
+     *
+     * @return the conversions available
+     * @since 4.17.0
+     */
+    @NotNull Iterable<Conversion<?, ?>> conversions();
+  }
+
+  /**
+   * A single conversion that may be provided by a provider.
+   *
+   * @param <I> input type
+   * @param <O> output type
+   * @since 4.17.0
+   */
+  @ApiStatus.NonExtendable
+  interface Conversion<I, O> extends Examinable {
+    /**
+     * Create a new conversion.
+     *
+     * @param src the source type
+     * @param dst the destination type
+     * @param op the conversion operation
+     * @param <I1> the input type
+     * @param <O1> the output type
+     * @return a conversion object
+     * @since 4.17.0
+     */
+    static <I1, O1> @NotNull Conversion<I1, O1> convert(final @NotNull Class<I1> src, final @NotNull Class<O1> dst, final @NotNull BiFunction<Key, I1, O1> op) {
+      return new DataComponentValueConversionImpl<>(
+        requireNonNull(src, "src"),
+        requireNonNull(dst, "dst"),
+        requireNonNull(op, "op")
+      );
+    }
+
+    /**
+     * The source type.
+     *
+     * @return the source type
+     * @since 4.17.0
+     */
+    @Contract(pure = true)
+    @NotNull Class<I> source();
+
+    /**
+     * The destination type.
+     *
+     * @return the destination type
+     * @since 4.17.0
+     */
+    @Contract(pure = true)
+    @NotNull Class<O> destination();
+
+    /**
+     * Perform the actual conversion.
+     *
+     * @param key the key used for the data holder
+     * @param input the source type
+     * @return a data holder of the destination type
+     * @since 4.17.0
+     */
+    @NotNull O convert(final @NotNull Key key, final @NotNull I input);
+  }
+
+  static final class ConversionCache {
+    // input -> output -> conversion
+    private static final ConcurrentMap<Class<?>, ConcurrentMap<Class<?>, RegisteredConversion>> CACHE = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, Set<RegisteredConversion>> CONVERSIONS = collectConversions();
+
+    private static Map<Class<?>, Set<RegisteredConversion>> collectConversions() {
+      final Map<Class<?>, Set<RegisteredConversion>> collected = new ConcurrentHashMap<>();
+      for (final Provider provider : PROVIDERS) {
+        final @NotNull Key id = requireNonNull(provider.id(), () -> "ID of provider " + provider + " is null");
+        for (final Conversion<?, ?> conv : provider.conversions()) {
+          collected.computeIfAbsent(conv.source(), $ -> ConcurrentHashMap.newKeySet()).add(new RegisteredConversion(id, conv));
+        }
+      }
+
+      for (final Map.Entry<Class<?>, Set<RegisteredConversion>> entry : collected.entrySet()) {
+        entry.setValue(Collections.unmodifiableSet(entry.getValue()));
+      }
+
+      return new ConcurrentHashMap<>(collected);
+    }
+
+    static RegisteredConversion compute(final Class<?> src, final Class<?> dst) {
+      final Deque<Class<?>> sourceTypes = new ArrayDeque<>();
+      sourceTypes.add(src);
+      // walk up the source type hierarchy to find an option
+      for (Class<?> sourcePtr; (sourcePtr = sourceTypes.poll()) != null;) {
+        final Set<RegisteredConversion> conversions = CONVERSIONS.get(sourcePtr);
+        if (conversions != null) {
+          // if we have values for the source type, evaluate each to find the one that matches either the exact destination type, or the nearest subtype
+          RegisteredConversion nearest = null;
+          for (final RegisteredConversion potential : conversions) {
+            final Class<?> potentialDst = potential.conversion.destination();
+
+            if (dst.equals(potentialDst)) return potential; // exact match
+            if (!dst.isAssignableFrom(potentialDst)) continue; // out of hierarchy
+
+            // if we are up the hierarchy
+            if (nearest == null || potentialDst.isAssignableFrom(nearest.conversion.destination())) {
+              nearest = potential;
+            }
+          }
+
+          if (nearest != null) return nearest; // we found a match
+        }
+
+        addSupertypes(sourcePtr, sourceTypes);
+      }
+
+      return RegisteredConversion.NONE;
+    }
+
+    private static void addSupertypes(final Class<?> clazz, final Deque<Class<?>> queue) {
+      if (clazz.getSuperclass() != null) {
+        queue.add(clazz.getSuperclass());
+      }
+
+      queue.addAll(Arrays.asList(clazz.getInterfaces()));
+    }
+
+    @SuppressWarnings("unchecked")
+    static <I extends DataComponentValue, O extends DataComponentValue> @Nullable Conversion<? super I, ? extends O> converter(final Class<I> src, final Class<O> dst) {
+      final RegisteredConversion result = CACHE.computeIfAbsent(src, $ -> new ConcurrentHashMap<>()).computeIfAbsent(dst, $$ -> compute(src, dst));
+      if (result == RegisteredConversion.NONE) return null;
+
+      return (Conversion<? super I, ? extends O>) result.conversion;
+    }
+  }
+
+  static final class RegisteredConversion {
+    static final RegisteredConversion NONE = new RegisteredConversion(null, null);
+
+    final Key provider;
+    final Conversion<?, ?> conversion;
+
+    RegisteredConversion(final Key provider, final Conversion<?, ?> conversion) {
+      this.provider = provider;
+      this.conversion = conversion;
+    }
+  }
+}

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -614,7 +614,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @return the unmodifiable map
      * @since 4.17.0
      */
-    public <V extends DataComponentValue> @NotNull Map<Key, V> dataComponentsConvertedTo(final @NotNull Class<V> targetType) {
+    public <V extends DataComponentValue> @NotNull Map<Key, V> dataComponentsAs(final @NotNull Class<V> targetType) {
       if (this.dataComponents.isEmpty()) {
         return Collections.emptyMap();
       } else {

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -143,7 +143,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.17.0
    */
-  public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @NotNull Map<Key, DataComponentValue> dataComponents) {
+  public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @NotNull Map<Key, ? extends DataComponentValue> dataComponents) {
     return showItem(ShowItem.showItem(item, count, dataComponents));
   }
 
@@ -491,11 +491,11 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @since 4.17.0
      * @sinceMinecraft 1.20.5
      */
-    public static @NotNull ShowItem showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @NotNull Map<Key, DataComponentValue> dataComponents) {
+    public static @NotNull ShowItem showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @NotNull Map<Key, ? extends DataComponentValue> dataComponents) {
       return new ShowItem(requireNonNull(item, "item").key(), count, null, dataComponents);
     }
 
-    private ShowItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt, final @NotNull Map<Key, DataComponentValue> dataComponents) {
+    private ShowItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt, final @NotNull Map<Key, ? extends DataComponentValue> dataComponents) {
       this.item = item;
       this.count = count;
       this.nbt = nbt;
@@ -592,7 +592,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     /**
      * Set the data components used on this item.
      *
-     * <p>This will clear any legacy nbt-format data on the item.</p>
+     * <p>This will clear any legacy NBT-format data on the item.</p>
      *
      * @param holder the new data components to set
      * @return a show item data object that has the provided components

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -23,6 +23,9 @@
  */
 package net.kyori.adventure.text.event;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
@@ -87,7 +90,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @since 4.0.0
    */
   public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
-    return showItem(item, count, null);
+    return showItem(item, count, Collections.emptyMap());
   }
 
   /**
@@ -99,7 +102,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @since 4.6.0
    */
   public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
-    return showItem(item, count, null);
+    return showItem(item, count, Collections.emptyMap());
   }
 
   /**
@@ -111,8 +114,9 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @return a hover event
    * @since 4.0.0
    */
+  @Deprecated
   public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
-    return showItem(ShowItem.of(item, count, nbt));
+    return showItem(ShowItem.showItem(item, count, nbt));
   }
 
   /**
@@ -123,9 +127,24 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @param nbt the nbt
    * @return a hover event
    * @since 4.6.0
+   * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
    */
+  @Deprecated
   public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
-    return showItem(ShowItem.of(item, count, nbt));
+    return showItem(ShowItem.showItem(item, count, nbt));
+  }
+
+  /**
+   * Creates a hover event that shows an item on hover.
+   *
+   * @param item the item
+   * @param count the count
+   * @param dataComponents the data components
+   * @return a hover event
+   * @since 4.17.0
+   */
+  public static @NotNull HoverEvent<ShowItem> showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @NotNull Map<Key, ItemDataHolder> dataComponents) {
+    return showItem(ShowItem.showItem(item, count, dataComponents));
   }
 
   /**
@@ -216,7 +235,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
    * @param value the achievement value
    * @return a hover event
    * @since 4.14.0
-   * @deprecated Removed in Vanilla 1.12, but we keep it for backwards compat
+   * @deprecated Removed in Vanilla 1.12, but we keep it for backwards compatibility
    */
   @Deprecated
   public static @NotNull HoverEvent<String> showAchievement(final @NotNull String value) {
@@ -344,6 +363,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     private final Key item;
     private final int count;
     private final @Nullable BinaryTagHolder nbt;
+    private final Map<Key, ItemDataHolder> dataComponents;
 
     /**
      * Creates.
@@ -354,7 +374,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @since 4.14.0
      */
     public static @NotNull ShowItem showItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
-      return showItem(item, count, null);
+      return showItem(item, count, Collections.emptyMap());
     }
 
     /**
@@ -369,7 +389,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     @Deprecated
     @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
     public static @NotNull ShowItem of(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
-      return of(item, count, null);
+      return showItem(item, count, Collections.emptyMap());
     }
 
     /**
@@ -381,7 +401,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @since 4.14.0
      */
     public static @NotNull ShowItem showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
-      return showItem(item, count, null);
+      return showItem(item, count, Collections.emptyMap());
     }
 
     /**
@@ -407,9 +427,11 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @param nbt the nbt
      * @return a {@code ShowItem}
      * @since 4.14.0
+     * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
      */
+    @Deprecated
     public static @NotNull ShowItem showItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
-      return new ShowItem(requireNonNull(item, "item"), count, nbt);
+      return new ShowItem(requireNonNull(item, "item"), count, nbt, Collections.emptyMap());
     }
 
     /**
@@ -425,7 +447,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     @Deprecated
     @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
     public static @NotNull ShowItem of(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
-      return new ShowItem(requireNonNull(item, "item"), count, nbt);
+      return new ShowItem(requireNonNull(item, "item"), count, nbt, Collections.emptyMap());
     }
 
     /**
@@ -436,9 +458,11 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      * @param nbt the nbt
      * @return a {@code ShowItem}
      * @since 4.14.0
+     * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
      */
+    @Deprecated
     public static @NotNull ShowItem showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
-      return new ShowItem(requireNonNull(item, "item").key(), count, nbt);
+      return new ShowItem(requireNonNull(item, "item").key(), count, nbt, Collections.emptyMap());
     }
 
     /**
@@ -454,13 +478,28 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     @Deprecated
     @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
     public static @NotNull ShowItem of(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
-      return new ShowItem(requireNonNull(item, "item").key(), count, nbt);
+      return new ShowItem(requireNonNull(item, "item").key(), count, nbt, Collections.emptyMap());
     }
 
-    private ShowItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
+    /**
+     * Creates.
+     *
+     * @param item the item
+     * @param count the count
+     * @param dataComponents the data components
+     * @return a {@code ShowItem}
+     * @since 4.17.0
+     * @sinceMinecraft 1.20.5
+     */
+    public static @NotNull ShowItem showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @NotNull Map<Key, ItemDataHolder> dataComponents) {
+      return new ShowItem(requireNonNull(item, "item").key(), count, null, dataComponents);
+    }
+
+    private ShowItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt, final @NotNull Map<Key, ItemDataHolder> dataComponents) {
       this.item = item;
       this.count = count;
       this.nbt = nbt;
+      this.dataComponents = Collections.unmodifiableMap(new HashMap<>(dataComponents));
     }
 
     /**
@@ -482,7 +521,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      */
     public @NotNull ShowItem item(final @NotNull Key item) {
       if (requireNonNull(item, "item").equals(this.item)) return this;
-      return new ShowItem(item, this.count, this.nbt);
+      return new ShowItem(item, this.count, this.nbt, this.dataComponents);
     }
 
     /**
@@ -504,15 +543,19 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
      */
     public @NotNull ShowItem count(final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
       if (count == this.count) return this;
-      return new ShowItem(this.item, count, this.nbt);
+      return new ShowItem(this.item, count, this.nbt, this.dataComponents);
     }
 
     /**
      * Gets the nbt.
      *
+     * <p>If there are data components on this item, it will never have NBT data.</p>
+     *
      * @return the nbt
      * @since 4.0.0
+     * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
      */
+    @Deprecated
     public @Nullable BinaryTagHolder nbt() {
       return this.nbt;
     }
@@ -520,13 +563,45 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
     /**
      * Sets the nbt.
      *
+     * <p>This will clear any modern data components set on the item.</p>
+     *
      * @param nbt the nbt
      * @return a {@code ShowItem}
      * @since 4.0.0
+     * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
      */
+    @Deprecated
     public @NotNull ShowItem nbt(final @Nullable BinaryTagHolder nbt) {
       if (Objects.equals(nbt, this.nbt)) return this;
-      return new ShowItem(this.item, this.count, nbt);
+      return new ShowItem(this.item, this.count, nbt, Collections.emptyMap());
+    }
+
+    /**
+     * Get the data components used for this item.
+     *
+     * <p>If there is NBT data on this item, it will never have any data components set.</p>
+     *
+     * @return an unmodifiable map of data components
+     * @since 4.17.0
+     * @sinceMinecraft 1.20.5
+     */
+    public @NotNull Map<Key, ItemDataHolder> dataComponents() {
+      return this.dataComponents;
+    }
+
+    /**
+     * Set the data components used on this item.
+     *
+     * <p>This will clear any legacy nbt-format data on the item.</p>
+     *
+     * @param holder the new data components to set
+     * @return a show item data object that has the provided components
+     * @since 4.17.0
+     * @sinceMinecraft 1.20.5
+     */
+    public @NotNull ShowItem dataComponents(final @NotNull Map<Key, ItemDataHolder> holder) {
+      if (Objects.equals(this.dataComponents, holder)) return this;
+      return new ShowItem(this.item, this.count, null, holder.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(holder)));
     }
 
     @Override
@@ -534,7 +609,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
       if (this == other) return true;
       if (other == null || this.getClass() != other.getClass()) return false;
       final ShowItem that = (ShowItem) other;
-      return this.item.equals(that.item) && this.count == that.count && Objects.equals(this.nbt, that.nbt);
+      return this.item.equals(that.item) && this.count == that.count && Objects.equals(this.nbt, that.nbt) && Objects.equals(this.dataComponents, that.dataComponents);
     }
 
     @Override
@@ -542,6 +617,7 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
       int result = this.item.hashCode();
       result = (31 * result) + Integer.hashCode(this.count);
       result = (31 * result) + Objects.hashCode(this.nbt);
+      result = (31 * result) + Objects.hashCode(this.dataComponents);
       return result;
     }
 
@@ -550,7 +626,8 @@ public final class HoverEvent<V> implements Examinable, HoverEventSource<V>, Sty
       return Stream.of(
         ExaminableProperty.of("item", this.item),
         ExaminableProperty.of("count", this.count),
-        ExaminableProperty.of("nbt", this.nbt)
+        ExaminableProperty.of("nbt", this.nbt),
+        ExaminableProperty.of("dataComponents", this.dataComponents)
       );
     }
 

--- a/api/src/main/java/net/kyori/adventure/text/event/ItemDataHolder.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ItemDataHolder.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.event;
+
+import net.kyori.examination.Examinable;
+
+/**
+ * A holder for the value of an item's data component.
+ *
+ * <p>The exact value is platform-specific. Serializers may provide their
+ * own implementations as well, and any logic to serialize or deserialize
+ * should be done per-serializer.</p>
+ *
+ * @since 4.17.0
+ * @sinceMinecraft 1.20.5
+ */
+public interface ItemDataHolder extends Examinable {
+}

--- a/api/src/main/java/net/kyori/adventure/text/event/RemovedDataComponentValueImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/RemovedDataComponentValueImpl.java
@@ -23,17 +23,6 @@
  */
 package net.kyori.adventure.text.event;
 
-import net.kyori.examination.Examinable;
-
-/**
- * A holder for the value of an item's data component.
- *
- * <p>The exact value is platform-specific. Serializers may provide their
- * own implementations as well, and any logic to serialize or deserialize
- * should be done per-serializer.</p>
- *
- * @since 4.17.0
- * @sinceMinecraft 1.20.5
- */
-public interface ItemDataHolder extends Examinable {
+enum RemovedDataComponentValueImpl implements DataComponentValue.Removed {
+  REMOVED
 }

--- a/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMap.java
+++ b/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMap.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.util;
+
+import net.kyori.adventure.builder.AbstractBuilder;
+import org.jetbrains.annotations.CheckReturnValue;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A map type that will traverse class hierarchy to find a value for a key.
+ *
+ * <p>These maps are null-hostile, so both keys and values must not be null.</p>
+ *
+ * <p>There is a concept of <em>strict</em> mode, where map values have to be strictly non-ambiguous.
+ * When this enabled (by default it is not), a value will not be added if any subtypes or supertypes are already registered to the map.</p>
+ *
+ * <p>Inheritance aware maps are always immutable, so any mutation operations will apply any changes to a new, modified instance.</p>
+ *
+ * @param <C> the base class type
+ * @param <V> the value type
+ * @since 4.17.0
+ */
+public interface InheritanceAwareMap<C, V> {
+  /**
+   * Get an empty inheritance aware map.
+   *
+   * @param <K> class type upper bound
+   * @param <E> value type
+   * @return the map
+   * @since 4.17.0
+   */
+  @SuppressWarnings("unchecked")
+  static <K, E> @NotNull InheritanceAwareMap<K, E> empty() {
+    return InheritanceAwareMapImpl.EMPTY;
+  }
+
+  /**
+   * Create a new builder for an inheritance aware map.
+   *
+   * @param <K> class type upper bound
+   * @param <E> value type
+   * @return a new builder
+   * @since 4.17.0
+   */
+  static <K, E> InheritanceAwareMap.@NotNull Builder<K, E> builder() {
+    return new InheritanceAwareMapImpl.BuilderImpl<>();
+  }
+
+  /**
+   * Create a new builder for an inheritance aware map.
+   *
+   * @param <K> class type upper bound
+   * @param <E> value type
+   * @param existing the existing map to populate the builder with
+   * @return a new builder
+   * @since 4.17.0
+   */
+  static <K, E> InheritanceAwareMap.@NotNull Builder<K, E> builder(final InheritanceAwareMap<? extends K, ? extends E> existing) {
+    return new InheritanceAwareMapImpl.BuilderImpl<K, E>()
+      .putAll(existing);
+  }
+
+  /**
+   * Check whether this map contains a value (direct or computed) for the provided class.
+   *
+   * @param clazz the class type to check
+   * @return whether such a value is present
+   * @since 4.17.0
+   */
+  boolean containsKey(final @NotNull Class<? extends C> clazz);
+
+  /**
+   * Get the applicable value for the provided class.
+   *
+   * <p>This can be either a direct or inherited value.</p>
+   *
+   * @param clazz the class type
+   * @return the value, if any is available
+   * @since 4.17.0
+   */
+  @Nullable V get(final @NotNull Class<? extends C> clazz);
+
+  /**
+   * Get an updated inheritance aware map with the provided key changed.
+   *
+   * @param clazz the class type
+   * @param value the value to update to
+   * @return the updated map
+   * @since 4.17.0
+   */
+  @CheckReturnValue
+  @NotNull InheritanceAwareMap<C, V> with(final @NotNull Class<? extends C> clazz, final @NotNull V value);
+
+  /**
+   * Get an updated inheritance aware map with the provided key removed.
+   *
+   * @param clazz the class type to remove a direct value for
+   * @return the updated map
+   * @since 4.17.0
+   */
+  @CheckReturnValue
+  @NotNull InheritanceAwareMap<C, V> without(final @NotNull Class<? extends C> clazz);
+
+  /**
+   * A builder for inheritance-aware maps.
+   *
+   * @param <C> the class type
+   * @param <V> the value type
+   * @since 4.17.0
+   */
+  interface Builder<C, V> extends AbstractBuilder<InheritanceAwareMap<C, V>> {
+    /**
+     * Set strict mode for this builder.
+     *
+     * <p>If this builder has values from when it was not in strict mode, all previous values will be re-validated for any hierarchy ambiguities.</p>
+     *
+     * @param strict whether to enable strict mode.
+     * @return this builder
+     * @since 4.17.0
+     */
+    @NotNull Builder<C, V> strict(final boolean strict);
+
+    /**
+     * Put another value in this map.
+     *
+     * @param clazz the class type
+     * @param value the value for the provided type and any subtypes
+     * @return this builder
+     * @since 4.17.0
+     */
+    @NotNull Builder<C, V> put(final @NotNull Class<? extends C> clazz, final @NotNull V value);
+
+    /**
+     * Remove a value in this map.
+     *
+     * @param clazz the class type
+     * @return this builder
+     * @since 4.17.0
+     */
+    @NotNull Builder<C, V> remove(final @NotNull Class<? extends C> clazz);
+
+    /**
+     * Put values from an existing inheritance-aware map into this map.
+     *
+     * @param map the existing map
+     * @return this builder
+     * @since 4.17.0
+     */
+    @NotNull Builder<C, V> putAll(final @NotNull InheritanceAwareMap<? extends C, ? extends V> map);
+  }
+
+}

--- a/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMapImpl.java
+++ b/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMapImpl.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.util;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+final class InheritanceAwareMapImpl<C, V> implements InheritanceAwareMap<C, V> {
+  private static final Object NONE = new Object(); // null sentinel for CHM
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  static final InheritanceAwareMapImpl EMPTY = new InheritanceAwareMapImpl(false, Collections.emptyMap());
+
+  private final Map<Class<? extends C>, V> declaredValues;
+  private final boolean strict;
+  private transient final ConcurrentMap<Class<? extends C>, Object> cache = new ConcurrentHashMap<>();
+
+  InheritanceAwareMapImpl(final boolean strict, final Map<Class<? extends C>, V> declaredValues) {
+    this.strict = strict;
+    this.declaredValues = declaredValues;
+  }
+
+  @Override
+  public boolean containsKey(final @NotNull Class<? extends C> clazz) {
+    return this.get(clazz) != null;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @Nullable V get(final @NotNull Class<? extends C> clazz) {
+    final Object ret = this.cache.computeIfAbsent(clazz, c -> {
+      final @Nullable V value = this.declaredValues.get(c);
+      if (value != null) return value;
+
+      for (final Map.Entry<Class<? extends C>, V> entry : this.declaredValues.entrySet()) {
+        if (entry.getKey().isAssignableFrom(c)) {
+          return entry.getValue();
+        }
+      }
+
+      return NONE;
+    });
+
+    return ret == NONE ? null : (V) ret;
+  }
+
+  @Override
+  public @NotNull InheritanceAwareMap<C, V> with(final @NotNull Class<? extends C> clazz, final @NotNull V value) {
+    if (Objects.equals(this.declaredValues.get(clazz), value)) return this;
+    if (this.strict) validateNoneInHierarchy(clazz, this.declaredValues);
+
+    final Map<Class<? extends C>, V> newValues = new LinkedHashMap<>(this.declaredValues);
+    newValues.put(clazz, value);
+    return new InheritanceAwareMapImpl<>(this.strict, Collections.unmodifiableMap(newValues));
+  }
+
+  @Override
+  public @NotNull InheritanceAwareMap<C, V> without(final @NotNull Class<? extends C> clazz) {
+    if (!this.declaredValues.containsKey(clazz)) return this;
+
+    final Map<Class<? extends C>, V> newValues = new LinkedHashMap<>(this.declaredValues);
+    newValues.remove(clazz);
+    return new InheritanceAwareMapImpl<>(this.strict, Collections.unmodifiableMap(newValues));
+  }
+
+  static final class BuilderImpl<C, V> implements Builder<C, V> {
+    private boolean strict;
+    private final Map<Class<? extends C>, V> values = new LinkedHashMap<>();
+
+    @Override
+    public @NotNull InheritanceAwareMap<C, V> build() {
+      return new InheritanceAwareMapImpl<>(this.strict, Collections.unmodifiableMap(new LinkedHashMap<>(this.values)));
+    }
+
+    @Override
+    public @NotNull Builder<C, V> strict(final boolean strict) {
+      if (strict && !this.strict) { // re-validate contents
+        for (final Class<? extends C> clazz : this.values.keySet()) {
+          validateNoneInHierarchy(clazz, this.values);
+        }
+      }
+      this.strict = strict;
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder<C, V> put(final @NotNull Class<? extends C> clazz, final @NotNull V value) {
+      if (this.strict) validateNoneInHierarchy(clazz, this.values);
+      this.values.put(
+        requireNonNull(clazz, "clazz"),
+        requireNonNull(value, "value")
+      );
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder<C, V> remove(final @NotNull Class<? extends C> clazz) {
+      this.values.remove(requireNonNull(clazz, "clazz"));
+      return this;
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public @NotNull Builder<C, V> putAll(final @NotNull InheritanceAwareMap<? extends C, ? extends V> map) {
+      final InheritanceAwareMapImpl<?, V> impl = (InheritanceAwareMapImpl<?, V>) map;
+      if (this.strict) {
+        if (!this.values.isEmpty() || !impl.strict) { // validate all
+          for (final Map.Entry<? extends Class<?>, V> entry : impl.declaredValues.entrySet()) {
+            validateNoneInHierarchy(entry.getKey(), this.values);
+            this.values.put((Class<? extends C>) entry.getKey(), entry.getValue());
+          }
+          return this;
+        }
+      }
+
+      // otherwise (simpler)
+      this.values.putAll((Map) impl.declaredValues);
+      return this;
+    }
+  }
+
+  private static void validateNoneInHierarchy(final Class<?> beingRegistered, final Map<? extends Class<?>, ?> entries) {
+    for (final Class<?> clazz : entries.keySet()) {
+      testHierarchy(clazz, beingRegistered);
+    }
+  }
+
+  private static void testHierarchy(final Class<?> existing, final Class<?> beingRegistered) {
+    if (!existing.equals(beingRegistered) && (existing.isAssignableFrom(beingRegistered) || beingRegistered.isAssignableFrom(existing))) {
+      throw new IllegalArgumentException("Conflict detected between already registered type " + existing
+        + " and newly registered type " + beingRegistered + "! Types in a strict inheritance-aware map must not share a common hierarchy!");
+    }
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistryTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistryTest.java
@@ -1,0 +1,159 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.event;
+
+import com.google.auto.service.AutoService;
+import java.util.Arrays;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.key.Key.key;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DataComponentValueConverterRegistryTest {
+  @Test
+  void testKnownSourceToUnknownDest() {
+    final IllegalArgumentException iae = assertThrows(IllegalArgumentException.class, () -> {
+      DataComponentValueConverterRegistry.convert(Unregistered.class, key("test"), new DirectValue(3));
+    });
+
+    assertTrue(iae.getMessage().contains("There is no data holder converter registered"));
+  }
+
+  @Test
+  void testUnknownSourceToKnownDest() {
+    final IllegalArgumentException iae = assertThrows(IllegalArgumentException.class, () -> {
+      DataComponentValueConverterRegistry.convert(DirectValue.class, key("test"), new Unregistered());
+    });
+
+    assertTrue(iae.getMessage().contains("There is no data holder converter registered"));
+
+  }
+
+  @Test
+  void testFailedConversionBlamesProvider() {
+    final IllegalStateException ise = assertThrows(IllegalStateException.class, () -> {
+      DataComponentValueConverterRegistry.convert(Failing.class, key("test"), BinaryTagHolder.binaryTagHolder("{}"));
+    });
+
+    assertTrue(ise.getMessage().contains(TestConverterProvider.ID.asString()));
+  }
+
+  @Test
+  void testExactToExact() {
+    final DirectValue input = new DirectValue(new Object());
+    final ItfValueImpl result = DataComponentValueConverterRegistry.convert(ItfValueImpl.class, key("test"), input);
+
+    assertEquals(input.value, result.value);
+  }
+
+  @Test
+  void testSubtypeToExact() {
+    final ItfValue input = new ItfValueImpl(new Object());
+    final DirectValue result = DataComponentValueConverterRegistry.convert(DirectValue.class, key("test"), input);
+
+    assertEquals(input.value(), result.value);
+  }
+
+  @Test
+  void testSubtypeToSupertype() {
+    final ItfValue input = new ItfValueImpl(new Object());
+    final DataComponentValue result = DataComponentValueConverterRegistry.convert(Intermediate.class, key("test"), input);
+
+    assertInstanceOf(DirectValue.class, result);
+    assertEquals(input.value(), ((DirectValue) result).value);
+  }
+
+  @Test
+  void testExactToSupertype() {
+    final DirectValue input = new DirectValue(new Object());
+    final ItfValue result = DataComponentValueConverterRegistry.convert(ItfValue.class, key("test"), input);
+
+    assertEquals(input.value, result.value());
+  }
+
+  @AutoService(DataComponentValueConverterRegistry.Provider.class)
+  public static final class TestConverterProvider implements DataComponentValueConverterRegistry.Provider {
+    static final Key ID = key("adventure", "test/converter_registry");
+
+    @Override
+    public @NotNull Key id() {
+      return ID;
+    }
+
+    @Override
+    public @NotNull Iterable<DataComponentValueConverterRegistry.Conversion<?, ?>> conversions() {
+      // gah j8
+      return Arrays.asList(
+        DataComponentValueConverterRegistry.Conversion.convert(DirectValue.class, ItfValueImpl.class, (key, dir) -> new ItfValueImpl(dir.value)),
+        DataComponentValueConverterRegistry.Conversion.convert(ItfValue.class, DirectValue.class, (key, itf) -> new DirectValue(itf.value())),
+        DataComponentValueConverterRegistry.Conversion.convert(BinaryTagHolder.class, Failing.class, (key, itf) -> {
+          throw new RuntimeException("hah!");
+        })
+      );
+    }
+  }
+
+  static final class Unregistered implements DataComponentValue {
+    // i shall not be converted
+  }
+
+  static final class Failing implements DataComponentValue {
+    // this is a marker interface to trigger a failure
+  }
+
+  interface Intermediate extends DataComponentValue {
+
+  }
+
+  static final class DirectValue implements Intermediate {
+    final Object value;
+
+    DirectValue(final Object value) {
+      this.value = value;
+    }
+  }
+
+  interface ItfValue extends DataComponentValue {
+    Object value();
+  }
+
+  static final class ItfValueImpl implements ItfValue {
+    final Object value;
+
+    ItfValueImpl(final Object value) {
+      this.value = value;
+    }
+
+    @Override
+    public Object value() {
+      return this.value;
+    }
+  }
+}

--- a/api/src/test/java/net/kyori/adventure/text/event/HoverEventTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/event/HoverEventTest.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.event;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.key.Key;
@@ -113,8 +114,8 @@ class HoverEventTest {
         HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, Component.empty())
       )
       .addEqualityGroup(
-        HoverEvent.showItem(HoverEvent.ShowItem.showItem(Key.key("air"), 1, null)),
-        HoverEvent.hoverEvent(HoverEvent.Action.SHOW_ITEM, HoverEvent.ShowItem.showItem(Key.key("air"), 1, null))
+        HoverEvent.showItem(HoverEvent.ShowItem.showItem(Key.key("air"), 1, Collections.emptyMap())),
+        HoverEvent.hoverEvent(HoverEvent.Action.SHOW_ITEM, HoverEvent.ShowItem.showItem(Key.key("air"), 1, Collections.emptyMap()))
       )
       .addEqualityGroup(
         HoverEvent.showEntity(HoverEvent.ShowEntity.showEntity(Key.key("cat"), entity)),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 version = "1.0"
 
 [versions]
+autoService = "1.1.1"
 checkstyle = "10.14.0"
 errorprone = "2.25.0"
 examination = "1.3.0"
@@ -15,6 +16,8 @@ truth = "1.4.2"
 
 [libraries]
 # shared
+autoService = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
+autoService-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 examination-api = { module = "net.kyori:examination-api", version.ref = "examination" }
 examination-string = { module = "net.kyori:examination-string", version.ref = "examination" }
 option = { module = "net.kyori:option", version = "1.0.0" }
@@ -55,8 +58,6 @@ truth-java8 = { module = "com.google.truth.extensions:truth-java8-extension", ve
 contractValidator = "ca.stellardrift:contract-validator:1.0.1"
 errorprone = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }
 stylecheck = "ca.stellardrift:stylecheck:0.2.1"
-autoService-annotations = "com.google.auto.service:auto-service-annotations:1.1.1"
-autoService-processor = "com.google.auto.service:auto-service:1.1.1"
 
 build-errorpronePlugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
 build-indra = { module = "net.kyori:indra-common", version.ref = "indra" }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializerImpl.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializerImpl.java
@@ -107,6 +107,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
       .registerExact(new IndexSerializer<>(TypeToken.get(TextDecoration.class), TextDecoration.NAMES))
       .registerExact(HoverEvent.ShowEntity.class, HoverEventShowEntitySerializer.INSTANCE)
       .registerExact(HoverEvent.ShowItem.class, HoverEventShowItemSerializer.INSTANCE)
+      .register(ConfigurateDataComponentValue.class, ConfigurateDataComponentValueTypeSerializer.INSTANCE)
       .build();
   }
 

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateDataComponentValue.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateDataComponentValue.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate4;
+
+import net.kyori.adventure.text.event.DataComponentValue;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.configurate.ConfigurationNode;
+
+/**
+ * A data component value that can integrate with configuration nodes.
+ *
+ * @since 4.17.0
+ */
+public interface ConfigurateDataComponentValue extends DataComponentValue {
+  /**
+   * Create a data component value capturing the value of an existing node.
+   *
+   * @param existing the existing node
+   * @return the captured value
+   * @since 4.17.0
+   */
+  static @NotNull ConfigurateDataComponentValue capturingDataComponentValue(final @NotNull ConfigurationNode existing) {
+    return SnapshottingConfigurateDataComponentValue.create(existing);
+  }
+
+  /**
+   * Apply the contained value to the supplied node.
+   *
+   * @param node the node to apply this value to
+   * @since 4.17.0
+   */
+  void applyTo(final @NotNull ConfigurationNode node);
+}

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateDataComponentValueTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateDataComponentValueTypeSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate4;
+
+import java.lang.reflect.Type;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.serialize.TypeSerializer;
+
+final class ConfigurateDataComponentValueTypeSerializer implements TypeSerializer<ConfigurateDataComponentValue> {
+  static final TypeSerializer<ConfigurateDataComponentValue> INSTANCE = new ConfigurateDataComponentValueTypeSerializer();
+
+  private ConfigurateDataComponentValueTypeSerializer() {
+  }
+
+  @Override
+  public ConfigurateDataComponentValue deserialize(final Type type, final ConfigurationNode node) throws SerializationException {
+    return ConfigurateDataComponentValue.capturingDataComponentValue(node);
+  }
+
+  @Override
+  public void serialize(final Type type, final @Nullable ConfigurateDataComponentValue obj, final ConfigurationNode node) throws SerializationException {
+    if (obj == null) {
+      node.set(null);
+      return;
+    }
+
+    obj.applyTo(node);
+  }
+}

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SnapshottingConfigurateDataComponentValue.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SnapshottingConfigurateDataComponentValue.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.serializer.configurate4;
+
+import java.util.stream.Stream;
+import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.configurate.AttributedConfigurationNode;
+import org.spongepowered.configurate.BasicConfigurationNode;
+import org.spongepowered.configurate.CommentedConfigurationNode;
+import org.spongepowered.configurate.ConfigurationNode;
+
+final class SnapshottingConfigurateDataComponentValue implements ConfigurateDataComponentValue {
+  private final ConfigurationNode ownedNode;
+
+  // capture the value of an existing node without exposing any mutable state
+  static @NotNull SnapshottingConfigurateDataComponentValue create(final ConfigurationNode existing) {
+    final ConfigurationNode owned;
+    if (existing instanceof AttributedConfigurationNode) {
+      owned = AttributedConfigurationNode.root(((AttributedConfigurationNode) existing).tagName(), existing.options());
+    } else if (existing instanceof CommentedConfigurationNode) {
+      owned = CommentedConfigurationNode.root(existing.options());
+    } else {
+      owned = BasicConfigurationNode.root(existing.options());
+    }
+
+    owned.from(existing);
+
+    return new SnapshottingConfigurateDataComponentValue(owned);
+  }
+
+  private SnapshottingConfigurateDataComponentValue(final ConfigurationNode owned) {
+    this.ownedNode = owned;
+  }
+
+  @Override
+  public void applyTo(final @NotNull ConfigurationNode node) {
+    node.from(this.ownedNode);
+  }
+
+  @Override
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("ownedNode", this.ownedNode)
+    );
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
@@ -170,7 +170,7 @@ final class HoverTag {
         if (hasLegacy(event)) {
           emitLegacyHover(event, emit);
         } else {
-          for (final Map.Entry<Key, DataComponentValue.TagSerializable> entry : event.dataComponentsConvertedTo(DataComponentValue.TagSerializable.class).entrySet()) {
+          for (final Map.Entry<Key, DataComponentValue.TagSerializable> entry : event.dataComponentsAs(DataComponentValue.TagSerializable.class).entrySet()) {
             emit.argument(entry.getKey().asMinimalString());
             emit.argument(entry.getValue().asBinaryTag().string());
           }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
@@ -23,11 +23,14 @@
  */
 package net.kyori.adventure.text.minimessage.tag.standard;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import net.kyori.adventure.key.InvalidKeyException;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.minimessage.Context;
@@ -123,10 +126,27 @@ final class HoverTag {
     @Override
     public HoverEvent.@NotNull ShowItem parse(final @NotNull ArgumentQueue args, final @NotNull Context ctx) throws ParsingException {
       try {
+        @SuppressWarnings("PatternValidation")
         final Key key = Key.key(args.popOr("Show item hover needs at least an item ID").value());
         final int count = args.hasNext() ? args.pop().asInt().orElseThrow(() -> ctx.newException("The count argument was not a valid integer")) : 1;
         if (args.hasNext()) {
-          return HoverEvent.ShowItem.showItem(key, count, BinaryTagHolder.binaryTagHolder(args.pop().value()));
+          // Compatibility with legacy versions:
+          // if the value starts with a '{' we assume it's SNBT, and parse it as such to create a legacy holder
+          // otherwise, we'll parse argument pairs as a map of ResourceLocation -> SNBT value
+          final String value = args.peek().value();
+          if (value.startsWith("{")) {
+            args.pop();
+            return legacyShowItem(key, count, value);
+          }
+
+          final Map<Key, DataComponentValue> datas = new HashMap<>();
+          while (args.hasNext()) {
+            @SuppressWarnings("PatternValidation")
+            final Key dataKey = Key.key(args.pop().value());
+            final String dataVal = args.popOr("a value was expected for key " + dataKey).value();
+            datas.put(dataKey, BinaryTagHolder.binaryTagHolder(dataVal));
+          }
+          return HoverEvent.ShowItem.showItem(key, count, datas);
         } else {
           return HoverEvent.ShowItem.showItem(key, count);
         }
@@ -135,16 +155,38 @@ final class HoverTag {
       }
     }
 
+    @SuppressWarnings("deprecation")
+    private static HoverEvent.@NotNull ShowItem legacyShowItem(final Key id, final int count, final String value) {
+      return HoverEvent.ShowItem.showItem(id, count, BinaryTagHolder.binaryTagHolder(value));
+    }
+
     @Override
     public void emit(final HoverEvent.ShowItem event, final TokenEmitter emit) {
       emit.argument(compactAsString(event.item()));
 
-      if (event.count() != 1 || event.nbt() != null) {
+      if (event.count() != 1 || hasLegacy(event) || !event.dataComponents().isEmpty()) {
         emit.argument(Integer.toString(event.count()));
 
-        if (event.nbt() != null) {
-          emit.argument(event.nbt().string());
+        if (hasLegacy(event)) {
+          emitLegacyHover(event, emit);
+        } else {
+          for (final Map.Entry<Key, DataComponentValue.TagSerializable> entry : event.dataComponentsConvertedTo(DataComponentValue.TagSerializable.class).entrySet()) {
+            emit.argument(entry.getKey().asMinimalString());
+            emit.argument(entry.getValue().asBinaryTag().string());
+          }
         }
+      }
+    }
+
+    @SuppressWarnings("deprecation")
+    static boolean hasLegacy(final HoverEvent.ShowItem event) {
+      return event.nbt() != null;
+    }
+
+    @SuppressWarnings("deprecation")
+    static void emitLegacyHover(final HoverEvent.ShowItem event, final TokenEmitter emit) {
+      if (event.nbt() != null) {
+        emit.argument(event.nbt().string());
       }
     }
   }

--- a/text-serializer-gson/build.gradle.kts
+++ b/text-serializer-gson/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 
 dependencies {
   api(libs.gson)
+  compileOnlyApi(libs.autoService.annotations)
+  annotationProcessor(libs.autoService)
 }
 
 applyJarMetadata("net.kyori.adventure.text.serializer.gson")

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonDataComponentValue.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonDataComponentValue.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.gson;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import net.kyori.adventure.text.event.DataComponentValue;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An {@link DataComponentValue} implementation that holds a JsonElement.
+ *
+ * <p>This holder is exposed to allow conversions to/from gson data holders.</p>
+ *
+ * @since 4.17.0
+ */
+@ApiStatus.NonExtendable
+public interface GsonDataComponentValue extends DataComponentValue {
+  /**
+   * Create a box for item data that can be understood by the gson serializer.
+   *
+   * @param data the item data to hold
+   * @return a newly created item data holder instance
+   * @since 4.17.0
+   */
+  static GsonDataComponentValue gsonDatacomponentValue(final @NotNull JsonElement data) {
+    if (data instanceof JsonNull) {
+      return GsonDataComponentValueImpl.RemovedGsonComponentValueImpl.INSTANCE;
+    } else {
+      return new GsonDataComponentValueImpl(requireNonNull(data, "data"));
+    }
+  }
+
+  /**
+   * The contained element, intended for read-only use.
+   *
+   * @return a copy of the contained element
+   * @since 4.17.0
+   */
+  @NotNull JsonElement element();
+}

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonDataComponentValueImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonDataComponentValueImpl.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.gson;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import java.util.Objects;
+import java.util.stream.Stream;
+import net.kyori.adventure.internal.Internals;
+import net.kyori.adventure.text.event.DataComponentValue;
+import net.kyori.examination.ExaminableProperty;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+class GsonDataComponentValueImpl implements GsonDataComponentValue {
+  private final JsonElement element;
+
+  GsonDataComponentValueImpl(final @NotNull JsonElement element) {
+    this.element = element;
+  }
+
+  @Override
+  public @NotNull JsonElement element() {
+    return this.element;
+  }
+
+  @Override
+  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    return Stream.of(
+      ExaminableProperty.of("element", this.element)
+    );
+  }
+
+  @Override
+  public String toString() {
+    return Internals.toString(this);
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if (this == other) return true;
+    if (other == null || getClass() != other.getClass()) return false;
+    final GsonDataComponentValueImpl that = (GsonDataComponentValueImpl) other;
+    return Objects.equals(this.element, that.element);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(this.element);
+  }
+
+  static final class RemovedGsonComponentValueImpl extends GsonDataComponentValueImpl implements DataComponentValue.Removed {
+    static final RemovedGsonComponentValueImpl INSTANCE = new RemovedGsonComponentValueImpl();
+
+    private RemovedGsonComponentValueImpl() {
+      super(JsonNull.INSTANCE);
+    }
+  }
+}

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
@@ -24,19 +24,25 @@
 package net.kyori.adventure.text.serializer.gson;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.option.OptionState;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static net.kyori.adventure.text.serializer.json.JSONComponentConstants.SHOW_ITEM_COMPONENTS;
 import static net.kyori.adventure.text.serializer.json.JSONComponentConstants.SHOW_ITEM_COUNT;
 import static net.kyori.adventure.text.serializer.json.JSONComponentConstants.SHOW_ITEM_ID;
 import static net.kyori.adventure.text.serializer.json.JSONComponentConstants.SHOW_ITEM_TAG;
@@ -55,12 +61,14 @@ final class ShowItemSerializer extends TypeAdapter<HoverEvent.ShowItem> {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public HoverEvent.ShowItem read(final JsonReader in) throws IOException {
     in.beginObject();
 
     Key key = null;
     int count = 1;
     @Nullable BinaryTagHolder nbt = null;
+    @Nullable Map<Key, DataComponentValue> dataComponents = null;
 
     while (in.hasNext()) {
       final String fieldName = in.nextName();
@@ -79,6 +87,17 @@ final class ShowItemSerializer extends TypeAdapter<HoverEvent.ShowItem> {
         } else {
           throw new JsonParseException("Expected " + SHOW_ITEM_TAG + " to be a string");
         }
+      } else if (fieldName.equals(SHOW_ITEM_COMPONENTS)) {
+        in.beginObject();
+        while (in.peek() != JsonToken.END_OBJECT) {
+          final Key id = Key.key(in.nextName());
+          final JsonElement tree = this.gson.fromJson(in, JsonElement.class);
+          if (dataComponents == null) {
+            dataComponents = new HashMap<>();
+          }
+          dataComponents.put(id, GsonDataComponentValue.gsonDatacomponentValue(tree));
+        }
+        in.endObject();
       } else {
         in.skipValue();
       }
@@ -89,7 +108,14 @@ final class ShowItemSerializer extends TypeAdapter<HoverEvent.ShowItem> {
     }
     in.endObject();
 
-    return HoverEvent.ShowItem.showItem(key, count, nbt);
+    if (dataComponents != null) {
+      if (nbt != null) {
+        // todo: strict
+      }
+      return HoverEvent.ShowItem.showItem(key, count, dataComponents);
+    } else {
+      return HoverEvent.ShowItem.showItem(key, count, nbt);
+    }
   }
 
   @Override
@@ -105,12 +131,28 @@ final class ShowItemSerializer extends TypeAdapter<HoverEvent.ShowItem> {
       out.value(count);
     }
 
+    final @NotNull Map<Key, DataComponentValue> dataComponents = value.dataComponents();
+    if (!dataComponents.isEmpty()) {
+      out.name(SHOW_ITEM_COMPONENTS);
+      out.beginObject();
+      for (final Map.Entry<Key, GsonDataComponentValue> entry : value.dataComponentsConvertedTo(GsonDataComponentValue.class).entrySet()) {
+        out.name(entry.getKey().asMinimalString());
+        this.gson.toJson(entry.getValue().element(), out);
+      }
+      out.endObject();
+    } else {
+      writeLegacy(out, value);
+    }
+
+    out.endObject();
+  }
+
+  @SuppressWarnings("deprecation")
+  private static void writeLegacy(final JsonWriter out, final HoverEvent.ShowItem value) throws IOException {
     final @Nullable BinaryTagHolder nbt = value.nbt();
     if (nbt != null) {
       out.name(SHOW_ITEM_TAG);
       out.value(nbt.string());
     }
-
-    out.endObject();
   }
 }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/GsonDataComponentValueConverterProvider.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/GsonDataComponentValueConverterProvider.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.serializer.gson.impl;
 
+import com.google.auto.service.AutoService;
 import com.google.gson.JsonNull;
 import java.util.Collections;
 import net.kyori.adventure.key.Key;
@@ -39,6 +40,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @since 4.17.0
  */
+@AutoService(DataComponentValueConverterRegistry.Provider.class)
 @ApiStatus.Internal
 public final class GsonDataComponentValueConverterProvider implements DataComponentValueConverterRegistry.Provider {
   private static final Key ID = Key.key("adventure", "serializer/gson");

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/GsonDataComponentValueConverterProvider.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/GsonDataComponentValueConverterProvider.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2024 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.gson.impl;
+
+import com.google.gson.JsonNull;
+import java.util.Collections;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.event.DataComponentValue;
+import net.kyori.adventure.text.event.DataComponentValueConverterRegistry;
+import net.kyori.adventure.text.serializer.gson.GsonDataComponentValue;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A provider for Gson's implementations of data component value converters.
+ *
+ * <p>This is public SPI, not API.</p>
+ *
+ * @since 4.17.0
+ */
+@ApiStatus.Internal
+public final class GsonDataComponentValueConverterProvider implements DataComponentValueConverterRegistry.Provider {
+  private static final Key ID = Key.key("adventure", "serializer/gson");
+
+  @Override
+  public @NotNull Key id() {
+    return ID;
+  }
+
+  @Override
+  public @NotNull Iterable<DataComponentValueConverterRegistry.Conversion<?, ?>> conversions() {
+    return Collections.singletonList(
+      DataComponentValueConverterRegistry.Conversion.convert(
+        DataComponentValue.Removed.class,
+        GsonDataComponentValue.class,
+        (k, removed) -> GsonDataComponentValue.gsonDatacomponentValue(JsonNull.INSTANCE)
+      )
+    );
+  }
+}

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/JSONComponentSerializerProviderImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/JSONComponentSerializerProviderImpl.java
@@ -21,9 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package net.kyori.adventure.text.serializer.gson;
+package net.kyori.adventure.text.serializer.gson.impl;
 
+import com.google.auto.service.AutoService;
 import java.util.function.Supplier;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import net.kyori.adventure.util.Services;
 import org.jetbrains.annotations.ApiStatus;
@@ -35,6 +37,7 @@ import org.jetbrains.annotations.NotNull;
  * @since 4.14.0
  */
 @ApiStatus.Internal
+@AutoService(JSONComponentSerializer.Provider.class)
 public final class JSONComponentSerializerProviderImpl implements JSONComponentSerializer.Provider, Services.Fallback {
   @Override
   public @NotNull JSONComponentSerializer instance() {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/package-info.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Internal classes for the Gson serializer.
+ */
+@ApiStatus.Internal
+package net.kyori.adventure.text.serializer.gson.impl;
+
+import org.jetbrains.annotations.ApiStatus;

--- a/text-serializer-gson/src/main/resources/META-INF/services/net.kyori.adventure.text.event.DataComponentValueConverterRegistry$Provider
+++ b/text-serializer-gson/src/main/resources/META-INF/services/net.kyori.adventure.text.event.DataComponentValueConverterRegistry$Provider
@@ -1,1 +1,0 @@
-net.kyori.adventure.text.serializer.gson.impl.GsonDataComponentValueConverterProvider

--- a/text-serializer-gson/src/main/resources/META-INF/services/net.kyori.adventure.text.event.DataComponentValueConverterRegistry$Provider
+++ b/text-serializer-gson/src/main/resources/META-INF/services/net.kyori.adventure.text.event.DataComponentValueConverterRegistry$Provider
@@ -1,0 +1,1 @@
+net.kyori.adventure.text.serializer.gson.impl.GsonDataComponentValueConverterProvider

--- a/text-serializer-gson/src/main/resources/META-INF/services/net.kyori.adventure.text.serializer.json.JSONComponentSerializer$Provider
+++ b/text-serializer-gson/src/main/resources/META-INF/services/net.kyori.adventure.text.serializer.json.JSONComponentSerializer$Provider
@@ -1,1 +1,0 @@
-net.kyori.adventure.text.serializer.gson.JSONComponentSerializerProviderImpl

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONComponentConstants.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONComponentConstants.java
@@ -64,7 +64,8 @@ public final class JSONComponentConstants {
   public static final String SHOW_ENTITY_NAME = "name";
   public static final String SHOW_ITEM_ID = "id";
   public static final String SHOW_ITEM_COUNT = "count";
-  public static final String SHOW_ITEM_TAG = "tag";
+  public static final @Deprecated String SHOW_ITEM_TAG = "tag";
+  public static final String SHOW_ITEM_COMPONENTS = "components";
 
   private JSONComponentConstants() {
     throw new IllegalStateException("Cannot instantiate");

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONOptions.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONOptions.java
@@ -93,6 +93,13 @@ public final class JSONOptions {
   public static final Option<Boolean> EMIT_DEFAULT_ITEM_HOVER_QUANTITY = Option.booleanOption(key("emit/default_item_hover_quantity"), true);
 
   /**
+   * How to emit the item data on {@code show_item} hover events.
+   *
+   * @since 4.17.0
+   */
+  public static final Option<ShowItemHoverDataMode> SHOW_ITEM_HOVER_DATA_MODE = Option.enumOption(key("emit/show_item_hover_data"), ShowItemHoverDataMode.class, ShowItemHoverDataMode.EMIT_EITHER);
+
+  /**
    * Versioned by world data version.
    */
   private static final OptionState.Versioned BY_DATA_VERSION = OptionState.versionedOptionState()
@@ -103,6 +110,7 @@ public final class JSONOptions {
         .value(EMIT_HOVER_SHOW_ENTITY_ID_AS_INT_ARRAY, false)
         .value(VALIDATE_STRICT_EVENTS, false)
         .value(EMIT_DEFAULT_ITEM_HOVER_QUANTITY, false)
+        .value(SHOW_ITEM_HOVER_DATA_MODE, ShowItemHoverDataMode.EMIT_LEGACY_NBT)
     )
     .version(
       VERSION_1_16,
@@ -118,6 +126,7 @@ public final class JSONOptions {
     .version(
       VERSION_1_20_5,
       b -> b.value(EMIT_DEFAULT_ITEM_HOVER_QUANTITY, true)
+        .value(SHOW_ITEM_HOVER_DATA_MODE, ShowItemHoverDataMode.EMIT_DATA_COMPONENTS)
     )
     .build();
 
@@ -131,6 +140,7 @@ public final class JSONOptions {
     .value(EMIT_HOVER_SHOW_ENTITY_ID_AS_INT_ARRAY, false)
     .value(EMIT_COMPACT_TEXT_COMPONENT, false)
     .value(VALIDATE_STRICT_EVENTS, false)
+    .value(SHOW_ITEM_HOVER_DATA_MODE, ShowItemHoverDataMode.EMIT_EITHER)
     .build();
 
   private static String key(final String value) {
@@ -183,5 +193,31 @@ public final class JSONOptions {
      * @since 4.15.0
      */
     BOTH,
+  }
+
+  /**
+   * Configure how to emit show_item hovers.
+   *
+   * @since 4.17.0
+   */
+  public enum ShowItemHoverDataMode {
+    /**
+     * Only emit the pre-1.20.5 item nbt.
+     *
+     * @since 4.17.0
+     */
+    EMIT_LEGACY_NBT,
+    /**
+     * Only emit modern data components.
+     *
+     * @since 4.17.0
+     */
+    EMIT_DATA_COMPONENTS,
+    /**
+     * Emit whichever of legacy or modern data the item has.
+     *
+     * @since 4.17.0
+     */
+    EMIT_EITHER,
   }
 }

--- a/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/ShowItemSerializerTest.java
+++ b/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/ShowItemSerializerTest.java
@@ -37,7 +37,12 @@ import org.junit.jupiter.api.Test;
 final class ShowItemSerializerTest extends SerializerTest {
   @Test
   void testDeserializeWithPopulatedTag() throws IOException {
+    final JSONComponentSerializer serializer = JSONComponentSerializer.builder()
+      .editOptions(opts -> opts.value(JSONOptions.SHOW_ITEM_HOVER_DATA_MODE, JSONOptions.ShowItemHoverDataMode.EMIT_EITHER))
+      .build();
+
     this.testObject(
+      serializer,
       Component.text().hoverEvent(
         HoverEvent.showItem(
           Key.key("minecraft", "diamond"),
@@ -89,7 +94,11 @@ final class ShowItemSerializerTest extends SerializerTest {
 
   @Test
   void testDeserializeWithCountOfOne() throws IOException {
+    final JSONComponentSerializer serializer = JSONComponentSerializer.builder()
+      .editOptions(opts -> opts.value(JSONOptions.SHOW_ITEM_HOVER_DATA_MODE, JSONOptions.ShowItemHoverDataMode.EMIT_EITHER))
+      .build();
     this.testObject(
+      serializer,
       Component.text().hoverEvent(
         HoverEvent.showItem(
           Key.key("minecraft", "diamond"),

--- a/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/ShowItemSerializerTest.java
+++ b/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/ShowItemSerializerTest.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.serializer.json;
 
 import java.io.IOException;
+import java.util.Collections;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.nbt.StringBinaryTag;
@@ -70,7 +71,7 @@ final class ShowItemSerializerTest extends SerializerTest {
         HoverEvent.showItem(
           Key.key("minecraft", "diamond"),
           2,
-          null
+          Collections.emptyMap()
         )
       ).build(),
       json -> {


### PR DESCRIPTION
This lets us properly represent item data components in hover events.

Things to do:

- [x] test coverage
- [x] implement converters for serializers
- [x] implement converts in platforms
- [x] handle components in configurate serializer
- [x] ~~add concept of a customizable 'native' representation for gson, so platforms can avoid some type conversions~~ this seems to cause about as many problems as it'd solve, current wip will be pushed in a separate PR in case it makes sense to pick up later
- [x] add jsonoption for whether to emit legacy nbt at all