### PR TITLE
feature(nbt): Builders with an initial capacity

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -155,7 +155,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *
    * @param initialCapacity the initial capacity
    * @return a new builder
-   * @since 4.24.0
+   * @since 4.25.0
    */
   static @NotNull Builder builder(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
     return new CompoundTagBuilder(initialCapacity);

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -31,6 +31,7 @@ import java.util.stream.Collector;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
 
 import static java.util.Objects.requireNonNull;
 
@@ -147,6 +148,17 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    */
   static @NotNull Builder builder() {
     return new CompoundTagBuilder();
+  }
+
+  /**
+   * Creates a builder with the specified initial capacity.
+   *
+   * @param initialCapacity the initial capacity
+   * @return a new builder
+   * @since 4.24.0
+   */
+  static @NotNull Builder builder(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
+    return new CompoundTagBuilder(initialCapacity);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
@@ -31,10 +31,19 @@ import org.jetbrains.annotations.Nullable;
 
 final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   private @Nullable Map<String, BinaryTag> tags;
+  private final int initialCapacity;
+
+  CompoundTagBuilder() {
+    this(-1);
+  }
+
+  CompoundTagBuilder(final int initialCapacity) {
+    this.initialCapacity = initialCapacity;
+  }
 
   private Map<String, BinaryTag> tags() {
     if (this.tags == null) {
-      this.tags = new HashMap<>();
+      this.tags = this.initialCapacity != -1 ? new HashMap<>(this.initialCapacity) : new HashMap<>();
     }
     return this.tags;
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
@@ -30,11 +30,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
+  private static final int DEFAULT_CAPACITY = -1;
+
   private @Nullable Map<String, BinaryTag> tags;
   private final int initialCapacity;
 
   CompoundTagBuilder() {
-    this(-1);
+    this(DEFAULT_CAPACITY);
   }
 
   CompoundTagBuilder(final int initialCapacity) {
@@ -43,7 +45,12 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
 
   private Map<String, BinaryTag> tags() {
     if (this.tags == null) {
-      this.tags = this.initialCapacity != -1 ? new HashMap<>(this.initialCapacity) : new HashMap<>();
+      if (this.initialCapacity != DEFAULT_CAPACITY) {
+        if (this.initialCapacity < 0) throw new IllegalArgumentException("initialCapacity cannot be less than 0, was " + this.initialCapacity);
+        this.tags = new HashMap<>(this.initialCapacity);
+      } else {
+        this.tags = new HashMap<>();
+      }
     }
     return this.tags;
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
@@ -74,6 +74,17 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
   }
 
   /**
+   * Creates a builder with the specified initial capacity.
+   *
+   * @param initialCapacity the initial capacity
+   * @return a new builder
+   * @since 4.24.0
+   */
+  static @NotNull Builder<BinaryTag> builder(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
+    return new ListTagBuilder<>(false, initialCapacity);
+  }
+
+  /**
    * Creates a builder that can accept elements of multiple types.
    *
    * @return a new builder
@@ -81,6 +92,17 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    */
   static @NotNull Builder<BinaryTag> heterogeneousListBinaryTag() {
     return new ListTagBuilder<>(true);
+  }
+
+  /**
+   * Creates a builder with the specified initial capacity that can accept elements of multiple types.
+   *
+   * @param initialCapacity the initial capacity
+   * @return a new builder
+   * @since 4.24.0
+   */
+  static @NotNull Builder<BinaryTag> heterogeneousListBinaryTag(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
+    return new ListTagBuilder<>(true, initialCapacity);
   }
 
   /**
@@ -95,6 +117,21 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
   static <T extends BinaryTag> @NotNull Builder<T> builder(final @NotNull BinaryTagType<T> type) {
     if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);
     return new ListTagBuilder<>(false, type);
+  }
+
+  /**
+   * Creates a builder with the specified initial capacity.
+   *
+   * @param type the element type
+   * @param initialCapacity the initial capacity
+   * @param <T> the element type
+   * @return a new builder
+   * @throws IllegalArgumentException if {@code type} is {@link BinaryTagTypes#END}
+   * @since 4.24.0
+   */
+  static <T extends BinaryTag> @NotNull Builder<T> builder(final @NotNull BinaryTagType<T> type, final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
+    if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);
+    return new ListTagBuilder<>(false, type, initialCapacity);
   }
 
   /**

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
@@ -78,7 +78,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    *
    * @param initialCapacity the initial capacity
    * @return a new builder
-   * @since 4.24.0
+   * @since 4.25.0
    */
   static @NotNull Builder<BinaryTag> builder(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
     return new ListTagBuilder<>(false, initialCapacity);
@@ -99,7 +99,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    *
    * @param initialCapacity the initial capacity
    * @return a new builder
-   * @since 4.24.0
+   * @since 4.25.0
    */
   static @NotNull Builder<BinaryTag> heterogeneousListBinaryTag(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
     return new ListTagBuilder<>(true, initialCapacity);
@@ -127,7 +127,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @param <T> the element type
    * @return a new builder
    * @throws IllegalArgumentException if {@code type} is {@link BinaryTagTypes#END}
-   * @since 4.24.0
+   * @since 4.25.0
    */
   static <T extends BinaryTag> @NotNull Builder<T> builder(final @NotNull BinaryTagType<T> type, final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
     if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder<T> {
+  private static final int DEFAULT_CAPACITY = -1;
+
   private @Nullable List<BinaryTag> tags;
   private final boolean permitsHeterogeneity;
   private BinaryTagType<? extends BinaryTag> elementType;
@@ -43,7 +45,7 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   }
 
   ListTagBuilder(final boolean permitsHeterogeneity, final BinaryTagType<? extends BinaryTag> type) {
-    this(permitsHeterogeneity, type, -1);
+    this(permitsHeterogeneity, type, DEFAULT_CAPACITY);
   }
 
   ListTagBuilder(final boolean permitsHeterogeneity, final BinaryTagType<? extends BinaryTag> type, final int initialCapacity) {
@@ -57,7 +59,12 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
     // check after changing from an empty tag
     this.elementType = ListBinaryTagImpl.validateTagType(tag, this.elementType, this.permitsHeterogeneity);
     if (this.tags == null) {
-      this.tags = this.initialCapacity != -1 ? new ArrayList<>(this.initialCapacity) : new ArrayList<>();
+      if (this.initialCapacity != DEFAULT_CAPACITY) {
+        if (this.initialCapacity < 0) throw new IllegalArgumentException("initialCapacity cannot be less than 0, was " + this.initialCapacity);
+        this.tags = new ArrayList<>(this.initialCapacity);
+      } else {
+        this.tags = new ArrayList<>();
+      }
     }
     this.tags.add(tag);
     return this;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
@@ -32,14 +32,24 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   private @Nullable List<BinaryTag> tags;
   private final boolean permitsHeterogeneity;
   private BinaryTagType<? extends BinaryTag> elementType;
+  private final int initialCapacity;
 
   ListTagBuilder(final boolean permitsHeterogeneity) {
     this(permitsHeterogeneity, BinaryTagTypes.END);
   }
 
+  ListTagBuilder(final boolean permitsHeterogeneity, final int initialCapacity) {
+    this(permitsHeterogeneity, BinaryTagTypes.END, initialCapacity);
+  }
+
   ListTagBuilder(final boolean permitsHeterogeneity, final BinaryTagType<? extends BinaryTag> type) {
+    this(permitsHeterogeneity, type, -1);
+  }
+
+  ListTagBuilder(final boolean permitsHeterogeneity, final BinaryTagType<? extends BinaryTag> type, final int initialCapacity) {
     this.permitsHeterogeneity = permitsHeterogeneity;
     this.elementType = type;
+    this.initialCapacity = initialCapacity;
   }
 
   @Override
@@ -47,7 +57,7 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
     // check after changing from an empty tag
     this.elementType = ListBinaryTagImpl.validateTagType(tag, this.elementType, this.permitsHeterogeneity);
     if (this.tags == null) {
-      this.tags = new ArrayList<>();
+      this.tags = this.initialCapacity != -1 ? new ArrayList<>(this.initialCapacity) : new ArrayList<>();
     }
     this.tags.add(tag);
     return this;


### PR DESCRIPTION
Adds methods to create `ListBinaryTag` and `CompoundBinaryTag` builders with an initial capacity.

Added an `int initialCapacity` field to both builder impls that defaults to -1.
When creating the backing list/map, the builders now use `initialCapacity` if it isn't -1.
For the builder impl constructors, I just overloaded them and added `initialCapcity`, as I didn't want to specify the `-1` outside the impl class/change the existing ones - lmk if that's actually fine and should be changed.

![image](https://github.com/user-attachments/assets/7e1e40b5-a8ee-49e2-a383-a86294ee3f0d)

