### PR TITLE
feature(minimessage): Rainbow tag saturation argument

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
@@ -86,7 +86,7 @@ final class RainbowTag extends AbstractColorChangingTag {
           }
         }
       }
-     }
+    }
     return new RainbowTag(reversed, phase, saturation, ctx);
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
@@ -51,12 +51,14 @@ final class RainbowTag extends AbstractColorChangingTag {
 
   private final boolean reversed;
   private final double dividedPhase;
+  private final float saturation;
 
   private int colorIndex = 0;
 
   static Tag create(final ArgumentQueue args, final Context ctx) {
     boolean reversed = false;
     int phase = 0;
+    float saturation = 1f;
 
     if (args.hasNext()) {
       String value = args.pop().value();
@@ -71,15 +73,26 @@ final class RainbowTag extends AbstractColorChangingTag {
           throw ctx.newException("Expected phase, got " + value);
         }
       }
-    }
-
-    return new RainbowTag(reversed, phase, ctx);
+      if (args.hasNext()) {
+        final String saturationValue = args.pop().value();
+        try {
+          saturation = Float.parseFloat(saturationValue);
+        } catch (final NumberFormatException ex) {
+          throw ctx.newException("Expected saturation, got " + saturationValue);
+        }
+      }
+      if (saturation < 0f || saturation > 1f) {
+        throw ctx.newException(String.format("Rainbow saturation is out of range (%s). Must be in the range [0.0, 1.0] (inclusive).", saturation));
+      }
+     }
+    return new RainbowTag(reversed, phase, saturation, ctx);
   }
 
