### PR TITLE
fix(text-serializer-legacy): colors with no text are skipped

### DIFF
--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -297,6 +297,8 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     private @Nullable TextFormat lastWritten;
     private StyleState[] styles = new StyleState[8];
     private int head = -1;
+    private boolean applyTrailingStyle = false;
+    private int tail = -1;
 
     @Override
     public void pushStyle(final @NotNull Style pushed) {
@@ -308,6 +310,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
 
       if (state == null) {
         this.styles[idx] = state = new StyleState();
+        this.tail = Math.max(this.tail, idx);
       }
 
       if (idx > 0) {
@@ -323,12 +326,17 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
 
     @Override
     public void component(final @NotNull String text) {
-      if (!text.isEmpty()) {
-        if (this.head < 0) throw new IllegalStateException("No style has been pushed!");
-
-        this.styles[this.head].applyFormat();
-        this.sb.append(text);
+      if (text.isEmpty()) {
+        if (this.head == 0) {
+          this.applyTrailingStyle = true;
+        }
+        return;
       }
+
+      if (this.head < 0) throw new IllegalStateException("No style has been pushed!");
+
+      this.styles[this.head].applyFormat();
+      this.sb.append(text);
     }
 
     @Override
@@ -351,6 +359,10 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
 
     @Override
     public String toString() {
+      if (this.applyTrailingStyle) {
+        this.styles[this.tail].applyFormat();
+      }
+
       return this.sb.toString();
     }
 

--- a/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
+++ b/text-serializer-legacy/src/test/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerTest.java
@@ -161,6 +161,12 @@ class LegacyComponentSerializerTest {
   }
 
   @Test
+  void testToLegacyJustColor() {
+    final TextComponent c0 = Component.text("", TextColor.color(0xffefd5));
+    assertEquals("§#ffefd5", LegacyComponentSerializer.builder().hexColors().build().serialize(c0));
+  }
+
+  @Test
   void testToLegacyWithHexColor() {
     final TextComponent c0 = Component.text("Kittens!", TextColor.color(0xffefd5));
     assertEquals("§#ffefd5Kittens!", LegacyComponentSerializer.builder().hexColors().build().serialize(c0));


### PR DESCRIPTION
Fixes KyoriPowered/adventure#1085 (Not 100% sure the issue is related, I can open a separate one if needed ^^)

LegacyComponentSerializer does not serialize colors added to components with an empty text, which causes issues when using components as prefixes.
While this is not really an intended use case, it's unintuitive, causing for example the second of these tests to fail:

```
  @Test
  void testJustColor() { // Passes (Existing test case)
    assertEquals(Component.text("", TextColor.color(0xabcdef)), LegacyComponentSerializer.legacyAmpersand().deserialize("&#abcdef"));
  }

  @Test
  void testJustColorInverse() { // Fails (Basically the inverse of the first test, does not currently exist)
    assertEquals("&#abcdef", LegacyComponentSerializer.legacyAmpersand().serialize(Component.text("", TextColor.color(0xabcdef))));
    // Actual result: "" (an empty string)
  }
 ```
 
 The change in the PR does not change any other behaviour.
 Most importantly, it does not add "unused" formatting codes (for example colors that are immediately replaced with no text in between or erroneous resets like the one reported in KyoriPowered/adventure#287).

 I added a specific test (testToLegacyJustColor) that fails on the current version of adventure but works with the patched version.