### PR TITLE
feat(api): Make ComponentLike extends ComponentBuilderApplicable

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/ComponentLike.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentLike.java
@@ -39,7 +39,7 @@ import static java.util.Objects.requireNonNull;
  * @since 4.0.0
  */
 @FunctionalInterface
-public interface ComponentLike {
+public interface ComponentLike extends ComponentBuilderApplicable {
   /**
    * Converts a list of {@link ComponentLike}s to a list of {@link Component}s.
    *
@@ -110,4 +110,10 @@ public interface ComponentLike {
    */
   @Contract(pure = true)
   @NotNull Component asComponent();
+
+  @Override
+  @SuppressWarnings("FunctionalInterfaceMethodChanged")
+  default void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component) {
+    this.asComponent().componentBuilderApply(component);
+  }
 }


### PR DESCRIPTION
This PR make the `ComponentLike` interface extends `ComponentBuilderApplicable`.

The main advantage of doing so is to allow using `ComponentLike`s in the `LinearComponents#linear` method. Imagine something in the lines of:
```java
LinearComponent.linear(NamedTextColor.YELLOW, player, NamedTextColor.AQUA, text(" just obtained "), reward, text("!"));
```
With `player` and `reward` being instances of a class that declares itself `ComponentLike`. It would be very clear syntax! Actually, we need to add `.asComponent()` so it takes away unnecessarily a bit of readability, I think.

Overall, I feel this serves well the purpose of `LinearComponents#linear` being to reduce the verbosity of declaring a succession of components.

Side note about the [`FunctionalInterfaceMethodChanged` warning](https://errorprone.info/bugpattern/FunctionalInterfaceMethodChanged), I suppressed it after discussing about it on Discord [here](https://discord.com/channels/289587909051416579/1342377788266512415/1343625412600791112).

Thanks!