### PR TITLE
feature(nbt): `CompoundBinaryTag` contains methods

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -164,11 +164,11 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
   boolean contains(final @NotNull String key);
 
   /**
-   * Returns whether the compound contains a tag of a specific type under a key.
+   * Returns whether the compound contains a tag of a specific type with a key.
    *
    * @param key the key to check for
    * @param type the type to check for
-   * @return whether there is a tag of <code>type</code> under <code>key</code>
+   * @return whether there is a tag of {@code type} with {@code key}
    * @since 4.25.0
    */
   boolean contains(final @NotNull String key, final @NotNull BinaryTagType<?> type);

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -155,6 +155,25 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
   }
 
   /**
+   * Returns whether the compound contains a specific key.
+   *
+   * @param key the key to check for
+   * @return whether the compound contains the key
+   * @since 4.24.0
+   */
+  boolean containsKey(final @NotNull String key);
+
+  /**
+   * Returns whether the compound contains a tag of a specific type under a key.
+   *
+   * @param key the key to check for
+   * @param type the type to check for
+   * @return whether there is a tag of <code>type</code> under <code>key</code>
+   * @since 4.24.0
+   */
+  boolean contains(final @NotNull String key, final @NotNull BinaryTagType<?> type);
+
+  /**
    * Gets a set of all keys.
    *
    * @return the keys

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -159,7 +159,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *
    * @param key the key to check for
    * @return whether the compound contains the key
-   * @since 4.24.0
+   * @since 4.25.0
    */
   boolean containsKey(final @NotNull String key);
 
@@ -169,7 +169,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @param key the key to check for
    * @param type the type to check for
    * @return whether there is a tag of <code>type</code> under <code>key</code>
-   * @since 4.24.0
+   * @since 4.25.0
    */
   boolean contains(final @NotNull String key, final @NotNull BinaryTagType<?> type);
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -161,7 +161,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return whether the compound contains the key
    * @since 4.25.0
    */
-  boolean containsKey(final @NotNull String key);
+  boolean contains(final @NotNull String key);
 
   /**
    * Returns whether the compound contains a tag of a specific type under a key.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -48,6 +48,12 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
     this.hashCode = tags.hashCode();
   }
 
+  @Override
+  public boolean containsKey(final @NotNull String key) {
+    return this.tags.containsKey(key);
+  }
+
+  @Override
   public boolean contains(final @NotNull String key, final @NotNull BinaryTagType<?> type) {
     final @Nullable BinaryTag tag = this.tags.get(key);
     return tag != null && type.test(tag.type());

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -49,7 +49,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public boolean containsKey(final @NotNull String key) {
+  public boolean contains(final @NotNull String key) {
     return this.tags.containsKey(key);
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -55,8 +56,8 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
 
   @Override
   public boolean contains(final @NotNull String key, final @NotNull BinaryTagType<?> type) {
-    final @Nullable BinaryTag tag = this.tags.get(key);
-    return tag != null && type.test(tag.type());
+    final BinaryTag tag = this.tags.get(Objects.requireNonNull(key, "key"));
+    return tag != null && Objects.requireNonNull(type, "type").test(tag.type());
   }
 
   @Override


### PR DESCRIPTION
Adds `CompoundBinaryTag#containsKey(Key)` and `#contains(Key, Type)` utility methods.

Pretty straightforward, only potential point of concern is that `#contains` currently uses the same numeric-types-match logic, (I.e. checking an int for being a long type would return true) - probably fine because that's how the other methods behave? but if not it can be changed into exact type matching.
![image](https://github.com/user-attachments/assets/4d8816c7-037b-47f6-aab2-3744f871c742)