### PR TITLE
fix invalid url extraction in legacy component serializer

### DIFF
--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -23,6 +23,8 @@
  */
 package net.kyori.adventure.text.serializer.legacy;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,7 +52,7 @@ import org.jetbrains.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
-  static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
+  static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/[^\\s<>\"'`{}|^\\[\\] ]*)?");
   static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*:");
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
   private static final char LEGACY_BUNGEE_HEX_CHAR = 'x';
@@ -506,7 +508,13 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
           if (!URL_SCHEME_PATTERN.matcher(clickUrl).find()) {
             clickUrl = "http://" + clickUrl;
           }
-          return (style == null ? url : url.style(style)).clickEvent(ClickEvent.openUrl(clickUrl));
+
+          try {
+            URI ignored = new URI(clickUrl); // just to validate that the uri is valid
+            return (style == null ? url : url.style(style)).clickEvent(ClickEvent.openUrl(clickUrl));
+          } catch (URISyntaxException ignored) {
+            return url;
+          }
         })
         .build();
       return this;

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -52,7 +52,7 @@ import org.jetbrains.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
-  static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/[^\\s<>\"'`{}|^\\[\\] ]*)?");
+  static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/([A-Za-z0-9\\-._~!$&'()*+,;=:@/]|%[0-9A-Fa-f]{2})*)?");
   static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*:");
   private static final TextDecoration[] DECORATIONS = TextDecoration.values();
   private static final char LEGACY_BUNGEE_HEX_CHAR = 'x';
@@ -510,9 +510,9 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
           }
 
           try {
-            URI ignored = new URI(clickUrl); // just to validate that the uri is valid
+            final URI ignored = new URI(clickUrl); // just to validate that the uri is valid
             return (style == null ? url : url.style(style)).clickEvent(ClickEvent.openUrl(clickUrl));
-          } catch (URISyntaxException ignored) {
+          } catch (final URISyntaxException ignored) {
             return url;
           }
         })

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
@@ -165,4 +165,15 @@ class LinkingLegacyComponentSerializerTest {
       .build();
     assertEquals(expectedWithPathAndSuffix, LegacyComponentSerializer.builder().character('&').extractUrls().build().deserialize(withUnsafeChars));
   }
+
+  @Test
+  void testLinkifyWithPercentEncodedChars() {
+    final String bareUrl = "https://www.example.com/hello/:world$_:%5E)/test";
+    final String withSurroundingBrackets = "did you hear about https://www.example.com/hello/:world$_:%5E)/test? they're really cool";
+    final TextComponent expectedWithSurroundingBrackets = Component.text().content("did you hear about ")
+      .append(Component.text(bareUrl).clickEvent(ClickEvent.openUrl(bareUrl)))
+      .append(Component.text("? they're really cool"))
+      .build();
+    assertEquals(expectedWithSurroundingBrackets, LegacyComponentSerializer.builder().character('&').extractUrls().build().deserialize(withSurroundingBrackets));
+  }
 }

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LinkingLegacyComponentSerializerTest.java
@@ -138,4 +138,31 @@ class LinkingLegacyComponentSerializerTest {
       .build();
     assertEquals(expectedManyUrls, serializer.deserialize(manyUrls));
   }
+
+  @Test
+  void testLinkifyWithFollowingInvalidChars() {
+    final String bareUrl = "https://www.example.com/";
+    final String withSurroundingBrackets = "did you hear about <https://www.example.com/>? they're really cool";
+    final TextComponent expectedWithSurroundingBrackets = Component.text().content("did you hear about <")
+      .append(Component.text(bareUrl).clickEvent(ClickEvent.openUrl(bareUrl)))
+      .append(Component.text(">? they're really cool"))
+      .build();
+    assertEquals(expectedWithSurroundingBrackets, LegacyComponentSerializer.builder().character('&').extractUrls().build().deserialize(withSurroundingBrackets));
+
+    final String bareUrlWithPath = "https://www.example.com/hello_world";
+    final String withSpace = "did you hear about <https://www.example.com/hello_world test>? they're really cool";
+    final TextComponent expectedWithSpace = Component.text().content("did you hear about <")
+      .append(Component.text(bareUrlWithPath).clickEvent(ClickEvent.openUrl(bareUrlWithPath)))
+      .append(Component.text(" test>? they're really cool"))
+      .build();
+    assertEquals(expectedWithSpace, LegacyComponentSerializer.builder().character('&').extractUrls().build().deserialize(withSpace));
+
+    final String bareUrlWithPathAndSuffix = "https://www.example.com/hello/:world$_:";
+    final String withUnsafeChars = "did you hear about <https://www.example.com/hello/:world$_:^)>? they're really cool";
+    final TextComponent expectedWithPathAndSuffix = Component.text().content("did you hear about <")
+      .append(Component.text(bareUrlWithPathAndSuffix).clickEvent(ClickEvent.openUrl(bareUrlWithPathAndSuffix)))
+      .append(Component.text("^)>? they're really cool"))
+      .build();
+    assertEquals(expectedWithPathAndSuffix, LegacyComponentSerializer.builder().character('&').extractUrls().build().deserialize(withUnsafeChars));
+  }
 }


### PR DESCRIPTION
The legacy component serializer currently extracts some invalid urls from an input string, leading to a client disconnect due to the validation performed in `net.minecraft.Util.parseAndValidateUntrustedUri(String)` (specifically calling `new URI()` on the input).

An example input where this is happening is: `Discord: <https://example.com/>`, as this results in an open url action with the url `https://example.com/>` which is invalid.

To circument this I've made the url regex more strict on the path part (only allowing chars as specified in rfc 3986 section 3.3), and added a validity check by calling `new URI()` before adding the click event. I'm not sure if the second check is actually required, however, I feel it is better to be safer here than accidentially disconnecting clients by extracting invalid urls.

Please let me know if additional test cases are required, I only added a few to validate the behaviour, maybe a few more would be better.