### PR TITLE
fix(api): fix removing mutated source from GlobalTranslator

### DIFF
--- a/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java
+++ b/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java
@@ -167,14 +167,12 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
 
     final AbstractTranslationStore<?> that = (AbstractTranslationStore<?>) other;
 
-    return this.name.equals(that.name)
-      && this.translations.equals(that.translations)
-      && this.defaultLocale.equals(that.defaultLocale);
+    return this.name.equals(that.name);
   }
 
   @Override
   public final int hashCode() {
-    return Objects.hash(this.name, this.translations, this.defaultLocale);
+    return this.name.hashCode();
   }
 
   @Override

--- a/api/src/test/java/net/kyori/adventure/translation/GlobalTranslatorTest.java
+++ b/api/src/test/java/net/kyori/adventure/translation/GlobalTranslatorTest.java
@@ -111,6 +111,16 @@ class GlobalTranslatorTest {
     assertEquals(Component.text("so valid").append(Component.translatable("test.2")), GlobalTranslator.render(input, Locale.UK));
   }
 
+  // https://github.com/KyoriPowered/adventure/issues/1273
+  @Test
+  void testRemovingMutatedSource() {
+    final TranslationStore.StringBased<MessageFormat> store = TranslationStore.messageFormat(Key.key("adventure", "test_mutating"));
+    GlobalTranslator.translator().addSource(store);
+    store.register("test", Locale.US, new MessageFormat("testing123"));
+    assertTrue(GlobalTranslator.translator().removeSource(store));
+    assertThat(GlobalTranslator.translator().sources()).doesNotContain(store);
+  }
+
   static class DummyTranslator implements Translator {
     static final DummyTranslator INSTANCE = new DummyTranslator();
 


### PR DESCRIPTION
Mutating a AbstractTranslationStore (e.g., registering a translation) causes its hash code to change. This results in the remove method searching for the wrong hash when trying to remove it.

This pr changes `AbstractTranslationStore#hashCode` to only use the translators name, as that is immutable.

Fixes #1273 