### PR TITLE
Allow creation of a ClickEvent from an Action and Payload

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
@@ -241,7 +241,8 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
    * @return a click event
    * @throws IllegalArgumentException if the action does not support a string payload
    * @since 4.0.0
-   * @deprecated For removal since 4.22.0, not all actions support string payloads
+   * @deprecated For removal since 4.22.0, not all actions support string payloads.
+   *     Use {@link #clickEvent(Action, Payload)} or the event-specific methods.
    */
   @Deprecated
   public static @NotNull ClickEvent clickEvent(final @NotNull Action action, final @NotNull String value) {
@@ -249,6 +250,19 @@ public final class ClickEvent implements Examinable, StyleBuilderApplicable {
     if (action == Action.CHANGE_PAGE) return changePage(value);
     if (!action.payloadType().equals(Payload.Text.class)) throw new IllegalArgumentException("Action " + action + " does not support string payloads");
     return new ClickEvent(action, Payload.string(value));
+  }
+
+  /**
+   * Creates a click event with a {@link Payload payload}.
+   *
+   * @param action the action
+   * @param payload the payload
+   * @return a click event
+   * @throws IllegalArgumentException if the action does not support that payload
+   * @since 4.25.0
+   */
+  public static @NotNull ClickEvent clickEvent(final @NotNull Action action, final @NotNull Payload payload) {
+    return new ClickEvent(action, payload);
   }
 
   private final Action action;

--- a/api/src/test/java/net/kyori/adventure/text/event/ClickEventTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/event/ClickEventTest.java
@@ -28,6 +28,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,24 +41,34 @@ class ClickEventTest {
       .addEqualityGroup(
         ClickEvent.openUrl("https://google.com/"),
         ClickEvent.openUrl(new URL("https://google.com/")),
-        ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://google.com/")
+        ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://google.com/"),
+        ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, ClickEvent.Payload.string("https://google.com/"))
       )
       .addEqualityGroup(
         ClickEvent.runCommand("/test"),
-        ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/test")
+        ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/test"),
+        ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, ClickEvent.Payload.string("/test"))
       )
       .addEqualityGroup(
         ClickEvent.suggestCommand("/test"),
-        ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/test")
+        ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/test"),
+        ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, ClickEvent.Payload.string("/test"))
       )
       .addEqualityGroup(
         ClickEvent.changePage(1),
         ClickEvent.changePage("1"),
-        ClickEvent.clickEvent(ClickEvent.Action.CHANGE_PAGE, "1")
+        ClickEvent.clickEvent(ClickEvent.Action.CHANGE_PAGE, "1"),
+        ClickEvent.clickEvent(ClickEvent.Action.CHANGE_PAGE, ClickEvent.Payload.integer(1))
       )
       .addEqualityGroup(
         ClickEvent.copyToClipboard("test"),
-        ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, "test")
+        ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, "test"),
+        ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, ClickEvent.Payload.string("test"))
+      )
+      .addEqualityGroup(
+        ClickEvent.custom(Key.key("test"), "test"),
+        ClickEvent.custom(Key.key("test"), BinaryTagHolder.binaryTagHolder("test")),
+        ClickEvent.clickEvent(ClickEvent.Action.CUSTOM, ClickEvent.Payload.custom(Key.key("test"), BinaryTagHolder.binaryTagHolder("test")))
       )
       .testEquals();
   }


### PR DESCRIPTION
This change adds the method `ClickEvent#clickEvent(Action, Payload)` which allows creation of new ClickEvent objects from arbitrary Actions and Payloads. This is useful for custom string -> Component parsers like [Minimessage](https://github.com/KyoriPowered/adventure/blob/fe49db381684f32a539b187438b8fa8d771af1db/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ClickTag.java#L67) or [Minedown](https://github.com/Phoenix616/MineDown/blob/e2125596d8475b3d5b29e2c45872890220c2e638/src/main/java/de/themoep/minedown/adventure/MineDownParser.java#L585) which in the past used the now deprecated `ClickEvent#clickEvent(Action, String)` method to easily create new click events from user-supplied action and value strings.