### PR TITLE
fix(nbt): Correct `defaultValue` nullability

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -377,7 +378,8 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return the array of bytes, or {@code defaultValue}
    * @since 4.0.0
    */
-  byte@NotNull[] getByteArray(final @NotNull String key, final byte@NotNull[] defaultValue);
+  @Contract("_, !null -> !null")
+  byte@Nullable[] getByteArray(final @NotNull String key, final byte@Nullable[] defaultValue);
 
   /**
    * Gets a string.
@@ -400,7 +402,8 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  @NotNull String getString(final @NotNull String key, final @NotNull String defaultValue);
+  @Contract("_, !null -> !null")
+  @Nullable String getString(final @NotNull String key, final @Nullable String defaultValue);
 
   /**
    * Gets a list.
@@ -423,7 +426,8 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull ListBinaryTag defaultValue);
+  @Contract("_, !null -> !null")
+  @Nullable ListBinaryTag getList(final @NotNull String key, final @Nullable ListBinaryTag defaultValue);
 
   /**
    * Gets a list, ensuring that the type is the same as {@code type}.
@@ -450,7 +454,8 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     does not match {@code expectedType}
    * @since 4.0.0
    */
-  @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull BinaryTagType<? extends BinaryTag> expectedType, final @NotNull ListBinaryTag defaultValue);
+  @Contract("_, _, !null -> !null")
+  @Nullable ListBinaryTag getList(final @NotNull String key, final @NotNull BinaryTagType<? extends BinaryTag> expectedType, final @Nullable ListBinaryTag defaultValue);
 
   /**
    * Gets a compound.
@@ -473,7 +478,8 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  @NotNull CompoundBinaryTag getCompound(final @NotNull String key, final @NotNull CompoundBinaryTag defaultValue);
+  @Contract("_, !null -> !null")
+  @Nullable CompoundBinaryTag getCompound(final @NotNull String key, final @Nullable CompoundBinaryTag defaultValue);
 
   /**
    * Gets an array of ints.
@@ -493,7 +499,8 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return the array of ints, or {@code defaultValue}
    * @since 4.0.0
    */
-  int@NotNull[] getIntArray(final @NotNull String key, final int@NotNull[] defaultValue);
+  @Contract("_, !null -> !null")
+  int@Nullable[] getIntArray(final @NotNull String key, final int@Nullable[] defaultValue);
 
   /**
    * Gets an array of longs.
@@ -513,7 +520,8 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return the array of longs, or {@code defaultValue}
    * @since 4.0.0
    */
-  long@NotNull[] getLongArray(final @NotNull String key, final long@NotNull[] defaultValue);
+  @Contract("_, !null -> !null")
+  long@Nullable[] getLongArray(final @NotNull String key, final long@Nullable[] defaultValue);
 
   /**
    * Gets a stream of entries in this compound tag.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
@@ -418,7 +419,8 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of bytes, or {@code defaultValue}
    * @since 4.0.0
    */
-  default byte@NotNull[] getByteArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final byte@NotNull[] defaultValue) {
+  @Contract("_, !null -> !null")
+  default byte@Nullable[] getByteArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final byte@Nullable[] defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.BYTE_ARRAY) {
       return ((ByteArrayBinaryTag) tag).value();
@@ -445,7 +447,8 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the string value, or {@code defaultValue}
    * @since 4.0.0
    */
-  default @NotNull String getString(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @NotNull String defaultValue) {
+  @Contract("_, !null -> !null")
+  default @Nullable String getString(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable String defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.STRING) {
       return ((StringBinaryTag) tag).value();
@@ -484,7 +487,8 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the list, or {@code defaultValue} if the tag at index {@code index} is not a list tag
    * @since 4.4.0
    */
-  default @NotNull ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @NotNull ListBinaryTag defaultValue) {
+  @Contract("_, !null -> !null")
+  default @Nullable ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable ListBinaryTag defaultValue) {
     return this.getList(index, null, defaultValue);
   }
 
@@ -499,7 +503,8 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the list, or {@code defaultValue} if the tag at index {@code index} is not a list tag, or if the list tag's element type is not {@code elementType}
    * @since 4.4.0
    */
-  default @NotNull ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable BinaryTagType<?> elementType, final @NotNull ListBinaryTag defaultValue) {
+  @Contract("_, _, !null -> !null")
+  default @Nullable ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable BinaryTagType<?> elementType, final @Nullable ListBinaryTag defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.LIST) {
       final ListBinaryTag list = (ListBinaryTag) tag;
@@ -529,7 +534,8 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the compound, or {@code defaultValue}
    * @since 4.0.0
    */
-  default @NotNull CompoundBinaryTag getCompound(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @NotNull CompoundBinaryTag defaultValue) {
+  @Contract("_, !null -> !null")
+  default @Nullable CompoundBinaryTag getCompound(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable CompoundBinaryTag defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.COMPOUND) {
       return (CompoundBinaryTag) tag;
@@ -560,7 +566,8 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of ints, or {@code defaultValue}
    * @since 4.0.0
    */
-  default int@NotNull[] getIntArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final int@NotNull[] defaultValue) {
+  @Contract("_, !null -> !null")
+  default int@Nullable[] getIntArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final int@Nullable[] defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.INT_ARRAY) {
       return ((IntArrayBinaryTag) tag).value();
@@ -591,7 +598,8 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of longs, or {@code defaultValue}
    * @since 4.0.0
    */
-  default long@NotNull[] getLongArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final long@NotNull[] defaultValue) {
+  @Contract("_, !null -> !null")
+  default long@Nullable[] getLongArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final long@Nullable[] defaultValue) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.LONG_ARRAY) {
       return ((LongArrayBinaryTag) tag).value();


### PR DESCRIPTION
Currently all the `getX(String Key, X defaultValue)` methods have the `defaultValue` as `@NotNull`, which means you can't do something like `compound.getString("key", null)` to get the string under the key, or `null` otherwise.

This PR changes the relevant methods on `CompoundBinaryTag` and `ListBinaryTag` to have `@Nullable` return types, `@Nullable` `defaultValue` params, and a contract to specify that a non-null default value means a non-null return type.

> [!NOTE]
> Wasn't sure if `@Contract` should be in the same line as the method or above it and checkstyle was passing either way, so I put it above the method - let me know if I should in-line it.

![image](https://github.com/user-attachments/assets/96a8e973-42bb-4fb8-8fcf-515feecc722c)
