### PR TITLE
Render translatable arguments and children

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -89,34 +89,12 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
       }
 
       @Override
-      protected @NotNull Component renderTranslatable(final @NotNull TranslatableComponent component, final @NotNull Locale context) {
+      protected @NotNull Component renderTranslatableInner(final @NotNull TranslatableComponent component, final @NotNull Locale context) {
         final TriState anyTranslations = source.hasAnyTranslations();
-        if (anyTranslations == TriState.TRUE || anyTranslations == TriState.NOT_SET) {
-          final List<TranslationArgument> arguments = component.arguments();
-          if (arguments.isEmpty()) {
-            final @Nullable Component translated = source.translate(component, context);
-            if (translated == null) return super.renderTranslatable(component, context);
+        if (anyTranslations == TriState.FALSE) return component;
 
-            return this.optionallyRenderChildren(translated, context);
-          }
-
-          final TranslatableComponent.Builder builder = component.toBuilder();
-          final List<TranslationArgument> translatedArguments = new ArrayList<>(arguments);
-          for (int i = 0; i < translatedArguments.size(); i++) {
-            final TranslationArgument arg = translatedArguments.get(i);
-            if (arg.value() instanceof Component && !(arg.value() instanceof VirtualComponent)) {
-              translatedArguments.set(i, TranslationArgument.component(this.render((Component) arg.value(), context)));
-            }
-          }
-
-          builder.arguments(translatedArguments);
-
-          final @Nullable Component translated = source.translate(builder.build(), context);
-          if (translated == null) return super.renderTranslatable(component, context);
-
-          return this.optionallyRenderChildren(translated, context);
-        }
-        return component;
+        final @Nullable Component translated = source.translate(component, context);
+        return translated == null ? super.renderTranslatableInner(component, context) : translated;
       }
     };
   }
@@ -205,27 +183,37 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   }
 
   @Override
