### PR TITLE
Implement #canTranslate in GlobalTranslatorImpl and call #canTranslate of its sources

### DIFF
--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
@@ -81,6 +81,17 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
   }
 
   @Override
+  public boolean canTranslate(final @NotNull String key, final @NotNull Locale locale) {
+    requireNonNull(key, "key");
+    requireNonNull(locale, "locale");
+    for (final Translator source : this.sources) {
+      boolean canTranslate = source.canTranslate(key, locale);
+      if (canTranslate) return true;
+    }
+    return false;
+  }
+
+  @Override
   public @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
     requireNonNull(key, "key");
     requireNonNull(locale, "locale");

--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
@@ -85,8 +85,7 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
     requireNonNull(key, "key");
     requireNonNull(locale, "locale");
     for (final Translator source : this.sources) {
-      boolean canTranslate = source.canTranslate(key, locale);
-      if (canTranslate) return true;
+      if (source.canTranslate(key, locale)) return true;
     }
     return false;
   }


### PR DESCRIPTION
Similar to the other methods in the GlobalTranslator, it simply iterates through the sources and checks whether a translation is possible there.

The reason for the proposed change is that if you add a source to the GlobalTranslator which overwrites #canTranslate, the logic in there is not taken into account.

In my individual case, this is necessary because I have my own implementations of TranslatableComponent in my project, to which my Translator only reacts if the instance passed to #translate is of the type of my own implementation and therefore my Translator is no longer addressed at all.