### PR TITLE
fix(workflows): use Java 21 to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,4 +9,6 @@ on:
 jobs:
   call-build:
     uses: "KyoriPowered/.github/.github/workflows/shared-ci.yaml@trunk"
+    with:
+      runtime_version: 21
     secrets: "inherit"


### PR DESCRIPTION
This just set the runtime_version of [`shared-ci.yml`](https://github.com/KyoriPowered/.github/blob/trunk/.github/workflows/shared-ci.yaml) to Java 21.