### PR TITLE
Use DecorationMap for style builder

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.adventure.text.format;
 
-import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -317,19 +316,19 @@ final class StyleImpl implements Style {
     @Nullable Key font;
     @Nullable TextColor color;
     @Nullable ShadowColor shadowColor;
-    final Map<TextDecoration, TextDecoration.State> decorations;
+    DecorationMap decorations;
     @Nullable ClickEvent clickEvent;
     @Nullable HoverEvent<?> hoverEvent;
     @Nullable String insertion;
 
     BuilderImpl() {
-      this.decorations = new EnumMap<>(DecorationMap.EMPTY);
+      this.decorations = DecorationMap.EMPTY;
     }
 
     BuilderImpl(final @NotNull StyleImpl style) {
       this.color = style.color;
       this.shadowColor = style.shadowColor;
-      this.decorations = new EnumMap<>(style.decorations);
+      this.decorations = style.decorations;
       this.clickEvent = style.clickEvent;
       this.hoverEvent = style.hoverEvent;
       this.insertion = style.insertion;
@@ -374,7 +373,7 @@ final class StyleImpl implements Style {
     public @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
       requireNonNull(state, "state");
       requireNonNull(decoration, "decoration");
-      this.decorations.put(decoration, state);
+      this.decorations = this.decorations.with(decoration, state);
       return this;
     }
 
@@ -383,7 +382,7 @@ final class StyleImpl implements Style {
       requireNonNull(state, "state");
       final TextDecoration.@Nullable State oldState = this.decorations.get(decoration);
       if (oldState == TextDecoration.State.NOT_SET) {
-        this.decorations.put(decoration, state);
+        this.decorations = this.decorations.with(decoration, state);
       }
       if (oldState != null) {
         return this;
@@ -499,7 +498,7 @@ final class StyleImpl implements Style {
     private boolean isEmpty() {
       return this.color == null
         && this.shadowColor == null
-        && this.decorations.values().stream().allMatch(state -> state == TextDecoration.State.NOT_SET)
+        && this.decorations == DecorationMap.EMPTY
         && this.clickEvent == null
         && this.hoverEvent == null
         && this.insertion == null


### PR DESCRIPTION
This PR changes `StyleImpl.BuilderImpl` to use a `DecorationMap` instead of an `EnumMap` for decorations. Awhile ago, I noticed that converting the `DecorationMap` used in `Style` to the `EnumMap` used in the builder took up a substantial portion of time when merging styles. Comparing using the `ComponentCompactionBenchmark.moreComplex` benchmark:

### Before
```
Benchmark                                           Mode      Cnt     Score   Error  Units
ComponentCompactionBenchmark.moreComplex          sample  7851094     2.041 ± 0.007  us/op
ComponentCompactionBenchmark.moreComplex:p0.00    sample              1.700          us/op
ComponentCompactionBenchmark.moreComplex:p0.50    sample              2.000          us/op
ComponentCompactionBenchmark.moreComplex:p0.90    sample              2.100          us/op
ComponentCompactionBenchmark.moreComplex:p0.95    sample              2.100          us/op
ComponentCompactionBenchmark.moreComplex:p0.99    sample              2.600          us/op
ComponentCompactionBenchmark.moreComplex:p0.999   sample              3.900          us/op
ComponentCompactionBenchmark.moreComplex:p0.9999  sample             56.000          us/op
ComponentCompactionBenchmark.moreComplex:p1.00    sample           1206.272          us/op
```

### After
```
Benchmark                                           Mode      Cnt     Score   Error  Units
ComponentCompactionBenchmark.moreComplex          sample  6582923     0.636 ± 0.006  us/op
ComponentCompactionBenchmark.moreComplex:p0.00    sample              0.500          us/op
ComponentCompactionBenchmark.moreComplex:p0.50    sample              0.600          us/op
ComponentCompactionBenchmark.moreComplex:p0.90    sample              0.700          us/op
ComponentCompactionBenchmark.moreComplex:p0.95    sample              0.700          us/op
ComponentCompactionBenchmark.moreComplex:p0.99    sample              0.800          us/op
ComponentCompactionBenchmark.moreComplex:p0.999   sample              1.600          us/op
ComponentCompactionBenchmark.moreComplex:p0.9999  sample             17.668          us/op
ComponentCompactionBenchmark.moreComplex:p1.00    sample           1267.712          us/op
```