### PR TITLE
feat(nbt): update number parsing for 1.21.5

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/Tokens.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/Tokens.java
@@ -47,6 +47,9 @@ final class Tokens {
   static final char TYPE_FLOAT = 'f';
   static final char TYPE_DOUBLE = 'd';
 
+  static final char TYPE_SIGNED = 's';
+  static final char TYPE_UNSIGNED = 'u';
+
   static final String LITERAL_TRUE = "true";
   static final String LITERAL_FALSE = "false";
 
@@ -73,17 +76,18 @@ final class Tokens {
   }
 
   /**
-   * Return whether a character could be at some position in a number.
-   *
-   * <p>A string passing this check does not necessarily mean it is syntactically valid.</p>
+   * Return whether a character is a numeric type identifier.
    *
    * @param c character to check
-   * @return if possibly part of a number
+   * @return if a numeric type identifier
    */
-  static boolean numeric(final char c) {
-    return (c >= '0' && c <= '9') // digit
-      || c == '+' || c == '-' // positive or negative
-      || c == 'e' || c == 'E' // exponent
-      || c == '.'; // decimal
+  static boolean numericType(char c) {
+    c = Character.toLowerCase(c);
+    return c == TYPE_BYTE
+      || c == TYPE_SHORT
+      || c == TYPE_INT
+      || c == TYPE_LONG
+      || c == TYPE_FLOAT
+      || c == TYPE_DOUBLE;
   }
 }

--- a/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
@@ -153,7 +153,17 @@ class StringIOTest {
     assertEquals("448228", this.tagToString(IntBinaryTag.intBinaryTag(448228)));
 
     assertEquals(IntBinaryTag.intBinaryTag(4482828), this.stringToTag("4482828"));
+    assertEquals(IntBinaryTag.intBinaryTag(4482828), this.stringToTag("4_4_8______2_8_2_8"));
     assertEquals(IntBinaryTag.intBinaryTag(-24), this.stringToTag("-24"));
+    assertEquals(IntBinaryTag.intBinaryTag(0xABC), this.stringToTag("0xABC"));
+    assertEquals(IntBinaryTag.intBinaryTag(0b1001), this.stringToTag("0b1001"));
+  }
+
+  @Test
+  void testNumberSign() throws IOException {
+    assertEquals(ByteBinaryTag.byteBinaryTag((byte) -16), this.stringToTag("240ub"));
+    assertEquals(ByteBinaryTag.byteBinaryTag((byte) -16), this.stringToTag("-16sb"));
+    assertEquals(IntBinaryTag.intBinaryTag(-0xABC), this.stringToTag("-0xABCsI"));
   }
 
   @Test
@@ -180,6 +190,7 @@ class StringIOTest {
     assertEquals(FloatBinaryTag.floatBinaryTag(-4.3e-4f), this.stringToTag("-4.3e-4F"));
     assertEquals(FloatBinaryTag.floatBinaryTag(4.3e-4f), this.stringToTag("+4.3e-4F"));
     assertEquals(FloatBinaryTag.floatBinaryTag(0.3f), this.stringToTag(".3F"));
+    assertEquals(FloatBinaryTag.floatBinaryTag(3.0f), this.stringToTag("3.F"));
   }
 
   @Test
@@ -190,6 +201,8 @@ class StringIOTest {
     assertEquals(DoubleBinaryTag.doubleBinaryTag(4.3e-4d), this.stringToTag("4.3e-4d"));
     assertEquals(DoubleBinaryTag.doubleBinaryTag(-4.3e-4d), this.stringToTag("-4.3e-4D"));
     assertEquals(DoubleBinaryTag.doubleBinaryTag(4.3e-4d), this.stringToTag("+4.3e-4D"));
+    assertEquals(DoubleBinaryTag.doubleBinaryTag(3.0d), this.stringToTag("3."));
+    assertEquals(DoubleBinaryTag.doubleBinaryTag(0.3d), this.stringToTag(".3"));
   }
 
   @Test


### PR DESCRIPTION
Adds support for:
- completely random underscores within the numbers 💩,
- hexadecimal and binary numbers,
- the new signed/unsigned suffix.

This makes `-0xabsL` or `2____2_____________________________________________________________________________________________________________________________________________________________________________________________________2` valid numbers. In more cases, it may be more lenient than vanilla where it would error, but it should accept what needs to be accepted. I opted to change the existing code with Java number parsing instead of implementing a full blown grammar around scientific notation like Minecraft does 🐥

Does not include changes for number array mixing (`[L; 1l, 2i, 3b, 4]`) or the escape changes, though I might try to do the first later in a separate PR