### PR TITLE
feat: add sequential (simple) head tag

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContents.java
+++ b/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContents.java
@@ -53,6 +53,13 @@ import static java.util.Objects.requireNonNull;
 @ApiStatus.NonExtendable
 public interface PlayerHeadObjectContents extends ObjectContents {
   /**
+   * The default value for whether the player's hat layer should render.
+   *
+   * @since 4.25.0
+   */
+  boolean DEFAULT_HAT = true;
+
+  /**
    * Gets the name of the player if present.
    *
    * @return the name of the player or null

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SequentialHeadTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SequentialHeadTag.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ObjectComponent;
+import net.kyori.adventure.text.minimessage.Context;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.minimessage.internal.serializer.Emitable;
+import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.object.ObjectContents;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
+import net.kyori.adventure.util.TriState;
+import org.intellij.lang.annotations.Subst;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A simplified head object tag for only setting either the name,
+ * uuid, or texture key of a head object component.
+ *
+ * @since 4.25.0
+ * @sinceMinecraft 1.21.9
+ */
+final class SequentialHeadTag {
+  private static final String HEAD = "head";
+  // TODO: Move this to HeadTag
+  private static final Pattern UUIDv4_PATTERN = Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ABCD][0-9a-f]{3}-[0-9a-f]{12}", Pattern.CASE_INSENSITIVE);
+
+  static final TagResolver RESOLVER = SerializableResolver.claimingComponent(
+    HEAD,
+    SequentialHeadTag::create,
+    SequentialHeadTag::claimComponent
+  );
+
+  private SequentialHeadTag() {
+  }
+
+  static Tag create(final ArgumentQueue args, final Context ctx) throws ParsingException {
+    if (!args.hasNext()) {
+      return Tag.selfClosingInserting(Component.object(
+        ObjectContents.playerHead().build()
+      ));
+    }
+
+    final Tag.Argument rawArgument = args.pop();
+    final @Subst("key") String argument = rawArgument.value();
+
+    final TriState outerLayer;
+    if (!args.hasNext()) {
+      outerLayer = argumentToTriState(rawArgument);
+      if (outerLayer != TriState.NOT_SET) {
+        return Tag.selfClosingInserting(Component.object(
+          ObjectContents.playerHead()
+            .hat(outerLayer.toBooleanOrElse(PlayerHeadObjectContents.DEFAULT_HAT))
+            .build()
+        ));
+      }
+    } else {
+      outerLayer = argumentToTriState(args.pop());
+    }
+
+    if (args.hasNext()) {
+      throw ctx.newException("Too many arguments present", args);
+    }
+
+    if (SequentialHeadTag.UUIDv4_PATTERN.matcher(argument).matches()) {
+      return Tag.selfClosingInserting(Component.object(
+        ObjectContents.playerHead()
+          .id(UUID.fromString(argument))
+          .hat(outerLayer.toBooleanOrElse(PlayerHeadObjectContents.DEFAULT_HAT))
+          .build()
+      ));
+    }
+
+    if (argument.contains("/") && Key.parseable(argument)) {
+      return Tag.selfClosingInserting(Component.object(
+        ObjectContents.playerHead()
+          .texture(Key.key(argument))
+          .hat(outerLayer.toBooleanOrElse(PlayerHeadObjectContents.DEFAULT_HAT))
+          .build()
+      ));
+    }
+
+    return Tag.selfClosingInserting(Component.object(
+      ObjectContents.playerHead()
+        .name(argument)
+        .hat(outerLayer.toBooleanOrElse(PlayerHeadObjectContents.DEFAULT_HAT))
+        .build()
+    ));
+  }
+
+  static @Nullable Emitable claimComponent(final Component input) {
+    if (!(input instanceof ObjectComponent)) {
+      return null;
+    }
+
+    final ObjectContents contents = ((ObjectComponent) input).contents();
+    if (!(contents instanceof PlayerHeadObjectContents)) {
+      return null;
+    }
+
+    final PlayerHeadObjectContents playerHead = ((PlayerHeadObjectContents) contents);
+
+    PresentType present = null;
+    if (playerHead.name() != null) {
+      present = PresentType.NAME;
+    }
+
+    if (playerHead.id() != null) {
+      if (present != null) {
+        return null;
+      }
+      present = PresentType.ID;
+    }
+
+    if (playerHead.texture() != null) {
+      if (present != null) {
+        return null;
+      }
+      present = PresentType.TEXTURE;
+    }
+
+    if (present == null) {
+      // TODO: Make this return null once the named tag is out, since it might contain more information
+      // which we cannot currently parse. Temporarily though, return an empty tag.
+      return emit -> {
+        emit.tag(HEAD);
+
+        if (playerHead.hat() != PlayerHeadObjectContents.DEFAULT_HAT) {
+          emit.argument(Boolean.toString(playerHead.hat()));
+        }
+      };
+    }
+
+    final PresentType finalPresent = present;
+    return emit -> {
+      emit.tag(HEAD);
+
+      final String value = finalPresent.map(playerHead);
+      emit.argument(value);
+
+      if (playerHead.hat() != PlayerHeadObjectContents.DEFAULT_HAT) {
+        emit.argument(Boolean.toString(playerHead.hat()));
+      }
+    };
+  }
+
+  private static TriState argumentToTriState(final Tag.Argument argument) {
+    if (argument.isTrue()) {
+      return TriState.TRUE;
+    } else if (argument.isFalse()) {
+      return TriState.FALSE;
+    } else {
+      return TriState.NOT_SET;
+    }
+  }
+
+  private enum PresentType {
+    NAME(PlayerHeadObjectContents::name),
+    ID(obj -> Objects.requireNonNull(obj.id()).toString()),
+    TEXTURE(obj -> Objects.requireNonNull(obj.texture()).asMinimalString());
+
+    private final Function<PlayerHeadObjectContents, String> mappingFunction;
+
+    PresentType(final Function<PlayerHeadObjectContents, String> mappingFunction) {
+      this.mappingFunction = mappingFunction;
+    }
+
+    public String map(final PlayerHeadObjectContents obj) {
+      return this.mappingFunction.apply(obj);
+    }
+  }
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -66,7 +66,8 @@ public final class StandardTags {
         NbtTag.RESOLVER,
         PrideTag.RESOLVER,
         ShadowColorTag.RESOLVER,
-        SpriteTag.RESOLVER
+        SpriteTag.RESOLVER,
+        SequentialHeadTag.RESOLVER
       )
       .build();
 
@@ -135,6 +136,20 @@ public final class StandardTags {
    */
   public static @NotNull TagResolver keybind() {
     return KeybindTag.RESOLVER;
+  }
+
+  /**
+   * Get a resolver for the {@value SequentialHeadTag#HEAD} tag.
+   *
+   * <p>This variant of the head tag handles an alternative shorthand
+   * way of writing the head tag {@code <head:name|uuid|texture:[outer_layer}>}.</p>
+   *
+   * @return a resolver for the {@value SequentialHeadTag#HEAD} tag.
+   * @since 4.25.0
+   * @sinceMinecraft 1.21.9
+   */
+  public static @NotNull TagResolver sequentialHead() {
+    return SequentialHeadTag.RESOLVER;
   }
 
   /**

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -142,7 +142,7 @@ public final class StandardTags {
    * Get a resolver for the {@value SequentialHeadTag#HEAD} tag.
    *
    * <p>This variant of the head tag handles an alternative shorthand
-   * way of writing the head tag {@code <head:name|uuid|texture:[outer_layer}>}.</p>
+   * way of writing the head tag {@code <head:name|uuid|texture:[outer_layer]>}.</p>
    *
    * @return a resolver for the {@value SequentialHeadTag#HEAD} tag.
    * @since 4.25.0

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/HeadTagsTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/standard/HeadTagsTest.java
@@ -1,0 +1,258 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.tag.standard;
+
+import java.util.UUID;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.AbstractTest;
+import net.kyori.adventure.text.object.ObjectContents;
+import org.junit.jupiter.api.Test;
+
+class HeadTagsTest extends AbstractTest {
+
+  @Test
+  void testEmptySerialization() {
+    final String expected = "<head>";
+
+    final Component component = Component.object(
+      ObjectContents.playerHead().build()
+    );
+
+    this.assertSerializedEquals(expected, component);
+  }
+
+  @Test
+  void testEmptyDeserialization() {
+    final Component expected = Component.object(
+      ObjectContents.playerHead().build()
+    );
+
+    final String input = "<head>";
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testHatSerialization() {
+    final String expected = "<head:false>";
+
+    final Component component = Component.object(
+      ObjectContents.playerHead()
+        .hat(false)
+        .build()
+    );
+
+    this.assertSerializedEquals(expected, component);
+  }
+
+  @Test
+  void testHatDeserialization() {
+    final Component expected = Component.object(
+      ObjectContents.playerHead()
+        .hat(false)
+        .build()
+    );
+
+    final String input = "<head:false>";
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testWithTexturesSerialization() {
+    final String expected = "<head:entity/player/wide/steve>";
+
+    final Component component = Component.object(
+      ObjectContents.playerHead()
+        .texture(Key.key("entity/player/wide/steve"))
+        .build()
+    );
+
+    this.assertSerializedEquals(expected, component);
+  }
+
+  @Test
+  void testWithTexturesDeserialization() {
+    final Component expected = Component.object(
+      ObjectContents.playerHead()
+        .texture(Key.key("entity/player/wide/steve"))
+        .build()
+    );
+
+    final String input = "<head:entity/player/wide/steve>";
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testWithTexturesAndHatSerialization() {
+    final String expected = "<head:entity/player/wide/steve:false>";
+
+    final Component component = Component.object(
+      ObjectContents.playerHead()
+        .texture(Key.key("entity/player/wide/steve"))
+        .hat(false)
+        .build()
+    );
+
+    this.assertSerializedEquals(expected, component);
+  }
+
+  @Test
+  void testWithNameSerialisation() {
+    final String expected = "<head:electronicboy>";
+
+    final Component component = Component.object(
+      ObjectContents.playerHead("electronicboy")
+    );
+
+    this.assertSerializedEquals(expected, component);
+  }
+
+  @Test
+  void testWithNameDeserialization() {
+    final Component expected = Component.object(
+      ObjectContents.playerHead("electronicboy")
+    );
+
+    final String input = "<head:electronicboy>";
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
+  void testWithUuidSerialisation() {
+    final String expected = "<head:ef82a52d-c5a4-4b64-a811-2c28828cc120>";
+
+    final Component component = Component.object(
+      ObjectContents.playerHead(UUID.fromString("ef82a52d-c5a4-4b64-a811-2c28828cc120"))
+    );
+
+    this.assertSerializedEquals(expected, component);
+  }
+
+  @Test
+  void testWithUuidDeserialization() {
+    final Component expected = Component.object(
+      ObjectContents.playerHead(UUID.fromString("ef82a52d-c5a4-4b64-a811-2c28828cc120"))
+    );
+
+    final String input = "<head:ef82a52d-c5a4-4b64-a811-2c28828cc120>";
+    this.assertParsedEquals(expected, input);
+  }
+
+  //  @Test
+  //  void testWithNameAndUuidSerialisation() {
+  //    final String expected = "<head name=Strokkur24 uuid=ef82a52d-c5a4-4b64-a811-2c28828cc120>";
+  //
+  //    final Component component = Component.object(
+  //      ObjectContents.playerHead()
+  //        .id(UUID.fromString("ef82a52d-c5a4-4b64-a811-2c28828cc120"))
+  //        .name("Strokkur24")
+  //        .build()
+  //    );
+  //
+  //    this.assertSerializedEquals(expected, component);
+  //  }
+  //
+  //  @Test
+  //  void testWithNameAndUuidDeserialization() {
+  //    final Component expected = Component.object(
+  //      ObjectContents.playerHead()
+  //        .id(UUID.fromString("ef82a52d-c5a4-4b64-a811-2c28828cc120"))
+  //        .name("Strokkur24")
+  //        .build()
+  //    );
+  //
+  //    final String input = "<head name=Strokkur24 uuid=ef82a52d-c5a4-4b64-a811-2c28828cc120>";
+  //    this.assertParsedEquals(expected, input);
+  //  }
+  //
+  //  @Test
+  //  void testWithNameAndUuidReversedDeserialization() {
+  //    final Component expected = Component.object(
+  //      ObjectContents.playerHead()
+  //        .id(UUID.fromString("ef82a52d-c5a4-4b64-a811-2c28828cc120"))
+  //        .name("Strokkur24")
+  //        .build()
+  //    );
+  //
+  //    final String input = "<head uuid=ef82a52d-c5a4-4b64-a811-2c28828cc120 name=Strokkur24>";
+  //    this.assertParsedEquals(expected, input);
+  //  }
+  //
+  //  @Test
+  //  void testWithNameAndTexturesAndHatSerialisation() {
+  //    final String expected = "<head name=Strokkur24 uuid=ef82a52d-c5a4-4b64-a811-2c28828cc120 !hat>";
+  //
+  //    final Component component = Component.object(
+  //      ObjectContents.playerHead()
+  //        .id(UUID.fromString("ef82a52d-c5a4-4b64-a811-2c28828cc120"))
+  //        .name("Strokkur24")
+  //        .hat(false)
+  //        .build()
+  //    );
+  //
+  //    this.assertSerializedEquals(expected, component);
+  //  }
+
+  @Test
+  void testWithNameAndHatDeserialization() {
+    final String expected = "<head:Strokkur24:false>";
+
+    final Component component = Component.object(
+      ObjectContents.playerHead()
+        .name("Strokkur24")
+        .hat(false)
+        .build()
+    );
+
+    this.assertSerializedEquals(expected, component);
+  }
+
+  @Test
+  void testWithUuidAndHatDeserialization() {
+    final String expected = "<head:ef82a52d-c5a4-4b64-a811-2c28828cc120:false>";
+
+    final Component component = Component.object(
+      ObjectContents.playerHead()
+        .id(UUID.fromString("ef82a52d-c5a4-4b64-a811-2c28828cc120"))
+        .hat(false)
+        .build()
+    );
+
+    this.assertSerializedEquals(expected, component);
+  }
+
+  //  @Test
+  //  void testWithNameAndTexturesAndHatDeserialization() {
+  //    final Component expected = Component.object(
+  //      ObjectContents.playerHead()
+  //        .id(UUID.fromString("ef82a52d-c5a4-4b64-a811-2c28828cc120"))
+  //        .name("Strokkur24")
+  //        .hat(false)
+  //        .build()
+  //    );
+  //
+  //    final String input = "<head name=Strokkur24 uuid=ef82a52d-c5a4-4b64-a811-2c28828cc120 !hat>";
+  //    this.assertParsedEquals(expected, input);
+  //  }
+}


### PR DESCRIPTION
This PR separates out the simplified/sequential form of the head tag from #1305.