### PR TITLE
Fix potential unwanted behavior TextColor.java

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -133,7 +133,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @since 4.0.0
    */
   static @NotNull TextColor color(final @Range(from = 0x0, to = 0xff) int r, final @Range(from = 0x0, to = 0xff) int g, final @Range(from = 0x0, to = 0xff) int b) {
-    return color((r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff));
+    return color(((int) r & 0xff) << 16 | ((int) g & 0xff) << 8 | ((int) b & 0xff));
   }
 
   /**


### PR DESCRIPTION
If you pass a long in the function instead of an int it will result to some undifined behavior even if the value of the long is inside the range of 0 - 255.

Code exemple :
```
long time = player.getWorld().getFullTime() % 64;
TextColor color1 = TextColor.color((int)time, 0, 0);
TextColor color2 = TextColor.color(time, 0, 0);

player.sendMessage("Game time value : " + time);
player.sendMessage("Color1 red value : " + color1.red());
player.sendMessage("Color2 red value : " + color2.red());
```

In game i will have :
```
Game time value : 61
Color1 red value : 61
Color2 red value : 195
```

I just added a cast to the methode so any long used will be treated as an int, the range of the methode allready prevent number bigger that the interger limit to be put inside.
