### PR TITLE
feature(nbt): getting `BinaryTagType`s by their id

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagType.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagType.java
@@ -82,7 +82,7 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @return a binary tag type
    * @throws IllegalArgumentException if <code>id</code> doesn't match any <code>BinaryTagType</code>.
    * @see #id()
-   * @since 4.24.0
+   * @since 4.25.0
    */
   public static @NotNull BinaryTagType<? extends BinaryTag> binaryTagType(final byte id) {
     if (id >= 0 && id < BY_ID.length) {

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagType.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagType.java
@@ -26,8 +26,6 @@ package net.kyori.adventure.nbt;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Predicate;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -40,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  * @since 4.0.0
  */
 public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<BinaryTagType<? extends BinaryTag>> {
-  private static final List<BinaryTagType<? extends BinaryTag>> TYPES = new ArrayList<>();
+  private static final BinaryTagType<? extends BinaryTag>[] BY_ID = new BinaryTagType<?>[13];
 
   /**
    * Gets the id.
@@ -77,14 +75,20 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
     ((BinaryTagType<T>) type).write(tag, output);
   }
 
-  static @NotNull BinaryTagType<? extends BinaryTag> binaryTagType(final byte id) {
-    for (int i = 0; i < TYPES.size(); i++) {
-      final BinaryTagType<? extends BinaryTag> type = TYPES.get(i);
-      if (type.id() == id) {
-        return type;
-      }
+  /**
+   * Gets a {@link BinaryTagType} by its id.
+   *
+   * @param id the id
+   * @return a binary tag type
+   * @throws IllegalArgumentException if <code>id</code> doesn't match any <code>BinaryTagType</code>.
+   * @see #id()
+   * @since 4.24.0
+   */
+  public static @NotNull BinaryTagType<? extends BinaryTag> binaryTagType(final byte id) {
+    if (id >= 0 && id < BY_ID.length) {
+      return BY_ID[id];
     }
-    throw new IllegalArgumentException(String.valueOf(id));
+    throw new IllegalArgumentException("Byte id '" + id + "' does not match any binary tag types.");
   }
 
   @Deprecated
@@ -102,7 +106,7 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
   }
 
   private static <T extends BinaryTag, Y extends BinaryTagType<T>> Y register(final Y type) {
-    TYPES.add(type);
+    BY_ID[type.id()] = type;
     return type;
   }
 


### PR DESCRIPTION
Exposes `BinaryTagType#binaryTagType(byte id)`, to get a tag type by it's byte id.
This is needed if you're writing any sort of custom serialization, as currently you can get the id to serialize, but there's no way to de-serialize.

I also changed `BinaryTagType.List TYPES` to a `BinaryTagType[]` - technically hard-coding the size is not great, but seeing as:
- There haven't been any new types in over 8 years.
- It's a very easy change to make if any ever get added.
- It'll error on startup when calling `register` with any potential new tag type, so it's not an issue that's going to be missed.

it should be fine imo; still, lmk if you want me to revert it to the old list iteration & compare id approach.

Also, maybe it should return `null` instead of throwing? I just followed what the method already did, but maybe it would be better to change that, idk.

![image](https://github.com/user-attachments/assets/3a44b8c7-2210-4705-8e4f-7e9fa4eb17bb)