### PR TITLE
feature(minimessage): Check for colors before parsing phases

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ColorTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ColorTagResolver.java
@@ -90,7 +90,7 @@ final class ColorTagResolver implements TagResolver, SerializableResolver.Single
     return Tag.styling(color);
   }
 
-  static @NotNull TextColor resolveColor(final @NotNull String colorName, final @NotNull Context ctx) throws ParsingException {
+  static @Nullable TextColor resolveColorOrNull(final String colorName) {
     final TextColor color;
     if (COLOR_ALIASES.containsKey(colorName)) {
       color = COLOR_ALIASES.get(colorName);
@@ -100,6 +100,11 @@ final class ColorTagResolver implements TagResolver, SerializableResolver.Single
       color = NamedTextColor.NAMES.value(colorName);
     }
 
+    return color;
+  }
+
+  static @NotNull TextColor resolveColor(final @NotNull String colorName, final @NotNull Context ctx) throws ParsingException {
+    final TextColor color = resolveColorOrNull(colorName);
     if (color == null) {
       throw ctx.newException(String.format("Unable to parse a color from '%s'. Please use named colours or hex (#RRGGBB) colors.", colorName));
     }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTag.java
@@ -72,20 +72,29 @@ class GradientTag extends AbstractColorChangingTag {
       textColors = new ArrayList<>();
       while (args.hasNext()) {
         final Tag.Argument arg = args.pop();
-        // last argument? maybe this is the phase?
-        if (!args.hasNext()) {
-          final OptionalDouble possiblePhase = arg.asDouble();
-          if (possiblePhase.isPresent()) {
-            phase = possiblePhase.getAsDouble();
-            if (phase < -1d || phase > 1d) {
-              throw ctx.newException(String.format("Gradient phase is out of range (%s). Must be in the range [-1.0, 1.0] (inclusive).", phase), args);
-            }
-            break;
-          }
-        }
 
-        final TextColor parsedColor = ColorTagResolver.resolveColor(arg.value(), ctx);
-        textColors.add(parsedColor);
+        // Determine if this is a color first. Double#parseDouble is "slow" in cases where we hit a string.
+        final String argValue = arg.value();
+        final TextColor color = ColorTagResolver.resolveColorOrNull(argValue);
+
+        if (color != null) {
+          textColors.add(color);
+        } else {
+          // last argument? maybe this is the phase?
+          if (!args.hasNext()) {
+            final OptionalDouble possiblePhase = arg.asDouble();
+            if (possiblePhase.isPresent()) {
+              phase = possiblePhase.getAsDouble();
+              if (phase < -1d || phase > 1d) {
+                throw ctx.newException(String.format("Gradient phase is out of range (%s). Must be in the range [-1.0, 1.0] (inclusive).", phase), args);
+              }
+              break;
+            }
+          }
+
+          // We hit an invalid color.
+          throw ctx.newException(String.format("Unable to parse a color from '%s'. Please use named colors or hex (#RRGGBB) colors.", argValue), args);
+        }
       }
 
       if (textColors.size() == 1) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TransitionTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TransitionTag.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 import java.util.OptionalDouble;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.tag.Inserting;
@@ -63,29 +62,29 @@ public final class TransitionTag implements Inserting, Examinable {
       textColors = new ArrayList<>();
       while (args.hasNext()) {
         final Tag.Argument arg = args.pop();
-        // last argument? maybe this is the phase?
-        if (!args.hasNext()) {
-          final OptionalDouble possiblePhase = arg.asDouble();
-          if (possiblePhase.isPresent()) {
-            phase = (float) possiblePhase.getAsDouble();
-            if (phase < -1f || phase > 1f) {
-              throw ctx.newException(String.format("Gradient phase is out of range (%s). Must be in the range [-1.0f, 1.0f] (inclusive).", phase), args);
-            }
-            break;
-          }
-        }
 
+        // Determine if this is a color first. Double#parseDouble is "slow" in cases where we hit a string.
         final String argValue = arg.value();
-        final TextColor parsedColor;
-        if (argValue.charAt(0) == TextColor.HEX_CHARACTER) {
-          parsedColor = TextColor.fromHexString(argValue);
+        final TextColor color = ColorTagResolver.resolveColorOrNull(argValue);
+
+        if (color != null) {
+          textColors.add(color);
         } else {
-          parsedColor = NamedTextColor.NAMES.value(arg.lowerValue());
-        }
-        if (parsedColor == null) {
+          // last argument? maybe this is the phase?
+          if (!args.hasNext()) {
+            final OptionalDouble possiblePhase = arg.asDouble();
+            if (possiblePhase.isPresent()) {
+              phase = (float) possiblePhase.getAsDouble();
+              if (phase < -1f || phase > 1f) {
+                throw ctx.newException(String.format("Gradient phase is out of range (%s). Must be in the range [-1.0f, 1.0f] (inclusive).", phase), args);
+              }
+              break;
+            }
+          }
+
+          // We hit an invalid argument here!
           throw ctx.newException(String.format("Unable to parse a color from '%s'. Please use named colors or hex (#RRGGBB) colors.", argValue), args);
         }
-        textColors.add(parsedColor);
       }
 
       if (textColors.size() < 2) {


### PR DESCRIPTION
This is another incredibly minor performance improvement as parseDouble incurs a slight performance cost when failing. If we instead check for colors first, we can guarantee that we are either parsing a valid double or throwing an exception (in which case we don't really care about performance).

Closes #1178.