### PR TITLE
feat(json): add option to prepend https to click event urls

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
@@ -55,6 +55,8 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
   /**
    * Creates a click event that opens a url.
    *
+   * <p>Since <em>Minecraft: Java Edition</em> 1.21.5 the url will fail to parse if not a {@code http://} or {@code https://} scheme.</p>
+   *
    * @param url the url to open
    * @return a click event
    * @since 4.0.0

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -211,12 +211,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
         if (action != null && action.readable()) {
           switch (action) {
             case OPEN_URL:
-              if (value != null) {
-                if (this.emitClickUrlHttps && !StyleSerializer.isValidUrlScheme(value)) {
-                  value = StyleSerializer.FALLBACK_URL_PROTOCOL + value;
-                }
-                style.clickEvent(ClickEvent.openUrl(value));
-              }
+              if (value != null) style.clickEvent(ClickEvent.openUrl(value));
               break;
             case RUN_COMMAND:
               if (value != null) style.clickEvent(ClickEvent.runCommand(value));

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -82,6 +82,8 @@ final class StyleSerializer extends TypeAdapter<Style> {
     TextDecoration.OBFUSCATED
   };
 
+  private static final String FALLBACK_URL_PROTOCOL = "https://";
+
   static {
     // Ensure coverage of decorations
     final Set<TextDecoration> knownDecorations = EnumSet.allOf(TextDecoration.class);
@@ -106,6 +108,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
       features.value(JSONOptions.VALIDATE_STRICT_EVENTS),
       features.value(JSONOptions.SHADOW_COLOR_MODE) != JSONOptions.ShadowColorEmitMode.NONE,
       features.value(JSONOptions.EMIT_CHANGE_PAGE_CLICK_EVENT_PAGE_AS_STRING),
+      features.value(JSONOptions.EMIT_CLICK_URL_HTTPS),
       gson
     ).nullSafe();
   }
@@ -119,6 +122,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
   private final boolean strictEventValues;
   private final boolean emitShadowColor;
   private final boolean emitStringPage;
+  private final boolean emitClickUrlHttps;
   private final Gson gson;
 
   private StyleSerializer(
@@ -131,6 +135,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
     final boolean strictEventValues,
     final boolean emitShadowColor,
     final boolean emitStringPage,
+    final boolean emitClickUrlHttps,
     final Gson gson
   ) {
     this.legacyHover = legacyHover;
@@ -142,6 +147,7 @@ final class StyleSerializer extends TypeAdapter<Style> {
     this.strictEventValues = strictEventValues;
     this.emitShadowColor = emitShadowColor;
     this.emitStringPage = emitStringPage;
+    this.emitClickUrlHttps = emitClickUrlHttps;
     this.gson = gson;
   }
 
@@ -205,7 +211,12 @@ final class StyleSerializer extends TypeAdapter<Style> {
         if (action != null && action.readable()) {
           switch (action) {
             case OPEN_URL:
-              if (value != null) style.clickEvent(ClickEvent.openUrl(value));
+              if (value != null) {
+                if (this.emitClickUrlHttps && !StyleSerializer.isValidUrlScheme(value)) {
+                  value = StyleSerializer.FALLBACK_URL_PROTOCOL + value;
+                }
+                style.clickEvent(ClickEvent.openUrl(value));
+              }
               break;
             case RUN_COMMAND:
               if (value != null) style.clickEvent(ClickEvent.runCommand(value));
@@ -383,7 +394,11 @@ final class StyleSerializer extends TypeAdapter<Style> {
                 out.name(CLICK_EVENT_VALUE);
                 break;
             }
-            out.value(((ClickEvent.Payload.Text) payload).value());
+            String payloadValue = ((ClickEvent.Payload.Text) payload).value();
+            if (action == ClickEvent.Action.OPEN_URL && this.emitClickUrlHttps && !StyleSerializer.isValidUrlScheme(payloadValue)) {
+              payloadValue = StyleSerializer.FALLBACK_URL_PROTOCOL + payloadValue;
+            }
+            out.value(payloadValue);
           } else if (payload instanceof ClickEvent.Payload.Custom) {
             final ClickEvent.Payload.Custom customPayload = (ClickEvent.Payload.Custom) payload;
             out.name(CLICK_EVENT_ID);
@@ -410,7 +425,11 @@ final class StyleSerializer extends TypeAdapter<Style> {
         out.name(CLICK_EVENT_ACTION);
         this.gson.toJson(action, SerializerFactory.CLICK_ACTION_TYPE, out);
         out.name(CLICK_EVENT_VALUE);
-        out.value(clickEvent.value());
+        String payloadValue = clickEvent.value();
+        if (action == ClickEvent.Action.OPEN_URL && this.emitClickUrlHttps && !StyleSerializer.isValidUrlScheme(payloadValue)) {
+          payloadValue = StyleSerializer.FALLBACK_URL_PROTOCOL + payloadValue;
+        }
+        out.value(payloadValue);
         out.endObject();
       }
     }
@@ -508,5 +527,10 @@ final class StyleSerializer extends TypeAdapter<Style> {
     } else {
       out.nullValue();
     }
+  }
+
+  @SuppressWarnings({"BooleanMethodIsAlwaysInverted", "HttpUrlsUsage"})
+  private static boolean isValidUrlScheme(final String url) {
+    return url.startsWith("http://") || url.startsWith("https://");
   }
 }

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONOptions.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONOptions.java
@@ -105,6 +105,7 @@ public final class JSONOptions {
    * @since 4.15.0
    */
   public static final Option<Boolean> VALIDATE_STRICT_EVENTS = UNSAFE_SCHEMA.booleanOption(key("validate/strict_events"), true);
