### PR TITLE
ensure numbers where we expected booleans parse correctly.

### DIFF
--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonHacks.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonHacks.java
@@ -45,8 +45,10 @@ final class GsonHacks {
     final JsonToken peek = in.peek();
     if (peek == JsonToken.BOOLEAN) {
       return in.nextBoolean();
-    } else if (peek == JsonToken.STRING || peek == JsonToken.NUMBER) {
+    } else if (peek == JsonToken.STRING) {
       return Boolean.parseBoolean(in.nextString());
+    } else if (peek == JsonToken.NUMBER) {
+      return in.nextString().equals("1");
     } else {
       throw new JsonParseException("Token of type " + peek + " cannot be interpreted as a boolean");
     }

--- a/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/StyleTest.java
+++ b/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/StyleTest.java
@@ -35,7 +35,6 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/StyleTest.java
+++ b/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/StyleTest.java
@@ -95,7 +95,7 @@ class StyleTest extends SerializerTest {
       object.addProperty(JSONComponentConstants.TEXT, "");
       object.addProperty(name(TextDecoration.BOLD), 1);
     })).style();
-    assertFalse(s0.hasDecoration(TextDecoration.BOLD));
+    assertTrue(s0.hasDecoration(TextDecoration.BOLD));
 
     assertThrows(RuntimeException.class, () -> {
       deserialize(object(object -> {


### PR DESCRIPTION
Boolean.parseBoolean expects the literal "true", which doesn't match the number 1.

The fix is to parse "1" as truthy, and all other values as falsy, like Boolean.parseBoolean() does.

fixes PaperMC/Velocity#1286

I'm assuming its meant to accept "1" as valid, seeing as it was specifically peeking for Numbers.
In velocity at least, "1" in json is emitted by the nbt component converter, from bytes