### PR TITLE
feature(api): Improve handling of component children and component translating

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -2106,6 +2107,41 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
   @Contract(pure = true)
   default @NotNull Component appendSpace() {
     return this.append(space());
+  }
+
+  /**
+   * Appends components to this component.
+   *
+   * @param components the children to add
+   * @return a component with the children added to the existing children
+   * @since 4.20.0
+   */
+  @Contract(pure = true)
+  default @NotNull Component append(final @NotNull ComponentLike @NotNull... components) {
+    if (components.length == 0) return this;
+
+    final List<ComponentLike> newChildren = new ArrayList<>(components.length + this.children().size());
+    newChildren.addAll(this.children());
+    Collections.addAll(newChildren, components);
+    return this.children(newChildren);
+  }
+
+  /**
+   * Appends a list of components to this component.
+   *
+   * @param components the children to add
+   * @return a component with the children added to the existing children
+   * @since 4.20.0
+   */
+  @Contract(pure = true)
+  default @NotNull Component append(final @NotNull List<? extends ComponentLike> components) {
+    if (components.isEmpty()) return this;
+    if (this.children().isEmpty()) return this.children(components);
+
+    final List<ComponentLike> newChildren = new ArrayList<>(components.size() + this.children().size());
+    newChildren.addAll(this.children());
+    newChildren.addAll(components);
+    return this.children(newChildren);
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/ScopedComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScopedComponent.java
@@ -107,6 +107,18 @@ public interface ScopedComponent<C extends Component> extends Component {
 
   @Override
   @SuppressWarnings("unchecked")
+  default @NotNull C append(final @NotNull List<? extends ComponentLike> components) {
+    return (C) Component.super.append(components);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  default @NotNull C append(final @NotNull ComponentLike @NotNull... components) {
+    return (C) Component.super.append(components);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
   default @NotNull C appendNewline() {
     return (C) Component.super.appendNewline();
   }

--- a/api/src/main/java/net/kyori/adventure/translation/Translator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translator.java
@@ -105,6 +105,14 @@ public interface Translator {
   /**
    * Gets a translated component from a translatable component and locale.
    *
+   * <p>Care should be taken to ensure you do not unintentionally remove the children of {@code component}.
+   * This can be avoided by copying over the children using the following code as an example:</p>
+   *
+   * <pre>{@code
+   * final Component myNewComponent = ...; // get your component here
+   * return myNewComponent.append(component.children()); // ensure it has the original components children as well
+   * }</pre>
+   *
    * @param locale a locale
    * @param component a translatable component
    * @return a translated component or {@code null} to use {@link #translate(String, Locale)} instead (if available)

--- a/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/TextComponentTest.java
@@ -196,4 +196,12 @@ class TextComponentTest extends AbstractComponentTest<TextComponent, TextCompone
       Component.text("").children(Collections.emptyList())
     );
   }
+
+  @Test
+  void testAddingMultipleChildren() {
+    final Component c0 = Component.text("1").append(Component.text("2"));
+    final Component c1 = c0.append(Component.text("3")).append(Component.text("4"));
+
+    assertEquals(c1, c0.append(Component.text("3"), Component.text("4")));
+  }
 }

--- a/api/src/test/java/net/kyori/adventure/translation/GlobalTranslatorTest.java
+++ b/api/src/test/java/net/kyori/adventure/translation/GlobalTranslatorTest.java
@@ -103,6 +103,14 @@ class GlobalTranslatorTest {
     );
   }
 
+  @Test
+  void letTransChildrenLive() {
+    final Component input = Component.translatable("test.1")
+      .append(Component.translatable("test.2"));
+    GlobalTranslator.translator().addSource(DummyTranslator.INSTANCE);
+    assertEquals(Component.text("so valid").append(Component.translatable("test.2")), GlobalTranslator.render(input, Locale.UK));
+  }
+
   static class DummyTranslator implements Translator {
     static final DummyTranslator INSTANCE = new DummyTranslator();
 
@@ -120,6 +128,10 @@ class GlobalTranslatorTest {
 
     @Override
     public @Nullable Component translate(final @NotNull TranslatableComponent component, final @NotNull Locale locale) {
+      if (component.key().equals("test.1")) {
+        return Component.text("so valid").children(component.children());
+      }
+
       return (component.key().equals("otherDummy") && locale.equals(Locale.US))
         ? Component.text()
           .append(Component.text("Hello "))


### PR DESCRIPTION
- Adds append methods that accept multiple children with fast-exits to improve performance.
- Add a note on Translator's component translate method to tell devs to not forget about their children.

This is in response to investigating #974 which is caused by MiniMessageTranslator not copying over children.