+
   /**
    * Whether to emit the default hover event item stack quantity of {@code 1}.
    *
@@ -134,6 +135,15 @@ public final class JSONOptions {
    * @since 4.22.0
    */
   public static final Option<Boolean> EMIT_CHANGE_PAGE_CLICK_EVENT_PAGE_AS_STRING = UNSAFE_SCHEMA.booleanOption(key("emit/change_page_click_event_page_as_string"), false);
+
+  /**
+   * Whether to prepend {@code https://} to {@code open_url} click event URIs without a protocol.
+   *
+   * <p>As of minecraft 1.21.5 URIs without protocol fail to parse.</p>
+   *
+   * @since 4.25.0
+   */
+  public static final Option<Boolean> EMIT_CLICK_URL_HTTPS = UNSAFE_SCHEMA.booleanOption(key("emit/click_url_https"), false);
 
   // aim for compatibility? or something
   private static final OptionSchema SCHEMA = OptionSchema.childSchema(UNSAFE_SCHEMA).frozenView();
@@ -180,6 +190,7 @@ public final class JSONOptions {
       b -> b.value(EMIT_HOVER_EVENT_TYPE, HoverEventValueMode.SNAKE_CASE)
         .value(EMIT_CLICK_EVENT_TYPE, ClickEventValueMode.SNAKE_CASE)
         .value(EMIT_HOVER_SHOW_ENTITY_KEY_AS_TYPE_AND_UUID_AS_ID, false)
+        .value(EMIT_CLICK_URL_HTTPS, true)
     )
     .version(
       VERSION_1_21_6,
@@ -200,6 +211,7 @@ public final class JSONOptions {
     .value(VALIDATE_STRICT_EVENTS, false)
     .value(SHOW_ITEM_HOVER_DATA_MODE, ShowItemHoverDataMode.EMIT_EITHER)
     .value(SHADOW_COLOR_MODE, ShadowColorEmitMode.EMIT_INTEGER)
+    .value(EMIT_CLICK_URL_HTTPS, true)
     .build();
 
   private static String key(final String value) {

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONOptions.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONOptions.java
@@ -137,9 +137,9 @@ public final class JSONOptions {
   public static final Option<Boolean> EMIT_CHANGE_PAGE_CLICK_EVENT_PAGE_AS_STRING = UNSAFE_SCHEMA.booleanOption(key("emit/change_page_click_event_page_as_string"), false);
 
   /**
-   * Whether to prepend {@code https://} to {@code open_url} click event URIs without a protocol.
+   * Whether to prepend {@code https://} to {@code open_url} click event URIs without a valid scheme.
    *
-   * <p>As of minecraft 1.21.5 URIs without protocol fail to parse.</p>
+   * <p>As of minecraft 1.21.5 URIs that are not a {@code http://} or {@code https://} scheme fail to parse.</p>
    *
    * @since 4.25.0
    */

--- a/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/StyleTest.java
+++ b/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/StyleTest.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.serializer.json;
 
 import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
 import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
@@ -37,6 +38,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.commons.ComponentTreeConstants;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -179,5 +181,34 @@ class StyleTest extends SerializerTest {
         }));
       }
     );
