### PR TITLE
feature(api): Skip style builder creation on merge

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -289,7 +289,13 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   @Override
   @SuppressWarnings("unchecked")
   public @NotNull B mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges) {
-    this.styleBuilder().merge(requireNonNull(that, "component").style(), merges);
+    final Style thatStyle = requireNonNull(that, "that").style();
+    if (thatStyle.isEmpty() && merges.isEmpty()) return (B) this;
+    if (!this.hasStyle()) {
+      this.style = thatStyle;
+    } else {
+      this.styleBuilder().merge(thatStyle, merges);
+    }
     return (B) this;
   }
 
@@ -313,6 +319,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
     return this.styleBuilder;
   }
 
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   protected final boolean hasStyle() {
     return this.styleBuilder != null || this.style != null;
   }

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -291,11 +291,7 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   public @NotNull B mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges) {
     final Style thatStyle = requireNonNull(that, "that").style();
     if (thatStyle.isEmpty() && merges.isEmpty()) return (B) this;
-    if (!this.hasStyle()) {
-      this.style = thatStyle;
-    } else {
-      this.styleBuilder().merge(thatStyle, merges);
-    }
+    this.styleBuilder().merge(thatStyle, merges);
     return (B) this;
   }
 


### PR DESCRIPTION
`mergeStyle` is called a lot, especially in TranslatableComponentRenderer, where there is no merging to be done. By skipping the creation of the builder if the merge is a no-op, we can save some allocations.