### PR TITLE
feature(api): Allow reading style values from builders

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -27,18 +27,22 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
+import net.kyori.adventure.text.format.ShadowColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.ARGBLike;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -217,10 +221,20 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   }
 
   @Override
+  public @Nullable Key font() {
+    return this.styleBuilder().font();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public @NotNull B font(final @Nullable Key font) {
     this.styleBuilder().font(font);
     return (B) this;
+  }
+
+  @Override
+  public @Nullable TextColor color() {
+    return this.styleBuilder().color();
   }
 
   @Override
@@ -238,6 +252,11 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   }
 
   @Override
+  public @Nullable ShadowColor shadowColor() {
+    return this.styleBuilder().shadowColor();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public @NotNull B shadowColor(final @Nullable ARGBLike argb) {
     this.styleBuilder().shadowColor(argb);
@@ -249,6 +268,21 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   public @NotNull B shadowColorIfAbsent(final @Nullable ARGBLike argb) {
     this.styleBuilder().shadowColorIfAbsent(argb);
     return (B) this;
+  }
+
+  @Override
+  public TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
+    return this.styleBuilder().decoration(decoration);
+  }
+
+  @Override
+  public @Unmodifiable @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
+    return this.styleBuilder().decorations();
+  }
+
+  @Override
+  public boolean hasDecoration(final @NotNull TextDecoration decoration) {
+    return this.styleBuilder().hasDecoration(decoration);
   }
 
   @Override
@@ -266,6 +300,11 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   }
 
   @Override
