### PR TITLE
Uppercase hex colors created by `asHexColor` to avoid item desyncs in Minecraft

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.format;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 import net.kyori.adventure.util.HSVLike;
 import net.kyori.adventure.util.RGBLike;
@@ -222,7 +223,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
       result.append('0');
     }
     result.append(hex);
-    return result.toString();
+    return result.toString().toUpperCase(Locale.ROOT);
   }
 
   /**


### PR DESCRIPTION
Fixes #1275

Bugs caused by the lowercased `asHexColor`:
* https://github.com/PaperMC/Paper/issues/12902
* https://github.com/GeyserMC/Geyser/issues/5725