### PR TITLE
Add `equals` to `VirtualComponent`

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/VirtualComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/VirtualComponentImpl.java
@@ -84,6 +84,14 @@ final class VirtualComponentImpl<C> extends TextComponentImpl implements Virtual
     return Objects.equals(this.contextType, that.contextType) && Objects.equals(this.renderer, that.renderer);
   }
 
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = (31 * result) + this.contextType.hashCode();
+    result = (31 * result) + this.renderer.hashCode();
+    return result;
+  }
+
   static final class BuilderImpl<C> extends TextComponentImpl.BuilderImpl {
     private final Class<C> contextType;
     private final VirtualComponentRenderer<C> renderer;

--- a/api/src/main/java/net/kyori/adventure/text/VirtualComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/VirtualComponentImpl.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
 import net.kyori.adventure.text.format.Style;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -77,7 +76,7 @@ final class VirtualComponentImpl<C> extends TextComponentImpl implements Virtual
   }
 
   @Override
-  public boolean equals(@Nullable Object other) {
+  public boolean equals(final @Nullable Object other) {
     if (this == other) return true;
     if (!(other instanceof VirtualComponentImpl)) return false;
     if (!super.equals(other)) return false;

--- a/api/src/main/java/net/kyori/adventure/text/VirtualComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/VirtualComponentImpl.java
@@ -25,8 +25,11 @@ package net.kyori.adventure.text;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
 import net.kyori.adventure.text.format.Style;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class VirtualComponentImpl<C> extends TextComponentImpl implements VirtualComponent {
   static <C> VirtualComponent createVirtual(final @NotNull Class<C> contextType, final @NotNull VirtualComponentRenderer<C> renderer) {
@@ -71,6 +74,15 @@ final class VirtualComponentImpl<C> extends TextComponentImpl implements Virtual
   @Override
   public @NotNull Builder toBuilder() {
     return new BuilderImpl<>(this);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object other) {
+    if (this == other) return true;
+    if (!(other instanceof VirtualComponentImpl)) return false;
+    if (!super.equals(other)) return false;
+    final VirtualComponentImpl<?> that = (VirtualComponentImpl<?>) other;
+    return Objects.equals(this.contextType, that.contextType) && Objects.equals(this.renderer, that.renderer);
   }
 
   static final class BuilderImpl<C> extends TextComponentImpl.BuilderImpl {


### PR DESCRIPTION
Fixes a problem I had with using virtual components as named translation arguments (like MiniMessage does), and them not updating because they were being compared equal despite not being equal.