+  public @Nullable ClickEvent clickEvent() {
+    return this.styleBuilder().clickEvent();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public @NotNull B clickEvent(final @Nullable ClickEvent event) {
     this.styleBuilder().clickEvent(event);
@@ -273,10 +312,20 @@ abstract class AbstractComponentBuilder<C extends BuildableComponent<C, B>, B ex
   }
 
   @Override
+  public @Nullable HoverEvent<?> hoverEvent() {
+    return this.styleBuilder().hoverEvent();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public @NotNull B hoverEvent(final @Nullable HoverEventSource<?> source) {
     this.styleBuilder().hoverEvent(source);
     return (B) this;
+  }
+
+  @Override
+  public @Nullable String insertion() {
+    return this.styleBuilder().insertion();
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
@@ -31,9 +31,12 @@ import java.util.function.Function;
 import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.text.format.MutableStyleSetter;
+import net.kyori.adventure.text.format.ShadowColor;
 import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.StyleGetter;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.Buildable;
@@ -41,6 +44,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 /**
  * A component builder.
@@ -50,7 +54,7 @@ import org.jetbrains.annotations.Nullable;
  * @since 4.0.0
  */
 @ApiStatus.NonExtendable
-public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends ComponentBuilder<C, B>> extends AbstractBuilder<C>, Buildable.Builder<C>, ComponentBuilderApplicable, ComponentLike, MutableStyleSetter<B> {
+public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends ComponentBuilder<C, B>> extends AbstractBuilder<C>, Buildable.Builder<C>, ComponentBuilderApplicable, ComponentLike, MutableStyleSetter<B>, StyleGetter {
   /**
    * Appends a component to this component.
    *
@@ -210,6 +214,15 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
   @NotNull B style(final @NotNull Consumer<Style.Builder> consumer);
 
   /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   * @sinceMinecraft 1.16
+   */
+  @Override
+  @Nullable Key font();
+
+  /**
    * Sets the font of this component.
    *
    * @param font the font
@@ -219,6 +232,14 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
   @Contract("_ -> this")
   @Override
   @NotNull B font(final @Nullable Key font);
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   */
+  @Override
+  @Nullable TextColor color();
 
   /**
    * Sets the color of this component.
@@ -241,6 +262,38 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
   @Contract("_ -> this")
   @Override
   @NotNull B colorIfAbsent(final @Nullable TextColor color);
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   */
+  @Override
+  @Nullable ShadowColor shadowColor();
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   */
+  @Override
+  boolean hasDecoration(final @NotNull TextDecoration decoration);
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   */
+  @Override
+  TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration);
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   */
+  @Override
+  @Unmodifiable @NotNull Map<TextDecoration, TextDecoration.State> decorations();
 
   /**
    * Sets the state of a set of decorations to {@code flag} on this component.
@@ -342,6 +395,14 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
   @NotNull B decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
   /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   */
+  @Override
+  @Nullable ClickEvent clickEvent();
+
+  /**
    * Sets the click event of this component.
    *
    * @param event the click event
@@ -353,6 +414,14 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
   @NotNull B clickEvent(final @Nullable ClickEvent event);
 
   /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   */
+  @Override
+  @Nullable HoverEvent<?> hoverEvent();
+
+  /**
    * Sets the hover event of this component.
    *
    * @param source the hover event source
@@ -362,6 +431,14 @@ public interface ComponentBuilder<C extends BuildableComponent<C, B>, B extends 
   @Contract("_ -> this")
   @Override
   @NotNull B hoverEvent(final @Nullable HoverEventSource<?> source);
+
+  /**
+   * {@inheritDoc}
+   *
+   * @since 4.25.0
+   */
+  @Override
+  @Nullable String insertion();
 
   /**
    * Sets the string to be inserted when this component is shift-clicked.

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -682,7 +682,16 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
    *
    * @since 4.0.0
    */
-  interface Builder extends AbstractBuilder<Style>, Buildable.Builder<Style>, MutableStyleSetter<Builder> {
+  interface Builder extends AbstractBuilder<Style>, Buildable.Builder<Style>, MutableStyleSetter<Builder>, StyleGetter {
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     * @sinceMinecraft 1.16
+     */
+    @Override
+    @Nullable Key font();
+
     /**
      * Sets the font.
      *
@@ -694,6 +703,14 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
     @Override
     @Contract("_ -> this")
     @NotNull Builder font(final @Nullable Key font);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     */
+    @Override
+    @Nullable TextColor color();
 
     /**
      * Sets the color.
@@ -716,6 +733,40 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
     @Override
     @Contract("_ -> this")
     @NotNull Builder colorIfAbsent(final @Nullable TextColor color);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     */
+    @Override
+    @Nullable ShadowColor shadowColor();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     */
+    @Override
+    default boolean hasDecoration(final @NotNull TextDecoration decoration) {
+      return StyleGetter.super.hasDecoration(decoration);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     */
+    @Override
+    TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     */
+    @Override
+    @Unmodifiable @NotNull Map<TextDecoration, TextDecoration.State> decorations();
 
     /**
      * Sets {@code decoration} to {@link TextDecoration.State#TRUE}.
@@ -801,6 +852,14 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
     @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
 
     /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     */
+    @Override
+    @Nullable ClickEvent clickEvent();
+
+    /**
      * Sets the click event.
      *
      * @param event the click event
@@ -812,6 +871,14 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
     @NotNull Builder clickEvent(final @Nullable ClickEvent event);
 
     /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     */
+    @Override
+    @Nullable HoverEvent<?> hoverEvent();
+
+    /**
      * Sets the hover event.
      *
      * @param source the hover event source
@@ -821,6 +888,14 @@ public interface Style extends Buildable<Style, Style.Builder>, Examinable, Styl
     @Override
     @Contract("_ -> this")
     @NotNull Builder hoverEvent(final @Nullable HoverEventSource<?> source);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.25.0
+     */
+    @Override
+    @Nullable String insertion();
 
     /**
      * Sets the string to be inserted.

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.format;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -36,6 +37,7 @@ import net.kyori.adventure.util.ARGBLike;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -336,9 +338,19 @@ final class StyleImpl implements Style {
     }
 
     @Override
+    public @Nullable Key font() {
+      return this.font;
+    }
+
+    @Override
     public @NotNull Builder font(final @Nullable Key font) {
       this.font = font;
       return this;
+    }
+
+    @Override
+    public @Nullable TextColor color() {
+      return this.color;
     }
 
     @Override
@@ -356,6 +368,11 @@ final class StyleImpl implements Style {
     }
 
     @Override
+    public @Nullable ShadowColor shadowColor() {
+      return this.shadowColor;
+    }
+
+    @Override
     public @NotNull Builder shadowColor(final @Nullable ARGBLike argb) {
       this.shadowColor = argb == null ? null : ShadowColor.shadowColor(argb);
       return this;
@@ -367,6 +384,20 @@ final class StyleImpl implements Style {
         this.shadowColor = argb == null ? null : ShadowColor.shadowColor(argb);
       }
       return this;
+    }
+
+    @Override
+    public TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
+      final TextDecoration.@Nullable State state = this.decorations.get(decoration);
+      if (state != null) {
+        return state;
+      }
+      throw new IllegalArgumentException(String.format("unknown decoration '%s'", decoration));
+    }
+
+    @Override
+    public @Unmodifiable @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
+      return Collections.unmodifiableMap(this.decorations);
     }
 
     @Override
@@ -391,15 +422,30 @@ final class StyleImpl implements Style {
     }
 
     @Override
+    public @Nullable ClickEvent clickEvent() {
+      return this.clickEvent;
+    }
+
+    @Override
     public @NotNull Builder clickEvent(final @Nullable ClickEvent event) {
       this.clickEvent = event;
       return this;
     }
 
     @Override
+    public @Nullable HoverEvent<?> hoverEvent() {
+      return this.hoverEvent;
+    }
+
+    @Override
     public @NotNull Builder hoverEvent(final @Nullable HoverEventSource<?> source) {
       this.hoverEvent = HoverEventSource.unbox(source);
       return this;
+    }
+
+    @Override
+    public @Nullable String insertion() {
+      return this.insertion;
     }
 
     @Override


### PR DESCRIPTION
See [Discord](https://discord.com/channels/289587909051416579/1342377752774443008/1402811720715735040) discussion.

Makes `ComponentBuilder` and `Style.Builder` implement `StyleGetter`, allowing access to set values before building.
The style builder holds the actual implementation, and the component builder simply redirects `StyleGetter` methods to its style builder.

For the JD, I used `{@inheritDoc}` with a changed `@since` tag to 4.25.0 - this does mean that the JD sometimes refers to itself as e.g. `stylable` instead of `component`, but imo I don't think that's a big deal compared to how much cleaner the JD is (also see Discord discussion).

I put all of the getters right above their setters as that seemed to be the convention, but let me know if you'd prefer having them all in one place for less adventure 5.0 merge conflicts.
<img width="1519" height="264" alt="image" src="https://github.com/user-attachments/assets/784b4df9-7a80-4862-9cae-5fbfa60ef375" />