-  @SuppressWarnings("JdkObsolete") // MessageFormat requires StringBuffer in its api
-  protected @NotNull Component renderTranslatable(final @NotNull TranslatableComponent component, final @NotNull C context) {
-    final @Nullable MessageFormat format = this.translate(component.key(), component.fallback(), context);
-    if (format == null) {
-      // we don't have a translation for this component, but the arguments or children
-      // of this component might need additional rendering
+  protected @NotNull Component renderTranslatable(@NotNull TranslatableComponent component, final @NotNull C context) {
+    final List<TranslationArgument> arguments = component.arguments();
+    final List<Component> children = component.children();
 
+    if (!arguments.isEmpty() || !children.isEmpty()) {
       final TranslatableComponent.Builder builder = Component.translatable()
-        .key(component.key()).fallback(component.fallback());
-      if (!component.arguments().isEmpty()) {
-        final List<TranslationArgument> args = new ArrayList<>(component.arguments());
-        for (int i = 0, size = args.size(); i < size; i++) {
-          final TranslationArgument arg = args.get(i);
-          if (arg.value() instanceof Component) {
-            args.set(i, TranslationArgument.component(this.render(((Component) arg.value()), context)));
+        .key(component.key())
+        .fallback(component.fallback());
+
+      if (!arguments.isEmpty()) {
+        final List<TranslationArgument> translatedArguments = new ArrayList<>(arguments);
+        for (int i = 0; i < translatedArguments.size(); i++) {
+          final TranslationArgument arg = translatedArguments.get(i);
+          if (arg.value() instanceof Component && !(arg.value() instanceof VirtualComponent)) {
+            translatedArguments.set(i, TranslationArgument.component(this.render((Component) arg.value(), context)));
           }
         }
-        builder.arguments(args);
+
+        builder.arguments(translatedArguments);
       }
-      return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
+
+      component = this.mergeStyleAndOptionallyDeepRender(component, builder, context);
     }
+
+    return this.renderTranslatableInner(component, context);
+  }
+
+  @SuppressWarnings("JdkObsolete") // MessageFormat requires StringBuffer in its api
+  protected @NotNull Component renderTranslatableInner(final @NotNull TranslatableComponent component, final @NotNull C context) {
+    final @Nullable MessageFormat format = this.translate(component.key(), component.fallback(), context);
+    if (format == null) return component;
 
     final List<TranslationArgument> args = component.arguments();
 
@@ -235,7 +223,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
     // no arguments makes this render very simple
     if (args.isEmpty()) {
       builder.content(format.format(null, new StringBuffer(), null).toString());
-      return this.optionallyRenderChildrenAppendAndBuild(component.children(), builder, context);
+      return builder.append(component.children()).build();
     }
 
     final Object[] nulls = new Object[args.size()];
@@ -247,28 +235,14 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
       final Integer index = (Integer) it.getAttribute(MessageFormat.Field.ARGUMENT);
       if (index != null) {
         final TranslationArgument arg = args.get(index);
-        if (arg.value() instanceof Component) {
-          builder.append(this.render(arg.asComponent(), context));
-        } else {
-          builder.append(arg.asComponent()); // todo: number rendering?
-        }
+        builder.append(arg.asComponent()); // todo: number rendering?
       } else {
         builder.append(Component.text(sb.substring(it.getIndex(), end)));
       }
       it.setIndex(end);
     }
 
-    return this.optionallyRenderChildrenAppendAndBuild(component.children(), builder, context);
-  }
-
-  protected Component optionallyRenderChildren(final Component component, final C context) {
-    final List<Component> children = component.children();
-    if (children.isEmpty()) return component;
-
-    final List<Component> rendered = new ArrayList<>(children.size());
-    children.forEach(child -> rendered.add(this.render(child, context)));
-
-    return component.children(rendered);
+    return builder.append(component.children()).build();
   }
 
   protected <O extends BuildableComponent<O, B>, B extends ComponentBuilder<O, B>> O mergeStyleAndOptionallyDeepRender(final Component component, final B builder, final C context) {

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -94,7 +94,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
         if (anyTranslations == TriState.FALSE) return component;
 
         final @Nullable Component translated = source.translate(component, context);
-        return translated == null ? super.renderTranslatableInner(component, context) : translated;
+        return translated != null ? this.render(translated, context) : super.renderTranslatableInner(component, context);
       }
     };
   }
@@ -188,9 +188,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
     final List<Component> children = component.children();
 
     if (!arguments.isEmpty() || !children.isEmpty()) {
-      final TranslatableComponent.Builder builder = Component.translatable()
-        .key(component.key())
-        .fallback(component.fallback());
+      final TranslatableComponent.Builder builder = component.toBuilder();
 
       if (!arguments.isEmpty()) {
         final List<TranslationArgument> translatedArguments = new ArrayList<>(arguments);
@@ -204,7 +202,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
         builder.arguments(translatedArguments);
       }
 
-      component = this.mergeStyleAndOptionallyDeepRender(component, builder, context);
+      component = builder.build();
     }
 
     return this.renderTranslatableInner(component, context);
@@ -213,7 +211,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   @SuppressWarnings("JdkObsolete") // MessageFormat requires StringBuffer in its api
   protected @NotNull Component renderTranslatableInner(final @NotNull TranslatableComponent component, final @NotNull C context) {
     final @Nullable MessageFormat format = this.translate(component.key(), component.fallback(), context);
-    if (format == null) return component;
+    if (format == null) return this.optionallyRenderChildren(component, context);
 
     final List<TranslationArgument> args = component.arguments();
 
@@ -223,7 +221,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
     // no arguments makes this render very simple
     if (args.isEmpty()) {
       builder.content(format.format(null, new StringBuffer(), null).toString());
-      return builder.append(component.children()).build();
+      return this.optionallyRenderChildrenAppendAndBuild(component.children(), builder, context);
     }
 
     final Object[] nulls = new Object[args.size()];
@@ -242,7 +240,17 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
       it.setIndex(end);
     }
 
-    return builder.append(component.children()).build();
+    return this.optionallyRenderChildrenAppendAndBuild(component.children(), builder, context);
+  }
+
+  protected Component optionallyRenderChildren(final Component component, final C context) {
+    final List<Component> children = component.children();
+    if (children.isEmpty()) return component;
+
+    final List<Component> rendered = new ArrayList<>(children.size());
+    children.forEach(child -> rendered.add(this.render(child, context)));
+
+    return component.children(rendered);
   }
 
   protected <O extends BuildableComponent<O, B>, B extends ComponentBuilder<O, B>> O mergeStyleAndOptionallyDeepRender(final Component component, final B builder, final C context) {

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -211,7 +211,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   @SuppressWarnings("JdkObsolete") // MessageFormat requires StringBuffer in its api
   protected @NotNull Component renderTranslatableInner(final @NotNull TranslatableComponent component, final @NotNull C context) {
     final @Nullable MessageFormat format = this.translate(component.key(), component.fallback(), context);
-    if (format == null) return this.optionallyRenderChildren(component, context);
+    if (format == null) return this.optionallyRenderChildrenAndStyle(component, context);
 
     final List<TranslationArgument> args = component.arguments();
 
@@ -243,7 +243,12 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
     return this.optionallyRenderChildrenAppendAndBuild(component.children(), builder, context);
   }
 
-  protected Component optionallyRenderChildren(final Component component, final C context) {
+  protected Component optionallyRenderChildrenAndStyle(Component component, final C context) {
+    final @Nullable HoverEvent<?> hoverEvent = component.hoverEvent();
+    if (hoverEvent != null) {
+      component = component.hoverEvent(hoverEvent.withRenderedValue(this, context));
+    }
+
     final List<Component> children = component.children();
     if (children.isEmpty()) return component;
 

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -93,7 +93,12 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
         final TriState anyTranslations = source.hasAnyTranslations();
         if (anyTranslations == TriState.FALSE) return component;
 
-        final @Nullable Component translated = source.translate(component, context);
+        final @Nullable Component translated;
+        if (source.canTranslate(component.key(), context)) {
+          translated = source.translate(component, context);
+        } else {
+          translated = null;
+        }
         return translated != null ? this.render(translated, context) : super.renderTranslatableInner(component, context);
       }
     };

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -45,6 +45,7 @@ import net.kyori.adventure.text.StorageNBTComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.TranslationArgument;
+import net.kyori.adventure.text.VirtualComponent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.translation.Translator;
@@ -91,9 +92,29 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
       protected @NotNull Component renderTranslatable(final @NotNull TranslatableComponent component, final @NotNull Locale context) {
         final TriState anyTranslations = source.hasAnyTranslations();
         if (anyTranslations == TriState.TRUE || anyTranslations == TriState.NOT_SET) {
-          final @Nullable Component translated = source.translate(component, context);
-          if (translated != null) return translated;
-          return super.renderTranslatable(component, context);
+          final List<TranslationArgument> arguments = component.arguments();
+          if (arguments.isEmpty()) {
+            final @Nullable Component translated = source.translate(component, context);
+            if (translated == null) return super.renderTranslatable(component, context);
+
+            return this.optionallyRenderChildren(translated, context);
+          }
+
+          final TranslatableComponent.Builder builder = component.toBuilder();
+          final List<TranslationArgument> translatedArguments = new ArrayList<>(arguments);
+          for (int i = 0; i < translatedArguments.size(); i++) {
+            final TranslationArgument arg = translatedArguments.get(i);
+            if (arg.value() instanceof Component && !(arg.value() instanceof VirtualComponent)) {
+              translatedArguments.set(i, TranslationArgument.component(this.render((Component) arg.value(), context)));
+            }
+          }
+
+          builder.arguments(translatedArguments);
+
+          final @Nullable Component translated = source.translate(builder.build(), context);
+          if (translated == null) return super.renderTranslatable(component, context);
+
+          return this.optionallyRenderChildren(translated, context);
         }
         return component;
       }
@@ -238,6 +259,16 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
     }
 
     return this.optionallyRenderChildrenAppendAndBuild(component.children(), builder, context);
+  }
+
+  protected Component optionallyRenderChildren(final Component component, final C context) {
+    final List<Component> children = component.children();
+    if (children.isEmpty()) return component;
+
+    final List<Component> rendered = new ArrayList<>(children.size());
+    children.forEach(child -> rendered.add(this.render(child, context)));
+
+    return component.children(rendered);
   }
 
   protected <O extends BuildableComponent<O, B>, B extends ComponentBuilder<O, B>> O mergeStyleAndOptionallyDeepRender(final Component component, final B builder, final C context) {

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTranslatorTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTranslatorTest.java
@@ -30,6 +30,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -51,7 +52,7 @@ public class MiniMessageTranslatorTest extends AbstractTest {
     @Override
     protected @Nullable String getMiniMessageString(final @NotNull String key, final @NotNull Locale locale) {
       // hack the test here by just returning the key
-      return key;
+      return !key.equals("test.untranslated") ? key : null;
     }
 
     @Override
@@ -193,6 +194,27 @@ public class MiniMessageTranslatorTest extends AbstractTest {
           Argument.tagResolver(Placeholder.component("name", Component.text("Kezz")))
         )
       ).compact()
+    );
+  }
+
+  @Test
+  public void testHoverEvent() {
+    assertEquals(
+      Component.translatable("test.untranslated")
+        .hoverEvent(HoverEvent.showText(Component.text("Test"))),
+      this.translate(
+        Component.translatable("test.untranslated")
+          .hoverEvent(HoverEvent.showText(Component.translatable("<arg:0>", Component.text("Test"))))
+      )
+    );
+
+    assertEquals(
+      Component.text("Test?")
+        .hoverEvent(HoverEvent.showText(Component.text("Test!"))),
+      this.translate(
+        Component.translatable("<arg:0>", Component.text("Test?"))
+          .hoverEvent(HoverEvent.showText(Component.translatable("<arg:0>", Component.text("Test!"))))
+      )
     );
   }
 

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTranslatorTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTranslatorTest.java
@@ -156,16 +156,10 @@ public class MiniMessageTranslatorTest extends AbstractTest {
       this.translate(
         Component.translatable(
           "<arg:0> is <arg:1>!",
+          Component.translatable("<arg:0>", Component.text("Kezz")),
           Component.translatable(
             "<arg:0>",
-            Component.text("Kezz")
-          ),
-          Component.translatable(
-            "<arg:0>",
-            Component.translatable(
-              "<arg:0>",
-              Component.text("cool")
-            )
+            Component.translatable("<arg:0>", Component.text("cool"))
           )
         )
       )

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTranslatorTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTranslatorTest.java
@@ -149,12 +149,52 @@ public class MiniMessageTranslatorTest extends AbstractTest {
     );
   }
 
