### PR TITLE
feat(minimessage): add sprite tag

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
@@ -14,9 +14,10 @@ import org.intellij.lang.annotations.Subst;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * An object sprite tag.
+ * A sprite object tag.
  *
  * @since 4.25.0
+ * @sinceMinecraft 1.21.9
  */
 final class SpriteTag {
   private static final String SPRITE = "sprite";
@@ -31,7 +32,7 @@ final class SpriteTag {
   }
 
   static Tag create(final ArgumentQueue args, final Context ctx) throws ParsingException {
-    final @Subst("empty") String firstArg = args.popOr("A value is required to produce an object component").value();
+    final @Subst("empty") String firstArg = args.popOr("An atlas id and or a sprite id is required to produce a sprite object component").value();
     final @Subst("empty") String secondArg = args.hasNext() ? args.pop().value() : null;
 
     if (secondArg == null) {
@@ -56,7 +57,7 @@ final class SpriteTag {
     final Key atlas = ((ObjectComponent.SpriteContents) contents).atlas();
     final Key key = ((ObjectComponent.SpriteContents) contents).sprite();
 
-    if (atlas == null) {
+    if (atlas == ObjectComponent.SpriteContents.DEFAULT_ATLAS) {
       return emit -> emit.tag(SPRITE).argument(key.asString());
     }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
@@ -41,8 +41,8 @@ import org.jetbrains.annotations.Nullable;
 /**
  * A sprite object tag.
  *
- * @sinceMinecraft 1.21.9
  * @since 4.25.0
+ * @sinceMinecraft 1.21.9
  */
 final class SpriteTag {
   private static final String SPRITE = "sprite";

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package net.kyori.adventure.text.minimessage.tag.standard;
 
 import net.kyori.adventure.key.Key;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
@@ -1,0 +1,52 @@
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ObjectComponent;
+import net.kyori.adventure.text.minimessage.Context;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.internal.serializer.Emitable;
+import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.intellij.lang.annotations.Subst;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An object sprite tag.
+ *
+ * @since 4.25.0
+ */
+final class SpriteTag {
+  private static final String SPRITE = "sprite";
+
+  static final TagResolver RESOLVER = SerializableResolver.claimingComponent(
+    SPRITE,
+    SpriteTag::create,
+    SpriteTag::claimComponent
+  );
+
+  private SpriteTag() {
+  }
+
+  static Tag create(final ArgumentQueue args, final Context ctx) throws ParsingException {
+    final @Subst("empty") String object = args.popOr("A value is required to produce an object component").value();
+    return Tag.selfClosingInserting(Component.object(ObjectComponent.Contents.sprite(Key.key(object))));
+  }
+
+  static @Nullable Emitable claimComponent(final Component input) {
+    if (!(input instanceof ObjectComponent)) {
+      return null;
+    }
+
+    final ObjectComponent.Contents contents = ((ObjectComponent) input).contents();
+    if (!(contents instanceof ObjectComponent.SpriteContents)) {
+      return null;
+    }
+
+    final Key key = ((ObjectComponent.SpriteContents) contents).sprite();
+
+    return emit -> emit.tag(SPRITE).argument(key.asString());
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
@@ -33,14 +33,16 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.object.ObjectContents;
+import net.kyori.adventure.text.object.SpriteObjectContents;
 import org.intellij.lang.annotations.Subst;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * A sprite object tag.
  *
- * @since 4.25.0
  * @sinceMinecraft 1.21.9
+ * @since 4.25.0
  */
 final class SpriteTag {
   private static final String SPRITE = "sprite";
@@ -59,12 +61,18 @@ final class SpriteTag {
     final @Subst("empty") String secondArg = args.hasNext() ? args.pop().value() : null;
 
     if (secondArg == null) {
-      return Tag.selfClosingInserting(Component.object(ObjectComponent.Contents.sprite(Key.key(firstArg))));
+      return Tag.selfClosingInserting(Component.object(
+        ObjectContents.sprite(
+          Key.key(firstArg)
+        )
+      ));
     }
-    return Tag.selfClosingInserting(Component.object(ObjectComponent.Contents.sprite(
-      Key.key(firstArg),
-      Key.key(secondArg)
-    )));
+    return Tag.selfClosingInserting(Component.object(
+      ObjectContents.sprite(
+        Key.key(firstArg),
+        Key.key(secondArg)
+      )
+    ));
   }
 
   static @Nullable Emitable claimComponent(final Component input) {
@@ -72,15 +80,17 @@ final class SpriteTag {
       return null;
     }
 
-    final ObjectComponent.Contents contents = ((ObjectComponent) input).contents();
-    if (!(contents instanceof ObjectComponent.SpriteContents)) {
+    final ObjectContents contents = ((ObjectComponent) input).contents();
+    if (!(contents instanceof SpriteObjectContents)) {
       return null;
     }
 
-    final Key atlas = ((ObjectComponent.SpriteContents) contents).atlas();
-    final Key key = ((ObjectComponent.SpriteContents) contents).sprite();
+    final SpriteObjectContents sprite = ((SpriteObjectContents) contents);
 
-    if (atlas == ObjectComponent.SpriteContents.DEFAULT_ATLAS) {
+    final Key atlas = sprite.atlas();
+    final Key key = sprite.sprite();
+
+    if (atlas == SpriteObjectContents.DEFAULT_ATLAS) {
       return emit -> emit.tag(SPRITE).argument(key.asString());
     }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
@@ -31,8 +31,16 @@ final class SpriteTag {
   }
 
   static Tag create(final ArgumentQueue args, final Context ctx) throws ParsingException {
-    final @Subst("empty") String object = args.popOr("A value is required to produce an object component").value();
-    return Tag.selfClosingInserting(Component.object(ObjectComponent.Contents.sprite(Key.key(object))));
+    final @Subst("empty") String firstArg = args.popOr("A value is required to produce an object component").value();
+    final @Subst("empty") String secondArg = args.hasNext() ? args.pop().value() : null;
+
+    if (secondArg == null) {
+      return Tag.selfClosingInserting(Component.object(ObjectComponent.Contents.sprite(Key.key(firstArg))));
+    }
+    return Tag.selfClosingInserting(Component.object(ObjectComponent.Contents.sprite(
+      Key.key(firstArg),
+      Key.key(secondArg)
+    )));
   }
 
   static @Nullable Emitable claimComponent(final Component input) {
@@ -45,8 +53,13 @@ final class SpriteTag {
       return null;
     }
 
+    final Key atlas = ((ObjectComponent.SpriteContents) contents).atlas();
     final Key key = ((ObjectComponent.SpriteContents) contents).sprite();
 
-    return emit -> emit.tag(SPRITE).argument(key.asString());
+    if (atlas == null) {
+      return emit -> emit.tag(SPRITE).argument(key.asString());
+    }
+
+    return emit -> emit.tag(SPRITE).argument(atlas.asString()).argument(key.asString());
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -296,7 +296,7 @@ public final class StandardTags {
    * @since 4.25.0
    * @sinceMinecraft 1.21.9
    */
-  public static @NotNull TagResolver spriteTag() {
+  public static @NotNull TagResolver sprite() {
     return SpriteTag.RESOLVER;
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -294,6 +294,7 @@ public final class StandardTags {
    *
    * @return a resolver for the {@value SpriteTag#SPRITE} tag.
    * @since 4.25.0
+   * @sinceMinecraft 1.21.9
    */
   public static @NotNull TagResolver spriteTag() {
     return SpriteTag.RESOLVER;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -65,7 +65,8 @@ public final class StandardTags {
         ScoreTag.RESOLVER,
         NbtTag.RESOLVER,
         PrideTag.RESOLVER,
-        ShadowColorTag.RESOLVER
+        ShadowColorTag.RESOLVER,
+        SpriteTag.RESOLVER
       )
       .build();
 
@@ -286,6 +287,16 @@ public final class StandardTags {
    */
   public static @NotNull TagResolver shadowColor() {
     return ShadowColorTag.RESOLVER;
+  }
+
+  /**
+   * Get a resolver for the {@value SpriteTag#SPRITE} tag.
+   *
+   * @return a resolver for the {@value SpriteTag#SPRITE} tag.
+   * @since 4.25.0
+   */
+  public static @NotNull TagResolver spriteTag() {
+    return SpriteTag.RESOLVER;
   }
 
   /**

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTagTest.java
@@ -53,4 +53,28 @@ class SpriteTagTest extends AbstractTest {
 
     this.assertParsedEquals(expected, input);
   }
+
+  @Test
+  void testSerializeAtlasSprite() {
+    final String expected = "This sentence is <sprite:'minecraft:items':'minecraft:item/emerald'/>!";
+
+    final TextComponent.Builder builder = Component.text()
+      .append(Component.text("This sentence is "))
+      .append(Component.object(ObjectComponent.Contents.sprite(Key.key("items"), Key.key("item/emerald"))))
+      .append(Component.text("!"));
+
+    this.assertSerializedEquals(expected, builder);
+  }
+
+  @Test
+  void testAtlasSprite() {
+    final String input = "A <sprite:items:item/diamond_sword> is strong.";
+    final Component expected = Component.text()
+      .append(Component.text("A "))
+      .append(Component.object(ObjectComponent.Contents.sprite(Key.key("items"), Key.key("item/diamond_sword"))))
+      .append(Component.text(" is strong."))
+      .build();
+
+    this.assertParsedEquals(expected, input);
+  }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTagTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ObjectComponent;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.minimessage.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class SpriteTagTest extends AbstractTest {
+  @Test
+  void testSerializeSprite() {
+    final String expected = "This sentence is <sprite:'minecraft:block/fire_0'/>!";
+
+    final TextComponent.Builder builder = Component.text()
+      .append(Component.text("This sentence is "))
+      .append(Component.object(ObjectComponent.Contents.sprite(Key.key("block/fire_0"))))
+      .append(Component.text("!"));
+
+    this.assertSerializedEquals(expected, builder);
+  }
+
+  @Test
+  void testSprite() {
+    final String input = "<sprite:block/stone> is hard.";
+    final Component expected = Component.text()
+      .append(Component.object(ObjectComponent.Contents.sprite(Key.key("block/stone"))))
+      .append(Component.text(" is hard."))
+      .build();
+
+    this.assertParsedEquals(expected, input);
+  }
+}

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTagTest.java
@@ -25,11 +25,9 @@ package net.kyori.adventure.text.minimessage.tag.standard;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.ObjectComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.AbstractTest;
 import net.kyori.adventure.text.object.ObjectContents;
-import net.kyori.adventure.text.object.SpriteObjectContents;
 import org.junit.jupiter.api.Test;
 
 class SpriteTagTest extends AbstractTest {

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTagTest.java
@@ -28,6 +28,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ObjectComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.AbstractTest;
+import net.kyori.adventure.text.object.ObjectContents;
+import net.kyori.adventure.text.object.SpriteObjectContents;
 import org.junit.jupiter.api.Test;
 
 class SpriteTagTest extends AbstractTest {
@@ -37,7 +39,7 @@ class SpriteTagTest extends AbstractTest {
 
     final TextComponent.Builder builder = Component.text()
       .append(Component.text("This sentence is "))
-      .append(Component.object(ObjectComponent.Contents.sprite(Key.key("block/fire_0"))))
+      .append(Component.object(ObjectContents.sprite(Key.key("block/fire_0"))))
       .append(Component.text("!"));
 
     this.assertSerializedEquals(expected, builder);
@@ -47,7 +49,7 @@ class SpriteTagTest extends AbstractTest {
   void testSprite() {
     final String input = "<sprite:block/stone> is hard.";
     final Component expected = Component.text()
-      .append(Component.object(ObjectComponent.Contents.sprite(Key.key("block/stone"))))
+      .append(Component.object(ObjectContents.sprite(Key.key("block/stone"))))
       .append(Component.text(" is hard."))
       .build();
 
@@ -60,7 +62,7 @@ class SpriteTagTest extends AbstractTest {
 
     final TextComponent.Builder builder = Component.text()
       .append(Component.text("This sentence is "))
-      .append(Component.object(ObjectComponent.Contents.sprite(Key.key("items"), Key.key("item/emerald"))))
+      .append(Component.object(ObjectContents.sprite(Key.key("items"), Key.key("item/emerald"))))
       .append(Component.text("!"));
 
     this.assertSerializedEquals(expected, builder);
@@ -71,7 +73,7 @@ class SpriteTagTest extends AbstractTest {
     final String input = "A <sprite:items:item/diamond_sword> is strong.";
     final Component expected = Component.text()
       .append(Component.text("A "))
-      .append(Component.object(ObjectComponent.Contents.sprite(Key.key("items"), Key.key("item/diamond_sword"))))
+      .append(Component.object(ObjectContents.sprite(Key.key("items"), Key.key("item/diamond_sword"))))
       .append(Component.text(" is strong."))
       .build();
 


### PR DESCRIPTION
Adds a `<sprite:[atlas]:key>` tag for inserting sprite objects via MiniMessage.