### PR TITLE
feat(nbt): Add stream API for compound/list tags

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -434,6 +435,14 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   long@NotNull[] getLongArray(final @NotNull String key, final long@NotNull[] defaultValue);
+
+  /**
+   * Gets a stream of entries in this compound tag.
+   *
+   * @return a new entry stream
+   * @since 4.21.0
+   */
+  Stream<Map.Entry<String, ? extends BinaryTag>> stream();
 
   /**
    * A compound tag builder.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -26,9 +26,13 @@ package net.kyori.adventure.nbt;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Binary tag holding a mapping of string keys to {@link BinaryTag} values.
@@ -58,6 +62,81 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
   static @NotNull CompoundBinaryTag from(final @NotNull Map<String, ? extends BinaryTag> tags) {
     if (tags.isEmpty()) return empty();
     return new CompoundBinaryTagImpl(new HashMap<>(tags)); // explicitly copy
+  }
+
+  /**
+   * Create a {@link Collector} to consume streams of map entries.
+   *
+   * <p>In the event of duplicate entries, the last seen entry will be preserved.</p>
+   *
+   * @return a collector for map entries
+   * @since 4.21.0
+   */
+  static @NotNull Collector<Map.Entry<String, ? extends BinaryTag>, ?, CompoundBinaryTag> toCompoundTag() {
+    return toCompoundTag(Map.Entry::getKey, Map.Entry::getValue);
+  }
+
+  /**
+   * Create a {@link Collector} to consume streams of a user-chosen type.
+   *
+   * <p>In the event of duplicate keys, the last seen entry will be preserved.</p>
+   *
+   * @param <T> the stream value type
+   * @param keyLens a function to extract a key from the target object
+   * @param valueLens a function to extract a tag value from the target object
+   * @return a collector creating compound tags
+   * @since 4.21.0
+   */
+  static <T> @NotNull Collector<T, ?, CompoundBinaryTag> toCompoundTag(final @NotNull Function<T, String> keyLens, final @NotNull Function<T, ? extends BinaryTag> valueLens) {
+    requireNonNull(keyLens, "keyLens");
+    requireNonNull(valueLens, "valueLens");
+
+    return Collector.of(
+      CompoundBinaryTag::builder,
+      (b, ent) -> b.put(keyLens.apply(ent), valueLens.apply(ent)),
+      (l, r) -> l.put(r.build()),
+      CompoundBinaryTag.Builder::build,
+      Collector.Characteristics.UNORDERED
+    );
+  }
+
+  /**
+   * Create a {@link Collector} to consume streams of map entries, with initial contents.
+   *
+   * <p>In the event of duplicate entries, the last seen entry will be preserved.</p>
+   *
+   * @param initial an existing tag that will initialize the builder
+   * @return a collector for map entries
+   * @since 4.21.0
+   */
+  static @NotNull Collector<Map.Entry<String, ? extends BinaryTag>, ?, CompoundBinaryTag> toCompoundTag(final @NotNull CompoundBinaryTag initial) {
+    return toCompoundTag(initial, Map.Entry::getKey, Map.Entry::getValue);
+  }
+
+  /**
+   * Create a {@link Collector} to consume streams of a user-chosen type, with initial contents.
+   *
+   * <p>In the event of duplicate keys, the last seen entry will be preserved.</p>
+   *
+   * @param <T> the stream value type
+   * @param initial an existing tag that will initialize the builder
+   * @param keyLens a function to extract a key from the target object
+   * @param valueLens a function to extract a tag value from the target object
+   * @return a collector creating compound tags
+   * @since 4.21.0
+   */
+  static <T> @NotNull Collector<T, ?, CompoundBinaryTag> toCompoundTag(final @NotNull CompoundBinaryTag initial, final @NotNull Function<T, String> keyLens, final @NotNull Function<T, ? extends BinaryTag> valueLens) {
+    requireNonNull(initial, "initial");
+    requireNonNull(keyLens, "keyLens");
+    requireNonNull(valueLens, "valueLens");
+
+    return Collector.of(
+      () -> CompoundBinaryTag.builder().put(initial),
+      (b, ent) -> b.put(keyLens.apply(ent), valueLens.apply(ent)),
+      (l, r) -> l.put(r.build()),
+      CompoundBinaryTag.Builder::build,
+      Collector.Characteristics.UNORDERED
+    );
   }
 
   /**

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -236,6 +236,12 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
     return defaultValue;
   }
 
+  @Override
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public Stream<Map.Entry<String, ? extends BinaryTag>> stream() {
+    return (Stream) this.tags.entrySet().stream();
+  }
+
   private CompoundBinaryTag edit(final Consumer<Map<String, BinaryTag>> consumer) {
     final Map<String, BinaryTag> tags = new HashMap<>(this.tags);
     consumer.accept(tags);

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -119,6 +120,34 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
   @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
   static @NotNull ListBinaryTag of(final @NotNull BinaryTagType<? extends BinaryTag> type, final @NotNull List<BinaryTag> tags) {
     return listBinaryTag(type, tags);
+  }
+
+  /**
+   * Create a {@link Collector} to consume streams of list tags.
+   *
+   * @return a collector of tags
+   * @since 4.21.0
+   */
+  static @NotNull Collector<BinaryTag, ?, ListBinaryTag> toListTag() {
+    return toListTag(null);
+  }
+
+  /**
+   * Create a {@link Collector} to consume streams of map entries, with initial contents.
+   *
+   * <p>In the event of duplicate entries, the last seen entry will be preserved.</p>
+   *
+   * @param initial an existing tag that will initialize the builder
+   * @return a collector for map entries
+   * @since 4.21.0
+   */
+  static @NotNull Collector<BinaryTag, ?, ListBinaryTag> toListTag(final @Nullable ListBinaryTag initial) {
+    return Collector.of(
+      initial == null ? ListBinaryTag::builder : () -> ListBinaryTag.builder().add((Iterable<? extends BinaryTag>) initial),
+      ListTagSetter::add,
+      (l, r) -> l.add((Iterable<? extends BinaryTag>) r.build()),
+      ListBinaryTag.Builder::build
+    );
   }
 
   @Override


### PR DESCRIPTION
There was some existing API for this, but it was missing collectors, and the stream api for compound tags.