### PR TITLE
chore(deps): Bump kotlin language + plugin version

### DIFF
--- a/extra-kotlin/build.gradle.kts
+++ b/extra-kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
   compilerOptions {
     jvmTarget = JvmTarget.JVM_1_8
     @Suppress("DEPRECATION")
-    languageVersion = KotlinVersion.KOTLIN_1_4
+    languageVersion = KotlinVersion.KOTLIN_1_6
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,5 +75,5 @@ zJmh = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
 [plugins]
 indra-sonatype = { id = "net.kyori.indra.publishing.sonatype", version.ref = "indra" }
 jmh = { id = "me.champeau.jmh", version.ref = "jmhPlugin" }
-kotlin = "org.jetbrains.kotlin.jvm:2.0.21"
+kotlin = "org.jetbrains.kotlin.jvm:2.1.0"
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
   ],
   "ignoreDeps": [
     "com.google.code.gson:gson",
-    "org.slf4j:slf4j-api",
-    "org.jetbrains.kotlin.jvm"
+    "org.slf4j:slf4j-api"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
The newer Kotlin Gradle plugin no longer supports maintaining our existing language version target. To keep our build toolchain up-to-date, we've had to bump the target language version to the minimum supported by the newest Kotlin plugin. We expect these sorts of bumps to continue for the forseeable future because of overly tight coupling between the Kotlin gradle plugin and the Kotlin compiler.

This may cause source compatibility breaks for some users of `adventure-extra-kotlin`. Those users should consider using a programming language that cares about stability if this is an issue.