### PR TITLE
`TranslatableComponent$Builder#addArgument`

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -308,6 +308,18 @@ public interface TranslatableComponent extends BuildableComponent<TranslatableCo
     }
 
     /**
+     * Adds a single translation arg.
+     *
+     * <p>Non-{@link Component} arguments can be wrapped in {@link TranslationArgument}, or represented with a {@link TranslationArgumentLike}.</p>
+     *
+     * @param like the translation arg
+     * @return this builder
+     * @since 4.25.0
+     */
+    @Contract("_ -> this")
+    @NotNull Builder addArgument(final @NotNull ComponentLike like);
+
+    /**
      * Sets the translation args.
      *
      * <p>Non-{@link Component} arguments can be wrapped in {@link TranslationArgument}, or represented with a {@link TranslationArgumentLike}.</p>

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
@@ -145,7 +145,7 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
   static final class BuilderImpl extends AbstractComponentBuilder<TranslatableComponent, Builder> implements TranslatableComponent.Builder {
     private @Nullable String key;
     private @Nullable String fallback;
-    private List<TranslationArgument> args = Collections.emptyList();
+    private List<TranslationArgument> args = null;
 
     BuilderImpl() {
     }
@@ -157,9 +157,22 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
       this.fallback = component.fallback();
     }
 
+    private List<TranslationArgument> args() {
+      if (this.args == null) {
+        this.args = new ArrayList<>();
+      }
+      return this.args;
+    }
+
     @Override
     public @NotNull Builder key(final @NotNull String key) {
       this.key = key;
+      return this;
+    }
+
+    @Override
+    public @NotNull Builder addArgument(final @NotNull ComponentLike like) {
+      this.args().add(asArgument(like, -1));
       return this;
     }
 
@@ -172,7 +185,11 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
 
     @Override
     public @NotNull Builder arguments(final @NotNull List<? extends ComponentLike> args) {
-      this.args = asArguments(requireNonNull(args, "args"));
+      requireNonNull(args, "args");
+      this.args = new ArrayList<>(args.size());
+      for (int i = 0; i < args.size(); i++) {
+        this.args.add(asArgument(args.get(i), i));
+      }
       return this;
     }
 
@@ -185,7 +202,7 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
     @Override
     public @NotNull TranslatableComponent build() {
       if (this.key == null) throw new IllegalStateException("key must be set");
-      return create(this.children, this.buildStyle(), this.key, this.fallback, this.args);
+      return create(this.children, this.buildStyle(), this.key, this.fallback, this.args == null ? Collections.emptyList() : this.args);
     }
   }
 
@@ -196,19 +213,22 @@ final class TranslatableComponentImpl extends AbstractComponent implements Trans
 
     final List<TranslationArgument> ret = new ArrayList<>(likes.size());
     for (int i = 0; i < likes.size(); i++) {
-      final ComponentLike like = likes.get(i);
-      if (like == null) {
-        throw new NullPointerException("likes[" + i + "]");
-      }
-      if (like instanceof TranslationArgument) {
-        ret.add((TranslationArgument) like);
-      } else if (like instanceof TranslationArgumentLike) {
-        ret.add(requireNonNull(((TranslationArgumentLike) like).asTranslationArgument(), "likes[" + i + "].asTranslationArgument()"));
-      } else {
-        ret.add(TranslationArgument.component(like));
-      }
+      ret.add(asArgument(likes.get(i), i));
     }
 
     return Collections.unmodifiableList(ret);
+  }
+
+  static TranslationArgument asArgument(final ComponentLike like, final int index) {
+    if (like == null) {
+      throw new NullPointerException("like" + (index != -1 ? "s[" + index + "]" : ""));
+    }
+    if (like instanceof TranslationArgument) {
+      return (TranslationArgument) like;
+    } else if (like instanceof TranslationArgumentLike) {
+      return requireNonNull(((TranslationArgumentLike) like).asTranslationArgument(), "like" + (index != -1 ? "s[" + index + "]" : "") + ".asTranslationArgument()");
+    } else {
+      return TranslationArgument.component(like);
+    }
   }
 }


### PR DESCRIPTION
## Additions

- `TranslatableComponent$Builder#addArgument` - adds a single translation argument, as opposed to the current methods which only allow setting the entire list.
- `TranslatableComponentImpl#asArgument` - converts a single `ComponentLike` into a `TranslationArgument`, with an optional `int` index for extra error info (ignored when `-1`, from e.g. the new `addArgument` ^).

## Changes

- `TranslatableComponentImpl$BuilderImpl.args` - now defaults to null, with:
- `TranslatableComponentImpl$BuilderImpl#args` - acting as a getter that defaults it to a new `ArrayList` if unset and returns its value (similarly to other builders around the API).
- `TranslatableComponentImpl$BuilderImpl#arguments` - now initializes `args` to a new `ArrayList` of the correct size and adds each argument manually using the new `TranslatableComponentImpl#asArgument`, so that the list is mutable (unlike the one returned by `asArguments`) .
- `TranslatableComponentImpl$BuilderImpl#build` - now defaults `args` to `Collections.emptyList()` if `null`.

> [!NOTE]
> `TranslatableComponentImpl#asArgument`'s logic to include/exclude the `int index` param from errors may be a little messy? I don't think it's a very big problem as it's just an internal util method, but let me know if you'd prefer a different approach.
> Or maybe using the string supplier variants for `requireNonNull` instead of computing the error strings every time.

<img width="1483" height="267" alt="image" src="https://github.com/user-attachments/assets/b6e5c26b-30b5-4ced-b85a-22bb9226b5a8" />