-  private RainbowTag(final boolean reversed, final int phase, final Context ctx) {
+  private RainbowTag(final boolean reversed, final int phase, final float saturation, final Context ctx) {
     super(ctx);
     this.reversed = reversed;
     this.dividedPhase = ((double) phase) / 10d;
+    this.saturation = saturation;
   }
 
   @Override
@@ -106,7 +119,7 @@ final class RainbowTag extends AbstractColorChangingTag {
   protected TextColor color() {
     final float index = this.colorIndex;
     final float hue = (float) ((index / this.size() + this.dividedPhase) % 1f);
-    return TextColor.color(HSVLike.hsvLike(hue, 1f, 1f));
+    return TextColor.color(HSVLike.hsvLike(hue, this.saturation, 1f));
   }
 
   @Override

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
@@ -67,18 +67,27 @@ final class RainbowTag extends AbstractColorChangingTag {
         value = value.substring(REVERSE.length());
       }
       if (value.length() > 0) {
-        try {
-          phase = Integer.parseInt(value);
-        } catch (final NumberFormatException ex) {
-          throw ctx.newException("Expected phase, got " + value);
-        }
-      }
-      if (args.hasNext()) {
-        final String saturationValue = args.pop().value();
-        try {
-          saturation = Float.parseFloat(saturationValue);
-        } catch (final NumberFormatException ex) {
-          throw ctx.newException("Expected saturation, got " + saturationValue);
+        // Check if the value is a float or an int
+        if (value.endsWith("f") || value.endsWith("F") || value.contains(".")) {
+          try {
+            saturation = Float.parseFloat(value);
+          } catch (final NumberFormatException ex) {
+            throw ctx.newException("Expected saturation, got " + value);
+          }
+        } else {
+          try {
+            phase = Integer.parseInt(value);
+          } catch (final NumberFormatException ex) {
+            throw ctx.newException("Expected phase, got " + value);
+          }
+          if (args.hasNext()) {
+            final String saturationValue = args.pop().value();
+            try {
+              saturation = Float.parseFloat(saturationValue);
+            } catch (final NumberFormatException ex) {
+              throw ctx.newException("Expected saturation, got " + saturationValue);
+            }
+          }
         }
       }
       if (saturation < 0f || saturation > 1f) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
@@ -67,31 +67,24 @@ final class RainbowTag extends AbstractColorChangingTag {
         value = value.substring(REVERSE.length());
       }
       if (value.length() > 0) {
-        // Check if the value is a float or an int
-        if (value.endsWith("f") || value.endsWith("F") || value.contains(".")) {
-          try {
-            saturation = Float.parseFloat(value);
-          } catch (final NumberFormatException ex) {
-            throw ctx.newException("Expected saturation, got " + value);
-          }
-        } else {
-          try {
-            phase = Integer.parseInt(value);
-          } catch (final NumberFormatException ex) {
-            throw ctx.newException("Expected phase, got " + value);
-          }
-          if (args.hasNext()) {
-            final String saturationValue = args.pop().value();
-            try {
-              saturation = Float.parseFloat(saturationValue);
-            } catch (final NumberFormatException ex) {
-              throw ctx.newException("Expected saturation, got " + saturationValue);
-            }
-          }
+        try {
+          phase = Integer.parseInt(value);
+        } catch (final NumberFormatException ex) {
+          throw ctx.newException("Expected phase, got " + value);
         }
       }
-      if (saturation < 0f || saturation > 1f) {
-        throw ctx.newException(String.format("Rainbow saturation is out of range (%s). Must be in the range [0.0, 1.0] (inclusive).", saturation));
+      if (args.hasNext()) {
+        final String saturationValue = args.pop().value();
+        if (!saturationValue.isEmpty()) {
+          try {
+            saturation = Float.parseFloat(saturationValue);
+          } catch (final NumberFormatException ex) {
+            throw ctx.newException("Expected saturation, got " + saturationValue);
+          }
+          if (saturation < 0f || saturation > 1f) {
+            throw ctx.newException(String.format("Rainbow saturation is out of range (%s). Must be in the range [0.0, 1.0] (inclusive).", saturation));
+          }
+        }
       }
      }
     return new RainbowTag(reversed, phase, saturation, ctx);

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTagTest.java
@@ -401,4 +401,39 @@ class RainbowTagTest extends AbstractTest {
       input
     );
   }
+
+  @Test
+  void testSaturation() {
+    final String input = "<yellow>Woo: <rainbow:0:0.65>||||||||||||||||||||||||</rainbow>!";
+    final Component expected = empty().color(YELLOW)
+        .append(text("Woo: "))
+      .append(virtualOfChildren(textOfChildren(
+        text("|", color(0xFF5959)),
+        text("|", color(0xff8259)),
+        text("|", color(0xffac59)),
+        text("|", color(0xffd559)),
+        text("|", color(0xffff59)),
+        text("|", color(0xd5ff59)),
+        text("|", color(0xacff59)),
+        text("|", color(0x82ff59)),
+        text("|", color(0x59FF59)),
+        text("|", color(0x59ff82)),
+        text("|", color(0x59ffac)),
+        text("|", color(0x59ffd5)),
+        text("|", color(0x59ffff)),
+        text("|", color(0x59d5ff)),
+        text("|", color(0x59acff)),
+        text("|", color(0x5982ff)),
+        text("|", color(0x5959FF)),
+        text("|", color(0x8259ff)),
+        text("|", color(0xac59ff)),
+        text("|", color(0xd559ff)),
+        text("|", color(0xff59ff)),
+        text("|", color(0xff59d5)),
+        text("|", color(0xff59ac)),
+        text("|", color(0xFF5982))
+      )
+    )).append(text("!"));
+    this.assertParsedEquals(expected, input);
+  }
 }


### PR DESCRIPTION
Added a saturation argument (optional) to `rainbow` tag. It simply sets the saturation value of each `HSVLike` to the argument value or 1 if omited.

Why? Max saturation can be unpleasant for eyes, especially on longer texts.

The syntax would follow `<rainbow:[!][phase]:[saturation]>`. 

Since the current algortihm has default values if argument is of lenght 0 this allows for such syntax:
- `<rainbow:0:0.65>`
- `<rainbow::0.65>`

It also uses `Float#parseFloat` method meaning any legal Java float representation is allowed: `.65`, `0.65f`, `1` etc.

This PR also partially closes #1038 