### PR TITLE
feature(api): Silly micro optimisations for the mm color tag

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -215,7 +215,14 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @since 4.0.0
    */
   default @NotNull String asHexString() {
-    return String.format("%c%06x", HEX_CHARACTER, this.value());
+    final StringBuilder result = new StringBuilder();
+    result.append(HEX_PREFIX);
+    final String hex = Integer.toHexString(this.value());
+    for (int i = 0; i < 6 - hex.length(); i++) {
+      result.append('0');
+    }
+    result.append(hex);
+    return result.toString();
   }
 
   /**

--- a/text-minimessage/src/jmh/java/net/kyori/adventure/text/minimessage/benchmark/MiniMessageBenchmark.java
+++ b/text-minimessage/src/jmh/java/net/kyori/adventure/text/minimessage/benchmark/MiniMessageBenchmark.java
@@ -25,6 +25,8 @@ package net.kyori.adventure.text.minimessage.benchmark;
 
 import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -37,6 +39,13 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class MiniMessageBenchmark {
+  private static final Component MANY_COLORS = Component.textOfChildren(
+    Component.text("red", NamedTextColor.RED),
+    Component.text("another", TextColor.color(0xa1b2c3)),
+    Component.text("another", TextColor.color(0x001122)),
+    Component.text("another", TextColor.color(0xb1b2b3)),
+    Component.text("another", TextColor.color(0xf6a6a6))
+  );
 
   @Benchmark
   public Component testNiceMix() {
@@ -60,8 +69,7 @@ public class MiniMessageBenchmark {
   }
 
   @Benchmark
-  public Component testRainbow() {
-    final String input = "<rainbow>COLORS ARE COOL";
-    return MiniMessage.miniMessage().deserialize(input);
+  public String testManyColorsSerializing() {
+    return MiniMessage.miniMessage().serialize(MANY_COLORS);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ColorTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ColorTagResolver.java
@@ -109,9 +109,9 @@ final class ColorTagResolver implements TagResolver, SerializableResolver.Single
   @Override
   public boolean has(final @NotNull String name) {
     return isColorOrAbbreviation(name)
-      || TextColor.fromHexString(name) != null
       || NamedTextColor.NAMES.value(name) != null
-      || COLOR_ALIASES.containsKey(name);
+      || COLOR_ALIASES.containsKey(name)
+      || TextColor.fromHexString(name) != null;
   }
 
   @Override


### PR DESCRIPTION
This is a really stupid PR with a small and insignificant micro optimisation that does effectively nothing to improve performance. Closes #1176.

### Before
```
Benchmark                                                 Mode      Cnt     Score   Error  Units
MiniMessageBenchmark.testManyColorsSerializing          sample  1272317     4.964 ± 0.017  us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.00    sample              4.200          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.50    sample              4.664          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.90    sample              5.384          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.95    sample              5.624          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.99    sample              9.184          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.999   sample             25.120          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.9999  sample             49.698          us/op
MiniMessageBenchmark.testManyColorsSerializing:p1.00    sample           1644.544          us/op
```

### After
```
Benchmark                                                 Mode      Cnt     Score   Error  Units
MiniMessageBenchmark.testManyColorsSerializing          sample  1614818     3.503 ± 0.010  us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.00    sample              3.080          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.50    sample              3.292          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.90    sample              3.616          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.95    sample              3.856          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.99    sample              6.704          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.999   sample             18.560          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.9999  sample             32.001          us/op
MiniMessageBenchmark.testManyColorsSerializing:p1.00    sample           1773.568          us/op
```