+  }
+
+  @Test
+  void testClickUrlSchema() {
+    final JSONComponentSerializer serializerWithoutSchema = JSONComponentSerializer.builder()
+      .editOptions(b -> b.value(JSONOptions.EMIT_CLICK_URL_HTTPS, false))
+      .build();
+    final JSONComponentSerializer serializerWithSchema = JSONComponentSerializer.builder()
+      .editOptions(editor -> editor.value(JSONOptions.EMIT_CLICK_URL_HTTPS, true))
+      .build();
+
+    this.testClickEvent(serializerWithoutSchema, "kezz.gay");
+    this.testClickEvent(serializerWithoutSchema, "http://kezz.gay");
+    this.testClickEvent(serializerWithoutSchema, "https://kezz.gay");
+    this.testClickEvent(serializerWithSchema, "https://kezz.gay");
+    this.testClickEvent(serializerWithSchema, "http://kezz.gay");
+    this.testClickEvent(serializerWithSchema, "https://kezz.gay");
+  }
+
+  private void testClickEvent(final JSONComponentSerializer serializer, String url) {
+    final JsonObject object = object(json -> {
+      json.addProperty(ComponentTreeConstants.TEXT, "");
+      json.add(ComponentTreeConstants.CLICK_EVENT_SNAKE, object(clickEvent -> {
+        clickEvent.addProperty(ComponentTreeConstants.CLICK_EVENT_ACTION, name(ClickEvent.Action.OPEN_URL));
+        clickEvent.addProperty(ComponentTreeConstants.CLICK_EVENT_URL, url);
+      }));
+    });
+
+    assertEquals(object, serialize(serializer, Component.text("").clickEvent(ClickEvent.openUrl(url))));
   }
 }

--- a/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/StyleTest.java
+++ b/text-serializer-json/src/testFixtures/java/net/kyori/adventure/text/serializer/json/StyleTest.java
@@ -200,7 +200,7 @@ class StyleTest extends SerializerTest {
     this.testClickEvent(serializerWithSchema, "https://kezz.gay");
   }
 
-  private void testClickEvent(final JSONComponentSerializer serializer, String url) {
+  private void testClickEvent(final JSONComponentSerializer serializer, final String url) {
     final JsonObject object = object(json -> {
       json.addProperty(ComponentTreeConstants.TEXT, "");
       json.add(ComponentTreeConstants.CLICK_EVENT_SNAKE, object(clickEvent -> {


### PR DESCRIPTION
Related PaperMC/Velocity#1630; [discord discussion](https://discord.com/channels/289587909051416579/1342377788266512415/1406240907937972328)

Since 1.21.5 URIs without a `http://` or `https://` in a `open_url` click event are no longer silently ignored but fail parsing and disconnect. Developers still seem to expect these to be valid, probably because paper mitigates this in their [codec](https://github.com/PaperMC/Paper/blob/b4466ec981d104c4756d1a3b90c2ee0d6ce4e6bd/paper-server/src/main/java/io/papermc/paper/adventure/AdventureCodecs.java#L115).

This pr adds a JSONOption to be able to match papers behavior during (de)-serialization. Also documents this change on `ClickEvent#openUrl(String)` to inform developers that they should be sending valid URIs.

---
Tested with: 
```java
final GsonComponentSerializer serializer = GsonComponentSerializer.builder()
  .editOptions(options -> options.value(JSONOptions.EMIT_CLICK_URL_HTTPS, true))
  .build();
System.out.println(serializer.serialize(Component.text()
  .content("click me")
  .clickEvent(ClickEvent.openUrl("kyori.net"))
  .build()
));
System.out.println(serializer.deserialize(
  "{\"click_event\":{\"action\":\"open_url\",\"url\":\"kyori.net\"},\"text\":\"click me\"}"
));
```
output:
```json
{"click_event":{"action":"open_url","url":"https://kyori.net"},"text":"click me"}
```
```
TextComponentImpl{content="click me", style=StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=null, shadowColor=null, clickEvent=ClickEvent{action=open_url, payload=TextImpl{value="https://kyori.net"}}, hoverEvent=null, insertion=null, font=null}, children=[]}
```