### PR TITLE
feat(minimessage): add option to stop the serializer from escaping minimessage tags in component content

### DIFF
--- a/text-minimessage/build.gradle.kts
+++ b/text-minimessage/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
   api(projects.adventureApi)
   testImplementation(projects.adventureTextSerializerPlain)
   testImplementation(projects.adventureTextSerializerAnsi)
+  testImplementation(projects.adventureTextSerializerLegacy)
   annotationProcessor(projects.adventureAnnotationProcessors)
 }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -364,6 +364,22 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
     @NotNull Builder emitVirtuals(final boolean emitVirtuals);
 
     /**
+     * Configures if MiniMessage should escape tags in component content. (enabled by default)
+     *
+     * <p>
+     * By default, MiniMessage escapes all tags found in a components content when serializing a component.
+     * If a component has the raw text of {@code <italic>my text is italic</italic>} in the content,
+     * it will get escaped to {@code \<italic>my text is italic\</italic>}.
+     * Setting this value to false will prevent that.
+     * </p>
+     *
+     * @param escapeContent if component content should be escaped.
+     * @return this builder.
+     * @since 4.20.0
+     */
+    @NotNull Builder escapeContent(final boolean escapeContent);
+
+    /**
      * Print debug information to the given output (disabled by default).
      *
      * <p>Debug output includes detailed information about the parsing process to help debug parser behavior.</p>

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -55,7 +55,7 @@ final class MiniMessageImpl implements MiniMessage {
   static final class Instances {
     static final MiniMessage INSTANCE = SERVICE
       .map(Provider::miniMessage)
-      .orElseGet(() -> new MiniMessageImpl(TagResolver.standard(), false, true, null, DEFAULT_NO_OP, DEFAULT_COMPACTING_METHOD));
+      .orElseGet(() -> new MiniMessageImpl(TagResolver.standard(), false, true, true, null, DEFAULT_NO_OP, DEFAULT_COMPACTING_METHOD));
   }
 
   static final UnaryOperator<String> DEFAULT_NO_OP = UnaryOperator.identity();
@@ -63,15 +63,18 @@ final class MiniMessageImpl implements MiniMessage {
 
   private final boolean strict;
   private final boolean emitVirtuals;
+  private final boolean escapeContent;
   private final @Nullable Consumer<String> debugOutput;
   private final UnaryOperator<Component> postProcessor;
   private final UnaryOperator<String> preProcessor;
   final MiniMessageParser parser;
 
-  MiniMessageImpl(final @NotNull TagResolver resolver, final boolean strict, final boolean emitVirtuals, final @Nullable Consumer<String> debugOutput, final @NotNull UnaryOperator<String> preProcessor, final @NotNull UnaryOperator<Component> postProcessor) {
+  MiniMessageImpl(final @NotNull TagResolver resolver, final boolean strict, final boolean emitVirtuals, final boolean escapeContent,
+                  final @Nullable Consumer<String> debugOutput, final @NotNull UnaryOperator<String> preProcessor, final @NotNull UnaryOperator<Component> postProcessor) {
     this.parser = new MiniMessageParser(resolver);
     this.strict = strict;
     this.emitVirtuals = emitVirtuals;
+    this.escapeContent = escapeContent;
     this.debugOutput = debugOutput;
     this.preProcessor = preProcessor;
     this.postProcessor = postProcessor;
@@ -119,7 +122,7 @@ final class MiniMessageImpl implements MiniMessage {
 
   @Override
   public @NotNull String serialize(final @NotNull Component component) {
-    return MiniMessageSerializer.serialize(component, this.serialResolver(null), this.strict);
+    return MiniMessageSerializer.serialize(component, this.serialResolver(null), this.strict, this.escapeContent);
   }
 
   private SerializableResolver serialResolver(final @Nullable TagResolver extraResolver) {
@@ -176,6 +179,7 @@ final class MiniMessageImpl implements MiniMessage {
     private TagResolver tagResolver = TagResolver.standard();
     private boolean strict = false;
     private boolean emitVirtuals = true;
+    private boolean escapeContent = true;
     private Consumer<String> debug = null;
     private UnaryOperator<Component> postProcessor = DEFAULT_COMPACTING_METHOD;
     private UnaryOperator<String> preProcessor = DEFAULT_NO_OP;
@@ -221,6 +225,12 @@ final class MiniMessageImpl implements MiniMessage {
     }
 
     @Override
+    public @NotNull Builder escapeContent(boolean escapeContent) {
+      this.escapeContent = escapeContent;
+      return this;
+    }
+
+    @Override
     public @NotNull Builder debug(final @Nullable Consumer<String> debugOutput) {
       this.debug = debugOutput;
       return this;
@@ -240,7 +250,7 @@ final class MiniMessageImpl implements MiniMessage {
 
     @Override
     public @NotNull MiniMessage build() {
-      return new MiniMessageImpl(this.tagResolver, this.strict, this.emitVirtuals, this.debug, this.preProcessor, this.postProcessor);
+      return new MiniMessageImpl(this.tagResolver, this.strict, this.emitVirtuals, this.escapeContent, this.debug, this.preProcessor, this.postProcessor);
     }
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageSerializer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageSerializer.java
@@ -49,9 +49,9 @@ final class MiniMessageSerializer {
   // - abbreviated vs long tag names (tag-specific option)
   //
 
-  static @NotNull String serialize(final @NotNull Component component, final @NotNull SerializableResolver resolver, final boolean strict) {
+  static @NotNull String serialize(final @NotNull Component component, final @NotNull SerializableResolver resolver, final boolean strict, final boolean escapeContent) {
     final StringBuilder sb = new StringBuilder();
-    final Collector emitter = new Collector(resolver, strict, sb);
+    final Collector emitter = new Collector(resolver, strict, escapeContent, sb);
 
     emitter.mark();
     visit(component, emitter, resolver, true);
@@ -108,14 +108,16 @@ final class MiniMessageSerializer {
 
     private final SerializableResolver resolver;
     private final boolean strict;
+    private final boolean escapeContent;
     private final StringBuilder consumer;
     private String[] activeTags = new String[4];
     private int tagLevel = 0;
     private TagState tagState = TagState.TEXT;
 
-    Collector(final SerializableResolver resolver, final boolean strict, final StringBuilder consumer) {
+    Collector(final SerializableResolver resolver, final boolean strict, final boolean escapeContent, final StringBuilder consumer) {
       this.resolver = resolver;
       this.strict = strict;
+      this.escapeContent = escapeContent;
       this.consumer = consumer;
     }
 
@@ -211,7 +213,7 @@ final class MiniMessageSerializer {
 
     @Override
     public @NotNull TokenEmitter argument(final @NotNull Component arg) {
-      final String serialized = MiniMessageSerializer.serialize(arg, this.resolver, this.strict);
+      final String serialized = MiniMessageSerializer.serialize(arg, this.resolver, this.strict, this.escapeContent);
       return this.argument(serialized, QuotingOverride.QUOTED); // always quote tokens
     }
 
@@ -219,7 +221,7 @@ final class MiniMessageSerializer {
     public @NotNull Collector text(final @NotNull String text) {
       this.completeTag();
       // escape '\' and '<'
-      appendEscaping(this.consumer, text, TEXT_ESCAPES, true);
+      appendEscaping(this.consumer, text, TEXT_ESCAPES, true, this.escapeContent);
       return this;
     }
 
@@ -244,19 +246,19 @@ final class MiniMessageSerializer {
 
       if (hasSingleQuote) { // double-quoted
         this.consumer.append('"');
-        appendEscaping(this.consumer, content, DOUBLE_QUOTED_ESCAPES, true);
+        appendEscaping(this.consumer, content, DOUBLE_QUOTED_ESCAPES, true, this.escapeContent);
         this.consumer.append('"');
       } else if (hasDoubleQuote || mustBeQuoted) {
         // single-quoted
         this.consumer.append('\'');
-        appendEscaping(this.consumer, content, SINGLE_QUOTED_ESCAPES, true);
+        appendEscaping(this.consumer, content, SINGLE_QUOTED_ESCAPES, true, this.escapeContent);
         this.consumer.append('\'');
       } else { // unquoted
-        appendEscaping(this.consumer, content, TAG_TOKENS, false);
+        appendEscaping(this.consumer, content, TAG_TOKENS, false, this.escapeContent);
       }
     }
 
-    static void appendEscaping(final StringBuilder builder, final String text, final char[] escapeChars, final boolean allowEscapes) {
+    static void appendEscaping(final StringBuilder builder, final String text, final char[] escapeChars, final boolean allowEscapes, final boolean doEscape) {
       int startIdx = 0;
       boolean unescapedFound = false;
 
@@ -273,7 +275,7 @@ final class MiniMessageSerializer {
           }
         }
 
-        if (escaped) {
+        if (escaped && doEscape) {
           if (unescapedFound) builder.append(text, startIdx, i);
           startIdx = i + 1;
           builder.append(TokenParser.ESCAPE).append(test);

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageSerializerTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageSerializerTest.java
@@ -27,6 +27,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.Component.text;
@@ -78,4 +79,19 @@ public class MiniMessageSerializerTest extends AbstractTest {
     this.assertParsedEquals(component, expected);
   }
 
+  @Test
+  void testEscapeContentOption() {
+    final MiniMessage serializer = MiniMessage.builder().escapeContent(false).build();
+    final LegacyComponentSerializer legacy = LegacyComponentSerializer.legacyAmpersand();
+
+    final String input = "<aqua>&l a";
+
+    final String expectedEscaped = "\\<aqua><bold> a";
+    final String expectedNotEscaped = "<aqua><bold> a";
+
+    final Component component = legacy.deserialize(input);
+
+    this.assertSerializedEquals(expectedEscaped, component);
+    assertEquals(expectedNotEscaped, serializer.serialize(component));
+  }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/SerializerCollectorTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/SerializerCollectorTest.java
@@ -90,7 +90,7 @@ class SerializerCollectorTest {
 
   String serializeToString(final Consumer<MiniMessageSerializer.Collector> handler) {
     final StringBuilder output = new StringBuilder();
-    final MiniMessageSerializer.Collector collector = new MiniMessageSerializer.Collector((SerializableResolver) StandardTags.defaults(), false, output);
+    final MiniMessageSerializer.Collector collector = new MiniMessageSerializer.Collector((SerializableResolver) StandardTags.defaults(), false, true, output);
     handler.accept(collector);
 
     return output.toString();


### PR DESCRIPTION
While trying to support both minimessage and legacy ampersand codes to format text in my project, I came across an annoyance where the serializer would escape all minimessage tags in the `content` of a component. 

Meaning from an input of `<aqua>&l a` into the legacy component deserializer I was getting `\<aqua><bold> a` when re-serializing with the minimessage serializer, which obviously wouldn't format the aqua tag.
So this adds a simple option to the minimessage builder to tell the serializer, more specifically the collector to not escape tags in this situation.
And so now by setting `MiniMessage.Builder#escapeContent(boolean)` to false, an input of `<aqua>&l a` will result in a re-serialized output of `<aqua><bold> a` in term formatting everything as intended.