### PR TITLE
fix(nbt): zero byte tag radix parsing

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -332,16 +332,21 @@ final class TagStringReader {
     if (first == '+' || first == '-') {
       radixPrefixOffset = 1;
     }
+
+    // There should be more after '0b'/'0x', else it would be a regular byte tag or string
+    if (builder.length() < 3 + radixPrefixOffset) {
+      return DECIMAL_RADIX;
+    }
+
     if (original.startsWith("0b", radixPrefixOffset) || original.startsWith("0B", radixPrefixOffset)) {
       radix = BINARY_RADIX;
     } else if (original.startsWith("0x", radixPrefixOffset) || original.startsWith("0X", radixPrefixOffset)) {
       radix = HEX_RADIX;
     } else {
-      radix = DECIMAL_RADIX;
+      return DECIMAL_RADIX;
     }
-    if (radix != DECIMAL_RADIX) {
-      builder.delete(radixPrefixOffset, 2 + radixPrefixOffset);
-    }
+    // Remove the radix prefix
+    builder.delete(radixPrefixOffset, 2 + radixPrefixOffset);
     return radix;
   }
 

--- a/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
+++ b/nbt/src/test/java/net/kyori/adventure/nbt/StringIOTest.java
@@ -135,6 +135,7 @@ class StringIOTest {
     assertEquals("0b", this.tagToString(ByteBinaryTag.byteBinaryTag((byte) 0)));
     assertEquals("112b", this.tagToString(ByteBinaryTag.byteBinaryTag((byte) 112)));
 
+    assertEquals(ByteBinaryTag.byteBinaryTag((byte) 0), this.stringToTag("0b"));
     assertEquals(ByteBinaryTag.byteBinaryTag((byte) 12), this.stringToTag("12b"));
     assertEquals(ByteBinaryTag.byteBinaryTag((byte) 13), this.stringToTag("13B"));
   }


### PR DESCRIPTION
e.g. `{test:0b}` would error before this change. The second change is just cosmetic