### PR TITLE
fix(minimessage): First pass state not returning to NORMAL from STRING if quote is escaped

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
@@ -254,8 +254,14 @@ public final class TokenParser {
             case '\'':
             case '"':
               currentStringChar = (char) codePoint;
-              // Look ahead if the quote being opened is ever closed
-              if (message.indexOf(codePoint, i + 1) != -1) {
+              // Look ahead if the quote being opened is ever closed and not escaped
+              int fromIndex = i + 1;
+              int closingQuoteIndex = message.indexOf(codePoint, fromIndex);
+              while (closingQuoteIndex != -1 && isEscaped(message, closingQuoteIndex, fromIndex)) {
+                fromIndex = closingQuoteIndex + 1;
+                closingQuoteIndex = message.indexOf(codePoint, fromIndex);
+              }
+              if (closingQuoteIndex != -1) {
                 state = FirstPassState.STRING;
               }
               break;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
@@ -603,6 +603,26 @@ public final class TokenParser {
   }
 
   /**
+   * Determines if the character at {@code charIndex} in {@code text} is escaped by a backslash, considering only
+   * backslashes between {@code boundIndex} (inclusive) and {@code charIndex} (exclusive).
+   * @param text the input text
+   * @param charIndex the index of the character to check
+   * @param boundIndex the lower bound index for checking backslashes
+   * @return {@code true} if the character is escaped, {@code false} otherwise
+   */
+  public static boolean isEscaped(final String text, final int charIndex, final int boundIndex) {
+    int backslashCount = 0;
+    for (int i = charIndex - 1; i >= boundIndex; i--) {
+      if (text.charAt(i) == ESCAPE) {
+        backslashCount++;
+      } else {
+        break;
+      }
+    }
+    return (backslashCount & 1) != 0;
+  }
+
+  /**
    * Removes escaping {@code '\`} characters from a substring where the subsequent character matches a given predicate.
    *
    * @param text the input text

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -553,4 +553,14 @@ public class MiniMessageParserTest extends AbstractTest {
 
     this.assertParsedEquals(expected, input);
   }
+
+  // https://github.com/KyoriPowered/adventure/issues/1315
+  @Test
+  void testEscapedTerminatingQuoteArgument() {
+    final String input = "<hover:show_text:'Foo\\'>Bar";
+    final Component expected = Component.text("Bar").hoverEvent(Component.text("Foo\\"));
+
+    this.assertParsedEquals(expected, input);
+  }
+
 }


### PR DESCRIPTION
Closes #1315 

This PR addresses the `TokenParser#parseString`'s problem when faced with an input like `<hover:show_text:"Foo\">Bar`. The parsed result would be literal text as the parser never returns to `NORMAL` first pass due to it being mislead by the escaped quote.

While this solution is not the prettiest and adds more complexity it doesn't touch escape logic. Alternatively (which I think would be better) is to drop escape logic in first pass for strings entirely, because IIRC it doesn't really do much.

### Second pass problem
The second pass and tree build produce a tag value that unquotes the value even though the second quote (or terminating) is escaped.