### PR TITLE
Add a less verbose way of creating titles

### DIFF
--- a/api/src/main/java/net/kyori/adventure/title/Title.java
+++ b/api/src/main/java/net/kyori/adventure/title/Title.java
@@ -73,6 +73,21 @@ public interface Title extends Examinable {
   }
 
   /**
+   * Creates a title.
+   *
+   * @param title the title
+   * @param subtitle the subtitle
+   * @param fadeIn duration in ticks that the title fades in
+   * @param stay duration in ticks that the title stays on screen
+   * @param fadeOut duration in ticks that the title fades out
+   * @return the title
+   * @since 4.24.0
+   */
+  static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle, final int fadeIn, final int stay, final int fadeOut) {
+    return new TitleImpl(title, subtitle, Times.times(Ticks.duration(fadeIn), Ticks.duration(stay), Ticks.duration(fadeOut));
+  }
+
+  /**
    * Gets the title.
    *
    * @return the title

--- a/api/src/main/java/net/kyori/adventure/title/Title.java
+++ b/api/src/main/java/net/kyori/adventure/title/Title.java
@@ -77,14 +77,14 @@ public interface Title extends Examinable {
    *
    * @param title the title
    * @param subtitle the subtitle
-   * @param fadeIn duration in ticks that the title fades in
-   * @param stay duration in ticks that the title stays on screen
-   * @param fadeOut duration in ticks that the title fades out
+   * @param fadeInTicks duration in ticks that the title fades in
+   * @param stayTicks duration in ticks that the title stays on screen
+   * @param fadeOutTicks duration in ticks that the title fades out
    * @return the title
    * @since 4.24.0
    */
-  static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle, final int fadeIn, final int stay, final int fadeOut) {
-    return new TitleImpl(title, subtitle, Times.times(Ticks.duration(fadeIn), Ticks.duration(stay), Ticks.duration(fadeOut)));
+  static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle, final int fadeInTicks, final int stayTicks, final int fadeOutTicks) {
+    return new TitleImpl(title, subtitle, Times.times(Ticks.duration(fadeInTicks), Ticks.duration(stayTicks), Ticks.duration(fadeOutTicks)));
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/title/Title.java
+++ b/api/src/main/java/net/kyori/adventure/title/Title.java
@@ -84,7 +84,7 @@ public interface Title extends Examinable {
    * @since 4.24.0
    */
   static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle, final int fadeIn, final int stay, final int fadeOut) {
-    return new TitleImpl(title, subtitle, Times.times(Ticks.duration(fadeIn), Ticks.duration(stay), Ticks.duration(fadeOut));
+    return new TitleImpl(title, subtitle, Times.times(Ticks.duration(fadeIn), Ticks.duration(stay), Ticks.duration(fadeOut)));
   }
 
   /**


### PR DESCRIPTION
I have complained on the discord before about how creating titles is unnecessarily verbose and multiple people agreed with me. This is my idea to make it a little simpler. I think just specifying the duration in ticks is quite natural. Pretty much all APIs including Minecraft's own commands do it that way, so it shouldn't be confusing to anyone.

Another idea I had was adding a showTitle method that doesn't require a Title object and just takes the params directly but I'm not sure if that goes against adventure's design philosophy or not. I'm of course still open to any other ideas to improve title creation!