### PR TITLE
feature(nbt): `CompoundBinaryTag#builder(existing)`

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -31,6 +31,7 @@ import java.util.stream.Collector;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -149,18 +150,21 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
     return new CompoundTagBuilder();
   }
 
+  /**
+   * Creates a builder, pre-filled with the contents of {@code existing}.
+   *
+   * @param existing the compound to pre-fill the builder with
+   * @return a new builder
+   * @since 4.25.0
+   */
+  static @NotNull Builder builder(final @NotNull CompoundBinaryTag existing) {
+    return new CompoundTagBuilder(existing);
+  }
+
   @Override
   default @NotNull BinaryTagType<CompoundBinaryTag> type() {
     return BinaryTagTypes.COMPOUND;
   }
-
-  /**
-   * Creates a builder, pre-filled with the contents of this compound.
-   *
-   * @return a new builder
-   * @since 4.25.0
-   */
-  Builder createBuilder();
 
   /**
    * Gets a set of all keys.
@@ -169,6 +173,14 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   @NotNull Set<String> keySet();
+
+  /**
+   * Returns an unmodifiable map representing the contents of this compound.
+   *
+   * @return an unmodifiable map of contents
+   * @since 4.25.0
+   */
+  @Unmodifiable @NotNull Map<String, BinaryTag> asMap();
 
   /**
    * Gets a tag.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -155,6 +155,14 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
   }
 
   /**
+   * Creates a builder, pre-filled with the contents of this compound.
+   *
+   * @return a new builder
+   * @since 4.24.0
+   */
+  Builder createBuilder();
+
+  /**
    * Gets a set of all keys.
    *
    * @return the keys

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -158,7 +158,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * Creates a builder, pre-filled with the contents of this compound.
    *
    * @return a new builder
-   * @since 4.24.0
+   * @since 4.25.0
    */
   Builder createBuilder();
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -54,13 +54,13 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public Builder createBuilder() {
-    return new CompoundTagBuilder(new HashMap<>(this.tags)); // explicitly copy
+  public @NotNull Set<String> keySet() {
+    return Collections.unmodifiableSet(this.tags.keySet());
   }
 
   @Override
-  public @NotNull Set<String> keySet() {
-    return Collections.unmodifiableSet(this.tags.keySet());
+  public @NotNull Map<String, BinaryTag> asMap() {
+    return this.tags;
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -54,6 +54,11 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
+  public Builder createBuilder() {
+    return new CompoundTagBuilder(new HashMap<>(this.tags)); // explicitly copy
+  }
+
+  @Override
   public @NotNull Set<String> keySet() {
     return Collections.unmodifiableSet(this.tags.keySet());
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
@@ -35,8 +35,8 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   CompoundTagBuilder() {
   }
 
-  CompoundTagBuilder(final Map<String, BinaryTag> tags) {
-    this.tags = tags;
+  CompoundTagBuilder(final CompoundBinaryTag existing) {
+    this.tags = new HashMap<>(existing.asMap()); // explicitly copy
   }
 
   private Map<String, BinaryTag> tags() {

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
@@ -32,6 +32,13 @@ import org.jetbrains.annotations.Nullable;
 final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   private @Nullable Map<String, BinaryTag> tags;
 
+  CompoundTagBuilder() {
+  }
+
+  CompoundTagBuilder(final Map<String, BinaryTag> tags) {
+    this.tags = tags;
+  }
+
   private Map<String, BinaryTag> tags() {
     if (this.tags == null) {
       this.tags = new HashMap<>();


### PR DESCRIPTION
Adds `CompoundBinaryTag#createBuilder`, which creates a builder from the compound tag's current contents.
This is useful if you're editing a couple of values at once, like `compound.createBuilder().putInt("num", 6).putString("name", "Timothy").remove("old_value").build()`.

Might have merge conflicts with #1264, but I'll fix up whichever one is merged last.