### PR TITLE
Configurable virtual component emission

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -140,4 +140,13 @@ public interface Context {
     final @Nullable Throwable cause,
     final @NotNull ArgumentQueue args
   );
+
+  /**
+   * Dictates if transformations may emit virtual components or not.
+   *
+   * @return the boolean flag, {@code true} if transformations may
+   *     emit virtuals, {@code false} otherwise.
+   * @since 4.19.0
+   */
+  boolean emitVirtuals();
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -49,6 +49,7 @@ class ContextImpl implements Context {
   private static final Token[] EMPTY_TOKEN_ARRAY = new Token[0];
 
   private final boolean strict;
+  private final boolean emitVirtuals;
   private final Consumer<String> debugOutput;
   private String message;
   private final MiniMessage miniMessage;
@@ -59,6 +60,7 @@ class ContextImpl implements Context {
 
   ContextImpl(
     final boolean strict,
+    final boolean emitVirtuals,
     final Consumer<String> debugOutput,
     final String message,
     final MiniMessage miniMessage,
@@ -68,6 +70,7 @@ class ContextImpl implements Context {
     final @Nullable UnaryOperator<Component> postProcessor
   ) {
     this.strict = strict;
+    this.emitVirtuals = emitVirtuals;
     this.debugOutput = debugOutput;
     this.message = message;
     this.miniMessage = miniMessage;
@@ -79,6 +82,11 @@ class ContextImpl implements Context {
 
   public boolean strict() {
     return this.strict;
+  }
+
+  @Override
+  public boolean emitVirtuals() {
+    return this.emitVirtuals;
   }
 
   public Consumer<String> debugOutput() {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -347,6 +347,23 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
     @NotNull Builder strict(final boolean strict);
 
     /**
+     * Configures if MiniMessage should emit virtual components (enabled by default).
+     *
+     * <p>
+     * Emitting virtual components may enable MiniMessage to more accurately reconstruct
+     * the source string representation when serializing a component by inserting virtual components
+     * during deserialization.
+     * Emitting virtual components will, however, break equality to components deserialized from
+     * MiniMessage instances that do not emit virtual components.
+     * </p>
+     *
+     * @param emitVirtuals if virtual components should be emitted.
+     * @return this builder.
+     * @since 4.19.0
+     */
+    @NotNull Builder emitVirtuals(final boolean emitVirtuals);
+
+    /**
      * Print debug information to the given output (disabled by default).
      *
      * <p>Debug output includes detailed information about the parsing process to help debug parser behavior.</p>

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/AbstractColorChangingTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/AbstractColorChangingTag.java
@@ -35,6 +35,7 @@ import net.kyori.adventure.text.VirtualComponent;
 import net.kyori.adventure.text.VirtualComponentRenderer;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.internal.parser.node.TagNode;
 import net.kyori.adventure.text.minimessage.internal.parser.node.ValueNode;
 import net.kyori.adventure.text.minimessage.internal.serializer.Emitable;
@@ -69,6 +70,11 @@ abstract class AbstractColorChangingTag implements Modifying, Examinable {
   private boolean visited;
   private int size = 0;
   private int disableApplyingColorDepth = -1;
+  private final boolean emitVirtuals;
+
+  AbstractColorChangingTag(final Context ctx) {
+    this.emitVirtuals = ctx.emitVirtuals();
+  }
 
   protected final int size() {
     return this.size;
@@ -101,7 +107,7 @@ abstract class AbstractColorChangingTag implements Modifying, Examinable {
 
   @Override
   public final Component apply(final @NotNull Component current, final int depth) {
-    if (depth == 0) {
+    if (this.emitVirtuals && depth == 0) {
       // capture state into a virtual component, no other logic is needed in normal MM handling
       return Component.virtual(Void.class, new TagInfoHolder(this.preserveData(), current), current.style());
     }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTag.java
@@ -95,10 +95,11 @@ class GradientTag extends AbstractColorChangingTag {
       textColors = Collections.emptyList();
     }
 
-    return new GradientTag(phase, textColors);
+    return new GradientTag(phase, textColors, ctx);
   }
 
-  GradientTag(final double phase, final List<TextColor> colors) {
+  GradientTag(final double phase, final List<TextColor> colors, final Context ctx) {
+    super(ctx);
     if (colors.isEmpty()) {
       this.colors = new TextColor[]{DEFAULT_WHITE, DEFAULT_BLACK};
     } else {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/PrideTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/PrideTag.java
@@ -104,13 +104,13 @@ final class PrideTag extends GradientTag {
       }
     }
 
-    return new PrideTag(phase, FLAGS.get(flag), flag);
+    return new PrideTag(phase, FLAGS.get(flag), flag, ctx);
   }
 
   private final String flag;
 
-  PrideTag(final double phase, final @NotNull List<@NotNull TextColor> colors, final @NotNull String flag) {
-    super(phase, colors);
+  PrideTag(final double phase, final @NotNull List<@NotNull TextColor> colors, final @NotNull String flag, final Context ctx) {
+    super(phase, colors, ctx);
     this.flag = flag;
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
@@ -73,10 +73,11 @@ final class RainbowTag extends AbstractColorChangingTag {
       }
     }
 
-    return new RainbowTag(reversed, phase);
+    return new RainbowTag(reversed, phase, ctx);
   }
 
-  private RainbowTag(final boolean reversed, final int phase) {
+  private RainbowTag(final boolean reversed, final int phase, final Context ctx) {
+    super(ctx);
     this.reversed = reversed;
     this.dividedPhase = ((double) phase) / 10d;
   }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/AbstractTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/AbstractTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractTest {
   }
 
   public static Context dummyContext(final String originalMessage) {
-    return new ContextImpl(false, null, originalMessage, PARSER, null, TagResolver.empty(), UnaryOperator.identity(), Component::compact);
+    return new ContextImpl(false, true, null, originalMessage, PARSER, null, TagResolver.empty(), UnaryOperator.identity(), Component::compact);
   }
 
   public static ArgumentQueue emptyArgumentQueue(final Context context) {

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTagTest.java
@@ -28,6 +28,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.AbstractTest;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.junit.jupiter.api.Test;
 
@@ -639,5 +640,18 @@ class GradientTagTest extends AbstractTest {
     final Component parsed = PARSER.deserialize(input);
 
     this.assertSerializedEquals(input, parsed);
+  }
+
+  // https://github.com/KyoriPowered/adventure/issues/1163
+  @Test
+  void testDisabledVirtualComponentEmission() {
+    final String input = "<b><gradient:white:blue>A";
+    final Component expected = text("A", WHITE, TextDecoration.BOLD);
+
+    this.assertParsedEquals(
+      MiniMessage.builder().emitVirtuals(false).build(),
+      expected,
+      input
+    );
   }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTagTest.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.minimessage.tag.standard;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.AbstractTest;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.junit.jupiter.api.Test;
@@ -386,5 +387,18 @@ class RainbowTagTest extends AbstractTest {
     );
 
     this.assertParsedEquals(expected, input);
+  }
+
+  // https://github.com/KyoriPowered/adventure/issues/1163
+  @Test
+  void testDisabledVirtualComponentEmission() {
+    final String input = "<b><rainbow>A";
+    final Component expected = text("A", color(0xff0000), TextDecoration.BOLD);
+
+    this.assertParsedEquals(
+      MiniMessage.builder().emitVirtuals(false).build(),
+      expected,
+      input
+    );
   }
 }


### PR DESCRIPTION
Since the introduction of virtual components in adventure 4.18, mini
message color changing tags like gradient or rainbow have been making
use of them to store metadata in the parsed component with the goal of
reconstructing the color changing tag when deserialising.

As virtual components are however simply flattened into empty text
component when interacting with a serialiser that is not aware of them,
virtual components can quickly break the expected component layout of
the parsed component, specifically in relation to components parsed in
previous versions of mini message.

The commit introduces a simple flag on the MM builder that allows
consumers to disable the emission of virtual components.

Resolves: #1163
