### PR TITLE
feat(api): Allow passing parentStyle to Component#compact

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -2599,7 +2599,20 @@ public interface Component extends ComponentBuilderApplicable, ComponentLike, Ex
    */
   @ScopedComponentOverrideNotRequired
   default @NotNull Component compact() {
-    return ComponentCompaction.compact(this, null);
+    return this.compact(null);
+  }
+
+  /**
+   * Create a new component with any redundant style elements or children removed.
+   * It is assumed that the component will inherit the given {@code parentStyle}.
+   *
+   * @param parentStyle the style of the parent of this component
+   * @return the optimized component
+   * @since 4.25.0
+   */
+  @ScopedComponentOverrideNotRequired
+  default @NotNull Component compact(final @Nullable Style parentStyle) {
+    return ComponentCompaction.compact(this, parentStyle);
   }
 
   /**

--- a/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/ComponentCompactingTest.java
@@ -426,4 +426,11 @@ class ComponentCompactingTest {
     assertEquals(expectedComponent, expectedComponent.compact());
   }
 
+  @Test
+  void testCompactingWithParentStyle() {
+    final Component expectedComponent = text("meow");
+    final Component notCompact = text("meow").style(style(TextDecoration.BOLD));
+
+    assertEquals(expectedComponent, notCompact.compact(Style.style(TextDecoration.BOLD)));
+  }
 }


### PR DESCRIPTION
`Component#compact` optimizes the styles of a component tree by assuming this component is the root of the tree. This is fine in most situation, but sometimes, we know the context where the component will be used, and thus the styles could be optimized even further. By providing the initial `parentStyle` to the `ComponentCompaction.compact` method, it allows us to provide the additional context required to benefit more from this optimization.

The main use-case is for components that will be used in item lore, were we know the parent style is `Style.style(NamedTextColor.DARK_PURPLE, TextDecoration.ITALIC)`.

An alternative way to do this without this method would be to do:
```java
Component compacted = Component.empty().style(parentStyle).append(component).compact();
// But I just feel like this is way cleaner:
Component compacted = component.compact(parentStyle);
```
They would both lead to same result thanks to the optimization of compaction when the parent is just empty with only one child.

***

I don't know if I should add additional unit tests for anything else, since the code to account for the `parentStyle` already exists, I only added a simple way to call it.