+  @Test
+  public void testRecursiveArguments() {
+    assertEquals(
+      Component.text("Kezz is cool!"),
+      this.translate(
+        Component.translatable(
+          "<arg:0> is <arg:1>!",
+          Component.translatable(
+            "<arg:0>",
+            Component.text("Kezz")
+          ),
+          Component.translatable(
+            "<arg:0>",
+            Component.translatable(
+              "<arg:0>",
+              Component.text("cool")
+            )
+          )
+        )
+      )
+    );
+  }
+
+  @Test
+  public void testChildren() {
+    assertEquals(
+      Component.text()
+        .content("Kezz is ")
+        .append(Component.text("cool!"))
+        .build(),
+      this.translate(
+        Component.translatable()
+          .key("<arg:0> is ")
+          .arguments(Component.text("Kezz"))
+          .append(Component.translatable("<arg:0>", Component.text("cool!")))
+          .build()
+      )
+    );
+  }
+
   @AfterAll
   public static void afterAll() {
     GlobalTranslator.translator().removeSource(TRANSLATOR);
   }
 
   private Component translate(final TranslatableComponent component) {
-    return GlobalTranslator.translator().translate(component, LOCALE);
+    return GlobalTranslator.render(component, LOCALE);
   }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTranslatorTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTranslatorTest.java
@@ -183,6 +183,19 @@ public class MiniMessageTranslatorTest extends AbstractTest {
     );
   }
 
+  @Test
+  public void testLangTag() {
+    assertEquals(
+      Component.text("Kezz is cool!"),
+      this.translate(
+        Component.translatable(
+          "<lang:'<arg:0>':'<name>'> is <lang:'cool'>!",
+          Argument.tagResolver(Placeholder.component("name", Component.text("Kezz")))
+        )
+      ).compact()
+    );
+  }
+
   @AfterAll
   public static void afterAll() {
     GlobalTranslator.translator().removeSource(TRANSLATOR);


### PR DESCRIPTION
This is an attempt at fixing #1157.

~~Currently, it renders translation arguments & children components twice when using `MessageFormat` translations - not exactly sure on the best approach for avoiding this.~~