### PR TITLE
fix(api): Always fire bossBarNameChanged

### DIFF
--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarImpl.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarImpl.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.bossbar;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -92,12 +91,12 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
 
   @Override
   public @NotNull BossBar name(final @NotNull Component newName) {
+    // We do not check if the new name equals the old name here as the GlobalTranslator
+    // may produce a different resulting component for the end user.
     requireNonNull(newName, "name");
     final Component oldName = this.name;
-    if (!Objects.equals(newName, oldName)) {
-      this.name = newName;
-      this.forEachListener(listener -> listener.bossBarNameChanged(this, oldName, newName));
-    }
+    this.name = newName;
+    this.forEachListener(listener -> listener.bossBarNameChanged(this, oldName, newName));
     return this;
   }
 

--- a/api/src/test/java/net/kyori/adventure/bossbar/BossBarTest.java
+++ b/api/src/test/java/net/kyori/adventure/bossbar/BossBarTest.java
@@ -89,7 +89,7 @@ public class BossBarTest {
     assertEquals(1, this.name.get());
 
     assertEquals(Component.text("B"), this.bar.name(Component.text("B")).name());
-    assertEquals(1, this.name.get()); // value has not changed, should not have incremented
+    assertEquals(2, this.name.get()); // value has not changed, but we want this to have incremented
   }
 
   @Test


### PR DESCRIPTION
Developers use the GlobalTranslator to insert updated content in the resulting component sent to end users, so we shouldn't be checking this component. The only side effect would be that people who constantly call `name` would have packets repeatedly sent out, which feels like a them problem.