### PR TITLE
chore(5.0): nullability and module-info.java cleanup

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   api(libs.examination.api)
   api(libs.examination.string)
   compileOnlyApi(libs.jetbrainsAnnotations)
+  compileOnlyApi(libs.jspecify)
   testImplementation(libs.guava)
   annotationProcessor(projects.adventureAnnotationProcessors)
   testCompileOnly(libs.autoService.annotations)

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,38 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Adventure: a serverside user interface library for Minecraft: Java Edition.
+ *
+ * <p>See the <a href="https://docs.papermc.io/adventure/">documentation</a>
+ * for usage and dependency information for this project and associated libraries.</p>
+ */
+@NullMarked
+module net.kyori.adventure.api {
+  requires transitive net.kyori.adventure.key;
+  requires transitive static org.jspecify;
+
+  exports net.kyori.adventure;
+  exports net.kyori.adventure.audience;
+  exports net.kyori.adventure.bossbar;
+  exports net.kyori.adventure.builder;
+  exports net.kyori.adventure.chat;
+  exports net.kyori.adventure.dialog;
+  exports net.kyori.adventure.identity;
+  exports net.kyori.adventure.internal;
+  exports net.kyori.adventure.inventory;
+  exports net.kyori.adventure.nbt.api;
+  exports net.kyori.adventure.permission;
+  exports net.kyori.adventure.pointer;
+  exports net.kyori.adventure.resource;
+  exports net.kyori.adventure.sound;
+  exports net.kyori.adventure.text;
+  exports net.kyori.adventure.text.event;
+  exports net.kyori.adventure.text.flattener;
+  exports net.kyori.adventure.text.format;
+  exports net.kyori.adventure.text.object;
+  exports net.kyori.adventure.text.renderer;
+  exports net.kyori.adventure.text.serializer;
+  exports net.kyori.adventure.title;
+  exports net.kyori.adventure.translation;
+  exports net.kyori.adventure.util;
+}

--- a/api/src/main/java/net/kyori/adventure/audience/Audience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audience.java
@@ -50,7 +50,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.title.Title;
 import net.kyori.adventure.title.TitlePart;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A receiver of Minecraft media.
@@ -106,7 +105,7 @@ public interface Audience extends Pointered {
    * @return a do-nothing audience
    * @since 4.0.0
    */
-  static @NotNull Audience empty() {
+  static Audience empty() {
     return EmptyAudience.INSTANCE;
   }
 
@@ -118,7 +117,7 @@ public interface Audience extends Pointered {
    * @see ForwardingAudience
    * @since 4.0.0
    */
-  static @NotNull Audience audience(final @NotNull Audience@NotNull... audiences) {
+  static Audience audience(final Audience... audiences) {
     final int length = audiences.length;
     if (length == 0) {
       return empty();
@@ -139,7 +138,7 @@ public interface Audience extends Pointered {
    * @see ForwardingAudience
    * @since 4.0.0
    */
-  static @NotNull ForwardingAudience audience(final @NotNull Iterable<? extends Audience> audiences) {
+  static ForwardingAudience audience(final Iterable<? extends Audience> audiences) {
     return () -> audiences;
   }
 
@@ -151,7 +150,7 @@ public interface Audience extends Pointered {
    * @return a collector to create a forwarding audience
    * @since 4.0.0
    */
-  static @NotNull Collector<? super Audience, ?, ForwardingAudience> toAudience() {
+  static Collector<? super Audience, ?, ForwardingAudience> toAudience() {
     return Audiences.COLLECTOR;
   }
 
@@ -168,7 +167,7 @@ public interface Audience extends Pointered {
    * @return an audience providing a snapshot of all audiences that match the predicate when this method is invoked
    * @since 4.9.0
    */
-  default @NotNull Audience filterAudience(final @NotNull Predicate<? super Audience> filter) {
+  default Audience filterAudience(final Predicate<? super Audience> filter) {
     return filter.test(this)
       ? this
       : empty();
@@ -187,7 +186,7 @@ public interface Audience extends Pointered {
    * @param action the action
    * @since 4.9.0
    */
-  default void forEachAudience(final @NotNull Consumer<? super Audience> action) {
+  default void forEachAudience(final Consumer<? super Audience> action) {
     action.accept(this);
   }
 
@@ -200,7 +199,7 @@ public interface Audience extends Pointered {
    * @since 4.1.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull ComponentLike message) {
+  default void sendMessage(final ComponentLike message) {
     this.sendMessage(message.asComponent());
   }
 
@@ -211,7 +210,7 @@ public interface Audience extends Pointered {
    * @see Component
    * @since 4.1.0
    */
-  default void sendMessage(final @NotNull Component message) {
+  default void sendMessage(final Component message) {
   }
   /* End: system messages */
 
@@ -224,7 +223,7 @@ public interface Audience extends Pointered {
    * @since 4.12.0
    * @sinceMinecraft 1.19
    */
-  default void sendMessage(final @NotNull Component message, final ChatType.@NotNull Bound boundChatType) {
+  default void sendMessage(final Component message, final ChatType.Bound boundChatType) {
   }
 
   /**
@@ -236,7 +235,7 @@ public interface Audience extends Pointered {
    * @sinceMinecraft 1.19
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendMessage(final @NotNull ComponentLike message, final ChatType.@NotNull Bound boundChatType) {
+  default void sendMessage(final ComponentLike message, final ChatType.Bound boundChatType) {
     this.sendMessage(message.asComponent(), boundChatType);
   }
   /* End: disguised player messages
@@ -250,7 +249,7 @@ public interface Audience extends Pointered {
    * @since 4.12.0
    * @sinceMinecraft 1.19
    */
-  default void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.@NotNull Bound boundChatType) {
+  default void sendMessage(final SignedMessage signedMessage, final ChatType.Bound boundChatType) {
   }
 
   /**
@@ -262,7 +261,7 @@ public interface Audience extends Pointered {
    * @sinceMinecraft 1.19
    */
   @ForwardingAudienceOverrideNotRequired
-  default void deleteMessage(final @NotNull SignedMessage signedMessage) {
+  default void deleteMessage(final SignedMessage signedMessage) {
     if (signedMessage.canDelete()) {
       this.deleteMessage(Objects.requireNonNull(signedMessage.signature()));
     }
@@ -275,7 +274,7 @@ public interface Audience extends Pointered {
    * @since 4.12.0
    * @sinceMinecraft 1.19
    */
-  default void deleteMessage(final SignedMessage.@NotNull Signature signature) {
+  default void deleteMessage(final SignedMessage.Signature signature) {
   }
   /* End: signed player messages */
 
@@ -287,7 +286,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendActionBar(final @NotNull ComponentLike message) {
+  default void sendActionBar(final ComponentLike message) {
     this.sendActionBar(message.asComponent());
   }
 
@@ -298,7 +297,7 @@ public interface Audience extends Pointered {
    * @see Component
    * @since 4.0.0
    */
-  default void sendActionBar(final @NotNull Component message) {
+  default void sendActionBar(final Component message) {
   }
 
   /**
@@ -311,7 +310,7 @@ public interface Audience extends Pointered {
    * @since 4.3.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendPlayerListHeader(final @NotNull ComponentLike header) {
+  default void sendPlayerListHeader(final ComponentLike header) {
     this.sendPlayerListHeader(header.asComponent());
   }
 
@@ -324,7 +323,7 @@ public interface Audience extends Pointered {
    * @param header the header
    * @since 4.3.0
    */
-  default void sendPlayerListHeader(final @NotNull Component header) {
+  default void sendPlayerListHeader(final Component header) {
     this.sendPlayerListHeaderAndFooter(header, Component.empty());
   }
 
@@ -338,7 +337,7 @@ public interface Audience extends Pointered {
    * @since 4.3.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendPlayerListFooter(final @NotNull ComponentLike footer) {
+  default void sendPlayerListFooter(final ComponentLike footer) {
     this.sendPlayerListFooter(footer.asComponent());
   }
 
@@ -351,7 +350,7 @@ public interface Audience extends Pointered {
    * @param footer the footer
    * @since 4.3.0
    */
-  default void sendPlayerListFooter(final @NotNull Component footer) {
+  default void sendPlayerListFooter(final Component footer) {
     this.sendPlayerListHeaderAndFooter(Component.empty(), footer);
   }
 
@@ -363,7 +362,7 @@ public interface Audience extends Pointered {
    * @since 4.3.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendPlayerListHeaderAndFooter(final @NotNull ComponentLike header, final @NotNull ComponentLike footer) {
+  default void sendPlayerListHeaderAndFooter(final ComponentLike header, final ComponentLike footer) {
     this.sendPlayerListHeaderAndFooter(header.asComponent(), footer.asComponent());
   }
 
@@ -374,7 +373,7 @@ public interface Audience extends Pointered {
    * @param footer the footer
    * @since 4.3.0
    */
-  default void sendPlayerListHeaderAndFooter(final @NotNull Component header, final @NotNull Component footer) {
+  default void sendPlayerListHeaderAndFooter(final Component header, final Component footer) {
   }
 
   /**
@@ -385,7 +384,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void showTitle(final @NotNull Title title) {
+  default void showTitle(final Title title) {
     final Title.Times times = title.times();
     if (times != null) this.sendTitlePart(TitlePart.TIMES, times);
 
@@ -401,7 +400,7 @@ public interface Audience extends Pointered {
    * @param <T> the type of the value of the part
    * @since 4.9.0
    */
-  default <T> void sendTitlePart(final @NotNull TitlePart<T> part, final @NotNull T value) {
+  default <T> void sendTitlePart(final TitlePart<T> part, final T value) {
   }
 
   /**
@@ -429,7 +428,7 @@ public interface Audience extends Pointered {
    * @see BossBar
    * @since 4.0.0
    */
-  default void showBossBar(final @NotNull BossBar bar) {
+  default void showBossBar(final BossBar bar) {
   }
 
   /**
@@ -439,7 +438,7 @@ public interface Audience extends Pointered {
    * @see BossBar
    * @since 4.0.0
    */
-  default void hideBossBar(final @NotNull BossBar bar) {
+  default void hideBossBar(final BossBar bar) {
   }
 
   /**
@@ -451,7 +450,7 @@ public interface Audience extends Pointered {
    * @see Sound
    * @since 4.0.0
    */
-  default void playSound(final @NotNull Sound sound) {
+  default void playSound(final Sound sound) {
   }
 
   /**
@@ -464,7 +463,7 @@ public interface Audience extends Pointered {
    * @see Sound
    * @since 4.0.0
    */
-  default void playSound(final @NotNull Sound sound, final double x, final double y, final double z) {
+  default void playSound(final Sound sound, final double x, final double y, final double z) {
   }
 
   /**
@@ -481,7 +480,7 @@ public interface Audience extends Pointered {
    * @param emitter an emitter
    * @since 4.8.0
    */
-  default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {
+  default void playSound(final Sound sound, final Sound.Emitter emitter) {
   }
 
   /**
@@ -491,7 +490,7 @@ public interface Audience extends Pointered {
    * @since 4.8.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void stopSound(final @NotNull Sound sound) {
+  default void stopSound(final Sound sound) {
     this.stopSound(Objects.requireNonNull(sound, "sound").asStop());
   }
 
@@ -502,7 +501,7 @@ public interface Audience extends Pointered {
    * @see SoundStop
    * @since 4.0.0
    */
-  default void stopSound(final @NotNull SoundStop stop) {
+  default void stopSound(final SoundStop stop) {
   }
 
   /**
@@ -515,7 +514,7 @@ public interface Audience extends Pointered {
    * @since 4.0.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void openBook(final Book.@NotNull Builder book) {
+  default void openBook(final Book.Builder book) {
     this.openBook(book.build());
   }
 
@@ -528,7 +527,7 @@ public interface Audience extends Pointered {
    * @see Book
    * @since 4.0.0
    */
-  default void openBook(final @NotNull Book book) {
+  default void openBook(final Book book) {
   }
 
   // ------------------------
@@ -546,7 +545,7 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendResourcePacks(final @NotNull ResourcePackInfoLike first, final @NotNull ResourcePackInfoLike... others) {
+  default void sendResourcePacks(final ResourcePackInfoLike first, final ResourcePackInfoLike... others) {
     this.sendResourcePacks(ResourcePackRequest.addingRequest(first, others));
   }
 
@@ -560,7 +559,7 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    */
   @ForwardingAudienceOverrideNotRequired
-  default void sendResourcePacks(final @NotNull ResourcePackRequestLike request) {
+  default void sendResourcePacks(final ResourcePackRequestLike request) {
     this.sendResourcePacks(request.asResourcePackRequest());
   }
 
@@ -573,7 +572,7 @@ public interface Audience extends Pointered {
    * @see ResourcePackInfo
    * @since 4.15.0
    */
-  default void sendResourcePacks(final @NotNull ResourcePackRequest request) {
+  default void sendResourcePacks(final ResourcePackRequest request) {
   }
 
   /**
@@ -584,7 +583,7 @@ public interface Audience extends Pointered {
    * @sinceMinecraft 1.20.3
    */
   @ForwardingAudienceOverrideNotRequired
-  default void removeResourcePacks(final @NotNull ResourcePackRequestLike request) {
+  default void removeResourcePacks(final ResourcePackRequestLike request) {
     this.removeResourcePacks(request.asResourcePackRequest());
   }
 
@@ -596,7 +595,7 @@ public interface Audience extends Pointered {
    * @sinceMinecraft 1.20.3
    */
   @ForwardingAudienceOverrideNotRequired
-  default void removeResourcePacks(final @NotNull ResourcePackRequest request) {
+  default void removeResourcePacks(final ResourcePackRequest request) {
     final List<ResourcePackInfo> infos = request.packs();
     if (infos.size() == 1) {
       this.removeResourcePacks(infos.getFirst().id());
@@ -620,7 +619,7 @@ public interface Audience extends Pointered {
    * @sinceMinecraft 1.20.3
    */
   @ForwardingAudienceOverrideNotRequired
-  default void removeResourcePacks(final @NotNull ResourcePackInfoLike request, final @NotNull ResourcePackInfoLike @NotNull... others) {
+  default void removeResourcePacks(final ResourcePackInfoLike request, final ResourcePackInfoLike ... others) {
     final UUID[] otherReqs = new UUID[others.length];
     for (int i = 0; i < others.length; i++) {
       otherReqs[i] = others[i].asResourcePackInfo().id();
@@ -635,7 +634,7 @@ public interface Audience extends Pointered {
    * @since 4.16.0
    * @sinceMinecraft 1.20.3
    */
-  default void removeResourcePacks(final @NotNull Iterable<UUID> ids) {
+  default void removeResourcePacks(final Iterable<UUID> ids) {
     // break these out to id + arrays
     final Iterator<UUID> it = ids.iterator();
     if (!it.hasNext()) return;
@@ -668,7 +667,7 @@ public interface Audience extends Pointered {
    * @since 4.15.0
    * @sinceMinecraft 1.20.3
    */
-  default void removeResourcePacks(final @NotNull UUID id, final @NotNull UUID@NotNull... others) {
+  default void removeResourcePacks(final UUID id, final UUID... others) {
   }
 
   /**
@@ -693,7 +692,7 @@ public interface Audience extends Pointered {
    * @since 4.22.0
    * @sinceMinecraft 1.21.6
    */
-  default void showDialog(final @NotNull DialogLike dialog) {
+  default void showDialog(final DialogLike dialog) {
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/audience/Audiences.java
+++ b/api/src/main/java/net/kyori/adventure/audience/Audiences.java
@@ -30,7 +30,6 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import net.kyori.adventure.resource.ResourcePackCallback;
 import net.kyori.adventure.text.ComponentLike;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * {@link Audience}-related utilities.
@@ -53,11 +52,11 @@ public final class Audiences {
    * @return an action to send a message
    * @since 4.13.0
    */
-  public static @NotNull Consumer<? super Audience> sendingMessage(final @NotNull ComponentLike message) {
+  public static Consumer<? super Audience> sendingMessage(final ComponentLike message) {
     return audience -> audience.sendMessage(message);
   }
 
-  static @NotNull ResourcePackCallback unwrapCallback(final Audience forwarding, final Audience dest, final @NotNull ResourcePackCallback cb) {
+  static ResourcePackCallback unwrapCallback(final Audience forwarding, final Audience dest, final ResourcePackCallback cb) {
     if (cb == ResourcePackCallback.noOp()) return cb;
 
     return (uuid, status, audience) -> {

--- a/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/EmptyAudience.java
@@ -36,88 +36,87 @@ import net.kyori.adventure.resource.ResourcePackRequest;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
 
 final class EmptyAudience implements Audience {
   static final EmptyAudience INSTANCE = new EmptyAudience();
 
   @Override
-  public @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
+  public <T> Optional<T> get(final Pointer<T> pointer) {
     return Optional.empty();
   }
 
   @Contract("_, null -> null; _, !null -> !null")
   @Override
-  public <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
+  public <T> @Nullable T getOrDefault(final Pointer<T> pointer, final @Nullable T defaultValue) {
     return defaultValue;
   }
 
   @Override
-  public <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
+  public <T> @UnknownNullability T getOrDefaultFrom(final Pointer<T> pointer, final Supplier<? extends T> defaultValue) {
     return defaultValue.get();
   }
 
   @Override
-  public @NotNull Audience filterAudience(final @NotNull Predicate<? super Audience> filter) {
+  public Audience filterAudience(final Predicate<? super Audience> filter) {
     return this;
   }
 
   @Override
-  public void forEachAudience(final @NotNull Consumer<? super Audience> action) {
+  public void forEachAudience(final Consumer<? super Audience> action) {
   }
 
   @Override
-  public void sendMessage(final @NotNull ComponentLike message) {
+  public void sendMessage(final ComponentLike message) {
   }
 
   @Override
-  public void sendMessage(final @NotNull Component message) {
+  public void sendMessage(final Component message) {
   }
 
   @Override
-  public void sendMessage(final @NotNull Component message, final ChatType.@NotNull Bound boundChatType) {
+  public void sendMessage(final Component message, final ChatType.Bound boundChatType) {
   }
 
   @Override
-  public void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.@NotNull Bound boundChatType) {
+  public void sendMessage(final SignedMessage signedMessage, final ChatType.Bound boundChatType) {
   }
 
   @Override
-  public void deleteMessage(final SignedMessage.@NotNull Signature signature) {
+  public void deleteMessage(final SignedMessage.Signature signature) {
   }
 
   @Override
-  public void sendActionBar(final @NotNull ComponentLike message) {
+  public void sendActionBar(final ComponentLike message) {
   }
 
   @Override
-  public void sendPlayerListHeader(final @NotNull ComponentLike header) {
+  public void sendPlayerListHeader(final ComponentLike header) {
   }
 
   @Override
-  public void sendPlayerListFooter(final @NotNull ComponentLike footer) {
+  public void sendPlayerListFooter(final ComponentLike footer) {
   }
 
   @Override
-  public void sendPlayerListHeaderAndFooter(final @NotNull ComponentLike header, final @NotNull ComponentLike footer) {
+  public void sendPlayerListHeaderAndFooter(final ComponentLike header, final ComponentLike footer) {
   }
 
   @Override
-  public void openBook(final Book.@NotNull Builder book) {
+  public void openBook(final Book.Builder book) {
   }
 
   @Override
-  public void sendResourcePacks(final @NotNull ResourcePackInfoLike request, final @NotNull ResourcePackInfoLike@NotNull... others) {
+  public void sendResourcePacks(final ResourcePackInfoLike request, final ResourcePackInfoLike... others) {
   }
 
   @Override
-  public void removeResourcePacks(final @NotNull ResourcePackRequest request) {
+  public void removeResourcePacks(final ResourcePackRequest request) {
   }
 
   @Override
-  public void removeResourcePacks(final @NotNull ResourcePackInfoLike request, final @NotNull ResourcePackInfoLike@NotNull... others) {
+  public void removeResourcePacks(final ResourcePackInfoLike request, final ResourcePackInfoLike... others) {
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -45,9 +45,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.TitlePart;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A receiver that wraps one or more receivers.
@@ -67,15 +66,15 @@ public interface ForwardingAudience extends Audience {
    * @since 4.0.0
    */
   @ApiStatus.OverrideOnly
-  @NotNull Iterable<? extends Audience> audiences();
+  Iterable<? extends Audience> audiences();
 
   @Override
-  default @NotNull Pointers pointers() {
+  default Pointers pointers() {
     return Pointers.empty(); // unsupported
   }
 
   @Override
-  default @NotNull Audience filterAudience(final @NotNull Predicate<? super Audience> filter) {
+  default Audience filterAudience(final Predicate<? super Audience> filter) {
     @Nullable List<Audience> audiences = null;
     for (final Audience audience : this.audiences()) {
       if (filter.test(audience)) {
@@ -94,52 +93,52 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void forEachAudience(final @NotNull Consumer<? super Audience> action) {
+  default void forEachAudience(final Consumer<? super Audience> action) {
     for (final Audience audience : this.audiences()) audience.forEachAudience(action);
   }
 
   @Override
-  default void sendMessage(final @NotNull Component message) {
+  default void sendMessage(final Component message) {
     for (final Audience audience : this.audiences()) audience.sendMessage(message);
   }
 
   @Override
-  default void sendMessage(final @NotNull Component message, final ChatType.@NotNull Bound boundChatType) {
+  default void sendMessage(final Component message, final ChatType.Bound boundChatType) {
     for (final Audience audience : this.audiences()) audience.sendMessage(message, boundChatType);
   }
 
   @Override
-  default void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.@NotNull Bound boundChatType) {
+  default void sendMessage(final SignedMessage signedMessage, final ChatType.Bound boundChatType) {
     for (final Audience audience : this.audiences()) audience.sendMessage(signedMessage, boundChatType);
   }
 
   @Override
-  default void deleteMessage(final SignedMessage.@NotNull Signature signature) {
+  default void deleteMessage(final SignedMessage.Signature signature) {
     for (final Audience audience : this.audiences()) audience.deleteMessage(signature);
   }
 
   @Override
-  default void sendActionBar(final @NotNull Component message) {
+  default void sendActionBar(final Component message) {
     for (final Audience audience : this.audiences()) audience.sendActionBar(message);
   }
 
   @Override
-  default void sendPlayerListHeader(final @NotNull Component header) {
+  default void sendPlayerListHeader(final Component header) {
     for (final Audience audience : this.audiences()) audience.sendPlayerListHeader(header);
   }
 
   @Override
-  default void sendPlayerListFooter(final @NotNull Component footer) {
+  default void sendPlayerListFooter(final Component footer) {
     for (final Audience audience : this.audiences()) audience.sendPlayerListFooter(footer);
   }
 
   @Override
-  default void sendPlayerListHeaderAndFooter(final @NotNull Component header, final @NotNull Component footer) {
+  default void sendPlayerListHeaderAndFooter(final Component header, final Component footer) {
     for (final Audience audience : this.audiences()) audience.sendPlayerListHeaderAndFooter(header, footer);
   }
 
   @Override
-  default <T> void sendTitlePart(final @NotNull TitlePart<T> part, final @NotNull T value) {
+  default <T> void sendTitlePart(final TitlePart<T> part, final T value) {
     for (final Audience audience : this.audiences()) audience.sendTitlePart(part, value);
   }
 
@@ -154,52 +153,52 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void showBossBar(final @NotNull BossBar bar) {
+  default void showBossBar(final BossBar bar) {
     for (final Audience audience : this.audiences()) audience.showBossBar(bar);
   }
 
   @Override
-  default void hideBossBar(final @NotNull BossBar bar) {
+  default void hideBossBar(final BossBar bar) {
     for (final Audience audience : this.audiences()) audience.hideBossBar(bar);
   }
 
   @Override
-  default void playSound(final @NotNull Sound sound) {
+  default void playSound(final Sound sound) {
     for (final Audience audience : this.audiences()) audience.playSound(sound);
   }
 
   @Override
-  default void playSound(final @NotNull Sound sound, final double x, final double y, final double z) {
+  default void playSound(final Sound sound, final double x, final double y, final double z) {
     for (final Audience audience : this.audiences()) audience.playSound(sound, x, y, z);
   }
 
   @Override
-  default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {
+  default void playSound(final Sound sound, final Sound.Emitter emitter) {
     for (final Audience audience : this.audiences()) audience.playSound(sound, emitter);
   }
 
   @Override
-  default void stopSound(final @NotNull SoundStop stop) {
+  default void stopSound(final SoundStop stop) {
     for (final Audience audience : this.audiences()) audience.stopSound(stop);
   }
 
   @Override
-  default void openBook(final @NotNull Book book) {
+  default void openBook(final Book book) {
     for (final Audience audience : this.audiences()) audience.openBook(book);
   }
 
   @Override
-  default void sendResourcePacks(final @NotNull ResourcePackRequest request) {
+  default void sendResourcePacks(final ResourcePackRequest request) {
     for (final Audience audience : this.audiences()) audience.sendResourcePacks(request);
   }
 
   @Override
-  default void removeResourcePacks(final @NotNull Iterable<UUID> ids) {
+  default void removeResourcePacks(final Iterable<UUID> ids) {
     for (final Audience audience : this.audiences()) audience.removeResourcePacks(ids);
   }
 
   @Override
-  default void removeResourcePacks(final @NotNull UUID id, final @NotNull UUID @NotNull ... others) {
+  default void removeResourcePacks(final UUID id, final UUID ... others) {
     for (final Audience audience : this.audiences()) audience.removeResourcePacks(id, others);
   }
 
@@ -209,7 +208,7 @@ public interface ForwardingAudience extends Audience {
   }
 
   @Override
-  default void showDialog(final @NotNull DialogLike dialog) {
+  default void showDialog(final DialogLike dialog) {
     for (final Audience audience : this.audiences()) audience.showDialog(dialog);
   }
 
@@ -231,7 +230,7 @@ public interface ForwardingAudience extends Audience {
      * @since 4.0.0
      */
     @ApiStatus.OverrideOnly
-    @NotNull Audience audience();
+    Audience audience();
 
     /**
      * {@inheritDoc}
@@ -241,28 +240,28 @@ public interface ForwardingAudience extends Audience {
      */
     @Deprecated
     @Override
-    default @NotNull Iterable<? extends Audience> audiences() {
+    default Iterable<? extends Audience> audiences() {
       return Collections.singleton(this.audience());
     }
 
     @Override
-    default <T> @NotNull Optional<T> get(final @NotNull Pointer<T> pointer) {
+    default <T> Optional<T> get(final Pointer<T> pointer) {
       return this.audience().get(pointer);
     }
 
     @Contract("_, null -> null; _, !null -> !null")
     @Override
-    default <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
+    default <T> @Nullable T getOrDefault(final Pointer<T> pointer, final @Nullable T defaultValue) {
       return this.audience().getOrDefault(pointer, defaultValue);
     }
 
     @Override
-    default <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
+    default <T> @UnknownNullability T getOrDefaultFrom(final Pointer<T> pointer, final Supplier<? extends T> defaultValue) {
       return this.audience().getOrDefaultFrom(pointer, defaultValue);
     }
 
     @Override
-    default @NotNull Audience filterAudience(final @NotNull Predicate<? super Audience> filter) {
+    default Audience filterAudience(final Predicate<? super Audience> filter) {
       final Audience audience = this.audience();
       return filter.test(audience)
         ? this
@@ -270,57 +269,57 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void forEachAudience(final @NotNull Consumer<? super Audience> action) {
+    default void forEachAudience(final Consumer<? super Audience> action) {
       this.audience().forEachAudience(action);
     }
 
     @Override
-    default @NotNull Pointers pointers() {
+    default Pointers pointers() {
       return this.audience().pointers();
     }
 
     @Override
-    default void sendMessage(final @NotNull Component message) {
+    default void sendMessage(final Component message) {
       this.audience().sendMessage(message);
     }
 
     @Override
-    default void sendMessage(final @NotNull Component message, final ChatType.@NotNull Bound boundChatType) {
+    default void sendMessage(final Component message, final ChatType.Bound boundChatType) {
       this.audience().sendMessage(message, boundChatType);
     }
 
     @Override
-    default void sendMessage(final @NotNull SignedMessage signedMessage, final ChatType.@NotNull Bound boundChatType) {
+    default void sendMessage(final SignedMessage signedMessage, final ChatType.Bound boundChatType) {
       this.audience().sendMessage(signedMessage, boundChatType);
     }
 
     @Override
-    default void deleteMessage(final SignedMessage.@NotNull Signature signature) {
+    default void deleteMessage(final SignedMessage.Signature signature) {
       this.audience().deleteMessage(signature);
     }
 
     @Override
-    default void sendActionBar(final @NotNull Component message) {
+    default void sendActionBar(final Component message) {
       this.audience().sendActionBar(message);
     }
 
     @Override
-    default void sendPlayerListHeader(final @NotNull Component header) {
+    default void sendPlayerListHeader(final Component header) {
       this.audience().sendPlayerListHeader(header);
     }
 
     @Override
-    default void sendPlayerListFooter(final @NotNull Component footer) {
+    default void sendPlayerListFooter(final Component footer) {
       this.audience().sendPlayerListFooter(footer);
     }
 
     @Override
-    default void sendPlayerListHeaderAndFooter(final @NotNull Component header, final @NotNull Component footer) {
+    default void sendPlayerListHeaderAndFooter(final Component header, final Component footer) {
       this.audience().sendPlayerListHeaderAndFooter(header, footer);
     }
 
     @Override
-    default <T> void sendTitlePart(final @NotNull TitlePart<T> part, final @NotNull T value) {
+    default <T> void sendTitlePart(final TitlePart<T> part, final T value) {
       this.audience().sendTitlePart(part, value);
     }
 
@@ -335,52 +334,52 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void showBossBar(final @NotNull BossBar bar) {
+    default void showBossBar(final BossBar bar) {
       this.audience().showBossBar(bar);
     }
 
     @Override
-    default void hideBossBar(final @NotNull BossBar bar) {
+    default void hideBossBar(final BossBar bar) {
       this.audience().hideBossBar(bar);
     }
 
     @Override
-    default void playSound(final @NotNull Sound sound) {
+    default void playSound(final Sound sound) {
       this.audience().playSound(sound);
     }
 
     @Override
-    default void playSound(final @NotNull Sound sound, final double x, final double y, final double z) {
+    default void playSound(final Sound sound, final double x, final double y, final double z) {
       this.audience().playSound(sound, x, y, z);
     }
 
     @Override
-    default void playSound(final @NotNull Sound sound, final Sound.@NotNull Emitter emitter) {
+    default void playSound(final Sound sound, final Sound.Emitter emitter) {
       this.audience().playSound(sound, emitter);
     }
 
     @Override
-    default void stopSound(final @NotNull SoundStop stop) {
+    default void stopSound(final SoundStop stop) {
       this.audience().stopSound(stop);
     }
 
     @Override
-    default void openBook(final @NotNull Book book) {
+    default void openBook(final Book book) {
       this.audience().openBook(book);
     }
 
     @Override
-    default void sendResourcePacks(final @NotNull ResourcePackRequest request) {
+    default void sendResourcePacks(final ResourcePackRequest request) {
       this.audience().sendResourcePacks(request.callback(Audiences.unwrapCallback(this, this.audience(), request.callback())));
     }
 
     @Override
-    default void removeResourcePacks(final @NotNull Iterable<UUID> ids) {
+    default void removeResourcePacks(final Iterable<UUID> ids) {
       this.audience().removeResourcePacks(ids);
     }
 
     @Override
-    default void removeResourcePacks(final @NotNull UUID id, final @NotNull UUID @NotNull ... others) {
+    default void removeResourcePacks(final UUID id, final UUID ... others) {
       this.audience().removeResourcePacks(id, others);
     }
 
@@ -390,7 +389,7 @@ public interface ForwardingAudience extends Audience {
     }
 
     @Override
-    default void showDialog(final @NotNull DialogLike dialog) {
+    default void showDialog(final DialogLike dialog) {
       this.audience().showDialog(dialog);
     }
 

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
@@ -32,7 +32,6 @@ import net.kyori.adventure.util.PlatformAPI;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
 /**
@@ -79,7 +78,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @throws IllegalArgumentException if progress is less than 0 or greater than 1
    * @since 4.3.0
    */
-  static @NotNull BossBar bossBar(final @NotNull ComponentLike name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay) {
+  static BossBar bossBar(final ComponentLike name, final float progress, final Color color, final Overlay overlay) {
     BossBarImpl.checkProgress(progress);
     return bossBar(name.asComponent(), progress, color, overlay);
   }
@@ -95,7 +94,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @throws IllegalArgumentException if progress is less than 0 or greater than 1
    * @since 4.0.0
    */
-  static @NotNull BossBar bossBar(final @NotNull Component name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay) {
+  static BossBar bossBar(final Component name, final float progress, final Color color, final Overlay overlay) {
     BossBarImpl.checkProgress(progress);
     return new BossBarImpl(name, progress, color, overlay);
   }
@@ -112,7 +111,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @throws IllegalArgumentException if progress is less than 0 or greater than 1
    * @since 4.3.0
    */
-  static @NotNull BossBar bossBar(final @NotNull ComponentLike name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay, final @NotNull Set<Flag> flags) {
+  static BossBar bossBar(final ComponentLike name, final float progress, final Color color, final Overlay overlay, final Set<Flag> flags) {
     BossBarImpl.checkProgress(progress);
     return bossBar(name.asComponent(), progress, color, overlay, flags);
   }
@@ -129,7 +128,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @throws IllegalArgumentException if progress is less than 0 or greater than 1
    * @since 4.0.0
    */
-  static @NotNull BossBar bossBar(final @NotNull Component name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay, final @NotNull Set<Flag> flags) {
+  static BossBar bossBar(final Component name, final float progress, final Color color, final Overlay overlay, final Set<Flag> flags) {
     BossBarImpl.checkProgress(progress);
     return new BossBarImpl(name, progress, color, overlay, flags);
   }
@@ -140,7 +139,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @return the name
    * @since 4.0.0
    */
-  @NotNull Component name();
+  Component name();
 
   /**
    * Sets the name.
@@ -150,7 +149,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.3.0
    */
   @Contract("_ -> this")
-  default @NotNull BossBar name(final @NotNull ComponentLike name) {
+  default BossBar name(final ComponentLike name) {
     return this.name(name.asComponent());
   }
 
@@ -162,7 +161,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar name(final @NotNull Component name);
+  BossBar name(final Component name);
 
   /**
    * Gets the progress.
@@ -185,7 +184,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar progress(final float progress);
+  BossBar progress(final float progress);
 
   /**
    * Gets the color.
@@ -193,7 +192,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @return the color
    * @since 4.0.0
    */
-  @NotNull Color color();
+  Color color();
 
   /**
    * Sets the color.
@@ -203,7 +202,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar color(final @NotNull Color color);
+  BossBar color(final Color color);
 
   /**
    * Gets the overlay.
@@ -211,7 +210,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @return the overlay
    * @since 4.0.0
    */
-  @NotNull Overlay overlay();
+  Overlay overlay();
 
   /**
    * Sets the overlay.
@@ -221,7 +220,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar overlay(final @NotNull Overlay overlay);
+  BossBar overlay(final Overlay overlay);
 
   /**
    * Gets the flags.
@@ -229,7 +228,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @return the flags
    * @since 4.0.0
    */
-  @UnmodifiableView @NotNull Set<Flag> flags();
+  @UnmodifiableView Set<Flag> flags();
 
   /**
    * Sets the flags.
@@ -239,7 +238,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar flags(final @NotNull Set<Flag> flags);
+  BossBar flags(final Set<Flag> flags);
 
   /**
    * Checks if this bossbar has a flag.
@@ -248,7 +247,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @return {@code true} if this bossbar has the flag, {@code false} otherwise
    * @since 4.0.0
    */
-  boolean hasFlag(final @NotNull Flag flag);
+  boolean hasFlag(final Flag flag);
 
   /**
    * Adds a flag to this bossbar.
@@ -258,7 +257,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar addFlag(final @NotNull Flag flag);
+  BossBar addFlag(final Flag flag);
 
   /**
    * Removes a flag from this bossbar.
@@ -268,7 +267,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar removeFlag(final @NotNull Flag flag);
+  BossBar removeFlag(final Flag flag);
 
   /**
    * Adds flags to this bossbar.
@@ -278,7 +277,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar addFlags(final @NotNull Flag@NotNull... flags);
+  BossBar addFlags(final Flag... flags);
 
   /**
    * Removes flags from this bossbar.
@@ -288,7 +287,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar removeFlags(final @NotNull Flag@NotNull... flags);
+  BossBar removeFlags(final Flag... flags);
 
   /**
    * Adds flags to this bossbar.
@@ -298,7 +297,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar addFlags(final @NotNull Iterable<Flag> flags);
+  BossBar addFlags(final Iterable<Flag> flags);
 
   /**
    * Removes flags from this bossbar.
@@ -308,7 +307,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar removeFlags(final @NotNull Iterable<Flag> flags);
+  BossBar removeFlags(final Iterable<Flag> flags);
 
   /**
    * Adds a listener.
@@ -318,7 +317,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract(value = "_ -> this")
-  @NotNull BossBar addListener(final @NotNull Listener listener);
+  BossBar addListener(final Listener listener);
 
   /**
    * Removes a listener.
@@ -328,7 +327,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull BossBar removeListener(final @NotNull Listener listener);
+  BossBar removeListener(final Listener listener);
 
   /**
    * Gets an unmodifiable view of the viewers of this bossbar.
@@ -339,7 +338,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @since 4.14.0
    */
   @UnmodifiableView
-  @NotNull Iterable<? extends BossBarViewer> viewers();
+  Iterable<? extends BossBarViewer> viewers();
 
   /**
    * Show this bossbar to {@code viewer}.
@@ -349,7 +348,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @see Audience#showBossBar(BossBar)
    * @since 4.14.0
    */
-  default @NotNull BossBar addViewer(final @NotNull Audience viewer) {
+  default BossBar addViewer(final Audience viewer) {
     viewer.showBossBar(this);
     return this;
   }
@@ -362,7 +361,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
    * @see Audience#hideBossBar(BossBar)
    * @since 4.14.0
    */
-  default @NotNull BossBar removeViewer(final @NotNull Audience viewer) {
+  default BossBar removeViewer(final Audience viewer) {
     viewer.hideBossBar(this);
     return this;
   }
@@ -383,7 +382,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
      * @param newName the new name
      * @since 4.0.0
      */
-    default void bossBarNameChanged(final @NotNull BossBar bar, final @NotNull Component oldName, final @NotNull Component newName) {
+    default void bossBarNameChanged(final BossBar bar, final Component oldName, final Component newName) {
     }
 
     /**
@@ -394,7 +393,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
      * @param newProgress the new progress
      * @since 4.0.0
      */
-    default void bossBarProgressChanged(final @NotNull BossBar bar, final float oldProgress, final float newProgress) {
+    default void bossBarProgressChanged(final BossBar bar, final float oldProgress, final float newProgress) {
     }
 
     /**
@@ -405,7 +404,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
      * @param newColor the new color
      * @since 4.0.0
      */
-    default void bossBarColorChanged(final @NotNull BossBar bar, final @NotNull Color oldColor, final @NotNull Color newColor) {
+    default void bossBarColorChanged(final BossBar bar, final Color oldColor, final Color newColor) {
     }
 
     /**
@@ -416,7 +415,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
      * @param newOverlay the new overlay
      * @since 4.0.0
      */
-    default void bossBarOverlayChanged(final @NotNull BossBar bar, final @NotNull Overlay oldOverlay, final @NotNull Overlay newOverlay) {
+    default void bossBarOverlayChanged(final BossBar bar, final Overlay oldOverlay, final Overlay newOverlay) {
     }
 
     /**
@@ -427,7 +426,7 @@ public sealed interface BossBar extends Examinable permits BossBarImpl {
      * @param flagsRemoved the flags removed from the bossbar
      * @since 4.0.0
      */
-    default void bossBarFlagsChanged(final @NotNull BossBar bar, final @NotNull Set<Flag> flagsAdded, final @NotNull Set<Flag> flagsRemoved) {
+    default void bossBarFlagsChanged(final BossBar bar, final Set<Flag> flagsAdded, final Set<Flag> flagsRemoved) {
     }
   }
 

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarImpl.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarImpl.java
@@ -37,8 +37,7 @@ import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Services;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -59,7 +58,7 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
-    static @NotNull <I extends BossBarImplementation> I get(final @NotNull BossBar bar, final @NotNull Class<I> type) {
+    static <I extends BossBarImplementation> I get(final BossBar bar, final Class<I> type) {
       @Nullable BossBarImplementation implementation = ((BossBarImpl) bar).implementation;
       if (implementation == null) {
         implementation = SERVICE.get().create(bar);
@@ -69,25 +68,25 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
     }
   }
 
-  BossBarImpl(final @NotNull Component name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay) {
+  BossBarImpl(final Component name, final float progress, final Color color, final Overlay overlay) {
     this.name = requireNonNull(name, "name");
     this.progress = progress;
     this.color = requireNonNull(color, "color");
     this.overlay = requireNonNull(overlay, "overlay");
   }
 
-  BossBarImpl(final @NotNull Component name, final float progress, final @NotNull Color color, final @NotNull Overlay overlay, final @NotNull Set<Flag> flags) {
+  BossBarImpl(final Component name, final float progress, final Color color, final Overlay overlay, final Set<Flag> flags) {
     this(name, progress, color, overlay);
     this.flags.addAll(flags);
   }
 
   @Override
-  public @NotNull Component name() {
+  public Component name() {
     return this.name;
   }
 
   @Override
-  public @NotNull BossBar name(final @NotNull Component newName) {
+  public BossBar name(final Component newName) {
     // We do not check if the new name equals the old name here as the GlobalTranslator
     // may produce a different resulting component for the end user.
     requireNonNull(newName, "name");
@@ -103,7 +102,7 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NotNull BossBar progress(final float newProgress) {
+  public BossBar progress(final float newProgress) {
     checkProgress(newProgress);
     final float oldProgress = this.progress;
     if (newProgress != oldProgress) {
@@ -120,12 +119,12 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NotNull Color color() {
+  public Color color() {
     return this.color;
   }
 
   @Override
-  public @NotNull BossBar color(final @NotNull Color newColor) {
+  public BossBar color(final Color newColor) {
     requireNonNull(newColor, "color");
     final Color oldColor = this.color;
     if (newColor != oldColor) {
@@ -136,12 +135,12 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NotNull Overlay overlay() {
+  public Overlay overlay() {
     return this.overlay;
   }
 
   @Override
-  public @NotNull BossBar overlay(final @NotNull Overlay newOverlay) {
+  public BossBar overlay(final Overlay newOverlay) {
     requireNonNull(newOverlay, "overlay");
     final Overlay oldOverlay = this.overlay;
     if (newOverlay != oldOverlay) {
@@ -152,12 +151,12 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NotNull Set<Flag> flags() {
+  public Set<Flag> flags() {
     return Collections.unmodifiableSet(this.flags);
   }
 
   @Override
-  public @NotNull BossBar flags(final @NotNull Set<Flag> newFlags) {
+  public BossBar flags(final Set<Flag> newFlags) {
     if (newFlags.isEmpty() && !this.flags.isEmpty()) {
       final Set<Flag> oldFlags = EnumSet.copyOf(this.flags);
       this.flags.clear();
@@ -176,21 +175,21 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public boolean hasFlag(final @NotNull Flag flag) {
+  public boolean hasFlag(final Flag flag) {
     return this.flags.contains(flag);
   }
 
   @Override
-  public @NotNull BossBar addFlag(final @NotNull Flag flag) {
+  public BossBar addFlag(final Flag flag) {
     return this.editFlags(flag, Set::add, BossBarImpl::onFlagsAdded);
   }
 
   @Override
-  public @NotNull BossBar removeFlag(final @NotNull Flag flag) {
+  public BossBar removeFlag(final Flag flag) {
     return this.editFlags(flag, Set::remove, BossBarImpl::onFlagsRemoved);
   }
 
-  private @NotNull BossBar editFlags(final @NotNull Flag flag, final @NotNull BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
+  private BossBar editFlags(final Flag flag, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
     if (predicate.test(this.flags, flag)) {
       onChange.accept(this, Collections.singleton(flag));
     }
@@ -198,16 +197,16 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NotNull BossBar addFlags(final @NotNull Flag@NotNull... flags) {
+  public BossBar addFlags(final Flag... flags) {
     return this.editFlags(flags, Set::add, BossBarImpl::onFlagsAdded);
   }
 
   @Override
-  public @NotNull BossBar removeFlags(final @NotNull Flag@NotNull... flags) {
+  public BossBar removeFlags(final Flag... flags) {
     return this.editFlags(flags, Set::remove, BossBarImpl::onFlagsRemoved);
   }
 
-  private @NotNull BossBar editFlags(final Flag[] flags, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
+  private BossBar editFlags(final Flag[] flags, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
     if (flags.length == 0) return this;
     Set<Flag> changes = null;
     for (final Flag flag : flags) {
@@ -225,16 +224,16 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NotNull BossBar addFlags(final @NotNull Iterable<Flag> flags) {
+  public BossBar addFlags(final Iterable<Flag> flags) {
     return this.editFlags(flags, Set::add, BossBarImpl::onFlagsAdded);
   }
 
   @Override
-  public @NotNull BossBar removeFlags(final @NotNull Iterable<Flag> flags) {
+  public BossBar removeFlags(final Iterable<Flag> flags) {
     return this.editFlags(flags, Set::remove, BossBarImpl::onFlagsRemoved);
   }
 
-  private @NotNull BossBar editFlags(final Iterable<Flag> flags, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
+  private BossBar editFlags(final Iterable<Flag> flags, final BiPredicate<Set<Flag>, Flag> predicate, final BiConsumer<BossBarImpl, Set<Flag>> onChange) {
     Set<Flag> changes = null;
     for (final Flag flag : flags) {
       if (predicate.test(this.flags, flag)) {
@@ -251,26 +250,26 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NotNull BossBar addListener(final @NotNull Listener listener) {
+  public BossBar addListener(final Listener listener) {
     this.listeners.add(listener);
     return this;
   }
 
   @Override
-  public @NotNull BossBar removeListener(final @NotNull Listener listener) {
+  public BossBar removeListener(final Listener listener) {
     this.listeners.remove(listener);
     return this;
   }
 
   @Override
-  public @NotNull Iterable<? extends BossBarViewer> viewers() {
+  public Iterable<? extends BossBarViewer> viewers() {
     if (this.implementation != null) {
       return this.implementation.viewers();
     }
     return Collections.emptyList();
   }
 
-  private void forEachListener(final @NotNull Consumer<Listener> consumer) {
+  private void forEachListener(final Consumer<Listener> consumer) {
     for (final Listener listener : this.listeners) {
       consumer.accept(listener);
     }
@@ -285,7 +284,7 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("name", this.name),
       ExaminableProperty.of("progress", this.progress),

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarImplementation.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarImplementation.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.bossbar;
 
 import java.util.Collections;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * {@link BossBar} internal implementation.
@@ -44,7 +43,7 @@ public interface BossBarImplementation {
    * @since 4.12.0
    */
   @ApiStatus.Internal
-  static <I extends BossBarImplementation> @NotNull I get(final @NotNull BossBar bar, final @NotNull Class<I> type) {
+  static <I extends BossBarImplementation> I get(final BossBar bar, final Class<I> type) {
     return BossBarImpl.ImplementationAccessor.get(bar, type);
   }
 
@@ -55,7 +54,7 @@ public interface BossBarImplementation {
    * @since 4.14.0
    */
   @ApiStatus.Internal
-  default @NotNull Iterable<? extends BossBarViewer> viewers() {
+  default Iterable<? extends BossBarViewer> viewers() {
     return Collections.emptyList();
   }
 
@@ -74,6 +73,6 @@ public interface BossBarImplementation {
      * @since 4.12.0
      */
     @ApiStatus.Internal
-    @NotNull BossBarImplementation create(final @NotNull BossBar bar);
+    BossBarImplementation create(final BossBar bar);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarViewer.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarViewer.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.adventure.bossbar;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
 /**
@@ -39,5 +38,5 @@ public interface BossBarViewer {
    * @since 4.14.0
    */
   @UnmodifiableView
-  @NotNull Iterable<? extends BossBar> activeBossBars();
+  Iterable<? extends BossBar> activeBossBars();
 }

--- a/api/src/main/java/net/kyori/adventure/builder/AbstractBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/builder/AbstractBuilder.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.builder;
 
 import java.util.function.Consumer;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A builder.
@@ -47,7 +46,7 @@ public interface AbstractBuilder<R> {
    * @since 4.10.0
    */
   @Contract(mutates = "param1")
-  static <R, B extends AbstractBuilder<R>> @NotNull R configureAndBuild(final @NotNull B builder, final @Nullable Consumer<? super B> consumer) {
+  static <R, B extends AbstractBuilder<R>> R configureAndBuild(final B builder, final @Nullable Consumer<? super B> consumer) {
     if (consumer != null) {
       consumer.accept(builder);
     }
@@ -61,5 +60,5 @@ public interface AbstractBuilder<R> {
    * @since 4.10.0
    */
   @Contract(value = "-> new", pure = true)
-  @NotNull R build();
+  R build();
 }

--- a/api/src/main/java/net/kyori/adventure/chat/ChatType.java
+++ b/api/src/main/java/net/kyori/adventure/chat/ChatType.java
@@ -31,8 +31,7 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -106,7 +105,7 @@ public interface ChatType extends Examinable, Keyed {
    * @return the chat type
    * @since 4.12.0
    */
-  static @NotNull ChatType chatType(final @NotNull Keyed key) {
+  static ChatType chatType(final Keyed key) {
     return key instanceof ChatType ? (ChatType) key : new ChatTypeImpl(requireNonNull(key, "key").key());
   }
 
@@ -119,7 +118,7 @@ public interface ChatType extends Examinable, Keyed {
    * @sinceMinecraft 1.19
    */
   @Contract(value = "_ -> new", pure = true)
-  default ChatType.@NotNull Bound bind(final @NotNull ComponentLike name) {
+  default ChatType.Bound bind(final ComponentLike name) {
     return this.bind(name, null);
   }
 
@@ -133,12 +132,12 @@ public interface ChatType extends Examinable, Keyed {
    * @sinceMinecraft 1.19
    */
   @Contract(value = "_, _ -> new", pure = true)
-  default ChatType.@NotNull Bound bind(final @NotNull ComponentLike name, final @Nullable ComponentLike target) {
+  default ChatType.Bound bind(final ComponentLike name, final @Nullable ComponentLike target) {
     return new ChatTypeImpl.BoundImpl(this, requireNonNull(name.asComponent(), "name"), ComponentLike.unbox(target));
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("key", this.key()));
   }
 
@@ -158,7 +157,7 @@ public interface ChatType extends Examinable, Keyed {
      * @sinceMinecraft 1.19
      */
     @Contract(pure = true)
-    @NotNull ChatType type();
+    ChatType type();
 
     /**
      * Get the name component.
@@ -168,7 +167,7 @@ public interface ChatType extends Examinable, Keyed {
      * @sinceMinecraft 1.19
      */
     @Contract(pure = true)
-    @NotNull Component name();
+    Component name();
 
     /**
      * Get the target component.
@@ -181,7 +180,7 @@ public interface ChatType extends Examinable, Keyed {
     @Nullable Component target();
 
     @Override
-    default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    default Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("type", this.type()),
         ExaminableProperty.of("name", this.name()),

--- a/api/src/main/java/net/kyori/adventure/chat/ChatTypeImpl.java
+++ b/api/src/main/java/net/kyori/adventure/chat/ChatTypeImpl.java
@@ -26,19 +26,18 @@ package net.kyori.adventure.chat;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
-record ChatTypeImpl(@NotNull Key key) implements ChatType {
+record ChatTypeImpl(Key key) implements ChatType {
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   record BoundImpl(ChatType type, Component name, @Nullable Component target) implements Bound {
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return Internals.toString(this);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/chat/SignedMessage.java
+++ b/api/src/main/java/net/kyori/adventure/chat/SignedMessage.java
@@ -32,8 +32,7 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A signed chat message.
@@ -52,7 +51,7 @@ public sealed interface SignedMessage extends Identified, Examinable permits Sig
    * @sinceMinecraft 1.19
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull Signature signature(final byte[] signature) {
+  static Signature signature(final byte[] signature) {
     return new SignedMessageImpl.SignatureImpl(signature);
   }
 
@@ -66,7 +65,7 @@ public sealed interface SignedMessage extends Identified, Examinable permits Sig
    * @sinceMinecraft 1.19
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull SignedMessage system(final @NotNull String message, final @Nullable ComponentLike unsignedContent) {
+  static SignedMessage system(final String message, final @Nullable ComponentLike unsignedContent) {
     return new SignedMessageImpl(message, ComponentLike.unbox(unsignedContent));
   }
 
@@ -78,7 +77,7 @@ public sealed interface SignedMessage extends Identified, Examinable permits Sig
    * @sinceMinecraft 1.19
    */
   @Contract(pure = true)
-  @NotNull Instant timestamp();
+  Instant timestamp();
 
   /**
    * The salt.
@@ -118,7 +117,7 @@ public sealed interface SignedMessage extends Identified, Examinable permits Sig
    * @sinceMinecraft 1.19
    */
   @Contract(pure = true)
-  @NotNull String message();
+  String message();
 
   /**
    * Checks if this message is a system message.
@@ -145,7 +144,7 @@ public sealed interface SignedMessage extends Identified, Examinable permits Sig
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("timestamp", this.timestamp()),
       ExaminableProperty.of("salt", this.salt()),
@@ -174,7 +173,7 @@ public sealed interface SignedMessage extends Identified, Examinable permits Sig
     byte[] bytes();
 
     @Override
-    default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    default Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(ExaminableProperty.of("bytes", this.bytes()));
     }
   }

--- a/api/src/main/java/net/kyori/adventure/chat/SignedMessageImpl.java
+++ b/api/src/main/java/net/kyori/adventure/chat/SignedMessageImpl.java
@@ -27,7 +27,6 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
 
 // Used for system messages ONLY
 record SignedMessageImpl(String message, Component unsignedContent, Instant timestamp, long salt) implements SignedMessage {
@@ -43,7 +42,7 @@ record SignedMessageImpl(String message, Component unsignedContent, Instant time
   }
 
   @Override
-  public @NotNull Identity identity() {
+  public Identity identity() {
     return Identity.nil();
   }
 

--- a/api/src/main/java/net/kyori/adventure/identity/Identified.java
+++ b/api/src/main/java/net/kyori/adventure/identity/Identified.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.identity;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Something that can be identified by an {@link Identity}.
  *
@@ -37,5 +35,5 @@ public interface Identified {
    * @return the identity
    * @since 4.0.0
    */
-  @NotNull Identity identity();
+  Identity identity();
 }

--- a/api/src/main/java/net/kyori/adventure/identity/Identity.java
+++ b/api/src/main/java/net/kyori/adventure/identity/Identity.java
@@ -32,7 +32,6 @@ import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An identity used to track the sender of messages for the social interaction features
@@ -75,7 +74,7 @@ public sealed interface Identity extends Examinable, Identified permits Identity
    * @return the {@code null} identity
    * @since 4.0.0
    */
-  static @NotNull Identity nil() {
+  static Identity nil() {
     return NilIdentity.INSTANCE;
   }
 
@@ -86,7 +85,7 @@ public sealed interface Identity extends Examinable, Identified permits Identity
    * @return an identity
    * @since 4.0.0
    */
-  static @NotNull Identity identity(final @NotNull UUID uuid) {
+  static Identity identity(final UUID uuid) {
     if (uuid.equals(NilIdentity.NIL_UUID)) return NilIdentity.INSTANCE;
     return new IdentityImpl(uuid);
   }
@@ -97,15 +96,15 @@ public sealed interface Identity extends Examinable, Identified permits Identity
    * @return the uuid
    * @since 4.0.0
    */
-  @NotNull UUID uuid();
+  UUID uuid();
 
   @Override
-  default @NotNull Identity identity() {
+  default Identity identity() {
     return this;
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("uuid", this.uuid()));
   }
 }

--- a/api/src/main/java/net/kyori/adventure/identity/IdentityImpl.java
+++ b/api/src/main/java/net/kyori/adventure/identity/IdentityImpl.java
@@ -26,12 +26,11 @@ package net.kyori.adventure.identity;
 import java.util.UUID;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
 
 record IdentityImpl(UUID uuid) implements Examinable, Identity {
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/identity/NilIdentity.java
+++ b/api/src/main/java/net/kyori/adventure/identity/NilIdentity.java
@@ -24,8 +24,7 @@
 package net.kyori.adventure.identity;
 
 import java.util.UUID;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class NilIdentity implements Identity {
   static final UUID NIL_UUID = new UUID(0, 0);
@@ -35,7 +34,7 @@ final class NilIdentity implements Identity {
   }
 
   @Override
-  public @NotNull UUID uuid() {
+  public UUID uuid() {
     return NIL_UUID;
   }
 

--- a/api/src/main/java/net/kyori/adventure/internal/Internals.java
+++ b/api/src/main/java/net/kyori/adventure/internal/Internals.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.internal;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.string.StringExaminer;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Utilities internal to Adventure.
@@ -43,7 +42,7 @@ public final class Internals {
    * @return the result from examining
    * @since 4.10.0
    */
-  public static @NotNull String toString(final @NotNull Examinable examinable) {
+  public static String toString(final Examinable examinable) {
     return examinable.examine(StringExaminer.simpleEscaping());
   }
 }

--- a/api/src/main/java/net/kyori/adventure/internal/properties/AdventureProperties.java
+++ b/api/src/main/java/net/kyori/adventure/internal/properties/AdventureProperties.java
@@ -28,8 +28,7 @@ import java.util.function.Function;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.util.PlatformAPI;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Adventure properties.
@@ -82,7 +81,7 @@ public final class AdventureProperties {
    * @return a property
    * @since 4.10.0
    */
-  public static <T> @NotNull Property<T> property(final @NotNull String name, final @NotNull Function<String, T> parser, final @Nullable T defaultValue) {
+  public static <T> Property<T> property(final String name, final Function<String, T> parser, final @Nullable T defaultValue) {
     return property(name, parser, defaultValue, true);
   }
 
@@ -97,7 +96,7 @@ public final class AdventureProperties {
    * @return a property
    * @since 4.24.0
    */
-  public static <T> @NotNull Property<T> property(final @NotNull String name, final @NotNull Function<String, T> parser, final @Nullable T defaultValue, final boolean allowProviderDefaultOverride) {
+  public static <T> Property<T> property(final String name, final Function<String, T> parser, final @Nullable T defaultValue, final boolean allowProviderDefaultOverride) {
     return AdventurePropertiesImpl.property(name, parser, defaultValue, allowProviderDefaultOverride);
   }
 
@@ -125,7 +124,7 @@ public final class AdventureProperties {
      * @return the value
      * @since 4.24.0
      */
-    default @NotNull T valueOr(final @NotNull T defaultValue) {
+    default T valueOr(final T defaultValue) {
       final T value = this.value();
       return value == null ? Objects.requireNonNull(defaultValue, "defaultValue") : value;
     }
@@ -148,6 +147,6 @@ public final class AdventureProperties {
      * @param <T> the value type
      * @since 4.24.0
      */
-    <T> @Nullable T overrideDefault(final @NotNull Property<T> property, final @Nullable T existingDefault);
+    <T> @Nullable T overrideDefault(final Property<T> property, final @Nullable T existingDefault);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/internal/properties/AdventurePropertiesImpl.java
+++ b/api/src/main/java/net/kyori/adventure/internal/properties/AdventurePropertiesImpl.java
@@ -32,14 +32,13 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
 import net.kyori.adventure.util.Services;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.jspecify.annotations.Nullable;
 
 final class AdventurePropertiesImpl {
 
   static final class Providers {
-    static final @NotNull Optional<AdventureProperties.DefaultOverrideProvider> DEFAULT_PROVIDER = Services.service(AdventureProperties.DefaultOverrideProvider.class);
+    static final Optional<AdventureProperties.DefaultOverrideProvider> DEFAULT_PROVIDER = Services.service(AdventureProperties.DefaultOverrideProvider.class);
   }
 
   private static final String FILESYSTEM_DIRECTORY_NAME = "config";
@@ -69,11 +68,11 @@ final class AdventurePropertiesImpl {
   }
 
   @VisibleForTesting
-  static @NotNull String systemPropertyName(final String name) {
+  static String systemPropertyName(final String name) {
     return String.join(".", "net", "kyori", "adventure", name);
   }
 
-  static <T> AdventureProperties.@NotNull Property<T> property(final @NotNull String name, final @NotNull Function<String, T> parser, final @Nullable T defaultValue, final boolean allowProviderDefaultOverride) {
+  static <T> AdventureProperties.Property<T> property(final String name, final Function<String, T> parser, final @Nullable T defaultValue, final boolean allowProviderDefaultOverride) {
     return new PropertyImpl<>(name, parser, defaultValue, allowProviderDefaultOverride);
   }
 
@@ -85,7 +84,7 @@ final class AdventurePropertiesImpl {
     private boolean valueCalculated;
     private @Nullable T value;
 
-    PropertyImpl(final @NotNull String name, final @NotNull Function<String, T> parser, final @Nullable T defaultValue, final boolean allowProviderDefaultOverride) {
+    PropertyImpl(final String name, final Function<String, T> parser, final @Nullable T defaultValue, final boolean allowProviderDefaultOverride) {
       this.name = name;
       this.parser = parser;
       this.defaultValue = defaultValue;

--- a/api/src/main/java/net/kyori/adventure/inventory/Book.java
+++ b/api/src/main/java/net/kyori/adventure/inventory/Book.java
@@ -33,7 +33,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Buildable;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
 /**
@@ -56,7 +55,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @return a book
    * @since 4.0.0
    */
-  static @NotNull Book book(final @NotNull Component title, final @NotNull Component author, final @NotNull Collection<Component> pages) {
+  static Book book(final Component title, final Component author, final Collection<Component> pages) {
     return new BookImpl(title, author, new ArrayList<>(pages));
   }
 
@@ -69,7 +68,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @return a book
    * @since 4.0.0
    */
-  static @NotNull Book book(final @NotNull Component title, final @NotNull Component author, final @NotNull Component@NotNull... pages) {
+  static Book book(final Component title, final Component author, final Component... pages) {
     return book(title, author, Arrays.asList(pages));
   }
 
@@ -79,7 +78,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @return a builder
    * @since 4.0.0
    */
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new BookImpl.BuilderImpl();
   }
 
@@ -89,7 +88,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @return the title
    * @since 4.0.0
    */
-  @NotNull Component title();
+  Component title();
 
   /**
    * Changes the book's title.
@@ -99,7 +98,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  @NotNull Book title(final @NotNull Component title);
+  Book title(final Component title);
 
   /**
    * Gets the author.
@@ -107,7 +106,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @return the author
    * @since 4.0.0
    */
-  @NotNull Component author();
+  Component author();
 
   /**
    * Changes the book's author.
@@ -117,7 +116,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  @NotNull Book author(final @NotNull Component author);
+  Book author(final Component author);
 
   /**
    * Gets the list of pages.
@@ -127,7 +126,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @return the list of pages
    * @since 4.0.0
    */
-  @Unmodifiable @NotNull List<Component> pages();
+  @Unmodifiable List<Component> pages();
 
   /**
    * Returns an updated book with the provided pages.
@@ -137,7 +136,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  default @NotNull Book pages(final @NotNull Component@NotNull... pages) {
+  default Book pages(final Component... pages) {
     return this.pages(Arrays.asList(pages));
   }
 
@@ -149,7 +148,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  @NotNull Book pages(final @NotNull List<Component> pages);
+  Book pages(final List<Component> pages);
 
   /**
    * A builder for a {@link Book}.
@@ -165,7 +164,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder title(final @NotNull Component title);
+    Builder title(final Component title);
 
     /**
      * Set the author.
@@ -175,7 +174,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder author(final @NotNull Component author);
+    Builder author(final Component author);
 
     /**
      * Add a page to the book.
@@ -188,7 +187,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder addPage(final @NotNull Component page);
+    Builder addPage(final Component page);
 
     /**
      * Add pages to the book.
@@ -199,7 +198,7 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder pages(final @NotNull Component@NotNull... pages);
+    Builder pages(final Component... pages);
 
     /**
      * Add pages to the book.
@@ -210,6 +209,6 @@ public sealed interface Book extends Buildable<Book.Builder>, Examinable permits
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder pages(final @NotNull Collection<Component> pages);
+    Builder pages(final Collection<Component> pages);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/inventory/BookImpl.java
+++ b/api/src/main/java/net/kyori/adventure/inventory/BookImpl.java
@@ -31,49 +31,48 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
 record BookImpl(Component title, Component author, List<Component> pages) implements Book {
-  BookImpl(final @NotNull Component title, final @NotNull Component author, final @NotNull List<Component> pages) {
+  BookImpl(final Component title, final Component author, final List<Component> pages) {
     this.title = requireNonNull(title, "title");
     this.author = requireNonNull(author, "author");
     this.pages = Collections.unmodifiableList(requireNonNull(pages, "pages"));
   }
 
   @Override
-  public @NotNull Component title() {
+  public Component title() {
     return this.title;
   }
 
   @Override
-  public @NotNull Book title(final @NotNull Component title) {
+  public Book title(final Component title) {
     return new BookImpl(requireNonNull(title, "title"), this.author, this.pages);
   }
 
   @Override
-  public @NotNull Component author() {
+  public Component author() {
     return this.author;
   }
 
   @Override
-  public @NotNull Book author(final @NotNull Component author) {
+  public Book author(final Component author) {
     return new BookImpl(this.title, requireNonNull(author, "author"), this.pages);
   }
 
   @Override
-  public @NotNull List<Component> pages() {
+  public List<Component> pages() {
     return this.pages;
   }
 
   @Override
-  public @NotNull Book pages(final @NotNull List<Component> pages) {
+  public Book pages(final List<Component> pages) {
     return new BookImpl(this.title, this.author, new ArrayList<>(requireNonNull(pages, "pages")));
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("title", this.title),
       ExaminableProperty.of("author", this.author),
@@ -82,12 +81,12 @@ record BookImpl(Component title, Component author, List<Component> pages) implem
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl()
       .title(this.title)
       .author(this.author)
@@ -100,37 +99,37 @@ record BookImpl(Component title, Component author, List<Component> pages) implem
     private final List<Component> pages = new ArrayList<>();
 
     @Override
-    public @NotNull Builder title(final @NotNull Component title) {
+    public Builder title(final Component title) {
       this.title = requireNonNull(title, "title");
       return this;
     }
 
     @Override
-    public @NotNull Builder author(final @NotNull Component author) {
+    public Builder author(final Component author) {
       this.author = requireNonNull(author, "author");
       return this;
     }
 
     @Override
-    public @NotNull Builder addPage(final @NotNull Component page) {
+    public Builder addPage(final Component page) {
       this.pages.add(requireNonNull(page, "page"));
       return this;
     }
 
     @Override
-    public @NotNull Builder pages(final @NotNull Collection<Component> pages) {
+    public Builder pages(final Collection<Component> pages) {
       this.pages.addAll(requireNonNull(pages, "pages"));
       return this;
     }
 
     @Override
-    public @NotNull Builder pages(final @NotNull Component @NotNull ... pages) {
+    public Builder pages(final Component ... pages) {
       Collections.addAll(this.pages, pages);
       return this;
     }
 
     @Override
-    public @NotNull Book build() {
+    public Book build() {
       return new BookImpl(this.title, this.author, List.copyOf(this.pages));
     }
   }

--- a/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolder.java
+++ b/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolder.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.nbt.api;
 
 import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.adventure.util.Codec;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Holds a compound binary tag.
@@ -49,7 +48,7 @@ public interface BinaryTagHolder extends DataComponentValue.TagSerializable {
    * @throws EX if an error occurred while encoding the binary tag
    * @since 4.0.0
    */
-  static <T, EX extends Exception> @NotNull BinaryTagHolder encode(final @NotNull T nbt, final @NotNull Codec<? super T, String, ?, EX> codec) throws EX {
+  static <T, EX extends Exception> BinaryTagHolder encode(final T nbt, final Codec<? super T, String, ?, EX> codec) throws EX {
     return new BinaryTagHolderImpl(codec.encode(nbt));
   }
 
@@ -60,7 +59,7 @@ public interface BinaryTagHolder extends DataComponentValue.TagSerializable {
    * @return the encoded binary tag
    * @since 4.10.0
    */
-  static @NotNull BinaryTagHolder binaryTagHolder(final @NotNull String string) {
+  static BinaryTagHolder binaryTagHolder(final String string) {
     return new BinaryTagHolderImpl(string);
   }
 
@@ -70,10 +69,10 @@ public interface BinaryTagHolder extends DataComponentValue.TagSerializable {
    * @return the raw string value
    * @since 4.0.0
    */
-  @NotNull String string();
+  String string();
 
   @Override
-  default @NotNull BinaryTagHolder asBinaryTag() {
+  default BinaryTagHolder asBinaryTag() {
     return this;
   }
 
@@ -87,5 +86,5 @@ public interface BinaryTagHolder extends DataComponentValue.TagSerializable {
    * @throws DX if an error occurred while retrieving the binary tag
    * @since 4.0.0
    */
-  <T, DX extends Exception> @NotNull T get(final @NotNull Codec<T, String, DX, ?> codec) throws DX;
+  <T, DX extends Exception> T get(final Codec<T, String, DX, ?> codec) throws DX;
 }

--- a/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolderImpl.java
+++ b/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolderImpl.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.nbt.api;
 
 import net.kyori.adventure.util.Codec;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,12 +33,12 @@ record BinaryTagHolderImpl(String string) implements BinaryTagHolder {
   }
 
   @Override
-  public <T, DX extends Exception> @NotNull T get(final @NotNull Codec<T, String, DX, ?> codec) throws DX {
+  public <T, DX extends Exception> T get(final Codec<T, String, DX, ?> codec) throws DX {
     return codec.decode(this.string);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return this.string;
   }
 }

--- a/api/src/main/java/net/kyori/adventure/permission/PermissionChecker.java
+++ b/api/src/main/java/net/kyori/adventure/permission/PermissionChecker.java
@@ -28,7 +28,6 @@ import net.kyori.adventure.Adventure;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.pointer.Pointer;
 import net.kyori.adventure.util.TriState;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +51,7 @@ public interface PermissionChecker extends Predicate<String> {
    * @return a {@link PermissionChecker}
    * @since 4.8.0
    */
-  static @NotNull PermissionChecker always(final @NotNull TriState state) {
+  static PermissionChecker always(final TriState state) {
     requireNonNull(state);
     if (state == TriState.TRUE) return PermissionCheckers.TRUE;
     if (state == TriState.FALSE) return PermissionCheckers.FALSE;
@@ -66,10 +65,10 @@ public interface PermissionChecker extends Predicate<String> {
    * @return a tri-state result
    * @since 4.8.0
    */
-  @NotNull TriState value(final @NotNull String permission);
+  TriState value(final String permission);
 
   @Override
-  default boolean test(final @NotNull String permission) {
+  default boolean test(final String permission) {
     return this.value(permission) == TriState.TRUE;
   }
 }

--- a/api/src/main/java/net/kyori/adventure/permission/PermissionCheckers.java
+++ b/api/src/main/java/net/kyori/adventure/permission/PermissionCheckers.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.permission;
 
 import net.kyori.adventure.util.TriState;
-import org.jetbrains.annotations.NotNull;
 
 final class PermissionCheckers {
   static final PermissionChecker NOT_SET = new Always(TriState.NOT_SET);
@@ -36,12 +35,12 @@ final class PermissionCheckers {
 
   private record Always(TriState value) implements PermissionChecker {
       @Override
-      public @NotNull TriState value(final @NotNull String permission) {
+      public TriState value(final String permission) {
         return this.value;
       }
 
       @Override
-      public @NotNull String toString() {
+      public String toString() {
         return PermissionChecker.class.getSimpleName() + ".always(" + this.value + ")";
       }
   }

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointer.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointer.java
@@ -28,7 +28,6 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A pointer to a resource.
@@ -46,7 +45,7 @@ public sealed interface Pointer<V> extends Examinable, Keyed permits PointerImpl
    * @return the pointer
    * @since 4.8.0
    */
-  static <V> @NotNull Pointer<V> pointer(final @NotNull Class<V> type, final @NotNull Key key) {
+  static <V> Pointer<V> pointer(final Class<V> type, final Key key) {
     return new PointerImpl<>(type, key);
   }
 
@@ -56,7 +55,7 @@ public sealed interface Pointer<V> extends Examinable, Keyed permits PointerImpl
    * @return the value type
    * @since 4.8.0
    */
-  @NotNull Class<V> type();
+  Class<V> type();
 
   /**
    * Gets the key.
@@ -64,10 +63,10 @@ public sealed interface Pointer<V> extends Examinable, Keyed permits PointerImpl
    * @return the key
    * @since 4.8.0
    */
-  @NotNull Key key();
+  Key key();
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("type", this.type()),
       ExaminableProperty.of("key", this.key())

--- a/api/src/main/java/net/kyori/adventure/pointer/PointerImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointerImpl.java
@@ -25,11 +25,10 @@ package net.kyori.adventure.pointer;
 
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
-import org.jetbrains.annotations.NotNull;
 
 record PointerImpl<T>(Class<T> type, Key key) implements Pointer<T> {
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointered.java
@@ -26,9 +26,8 @@ package net.kyori.adventure.pointer;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Something that can retrieve values based on a given {@link Pointer}.
@@ -44,7 +43,7 @@ public interface Pointered {
    * @return the value
    * @since 4.8.0
    */
-  default <T> @NotNull Optional<T> get(final @NotNull Pointer<T> pointer) {
+  default <T> Optional<T> get(final Pointer<T> pointer) {
     return this.pointers().get(pointer);
   }
 
@@ -61,7 +60,7 @@ public interface Pointered {
    */
   @Contract("_, null -> _; _, !null -> !null")
   @SuppressWarnings("checkstyle:MethodName")
-  default <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
+  default <T> @Nullable T getOrDefault(final Pointer<T> pointer, final @Nullable T defaultValue) {
     return this.pointers().getOrDefault(pointer, defaultValue);
   }
 
@@ -77,7 +76,7 @@ public interface Pointered {
    * @since 4.8.0
    */
   @SuppressWarnings("checkstyle:MethodName")
-  default <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
+  default <T> @UnknownNullability T getOrDefaultFrom(final Pointer<T> pointer, final Supplier<? extends T> defaultValue) {
     return this.pointers().getOrDefaultFrom(pointer, defaultValue);
   }
 
@@ -87,7 +86,7 @@ public interface Pointered {
    * @return the pointers
    * @since 4.8.0
    */
-  default @NotNull Pointers pointers() {
+  default Pointers pointers() {
     return Pointers.empty();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/Pointers.java
@@ -28,9 +28,8 @@ import java.util.function.Supplier;
 import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.adventure.util.Buildable;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A collection of {@link Pointer pointers}.
@@ -45,7 +44,7 @@ public sealed interface Pointers extends Buildable<Pointers.Builder> permits Poi
    * @since 4.8.0
    */
   @Contract(pure = true)
-  static @NotNull Pointers empty() {
+  static Pointers empty() {
     return PointersImpl.EMPTY;
   }
 
@@ -57,7 +56,7 @@ public sealed interface Pointers extends Buildable<Pointers.Builder> permits Poi
    * @since 4.8.0
    */
   @Contract(pure = true)
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new PointersImpl.BuilderImpl();
   }
 
@@ -69,7 +68,7 @@ public sealed interface Pointers extends Buildable<Pointers.Builder> permits Poi
    * @return the value
    * @since 4.8.0
    */
-  <T> @NotNull Optional<T> get(final @NotNull Pointer<T> pointer);
+  <T> Optional<T> get(final Pointer<T> pointer);
 
   /**
    * Gets the value of {@code pointer}.
@@ -84,7 +83,7 @@ public sealed interface Pointers extends Buildable<Pointers.Builder> permits Poi
    */
   @Contract("_, null -> _; _, !null -> !null")
   @SuppressWarnings("checkstyle:MethodName")
-  default <T> @Nullable T getOrDefault(final @NotNull Pointer<T> pointer, final @Nullable T defaultValue) {
+  default <T> @Nullable T getOrDefault(final Pointer<T> pointer, final @Nullable T defaultValue) {
     return this.get(pointer).orElse(defaultValue);
   }
 
@@ -100,7 +99,7 @@ public sealed interface Pointers extends Buildable<Pointers.Builder> permits Poi
    * @since 4.8.0
    */
   @SuppressWarnings("checkstyle:MethodName")
-  default <T> @UnknownNullability T getOrDefaultFrom(final @NotNull Pointer<T> pointer, final @NotNull Supplier<? extends T> defaultValue) {
+  default <T> @UnknownNullability T getOrDefaultFrom(final Pointer<T> pointer, final Supplier<? extends T> defaultValue) {
     return this.get(pointer).orElseGet(defaultValue);
   }
 
@@ -114,7 +113,7 @@ public sealed interface Pointers extends Buildable<Pointers.Builder> permits Poi
    * @return if the pointer is supported
    * @since 4.8.0
    */
-  <T> boolean supports(final @NotNull Pointer<T> pointer);
+  <T> boolean supports(final Pointer<T> pointer);
 
   /**
    * A builder of pointers.
@@ -133,7 +132,7 @@ public sealed interface Pointers extends Buildable<Pointers.Builder> permits Poi
      * @since 4.8.0
      */
     @Contract("_, _ -> this")
-    default <T> @NotNull Builder withStatic(final @NotNull Pointer<T> pointer, final @Nullable T value) {
+    default <T> Builder withStatic(final Pointer<T> pointer, final @Nullable T value) {
       return this.withDynamic(pointer, () -> value);
     }
 
@@ -147,6 +146,6 @@ public sealed interface Pointers extends Buildable<Pointers.Builder> permits Poi
      * @since 4.8.0
      */
     @Contract("_, _ -> this")
-    <T> @NotNull Builder withDynamic(final @NotNull Pointer<T> pointer, @NotNull Supplier<@Nullable T> value);
+    <T> Builder withDynamic(final Pointer<T> pointer, Supplier<@Nullable T> value);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointersImpl.java
@@ -28,19 +28,18 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 record PointersImpl(Map<Pointer<?>, Supplier<?>> pointers) implements Pointers {
   static final PointersImpl EMPTY = new PointersImpl(Map.of());
 
-  PointersImpl(final @NotNull BuilderImpl pointers) {
+  PointersImpl(final BuilderImpl pointers) {
     this(Map.copyOf(pointers.pointers));
   }
 
   @Override
   @SuppressWarnings("unchecked") // all values are checked on entry
-  public @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
+  public <T> Optional<T> get(final Pointer<T> pointer) {
     Objects.requireNonNull(pointer, "pointer");
     final Supplier<?> supplier = this.pointers.get(pointer);
     if (supplier == null) {
@@ -51,13 +50,13 @@ record PointersImpl(Map<Pointer<?>, Supplier<?>> pointers) implements Pointers {
   }
 
   @Override
-  public <T> boolean supports(final @NotNull Pointer<T> pointer) {
+  public <T> boolean supports(final Pointer<T> pointer) {
     Objects.requireNonNull(pointer, "pointer");
     return this.pointers.containsKey(pointer);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -68,18 +67,18 @@ record PointersImpl(Map<Pointer<?>, Supplier<?>> pointers) implements Pointers {
       this.pointers = new HashMap<>();
     }
 
-    BuilderImpl(final @NotNull PointersImpl pointers) {
+    BuilderImpl(final PointersImpl pointers) {
       this.pointers = new HashMap<>(pointers.pointers);
     }
 
     @Override
-    public @NotNull <T> Builder withDynamic(final @NotNull Pointer<T> pointer, final @NotNull Supplier<@Nullable T> value) {
+    public <T> Builder withDynamic(final Pointer<T> pointer, final Supplier<@Nullable T> value) {
       this.pointers.put(Objects.requireNonNull(pointer, "pointer"), Objects.requireNonNull(value, "value"));
       return this;
     }
 
     @Override
-    public @NotNull Pointers build() {
+    public Pointers build() {
       return new PointersImpl(this);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/pointer/PointersSupplier.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointersSupplier.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.pointer;
 import java.util.function.Function;
 import net.kyori.adventure.builder.AbstractBuilder;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A supplier of {@link Pointers} that allows for the implementation of pointers
@@ -61,7 +60,7 @@ public sealed interface PointersSupplier<T> permits PointersSupplierImpl {
    * @return the builder
    * @since 4.17.0
    */
-  static <T> @NotNull Builder<T> builder() {
+  static <T> Builder<T> builder() {
     return new PointersSupplierImpl.BuilderImpl<>();
   }
 
@@ -72,7 +71,7 @@ public sealed interface PointersSupplier<T> permits PointersSupplierImpl {
    * @return the view
    * @since 4.17.0
    */
-  @NotNull Pointers view(final @NotNull T instance);
+  Pointers view(final T instance);
 
   /**
    * Checks if this supplier supports a given pointer.
@@ -82,7 +81,7 @@ public sealed interface PointersSupplier<T> permits PointersSupplierImpl {
    * @return if this supplier supports a given pointer
    * @since 4.17.0
    */
-  <P> boolean supports(final @NotNull Pointer<P> pointer);
+  <P> boolean supports(final Pointer<P> pointer);
 
   /**
    * Returns the resolver for a given pointer (if any).
@@ -92,7 +91,7 @@ public sealed interface PointersSupplier<T> permits PointersSupplierImpl {
    * @return the resolver, if any
    * @since 4.17.0
    */
-  <P> @Nullable Function<? super T, P> resolver(final @NotNull Pointer<P> pointer);
+  <P> @Nullable Function<? super T, P> resolver(final Pointer<P> pointer);
 
   /**
    * A builder for {@link PointersSupplier}.
@@ -110,7 +109,7 @@ public sealed interface PointersSupplier<T> permits PointersSupplierImpl {
      * @since 4.17.0
      */
     @Contract("_ -> this")
-    @NotNull Builder<T> parent(final @Nullable PointersSupplier<? super T> parent);
+    Builder<T> parent(final @Nullable PointersSupplier<? super T> parent);
 
     /**
      * Adds a resolver for a given pointer.
@@ -122,6 +121,6 @@ public sealed interface PointersSupplier<T> permits PointersSupplierImpl {
      * @since 4.17.0
      */
     @Contract("_, _ -> this")
-    <P> @NotNull Builder<T> resolving(final @NotNull Pointer<P> pointer, final @NotNull Function<T, P> resolver);
+    <P> Builder<T> resolving(final Pointer<P> pointer, final Function<T, P> resolver);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/pointer/PointersSupplierImpl.java
+++ b/api/src/main/java/net/kyori/adventure/pointer/PointersSupplierImpl.java
@@ -29,25 +29,24 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class PointersSupplierImpl<T> implements PointersSupplier<T> {
   private final @Nullable PointersSupplier<? super T> parent;
   private final Map<Pointer<?>, Function<T, ?>> resolvers;
 
-  PointersSupplierImpl(final @NotNull BuilderImpl<T> builder) {
+  PointersSupplierImpl(final BuilderImpl<T> builder) {
     this.parent = builder.parent;
     this.resolvers = Map.copyOf(builder.resolvers);
   }
 
   @Override
-  public @NotNull Pointers view(final @NotNull T instance) {
+  public Pointers view(final T instance) {
     return new ForwardingPointers<>(instance, this);
   }
 
   @Override
-  public <P> boolean supports(final @NotNull Pointer<P> pointer) {
+  public <P> boolean supports(final Pointer<P> pointer) {
     if (this.resolvers.containsKey(Objects.requireNonNull(pointer, "pointer"))) {
       return true;
     } else if (this.parent == null) {
@@ -59,7 +58,7 @@ final class PointersSupplierImpl<T> implements PointersSupplier<T> {
 
   @Override
   @SuppressWarnings("unchecked") // all values are checked on entry
-  public @Nullable <P> Function<? super T, P> resolver(final @NotNull Pointer<P> pointer) {
+  public @Nullable <P> Function<? super T, P> resolver(final Pointer<P> pointer) {
     final Function<? super T, ?> resolver = this.resolvers.get(Objects.requireNonNull(pointer, "pointer"));
 
     if (resolver != null) {
@@ -74,7 +73,7 @@ final class PointersSupplierImpl<T> implements PointersSupplier<T> {
   record ForwardingPointers<U>(U instance, PointersSupplierImpl<U> supplier) implements Pointers {
     @Override
     @SuppressWarnings("unchecked") // all values are checked on entry
-    public @NotNull <T> Optional<T> get(final @NotNull Pointer<T> pointer) {
+    public <T> Optional<T> get(final Pointer<T> pointer) {
       Function<? super U, ?> resolver = this.supplier.resolvers.get(Objects.requireNonNull(pointer, "pointer"));
 
       // Fallback to the parent.
@@ -94,13 +93,13 @@ final class PointersSupplierImpl<T> implements PointersSupplier<T> {
     }
 
     @Override
-    public <T> boolean supports(final @NotNull Pointer<T> pointer) {
+    public <T> boolean supports(final Pointer<T> pointer) {
       return this.supplier.supports(pointer);
     }
 
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"}) // all values are checked on entry
-    public @NotNull Builder toBuilder() {
+    public Builder toBuilder() {
       final Pointers.Builder builder = this.supplier.parent == null ? Pointers.builder() : this.supplier.parent.view(this.instance).toBuilder();
 
       for (final Map.Entry<Pointer<?>, Function<U, ?>> entry : this.supplier.resolvers.entrySet()) {
@@ -120,19 +119,19 @@ final class PointersSupplierImpl<T> implements PointersSupplier<T> {
     }
 
     @Override
-    public @NotNull Builder<T> parent(final @Nullable PointersSupplier<? super T> parent) {
+    public Builder<T> parent(final @Nullable PointersSupplier<? super T> parent) {
       this.parent = parent;
       return this;
     }
 
     @Override
-    public @NotNull <P> Builder<T> resolving(final @NotNull Pointer<P> pointer, final @NotNull Function<T, P> resolver) {
+    public <P> Builder<T> resolving(final Pointer<P> pointer, final Function<T, P> resolver) {
       this.resolvers.put(pointer, resolver);
       return this;
     }
 
     @Override
-    public @NotNull PointersSupplier<T> build() {
+    public PointersSupplier<T> build() {
       return new PointersSupplierImpl<>(this);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackCallback.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackCallback.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.resource;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import net.kyori.adventure.audience.Audience;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A callback for a resource pack application operation.
@@ -43,7 +42,7 @@ public interface ResourcePackCallback {
    * @return the no-op callback
    * @since 4.15.0
    */
-  static @NotNull ResourcePackCallback noOp() {
+  static ResourcePackCallback noOp() {
     return ResourcePackCallbacks.NO_OP;
   }
 
@@ -55,7 +54,7 @@ public interface ResourcePackCallback {
    * @return the created callback
    * @since 4.15.0
    */
-  static @NotNull ResourcePackCallback onTerminal(final @NotNull BiConsumer<UUID, Audience> success, final @NotNull BiConsumer<UUID, Audience> failure) {
+  static ResourcePackCallback onTerminal(final BiConsumer<UUID, Audience> success, final BiConsumer<UUID, Audience> failure) {
     return (uuid, status, audience) -> {
       if (status == ResourcePackStatus.SUCCESSFULLY_LOADED) {
         success.accept(uuid, audience);
@@ -76,5 +75,5 @@ public interface ResourcePackCallback {
    * @param audience the audience the pack is being applied to
    * @since 4.15.0
    */
-  void packEventReceived(final @NotNull UUID uuid, final @NotNull ResourcePackStatus status, final @NotNull Audience audience);
+  void packEventReceived(final UUID uuid, final ResourcePackStatus status, final Audience audience);
 }

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfo.java
@@ -32,7 +32,6 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents information about a resource pack that can be sent to players.
@@ -51,7 +50,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
    * @return the resource pack request
    * @since 4.15.0
    */
-  static @NotNull ResourcePackInfo resourcePackInfo(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash) {
+  static ResourcePackInfo resourcePackInfo(final UUID id, final URI uri, final String hash) {
     return new ResourcePackInfoImpl(id, uri, hash);
   }
 
@@ -61,7 +60,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
    * @return a builder
    * @since 4.15.0
    */
-  static @NotNull Builder resourcePackInfo() {
+  static Builder resourcePackInfo() {
     return new ResourcePackInfoImpl.BuilderImpl();
   }
 
@@ -71,7 +70,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
    * @return the id
    * @since 4.15.0
    */
-  @NotNull UUID id();
+  UUID id();
 
   /**
    * Gets the uri.
@@ -79,7 +78,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
    * @return the uri
    * @since 4.15.0
    */
-  @NotNull URI uri();
+  URI uri();
 
   /**
    * Gets the SHA-1 hash.
@@ -87,10 +86,10 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
    * @return the hash
    * @since 4.15.0
    */
-  @NotNull String hash();
+  String hash();
 
   @Override
-  default @NotNull ResourcePackInfo asResourcePackInfo() {
+  default ResourcePackInfo asResourcePackInfo() {
     return this;
   }
 
@@ -108,7 +107,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder id(final @NotNull UUID id);
+    Builder id(final UUID id);
 
     /**
      * Sets the uri.
@@ -122,7 +121,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder uri(final @NotNull URI uri);
+    Builder uri(final URI uri);
 
     /**
      * Sets the hash.
@@ -132,7 +131,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder hash(final @NotNull String hash);
+    Builder hash(final String hash);
 
     /**
      * Builds.
@@ -141,7 +140,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
      * @since 4.15.0
      */
     @Override
-    @NotNull ResourcePackInfo build();
+    ResourcePackInfo build();
 
     /**
      * Builds, computing a hash based on the provided URL.
@@ -151,7 +150,7 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
      * @return a future providing the new resource pack request
      * @since 4.15.0
      */
-    default @NotNull CompletableFuture<ResourcePackInfo> computeHashAndBuild() {
+    default CompletableFuture<ResourcePackInfo> computeHashAndBuild() {
       return this.computeHashAndBuild(ForkJoinPool.commonPool());
     }
 
@@ -164,10 +163,10 @@ public sealed interface ResourcePackInfo extends Examinable, ResourcePackInfoLik
      * @return a future providing the new resource pack request
      * @since 4.15.0
      */
-    @NotNull CompletableFuture<ResourcePackInfo> computeHashAndBuild(final @NotNull Executor executor);
+    CompletableFuture<ResourcePackInfo> computeHashAndBuild(final Executor executor);
 
     @Override
-    default @NotNull ResourcePackInfo asResourcePackInfo() {
+    default ResourcePackInfo asResourcePackInfo() {
       return this.build();
     }
   }

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoImpl.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoImpl.java
@@ -39,19 +39,18 @@ import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
 record ResourcePackInfoImpl(UUID id, URI uri, String hash) implements ResourcePackInfo {
-  ResourcePackInfoImpl(final @NotNull UUID id, final @NotNull URI uri, final @NotNull String hash) {
+  ResourcePackInfoImpl(final UUID id, final URI uri, final String hash) {
     this.id = requireNonNull(id, "id");
     this.uri = requireNonNull(uri, "uri");
     this.hash = requireNonNull(hash, "hash");
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("id", this.id),
       ExaminableProperty.of("uri", this.uri),
@@ -60,7 +59,7 @@ record ResourcePackInfoImpl(UUID id, URI uri, String hash) implements ResourcePa
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
@@ -73,13 +72,13 @@ record ResourcePackInfoImpl(UUID id, URI uri, String hash) implements ResourcePa
     }
 
     @Override
-    public @NotNull Builder id(final @NotNull UUID id) {
+    public Builder id(final UUID id) {
       this.id = requireNonNull(id, "id");
       return this;
     }
 
     @Override
-    public @NotNull Builder uri(final @NotNull URI uri) {
+    public Builder uri(final URI uri) {
       this.uri = requireNonNull(uri, "uri");
       if (this.id == null) {
         this.id = UUID.nameUUIDFromBytes(uri.toString().getBytes(StandardCharsets.UTF_8));
@@ -88,18 +87,18 @@ record ResourcePackInfoImpl(UUID id, URI uri, String hash) implements ResourcePa
     }
 
     @Override
-    public @NotNull Builder hash(final @NotNull String hash) {
+    public Builder hash(final String hash) {
       this.hash = requireNonNull(hash, "hash");
       return this;
     }
 
     @Override
-    public @NotNull ResourcePackInfo build() {
+    public ResourcePackInfo build() {
       return new ResourcePackInfoImpl(this.id, this.uri, this.hash);
     }
 
     @Override
-    public @NotNull CompletableFuture<ResourcePackInfo> computeHashAndBuild(final @NotNull Executor executor) {
+    public CompletableFuture<ResourcePackInfo> computeHashAndBuild(final Executor executor) {
       return computeHash(requireNonNull(this.uri, "uri"), executor)
         .thenApply(hash -> {
           this.hash(hash);

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoLike.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoLike.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.resource;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Something that can be represented as a {@link ResourcePackInfo}.
  *
@@ -37,5 +35,5 @@ public interface ResourcePackInfoLike {
    * @return a component
    * @since 4.15.0
    */
-  @NotNull ResourcePackInfo asResourcePackInfo();
+  ResourcePackInfo asResourcePackInfo();
 }

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequest.java
@@ -28,8 +28,7 @@ import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -49,7 +48,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
    * @return the created request
    * @since 4.15.0
    */
-  static @NotNull ResourcePackRequest addingRequest(final @NotNull ResourcePackInfoLike first, final @NotNull ResourcePackInfoLike@NotNull... others) {
+  static ResourcePackRequest addingRequest(final ResourcePackInfoLike first, final ResourcePackInfoLike... others) {
     return ResourcePackRequest.resourcePackRequest().packs(first, others).replace(false).build();
   }
 
@@ -59,7 +58,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
    * @return the pack request builder
    * @since 4.15.0
    */
-  static @NotNull Builder resourcePackRequest() {
+  static Builder resourcePackRequest() {
     return new ResourcePackRequestImpl.BuilderImpl();
   }
 
@@ -70,7 +69,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
    * @return the pack request builder
    * @since 4.15.0
    */
-  static @NotNull Builder resourcePackRequest(final @NotNull ResourcePackRequest existing) {
+  static Builder resourcePackRequest(final ResourcePackRequest existing) {
     return new ResourcePackRequestImpl.BuilderImpl(requireNonNull(existing, "existing"));
   }
 
@@ -80,7 +79,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
    * @return an unmodifiable list of packs to apply
    * @since 4.15.0
    */
-  @NotNull List<ResourcePackInfo> packs();
+  List<ResourcePackInfo> packs();
 
   /**
    * Set the resource packs to apply.
@@ -89,7 +88,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
    * @return an updated pack request
    * @since 4.15.0
    */
-  @NotNull ResourcePackRequest packs(final @NotNull Iterable<? extends ResourcePackInfoLike> packs);
+  ResourcePackRequest packs(final Iterable<? extends ResourcePackInfoLike> packs);
 
   /**
    * A callback to respond to resource pack application status events.
@@ -99,7 +98,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
    * @return the callback
    * @since 4.15.0
    */
-  @NotNull ResourcePackCallback callback();
+  ResourcePackCallback callback();
 
   /**
    * Set the callback to respond to resource pack application status events.
@@ -108,7 +107,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
    * @return an updated pack request
    * @since 4.15.0
    */
-  @NotNull ResourcePackRequest callback(final @NotNull ResourcePackCallback cb);
+  ResourcePackRequest callback(final ResourcePackCallback cb);
 
   /**
    * Whether to replace or add to existing resource packs.
@@ -126,7 +125,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
    * @return an updated pack request
    * @since 4.15.0
    */
-  @NotNull ResourcePackRequest replace(final boolean replace);
+  ResourcePackRequest replace(final boolean replace);
 
   /**
    * Gets whether the resource packs in this request are required.
@@ -151,7 +150,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
   @Nullable Component prompt();
 
   @Override
-  default @NotNull ResourcePackRequest asResourcePackRequest() {
+  default ResourcePackRequest asResourcePackRequest() {
     return this;
   }
 
@@ -170,7 +169,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
      * @since 4.15.0
      */
     @Contract("_, _ -> this")
-    @NotNull Builder packs(final @NotNull ResourcePackInfoLike first, final @NotNull ResourcePackInfoLike@NotNull... others);
+    Builder packs(final ResourcePackInfoLike first, final ResourcePackInfoLike... others);
 
     /**
      * Set the resource packs to apply.
@@ -180,7 +179,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder packs(final @NotNull Iterable<? extends ResourcePackInfoLike> packs);
+    Builder packs(final Iterable<? extends ResourcePackInfoLike> packs);
 
     /**
      * Set the callback to respond to resource pack application status events.
@@ -190,7 +189,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder callback(final @NotNull ResourcePackCallback cb);
+    Builder callback(final ResourcePackCallback cb);
 
     /**
      * Set whether to replace or add to existing resource packs.
@@ -200,7 +199,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder replace(final boolean replace);
+    Builder replace(final boolean replace);
 
     /**
      * Sets whether the resource pack is required or not.
@@ -215,7 +214,7 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder required(final boolean required);
+    Builder required(final boolean required);
 
     /**
      * Sets the prompt.
@@ -225,10 +224,10 @@ public sealed interface ResourcePackRequest extends Examinable, ResourcePackRequ
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder prompt(final @Nullable Component prompt);
+    Builder prompt(final @Nullable Component prompt);
 
     @Override
-    default @NotNull ResourcePackRequest asResourcePackRequest() {
+    default ResourcePackRequest asResourcePackRequest() {
       return this.build();
     }
   }

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequestImpl.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequestImpl.java
@@ -30,15 +30,14 @@ import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.MonkeyBars;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 record ResourcePackRequestImpl(List<ResourcePackInfo> packs, ResourcePackCallback callback, boolean replace, boolean required, @Nullable Component prompt) implements ResourcePackRequest {
   @Override
   @SuppressWarnings("UndefinedEquals")
-  public @NotNull ResourcePackRequest packs(final @NotNull Iterable<? extends ResourcePackInfoLike> packs) {
+  public ResourcePackRequest packs(final Iterable<? extends ResourcePackInfoLike> packs) {
     if (this.packs.equals(packs)) return this;
 
     return new ResourcePackRequestImpl(
@@ -51,7 +50,7 @@ record ResourcePackRequestImpl(List<ResourcePackInfo> packs, ResourcePackCallbac
   }
 
   @Override
-  public @NotNull ResourcePackRequest callback(final @NotNull ResourcePackCallback cb) {
+  public ResourcePackRequest callback(final ResourcePackCallback cb) {
     if (cb == this.callback) return this;
 
     return new ResourcePackRequestImpl(
@@ -64,19 +63,19 @@ record ResourcePackRequestImpl(List<ResourcePackInfo> packs, ResourcePackCallbac
   }
 
   @Override
-  public @NotNull ResourcePackRequest replace(final boolean replace) {
+  public ResourcePackRequest replace(final boolean replace) {
     if (replace == this.replace) return this;
 
     return new ResourcePackRequestImpl(this.packs, this.callback, replace, this.required, this.prompt);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("packs", this.packs),
       ExaminableProperty.of("callback", this.callback),
@@ -99,7 +98,7 @@ record ResourcePackRequestImpl(List<ResourcePackInfo> packs, ResourcePackCallbac
       this.replace = false;
     }
 
-    BuilderImpl(final @NotNull ResourcePackRequest req) {
+    BuilderImpl(final ResourcePackRequest req) {
       this.packs = req.packs();
       this.cb = req.callback();
       this.replace = req.replace();
@@ -108,43 +107,43 @@ record ResourcePackRequestImpl(List<ResourcePackInfo> packs, ResourcePackCallbac
     }
 
     @Override
-    public @NotNull Builder packs(final @NotNull ResourcePackInfoLike first, final @NotNull ResourcePackInfoLike @NotNull ... others) {
+    public Builder packs(final ResourcePackInfoLike first, final ResourcePackInfoLike ... others) {
       this.packs = MonkeyBars.nonEmptyArrayToList(ResourcePackInfoLike::asResourcePackInfo, first, others);
       return this;
     }
 
     @Override
-    public @NotNull Builder packs(final @NotNull Iterable<? extends ResourcePackInfoLike> packs) {
+    public Builder packs(final Iterable<? extends ResourcePackInfoLike> packs) {
       this.packs = MonkeyBars.toUnmodifiableList(ResourcePackInfoLike::asResourcePackInfo, packs);
       return this;
     }
 
     @Override
-    public @NotNull Builder callback(final @NotNull ResourcePackCallback cb) {
+    public Builder callback(final ResourcePackCallback cb) {
       this.cb = requireNonNull(cb, "cb");
       return this;
     }
 
     @Override
-    public @NotNull Builder replace(final boolean replace) {
+    public Builder replace(final boolean replace) {
       this.replace = replace;
       return this;
     }
 
     @Override
-    public @NotNull Builder required(final boolean required) {
+    public Builder required(final boolean required) {
       this.required = required;
       return this;
     }
 
     @Override
-    public @NotNull Builder prompt(final @Nullable Component prompt) {
+    public Builder prompt(final @Nullable Component prompt) {
       this.prompt = prompt;
       return this;
     }
 
     @Override
-    public @NotNull ResourcePackRequest build() {
+    public ResourcePackRequest build() {
       return new ResourcePackRequestImpl(this.packs, this.cb, this.replace, this.required, this.prompt);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequestLike.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackRequestLike.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.resource;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Something that can be represented as a {@link ResourcePackRequest}.
  *
@@ -37,5 +35,5 @@ public interface ResourcePackRequestLike {
    * @return the pack request representation of this object
    * @since 4.15.0
    */
-  @NotNull ResourcePackRequest asResourcePackRequest();
+  ResourcePackRequest asResourcePackRequest();
 }

--- a/api/src/main/java/net/kyori/adventure/sound/Sound.java
+++ b/api/src/main/java/net/kyori/adventure/sound/Sound.java
@@ -31,7 +31,6 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import net.kyori.adventure.util.Index;
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 
 import static java.util.Objects.requireNonNull;
@@ -69,7 +68,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return a new builder
    * @since 4.12.0
    */
-  static @NotNull Builder sound() {
+  static Builder sound() {
     return new SoundImpl.BuilderImpl();
   }
 
@@ -80,7 +79,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return a new builder
    * @since 4.12.0
    */
-  static @NotNull Builder sound(final @NotNull Sound existing) {
+  static Builder sound(final Sound existing) {
     return new SoundImpl.BuilderImpl(existing);
   }
 
@@ -91,7 +90,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return a new builder
    * @since 4.12.0
    */
-  static @NotNull Sound sound(final @NotNull Consumer<Sound.Builder> configurer) {
+  static Sound sound(final Consumer<Sound.Builder> configurer) {
     return AbstractBuilder.configureAndBuild(sound(), configurer);
   }
 
@@ -105,7 +104,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the sound
    * @since 4.0.0
    */
-  static @NotNull Sound sound(final @NotNull Key name, final @NotNull Source source, final float volume, final float pitch) {
+  static Sound sound(final Key name, final Source source, final float volume, final float pitch) {
     return sound().type(name).source(source).volume(volume).pitch(pitch).build();
   }
 
@@ -119,7 +118,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the sound
    * @since 4.0.0
    */
-  static @NotNull Sound sound(final @NotNull Type type, final @NotNull Source source, final float volume, final float pitch) {
+  static Sound sound(final Type type, final Source source, final float volume, final float pitch) {
     requireNonNull(type, "type");
     return sound(type.key(), source, volume, pitch);
   }
@@ -134,7 +133,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the sound
    * @since 4.0.0
    */
-  static @NotNull Sound sound(final @NotNull Supplier<? extends Type> type, final @NotNull Source source, final float volume, final float pitch) {
+  static Sound sound(final Supplier<? extends Type> type, final Source source, final float volume, final float pitch) {
     return sound().type(type).source(source).volume(volume).pitch(pitch).build();
   }
 
@@ -148,7 +147,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the sound
    * @since 4.8.0
    */
-  static @NotNull Sound sound(final @NotNull Key name, final Source.@NotNull Provider source, final float volume, final float pitch) {
+  static Sound sound(final Key name, final Source.Provider source, final float volume, final float pitch) {
     return sound(name, source.soundSource(), volume, pitch);
   }
 
@@ -162,7 +161,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the sound
    * @since 4.8.0
    */
-  static @NotNull Sound sound(final @NotNull Type type, final Source.@NotNull Provider source, final float volume, final float pitch) {
+  static Sound sound(final Type type, final Source.Provider source, final float volume, final float pitch) {
     return sound(type, source.soundSource(), volume, pitch);
   }
 
@@ -176,7 +175,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the sound
    * @since 4.8.0
    */
-  static @NotNull Sound sound(final @NotNull Supplier<? extends Type> type, final Source.@NotNull Provider source, final float volume, final float pitch) {
+  static Sound sound(final Supplier<? extends Type> type, final Source.Provider source, final float volume, final float pitch) {
     return sound(type, source.soundSource(), volume, pitch);
   }
 
@@ -186,7 +185,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the name
    * @since 4.0.0
    */
-  @NotNull Key name();
+  Key name();
 
   /**
    * Gets the source.
@@ -194,7 +193,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the source
    * @since 4.0.0
    */
-  @NotNull Source source();
+  Source source();
 
   /**
    * Gets the volume.
@@ -220,7 +219,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the seed to use
    * @since 4.12.0
    */
-  @NotNull OptionalLong seed();
+  OptionalLong seed();
 
   /**
    * Gets the {@link SoundStop} that will stop this specific sound.
@@ -228,7 +227,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
    * @return the sound stop
    * @since 4.8.0
    */
-  @NotNull SoundStop asStop();
+  SoundStop asStop();
 
   /**
    * The sound source.
@@ -362,7 +361,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
        * @return the source
        * @since 4.8.0
        */
-      @NotNull Source soundSource();
+      Source soundSource();
     }
   }
 
@@ -379,7 +378,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @since 4.0.0
      */
     @Override
-    @NotNull Key key();
+    Key key();
   }
 
   /**
@@ -397,7 +396,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return the emitter
      * @since 4.8.0
      */
-    static @NotNull Emitter self() {
+    static Emitter self() {
       return SoundImpl.EMITTER_SELF;
     }
   }
@@ -419,7 +418,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder type(final @NotNull Key type);
+    Builder type(final Key type);
 
     /**
      * Set the type of this sound.
@@ -430,7 +429,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder type(final @NotNull Type type);
+    Builder type(final Type type);
 
     /**
      * Set the type of this sound.
@@ -441,7 +440,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder type(final @NotNull Supplier<? extends Type> typeSupplier);
+    Builder type(final Supplier<? extends Type> typeSupplier);
 
     /**
      * A {@link Source} to tell the game where the sound is coming from.
@@ -452,7 +451,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder source(final @NotNull Source source);
+    Builder source(final Source source);
 
     /**
      * A {@link Source} to tell the game where the sound is coming from.
@@ -463,7 +462,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder source(final Source.@NotNull Provider source);
+    Builder source(final Source.Provider source);
 
     /**
      * The volume for this sound, indicating how far away it can be heard.
@@ -474,7 +473,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder volume(final @Range(from = 0, to = Integer.MAX_VALUE) float volume);
+    Builder volume(final @Range(from = 0, to = Integer.MAX_VALUE) float volume);
 
     /**
      * The pitch for this sound, indicating how high or low the sound can be heard.
@@ -485,7 +484,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder pitch(final @Range(from = -1, to = 1) float pitch);
+    Builder pitch(final @Range(from = -1, to = 1) float pitch);
 
     /**
      * The seed for this sound, used for weighted choices.
@@ -496,7 +495,7 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder seed(final long seed);
+    Builder seed(final long seed);
 
     /**
      * The seed for this sound, used for weighted choices.
@@ -507,6 +506,6 @@ public sealed interface Sound extends Examinable permits SoundImpl {
      * @return this builder
      * @since 4.12.0
      */
-    @NotNull Builder seed(final @NotNull OptionalLong seed);
+    Builder seed(final OptionalLong seed);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
@@ -30,9 +30,8 @@ import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.util.ShadyPines;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,7 +49,7 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
   private final OptionalLong seed;
   private SoundStop stop;
 
-  SoundImpl(final @NotNull Source source, final float volume, final float pitch, final OptionalLong seed) {
+  SoundImpl(final Source source, final float volume, final float pitch, final OptionalLong seed) {
     this.source = source;
     this.volume = volume;
     this.pitch = pitch;
@@ -58,7 +57,7 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
   }
 
   @Override
-  public @NotNull Source source() {
+  public Source source() {
     return this.source;
   }
 
@@ -73,12 +72,12 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
   }
 
   @Override
-  public @NotNull OptionalLong seed() {
+  public OptionalLong seed() {
     return this.seed;
   }
 
   @Override
-  public @NotNull SoundStop asStop() {
+  public SoundStop asStop() {
     if (this.stop == null) this.stop = SoundStop.namedOnSource(this.name(), this.source());
     return this.stop;
   }
@@ -105,7 +104,7 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("name", this.name()),
       ExaminableProperty.of("source", this.source),
@@ -133,7 +132,7 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull Sound existing) {
+    BuilderImpl(final Sound existing) {
       if (existing instanceof Eager) {
         this.type(((Eager) existing).name);
       } else if (existing instanceof Lazy) {
@@ -149,63 +148,63 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
     }
 
     @Override
-    public @NotNull Builder type(final @NotNull Key type) {
+    public Builder type(final Key type) {
       this.eagerType = requireNonNull(type, "type");
       this.lazyType = null;
       return this;
     }
 
     @Override
-    public @NotNull Builder type(final @NotNull Type type) {
+    public Builder type(final Type type) {
       this.eagerType = requireNonNull(requireNonNull(type, "type").key(), "type.key()");
       this.lazyType = null;
       return this;
     }
 
     @Override
-    public @NotNull Builder type(final @NotNull Supplier<? extends Type> typeSupplier) {
+    public Builder type(final Supplier<? extends Type> typeSupplier) {
       this.lazyType = requireNonNull(typeSupplier, "typeSupplier");
       this.eagerType = null;
       return this;
     }
 
     @Override
-    public @NotNull Builder source(final @NotNull Source source) {
+    public Builder source(final Source source) {
       this.source = requireNonNull(source, "source");
       return this;
     }
 
     @Override
-    public @NotNull Builder source(final Source.@NotNull Provider source) {
+    public Builder source(final Source.Provider source) {
       return this.source(source.soundSource());
     }
 
     @Override
-    public @NotNull Builder volume(final @Range(from = 0, to = Integer.MAX_VALUE) float volume) {
+    public Builder volume(final @Range(from = 0, to = Integer.MAX_VALUE) float volume) {
       this.volume = volume;
       return this;
     }
 
     @Override
-    public @NotNull Builder pitch(final @Range(from = -1, to = 1) float pitch) {
+    public Builder pitch(final @Range(from = -1, to = 1) float pitch) {
       this.pitch = pitch;
       return this;
     }
 
     @Override
-    public @NotNull Builder seed(final long seed) {
+    public Builder seed(final long seed) {
       this.seed = OptionalLong.of(seed);
       return this;
     }
 
     @Override
-    public @NotNull Builder seed(final @NotNull OptionalLong seed) {
+    public Builder seed(final OptionalLong seed) {
       this.seed = requireNonNull(seed, "seed");
       return this;
     }
 
     @Override
-    public @NotNull Sound build() {
+    public Sound build() {
       if (this.eagerType != null) {
         return new Eager(this.eagerType, this.source, this.volume, this.pitch, this.seed);
       } else if (this.lazyType != null) {
@@ -219,13 +218,13 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
   static final class Eager extends SoundImpl {
     final Key name;
 
-    Eager(final @NotNull Key name, final @NotNull Source source, final float volume, final float pitch, final OptionalLong seed) {
+    Eager(final Key name, final Source source, final float volume, final float pitch, final OptionalLong seed) {
       super(source, volume, pitch, seed);
       this.name = name;
     }
 
     @Override
-    public @NotNull Key name() {
+    public Key name() {
       return this.name;
     }
   }
@@ -233,13 +232,13 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
   static final class Lazy extends SoundImpl {
     final Supplier<? extends Type> supplier;
 
-    Lazy(final @NotNull Supplier<? extends Type> supplier, final @NotNull Source source, final float volume, final float pitch, final OptionalLong seed) {
+    Lazy(final Supplier<? extends Type> supplier, final Source source, final float volume, final float pitch, final OptionalLong seed) {
       super(source, volume, pitch, seed);
       this.supplier = supplier;
     }
 
     @Override
-    public @NotNull Key name() {
+    public Key name() {
       return this.supplier.get().key();
     }
   }

--- a/api/src/main/java/net/kyori/adventure/sound/SoundStop.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundStop.java
@@ -27,8 +27,7 @@ import java.util.function.Supplier;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,7 +49,7 @@ public sealed interface SoundStop extends Examinable permits SoundStopImpl {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NotNull SoundStop all() {
+  static SoundStop all() {
     return SoundStopImpl.ALL;
   }
 
@@ -61,7 +60,7 @@ public sealed interface SoundStop extends Examinable permits SoundStopImpl {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NotNull SoundStop named(final @NotNull Key sound) {
+  static SoundStop named(final Key sound) {
     requireNonNull(sound, "sound");
     return new SoundStopImpl(sound, null);
   }
@@ -73,7 +72,7 @@ public sealed interface SoundStop extends Examinable permits SoundStopImpl {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NotNull SoundStop named(final Sound.@NotNull Type sound) {
+  static SoundStop named(final Sound.Type sound) {
     requireNonNull(sound, "sound");
     return new SoundStopImpl(sound.key(), null);
   }
@@ -85,7 +84,7 @@ public sealed interface SoundStop extends Examinable permits SoundStopImpl {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NotNull SoundStop named(final @NotNull Supplier<? extends Sound.Type> sound) {
+  static SoundStop named(final Supplier<? extends Sound.Type> sound) {
     requireNonNull(sound, "sound");
     return new SoundStopImpl(sound.get().key(), null);
   }
@@ -97,7 +96,7 @@ public sealed interface SoundStop extends Examinable permits SoundStopImpl {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NotNull SoundStop source(final Sound.@NotNull Source source) {
+  static SoundStop source(final Sound.Source source) {
     requireNonNull(source, "source");
     return new SoundStopImpl(null, source);
   }
@@ -110,7 +109,7 @@ public sealed interface SoundStop extends Examinable permits SoundStopImpl {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NotNull SoundStop namedOnSource(final @NotNull Key sound, final Sound.@NotNull Source source) {
+  static SoundStop namedOnSource(final Key sound, final Sound.Source source) {
     requireNonNull(sound, "sound");
     requireNonNull(source, "source");
     return new SoundStopImpl(sound, source);
@@ -124,7 +123,7 @@ public sealed interface SoundStop extends Examinable permits SoundStopImpl {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NotNull SoundStop namedOnSource(final Sound.@NotNull Type sound, final Sound.@NotNull Source source) {
+  static SoundStop namedOnSource(final Sound.Type sound, final Sound.Source source) {
     requireNonNull(sound, "sound");
     return namedOnSource(sound.key(), source);
   }
@@ -137,7 +136,7 @@ public sealed interface SoundStop extends Examinable permits SoundStopImpl {
    * @return a sound stopper
    * @since 4.0.0
    */
-  static @NotNull SoundStop namedOnSource(final @NotNull Supplier<? extends Sound.Type> sound, final Sound.@NotNull Source source) {
+  static SoundStop namedOnSource(final Supplier<? extends Sound.Type> sound, final Sound.Source source) {
     requireNonNull(sound, "sound");
     requireNonNull(source, "source");
     return new SoundStopImpl(sound.get().key(), source);

--- a/api/src/main/java/net/kyori/adventure/sound/SoundStopImpl.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundStopImpl.java
@@ -27,14 +27,13 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 record SoundStopImpl(@Nullable Key sound, Sound.@Nullable Source source) implements SoundStop {
   static final SoundStopImpl ALL = new SoundStopImpl(null, null);
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("name", this.sound()),
       ExaminableProperty.of("source", this.source)
@@ -42,7 +41,7 @@ record SoundStopImpl(@Nullable Key sound, Sound.@Nullable Source source) impleme
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractComponentBuilder.java
@@ -37,8 +37,7 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.ARGBLike;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -62,7 +61,7 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
   protected AbstractComponentBuilder() {
   }
 
-  protected AbstractComponentBuilder(final @NotNull C component) {
+  protected AbstractComponentBuilder(final C component) {
     final List<Component> children = component.children();
     if (!children.isEmpty()) {
       this.children = new ArrayList<>(children);
@@ -74,7 +73,7 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B append(final @NotNull Component component) {
+  public B append(final Component component) {
     if (component == Component.empty()) return (B) this;
     this.prepareChildren();
     this.children.add(requireNonNull(component, "component"));
@@ -82,13 +81,13 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
   }
 
   @Override
-  public @NotNull B append(final @NotNull Component@NotNull... components) {
+  public B append(final Component... components) {
     return this.append((ComponentLike[]) components);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B append(final @NotNull ComponentLike@NotNull... components) {
+  public B append(final ComponentLike... components) {
     requireNonNull(components, "components");
     boolean prepared = false;
     for (final ComponentLike componentLike : components) {
@@ -106,7 +105,7 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B append(final @NotNull Iterable<? extends ComponentLike> components) {
+  public B append(final Iterable<? extends ComponentLike> components) {
     requireNonNull(components, "components");
     boolean prepared = false;
     for (final ComponentLike like : components) {
@@ -130,7 +129,7 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B applyDeep(final @NotNull Consumer<? super ComponentBuilder<?, ?>> consumer) {
+  public B applyDeep(final Consumer<? super ComponentBuilder<?, ?>> consumer) {
     this.apply(consumer);
     if (this.children == Collections.<Component>emptyList()) {
       return (B) this;
@@ -146,7 +145,7 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B mapChildren(final @NotNull Function<Component, ? extends Component> function) {
+  public B mapChildren(final Function<Component, ? extends Component> function) {
     if (this.children == Collections.<Component>emptyList()) {
       return (B) this;
     }
@@ -164,7 +163,7 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B mapChildrenDeep(final @NotNull Function<Component, ? extends Component> function) {
+  public B mapChildrenDeep(final Function<Component, ? extends Component> function) {
     if (this.children == Collections.<Component>emptyList()) {
       return (B) this;
     }
@@ -187,13 +186,13 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
   }
 
   @Override
-  public @NotNull List<Component> children() {
+  public List<Component> children() {
     return Collections.unmodifiableList(this.children);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B style(final @NotNull Style style) {
+  public B style(final Style style) {
     this.style = style;
     this.styleBuilder = null;
     return (B) this;
@@ -201,84 +200,84 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B style(final @NotNull Consumer<Style.Builder> consumer) {
+  public B style(final Consumer<Style.Builder> consumer) {
     consumer.accept(this.styleBuilder());
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B font(final @Nullable Key font) {
+  public B font(final @Nullable Key font) {
     this.styleBuilder().font(font);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B color(final @Nullable TextColor color) {
+  public B color(final @Nullable TextColor color) {
     this.styleBuilder().color(color);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B colorIfAbsent(final @Nullable TextColor color) {
+  public B colorIfAbsent(final @Nullable TextColor color) {
     this.styleBuilder().colorIfAbsent(color);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B shadowColor(final @Nullable ARGBLike argb) {
+  public B shadowColor(final @Nullable ARGBLike argb) {
     this.styleBuilder().shadowColor(argb);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B shadowColorIfAbsent(final @Nullable ARGBLike argb) {
+  public B shadowColorIfAbsent(final @Nullable ARGBLike argb) {
     this.styleBuilder().shadowColorIfAbsent(argb);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  public B decoration(final TextDecoration decoration, final TextDecoration.State state) {
     this.styleBuilder().decoration(decoration, state);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  public B decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state) {
     this.styleBuilder().decorationIfAbsent(decoration, state);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B clickEvent(final @Nullable ClickEvent event) {
+  public B clickEvent(final @Nullable ClickEvent event) {
     this.styleBuilder().clickEvent(event);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B hoverEvent(final @Nullable HoverEventSource<?> source) {
+  public B hoverEvent(final @Nullable HoverEventSource<?> source) {
     this.styleBuilder().hoverEvent(source);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B insertion(final @Nullable String insertion) {
+  public B insertion(final @Nullable String insertion) {
     this.styleBuilder().insertion(insertion);
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges) {
+  public B mergeStyle(final Component that, final Set<Style.Merge> merges) {
     final Style thatStyle = requireNonNull(that, "that").style();
     if (thatStyle.isEmpty() && merges.isEmpty()) return (B) this;
     this.styleBuilder().merge(thatStyle, merges);
@@ -287,13 +286,13 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B resetStyle() {
+  public B resetStyle() {
     this.style = null;
     this.styleBuilder = null;
     return (B) this;
   }
 
-  private Style.@NotNull Builder styleBuilder() {
+  private Style.Builder styleBuilder() {
     if (this.styleBuilder == null) {
       if (this.style != null) {
         this.styleBuilder = this.style.toBuilder();
@@ -310,7 +309,7 @@ abstract sealed class AbstractComponentBuilder<C extends Component, B extends Co
     return this.styleBuilder != null || this.style != null;
   }
 
-  protected @NotNull Style buildStyle() {
+  protected Style buildStyle() {
     if (this.styleBuilder != null) {
       return this.styleBuilder.build();
     } else if (this.style != null) {

--- a/api/src/main/java/net/kyori/adventure/text/AbstractNBTComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/AbstractNBTComponentBuilder.java
@@ -23,8 +23,7 @@
  */
 package net.kyori.adventure.text;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -36,7 +35,7 @@ abstract sealed class AbstractNBTComponentBuilder<C extends NBTComponent<C>, B e
   AbstractNBTComponentBuilder() {
   }
 
-  AbstractNBTComponentBuilder(final @NotNull C component) {
+  AbstractNBTComponentBuilder(final C component) {
     super(component);
     this.nbtPath = component.nbtPath();
     this.interpret = component.interpret();
@@ -45,21 +44,21 @@ abstract sealed class AbstractNBTComponentBuilder<C extends NBTComponent<C>, B e
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B nbtPath(final @NotNull String nbtPath) {
+  public B nbtPath(final String nbtPath) {
     this.nbtPath = requireNonNull(nbtPath, "nbtPath");
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B interpret(final boolean interpret) {
+  public B interpret(final boolean interpret) {
     this.interpret = interpret;
     return (B) this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @NotNull B separator(final @Nullable ComponentLike separator) {
+  public B separator(final @Nullable ComponentLike separator) {
     this.separator = ComponentLike.unbox(separator);
     return (B) this;
   }

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponent.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Given an in-game position, this component reads the NBT of the associated block and displays that information.
@@ -52,7 +51,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
    * @return the block position
    * @since 4.0.0
    */
-  @NotNull Pos pos();
+  Pos pos();
 
   /**
    * Sets the block position.
@@ -62,7 +61,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull BlockNBTComponent pos(final @NotNull Pos pos);
+  BlockNBTComponent pos(final Pos pos);
 
   /**
    * Sets the block position to a {@link LocalPos} with the given coordinates.
@@ -74,7 +73,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull BlockNBTComponent localPos(final double left, final double up, final double forwards) {
+  default BlockNBTComponent localPos(final double left, final double up, final double forwards) {
     return this.pos(LocalPos.localPos(left, up, forwards));
   }
 
@@ -88,7 +87,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull BlockNBTComponent worldPos(final WorldPos.@NotNull Coordinate x, final WorldPos.@NotNull Coordinate y, final WorldPos.@NotNull Coordinate z) {
+  default BlockNBTComponent worldPos(final WorldPos.Coordinate x, final WorldPos.Coordinate y, final WorldPos.Coordinate z) {
     return this.pos(WorldPos.worldPos(x, y, z));
   }
 
@@ -102,7 +101,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull BlockNBTComponent absoluteWorldPos(final int x, final int y, final int z) {
+  default BlockNBTComponent absoluteWorldPos(final int x, final int y, final int z) {
     return this.worldPos(WorldPos.Coordinate.absolute(x), WorldPos.Coordinate.absolute(y), WorldPos.Coordinate.absolute(z));
   }
 
@@ -116,12 +115,12 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull BlockNBTComponent relativeWorldPos(final int x, final int y, final int z) {
+  default BlockNBTComponent relativeWorldPos(final int x, final int y, final int z) {
     return this.worldPos(WorldPos.Coordinate.relative(x), WorldPos.Coordinate.relative(y), WorldPos.Coordinate.relative(z));
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("pos", this.pos())
@@ -144,7 +143,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder pos(final @NotNull Pos pos);
+    Builder pos(final Pos pos);
 
     /**
      * Sets the block position to a {@link LocalPos} with the given values.
@@ -156,7 +155,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NotNull Builder localPos(final double left, final double up, final double forwards) {
+    default Builder localPos(final double left, final double up, final double forwards) {
       return this.pos(LocalPos.localPos(left, up, forwards));
     }
 
@@ -170,7 +169,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NotNull Builder worldPos(final WorldPos.@NotNull Coordinate x, final WorldPos.@NotNull Coordinate y, final WorldPos.@NotNull Coordinate z) {
+    default Builder worldPos(final WorldPos.Coordinate x, final WorldPos.Coordinate y, final WorldPos.Coordinate z) {
       return this.pos(WorldPos.worldPos(x, y, z));
     }
 
@@ -184,7 +183,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NotNull Builder absoluteWorldPos(final int x, final int y, final int z) {
+    default Builder absoluteWorldPos(final int x, final int y, final int z) {
       return this.worldPos(WorldPos.Coordinate.absolute(x), WorldPos.Coordinate.absolute(y), WorldPos.Coordinate.absolute(z));
     }
 
@@ -198,7 +197,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NotNull Builder relativeWorldPos(final int x, final int y, final int z) {
+    default Builder relativeWorldPos(final int x, final int y, final int z) {
       return this.worldPos(WorldPos.Coordinate.relative(x), WorldPos.Coordinate.relative(y), WorldPos.Coordinate.relative(z));
     }
   }
@@ -221,7 +220,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @throws IllegalArgumentException if the position was in an invalid format
      * @since 4.0.0
      */
-    static @NotNull Pos fromString(final @NotNull String input) throws IllegalArgumentException {
+    static Pos fromString(final String input) throws IllegalArgumentException {
       final Matcher localMatch = BlockNBTComponentImpl.Tokens.LOCAL_PATTERN.matcher(input);
       if (localMatch.matches()) {
         return BlockNBTComponent.LocalPos.localPos(
@@ -250,7 +249,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @see #fromString(String)
      * @since 4.0.0
      */
-    @NotNull String asString();
+    String asString();
   }
 
   /**
@@ -268,7 +267,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @return a local position
      * @since 4.10.0
      */
-    static @NotNull LocalPos localPos(final double left, final double up, final double forwards) {
+    static LocalPos localPos(final double left, final double up, final double forwards) {
       return new BlockNBTComponentImpl.LocalPosImpl(left, up, forwards);
     }
 
@@ -312,7 +311,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @return a world position
      * @since 4.10.0
      */
-    static @NotNull WorldPos worldPos(final @NotNull Coordinate x, final @NotNull Coordinate y, final @NotNull Coordinate z) {
+    static WorldPos worldPos(final Coordinate x, final Coordinate y, final Coordinate z) {
       return new BlockNBTComponentImpl.WorldPosImpl(x, y, z);
     }
 
@@ -322,7 +321,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @return the x coordinate
      * @since 4.0.0
      */
-    @NotNull Coordinate x();
+    Coordinate x();
 
     /**
      * Gets the y coordinate.
@@ -330,7 +329,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @return the y coordinate
      * @since 4.0.0
      */
-    @NotNull Coordinate y();
+    Coordinate y();
 
     /**
      * Gets the z coordinate.
@@ -338,7 +337,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
      * @return the z coordinate
      * @since 4.0.0
      */
-    @NotNull Coordinate z();
+    Coordinate z();
 
     /**
      * A coordinate component within a {@link WorldPos}.
@@ -353,7 +352,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
        * @return a coordinate
        * @since 4.0.0
        */
-      static @NotNull Coordinate absolute(final int value) {
+      static Coordinate absolute(final int value) {
         return coordinate(value, Type.ABSOLUTE);
       }
 
@@ -364,7 +363,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
        * @return a coordinate
        * @since 4.0.0
        */
-      static @NotNull Coordinate relative(final int value) {
+      static Coordinate relative(final int value) {
         return coordinate(value, Type.RELATIVE);
       }
 
@@ -376,7 +375,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
        * @return a coordinate
        * @since 4.10.0
        */
-      static @NotNull Coordinate coordinate(final int value, final @NotNull Type type) {
+      static Coordinate coordinate(final int value, final Type type) {
         return new BlockNBTComponentImpl.WorldPosImpl.CoordinateImpl(value, type);
       }
 
@@ -394,7 +393,7 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
        * @return the type
        * @since 4.0.0
        */
-      @NotNull Type type();
+      Type type();
 
       /**
        * The type of a coordinate.

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
@@ -30,8 +30,7 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,7 +42,7 @@ record BlockNBTComponentImpl(
   @Nullable Component separator,
   Pos pos
 ) implements BlockNBTComponent {
-  static BlockNBTComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final @NotNull Pos pos) {
+  static BlockNBTComponent create(final List<? extends ComponentLike> children, final Style style, final String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final Pos pos) {
     return new BlockNBTComponentImpl(
       ComponentLike.asComponents(children, IS_NOT_EMPTY),
       requireNonNull(style, "style"),
@@ -55,44 +54,44 @@ record BlockNBTComponentImpl(
   }
 
   @Override
-  public @NotNull BlockNBTComponent nbtPath(final @NotNull String nbtPath) {
+  public BlockNBTComponent nbtPath(final String nbtPath) {
     if (Objects.equals(this.nbtPath, nbtPath)) return this;
     return create(this.children, this.style, nbtPath, this.interpret, this.separator, this.pos);
   }
 
   @Override
-  public @NotNull BlockNBTComponent interpret(final boolean interpret) {
+  public BlockNBTComponent interpret(final boolean interpret) {
     if (this.interpret == interpret) return this;
     return create(this.children, this.style, this.nbtPath, interpret, this.separator, this.pos);
   }
 
   @Override
-  public @NotNull BlockNBTComponent separator(final @Nullable ComponentLike separator) {
+  public BlockNBTComponent separator(final @Nullable ComponentLike separator) {
     return create(this.children, this.style, this.nbtPath, this.interpret, separator, this.pos);
   }
 
   @Override
-  public @NotNull BlockNBTComponent pos(final @NotNull Pos pos) {
+  public BlockNBTComponent pos(final Pos pos) {
     return create(this.children, this.style, this.nbtPath, this.interpret, this.separator, pos);
   }
 
   @Override
-  public @NotNull BlockNBTComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public BlockNBTComponent children(final List<? extends ComponentLike> children) {
     return create(children, this.style, this.nbtPath, this.interpret, this.separator, this.pos);
   }
 
   @Override
-  public @NotNull BlockNBTComponent style(final @NotNull Style style) {
+  public BlockNBTComponent style(final Style style) {
     return create(this.children, style, this.nbtPath, this.interpret, this.separator, this.pos);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -102,19 +101,19 @@ record BlockNBTComponentImpl(
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull BlockNBTComponent component) {
+    BuilderImpl(final BlockNBTComponent component) {
       super(component);
       this.pos = component.pos();
     }
 
     @Override
-    public @NotNull Builder pos(final @NotNull Pos pos) {
+    public Builder pos(final Pos pos) {
       this.pos = requireNonNull(pos, "pos");
       return this;
     }
 
     @Override
-    public @NotNull BlockNBTComponent build() {
+    public BlockNBTComponent build() {
       if (this.nbtPath == null) throw new IllegalStateException("nbt path must be set");
       if (this.pos == null) throw new IllegalStateException("pos must be set");
       return create(this.children, this.buildStyle(), this.nbtPath, this.interpret, this.separator, this.pos);
@@ -123,7 +122,7 @@ record BlockNBTComponentImpl(
 
   record LocalPosImpl(double left, double up, double forwards) implements LocalPos {
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("left", this.left),
         ExaminableProperty.of("up", this.up),
@@ -132,12 +131,12 @@ record BlockNBTComponentImpl(
     }
 
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return String.format("^%f ^%f ^%f", this.left, this.up, this.forwards);
     }
 
     @Override
-    public @NotNull String asString() {
+    public String asString() {
       return Tokens.serializeLocal(this.left) + ' ' + Tokens.serializeLocal(this.up) + ' ' + Tokens.serializeLocal(this.forwards);
     }
   }
@@ -150,7 +149,7 @@ record BlockNBTComponentImpl(
     }
 
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("x", this.x),
         ExaminableProperty.of("y", this.y),
@@ -159,23 +158,23 @@ record BlockNBTComponentImpl(
     }
 
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return this.x.toString() + ' ' + this.y.toString() + ' ' + this.z.toString();
     }
 
     @Override
-    public @NotNull String asString() {
+    public String asString() {
       return Tokens.serializeCoordinate(this.x()) + ' ' + Tokens.serializeCoordinate(this.y()) + ' ' + Tokens.serializeCoordinate(this.z());
     }
 
     record CoordinateImpl(int value, Type type) implements Coordinate {
-      CoordinateImpl(final int value, final @NotNull Type type) {
+      CoordinateImpl(final int value, final Type type) {
         this.value = value;
         this.type = requireNonNull(type, "type");
       }
 
       @Override
-      public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+      public Stream<? extends ExaminableProperty> examinableProperties() {
         return Stream.of(
           ExaminableProperty.of("value", this.value),
           ExaminableProperty.of("type", this.type)
@@ -183,7 +182,7 @@ record BlockNBTComponentImpl(
       }
 
       @Override
-      public @NotNull String toString() {
+      public String toString() {
         return (this.type == Type.RELATIVE ? "~" : "") + this.value;
       }
     }

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -60,9 +60,8 @@ import net.kyori.adventure.util.MonkeyBars;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -132,7 +131,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return an empty component
    * @since 4.0.0
    */
-  static @NotNull TextComponent empty() {
+  static TextComponent empty() {
     return TextComponentImpl.EMPTY;
   }
 
@@ -142,7 +141,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return a text component with a new line character as the content
    * @since 4.0.0
    */
-  static @NotNull TextComponent newline() {
+  static TextComponent newline() {
     return TextComponentImpl.NEWLINE;
   }
 
@@ -152,7 +151,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return a text component with a single space as the content
    * @since 4.0.0
    */
-  static @NotNull TextComponent space() {
+  static TextComponent space() {
     return TextComponentImpl.SPACE;
   }
 
@@ -168,7 +167,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.14.0
    */
   @Contract(pure = true)
-  static @NotNull Component join(final JoinConfiguration.@NotNull Builder configBuilder, final @NotNull ComponentLike@NotNull... components) {
+  static Component join(final JoinConfiguration.Builder configBuilder, final ComponentLike... components) {
     return join(configBuilder, Arrays.asList(components));
   }
 
@@ -184,7 +183,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.14.0
    */
   @Contract(pure = true)
-  static @NotNull Component join(final JoinConfiguration.@NotNull Builder configBuilder, final @NotNull Iterable<? extends ComponentLike> components) {
+  static Component join(final JoinConfiguration.Builder configBuilder, final Iterable<? extends ComponentLike> components) {
     return JoinConfigurationImpl.join(configBuilder.build(), components);
   }
 
@@ -200,7 +199,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.9.0
    */
   @Contract(pure = true)
-  static @NotNull Component join(final @NotNull JoinConfiguration config, final @NotNull ComponentLike@NotNull... components) {
+  static Component join(final JoinConfiguration config, final ComponentLike... components) {
     return join(config, Arrays.asList(components));
   }
 
@@ -216,7 +215,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.9.0
    */
   @Contract(pure = true)
-  static @NotNull Component join(final @NotNull JoinConfiguration config, final @NotNull Iterable<? extends ComponentLike> components) {
+  static Component join(final JoinConfiguration config, final Iterable<? extends ComponentLike> components) {
     return JoinConfigurationImpl.join(config, components);
   }
 
@@ -226,7 +225,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return a collector that can join components
    * @since 4.6.0
    */
-  static @NotNull Collector<Component, ? extends ComponentBuilder<?, ?>, Component> toComponent() {
+  static Collector<Component, ? extends ComponentBuilder<?, ?>, Component> toComponent() {
     return toComponent(Component.empty());
   }
 
@@ -237,7 +236,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return a collector that can join components
    * @since 4.6.0
    */
-  static @NotNull Collector<Component, ? extends ComponentBuilder<?, ?>, Component> toComponent(final @NotNull Component separator) {
+  static Collector<Component, ? extends ComponentBuilder<?, ?>, Component> toComponent(final Component separator) {
     return Collector.of(
       Component::text,
       (builder, add) -> {
@@ -271,7 +270,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static BlockNBTComponent.@NotNull Builder blockNBT() {
+  static BlockNBTComponent.Builder blockNBT() {
     return new BlockNBTComponentImpl.BuilderImpl();
   }
 
@@ -283,7 +282,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NotNull BlockNBTComponent blockNBT(final @NotNull Consumer<? super BlockNBTComponent.Builder> consumer) {
+  static BlockNBTComponent blockNBT(final Consumer<? super BlockNBTComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(blockNBT(), consumer);
   }
 
@@ -296,7 +295,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull BlockNBTComponent blockNBT(final @NotNull String nbtPath, final BlockNBTComponent.@NotNull Pos pos) {
+  static BlockNBTComponent blockNBT(final String nbtPath, final BlockNBTComponent.Pos pos) {
     return blockNBT(nbtPath, NBTComponent.INTERPRET_DEFAULT, pos);
   }
 
@@ -310,7 +309,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull BlockNBTComponent blockNBT(final @NotNull String nbtPath, final boolean interpret, final BlockNBTComponent.@NotNull Pos pos) {
+  static BlockNBTComponent blockNBT(final String nbtPath, final boolean interpret, final BlockNBTComponent.Pos pos) {
     return blockNBT(nbtPath, interpret, null, pos);
   }
 
@@ -325,7 +324,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull BlockNBTComponent blockNBT(final @NotNull String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final BlockNBTComponent.@NotNull Pos pos) {
+  static BlockNBTComponent blockNBT(final String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final BlockNBTComponent.Pos pos) {
     return BlockNBTComponentImpl.create(Collections.emptyList(), Style.empty(), nbtPath, interpret, separator, pos);
   }
 
@@ -342,7 +341,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static EntityNBTComponent.@NotNull Builder entityNBT() {
+  static EntityNBTComponent.Builder entityNBT() {
     return new EntityNBTComponentImpl.BuilderImpl();
   }
 
@@ -354,7 +353,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NotNull EntityNBTComponent entityNBT(final @NotNull Consumer<? super EntityNBTComponent.Builder> consumer) {
+  static EntityNBTComponent entityNBT(final Consumer<? super EntityNBTComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(entityNBT(), consumer);
   }
 
@@ -367,7 +366,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_, _ -> new")
-  static @NotNull EntityNBTComponent entityNBT(final @NotNull String nbtPath, final @NotNull String selector) {
+  static EntityNBTComponent entityNBT(final String nbtPath, final String selector) {
     return entityNBT().nbtPath(nbtPath).selector(selector).build();
   }
 
@@ -384,7 +383,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static KeybindComponent.@NotNull Builder keybind() {
+  static KeybindComponent.Builder keybind() {
     return new KeybindComponentImpl.BuilderImpl();
   }
 
@@ -396,7 +395,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NotNull KeybindComponent keybind(final @NotNull Consumer<? super KeybindComponent.Builder> consumer) {
+  static KeybindComponent keybind(final Consumer<? super KeybindComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(keybind(), consumer);
   }
 
@@ -408,7 +407,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull String keybind) {
+  static KeybindComponent keybind(final String keybind) {
     return keybind(keybind, Style.empty());
   }
 
@@ -420,7 +419,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.9.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind) {
+  static KeybindComponent keybind(final KeybindComponent.KeybindLike keybind) {
     return keybind(requireNonNull(keybind, "keybind").asKeybind(), Style.empty());
   }
 
@@ -433,7 +432,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @NotNull Style style) {
+  static KeybindComponent keybind(final String keybind, final Style style) {
     return KeybindComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), keybind);
   }
 
@@ -446,7 +445,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.9.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind, final @NotNull Style style) {
+  static KeybindComponent keybind(final KeybindComponent.KeybindLike keybind, final Style style) {
     return KeybindComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), requireNonNull(keybind, "keybind").asKeybind());
   }
 
@@ -459,7 +458,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @Nullable TextColor color) {
+  static KeybindComponent keybind(final String keybind, final @Nullable TextColor color) {
     return keybind(keybind, Style.style(color));
   }
 
@@ -472,7 +471,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.9.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind, final @Nullable TextColor color) {
+  static KeybindComponent keybind(final KeybindComponent.KeybindLike keybind, final @Nullable TextColor color) {
     return keybind(requireNonNull(keybind, "keybind").asKeybind(), Style.style(color));
   }
 
@@ -486,7 +485,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static KeybindComponent keybind(final String keybind, final @Nullable TextColor color, final TextDecoration... decorations) {
     return keybind(keybind, Style.style(color, decorations));
   }
 
@@ -500,7 +499,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.9.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static KeybindComponent keybind(final KeybindComponent.KeybindLike keybind, final @Nullable TextColor color, final TextDecoration... decorations) {
     return keybind(requireNonNull(keybind, "keybind").asKeybind(), Style.style(color, decorations));
   }
 
@@ -514,7 +513,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final @NotNull String keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static KeybindComponent keybind(final String keybind, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return keybind(keybind, Style.style(color, decorations));
   }
 
@@ -528,7 +527,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.9.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull KeybindComponent keybind(final KeybindComponent.@NotNull KeybindLike keybind, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static KeybindComponent keybind(final KeybindComponent.KeybindLike keybind, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return keybind(requireNonNull(keybind, "keybind").asKeybind(), Style.style(color, decorations));
   }
 
@@ -545,7 +544,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.25.0
    */
   @Contract(pure = true)
-  static ObjectComponent.@NotNull Builder object() {
+  static ObjectComponent.Builder object() {
     return new ObjectComponentImpl.BuilderImpl();
   }
 
@@ -557,7 +556,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.25.0
    */
   @Contract("_ -> new")
-  static @NotNull ObjectComponent object(final @NotNull Consumer<? super ObjectComponent.Builder> consumer) {
+  static ObjectComponent object(final Consumer<? super ObjectComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(object(), consumer);
   }
 
@@ -569,7 +568,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.25.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull ObjectComponent object(final @NotNull ObjectContents objectContents) {
+  static ObjectComponent object(final ObjectContents objectContents) {
     return ObjectComponentImpl.create(Collections.emptyList(), Style.empty(), objectContents);
   }
 
@@ -586,7 +585,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static ScoreComponent.@NotNull Builder score() {
+  static ScoreComponent.Builder score() {
     return new ScoreComponentImpl.BuilderImpl();
   }
 
@@ -598,7 +597,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NotNull ScoreComponent score(final @NotNull Consumer<? super ScoreComponent.Builder> consumer) {
+  static ScoreComponent score(final Consumer<? super ScoreComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(score(), consumer);
   }
 
@@ -611,7 +610,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull ScoreComponent score(final @NotNull String name, final @NotNull String objective) {
+  static ScoreComponent score(final String name, final String objective) {
     return ScoreComponentImpl.create(Collections.emptyList(), Style.empty(), name, objective);
   }
 
@@ -628,7 +627,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static SelectorComponent.@NotNull Builder selector() {
+  static SelectorComponent.Builder selector() {
     return new SelectorComponentImpl.BuilderImpl();
   }
 
@@ -640,7 +639,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NotNull SelectorComponent selector(final @NotNull Consumer<? super SelectorComponent.Builder> consumer) {
+  static SelectorComponent selector(final Consumer<? super SelectorComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(selector(), consumer);
   }
 
@@ -652,7 +651,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull SelectorComponent selector(final @NotNull String pattern) {
+  static SelectorComponent selector(final String pattern) {
     return selector(pattern, null);
   }
 
@@ -665,7 +664,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull SelectorComponent selector(final @NotNull String pattern, final @Nullable ComponentLike separator) {
+  static SelectorComponent selector(final String pattern, final @Nullable ComponentLike separator) {
     return SelectorComponentImpl.create(Collections.emptyList(), Style.empty(), pattern, separator);
   }
 
@@ -682,7 +681,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static StorageNBTComponent.@NotNull Builder storageNBT() {
+  static StorageNBTComponent.Builder storageNBT() {
     return new StorageNBTComponentImpl.BuilderImpl();
   }
 
@@ -694,7 +693,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NotNull StorageNBTComponent storageNBT(final @NotNull Consumer<? super StorageNBTComponent.Builder> consumer) {
+  static StorageNBTComponent storageNBT(final Consumer<? super StorageNBTComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(storageNBT(), consumer);
   }
 
@@ -707,7 +706,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull StorageNBTComponent storageNBT(final @NotNull String nbtPath, final @NotNull Key storage) {
+  static StorageNBTComponent storageNBT(final String nbtPath, final Key storage) {
     return storageNBT(nbtPath, NBTComponent.INTERPRET_DEFAULT, storage);
   }
 
@@ -721,7 +720,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull StorageNBTComponent storageNBT(final @NotNull String nbtPath, final boolean interpret, final @NotNull Key storage) {
+  static StorageNBTComponent storageNBT(final String nbtPath, final boolean interpret, final Key storage) {
     return storageNBT(nbtPath, interpret, null, storage);
   }
 
@@ -736,7 +735,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull StorageNBTComponent storageNBT(final @NotNull String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final @NotNull Key storage) {
+  static StorageNBTComponent storageNBT(final String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final Key storage) {
     return StorageNBTComponentImpl.create(Collections.emptyList(), Style.empty(), nbtPath, interpret, separator, storage);
   }
 
@@ -753,7 +752,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static TextComponent.@NotNull Builder text() {
+  static TextComponent.Builder text() {
     return new TextComponentImpl.BuilderImpl();
   }
 
@@ -764,7 +763,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return a text component
    * @since 4.10.0
    */
-  static @NotNull TextComponent textOfChildren(final @NotNull ComponentLike@NotNull... components) {
+  static TextComponent textOfChildren(final ComponentLike... components) {
     if (components.length == 0) return empty();
     return TextComponentImpl.create(Arrays.asList(components), Style.empty(), "");
   }
@@ -777,7 +776,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NotNull TextComponent text(final @NotNull Consumer<? super TextComponent.Builder> consumer) {
+  static TextComponent text(final Consumer<? super TextComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(text(), consumer);
   }
 
@@ -789,7 +788,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull TextComponent text(final @NotNull String content) {
+  static TextComponent text(final String content) {
     if (content.isEmpty()) return empty();
     return text(content, Style.empty());
   }
@@ -803,7 +802,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final @NotNull String content, final @NotNull Style style) {
+  static TextComponent text(final String content, final Style style) {
     return TextComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), content);
   }
 
@@ -816,7 +815,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final @NotNull String content, final @Nullable TextColor color) {
+  static TextComponent text(final String content, final @Nullable TextColor color) {
     return text(content, Style.style(color));
   }
 
@@ -830,7 +829,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final @NotNull String content, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TextComponent text(final String content, final @Nullable TextColor color, final TextDecoration... decorations) {
     return text(content, Style.style(color, decorations));
   }
 
@@ -844,7 +843,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final @NotNull String content, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TextComponent text(final String content, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return text(content, Style.style(color, decorations));
   }
 
@@ -856,7 +855,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull TextComponent text(final boolean value) {
+  static TextComponent text(final boolean value) {
     return text(String.valueOf(value));
   }
 
@@ -869,7 +868,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final boolean value, final @NotNull Style style) {
+  static TextComponent text(final boolean value, final Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -882,7 +881,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final boolean value, final @Nullable TextColor color) {
+  static TextComponent text(final boolean value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -896,7 +895,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final boolean value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TextComponent text(final boolean value, final @Nullable TextColor color, final TextDecoration... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -910,7 +909,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final boolean value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TextComponent text(final boolean value, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -922,7 +921,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static @NotNull TextComponent text(final char value) {
+  static TextComponent text(final char value) {
     if (value == '\n') return newline();
     if (value == ' ') return space();
     return text(String.valueOf(value));
@@ -937,7 +936,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final char value, final @NotNull Style style) {
+  static TextComponent text(final char value, final Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -950,7 +949,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final char value, final @Nullable TextColor color) {
+  static TextComponent text(final char value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -964,7 +963,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final char value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TextComponent text(final char value, final @Nullable TextColor color, final TextDecoration... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -978,7 +977,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final char value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TextComponent text(final char value, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -990,7 +989,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull TextComponent text(final double value) {
+  static TextComponent text(final double value) {
     return text(String.valueOf(value));
   }
 
@@ -1003,7 +1002,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final double value, final @NotNull Style style) {
+  static TextComponent text(final double value, final Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -1016,7 +1015,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final double value, final @Nullable TextColor color) {
+  static TextComponent text(final double value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -1030,7 +1029,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final double value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TextComponent text(final double value, final @Nullable TextColor color, final TextDecoration... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1044,7 +1043,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final double value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TextComponent text(final double value, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1056,7 +1055,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull TextComponent text(final float value) {
+  static TextComponent text(final float value) {
     return text(String.valueOf(value));
   }
 
@@ -1069,7 +1068,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final float value, final @NotNull Style style) {
+  static TextComponent text(final float value, final Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -1082,7 +1081,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final float value, final @Nullable TextColor color) {
+  static TextComponent text(final float value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -1096,7 +1095,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final float value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TextComponent text(final float value, final @Nullable TextColor color, final TextDecoration... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1110,7 +1109,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final float value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TextComponent text(final float value, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1122,7 +1121,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull TextComponent text(final int value) {
+  static TextComponent text(final int value) {
     return text(String.valueOf(value));
   }
 
@@ -1135,7 +1134,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final int value, final @NotNull Style style) {
+  static TextComponent text(final int value, final Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -1148,7 +1147,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final int value, final @Nullable TextColor color) {
+  static TextComponent text(final int value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -1162,7 +1161,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final int value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TextComponent text(final int value, final @Nullable TextColor color, final TextDecoration... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1176,7 +1175,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final int value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TextComponent text(final int value, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1188,7 +1187,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull TextComponent text(final long value) {
+  static TextComponent text(final long value) {
     return text(String.valueOf(value));
   }
 
@@ -1201,7 +1200,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final long value, final @NotNull Style style) {
+  static TextComponent text(final long value, final Style style) {
     return text(String.valueOf(value), style);
   }
 
@@ -1214,7 +1213,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TextComponent text(final long value, final @Nullable TextColor color) {
+  static TextComponent text(final long value, final @Nullable TextColor color) {
     return text(String.valueOf(value), color);
   }
 
@@ -1228,7 +1227,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final long value, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TextComponent text(final long value, final @Nullable TextColor color, final TextDecoration... decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1242,7 +1241,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TextComponent text(final long value, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TextComponent text(final long value, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return text(String.valueOf(value), color, decorations);
   }
 
@@ -1262,7 +1261,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.18.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static <C> @NotNull VirtualComponent virtual(final @NotNull Class<C> contextType, final @NotNull VirtualComponentRenderer<C> renderer) {
+  static <C> VirtualComponent virtual(final Class<C> contextType, final VirtualComponentRenderer<C> renderer) {
     requireNonNull(contextType, "context type");
     requireNonNull(renderer, "renderer");
     return VirtualComponentImpl.createVirtual(contextType, renderer);
@@ -1279,7 +1278,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.18.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static <C> @NotNull VirtualComponent virtual(final @NotNull Class<C> contextType, final @NotNull VirtualComponentRenderer<C> renderer, final @NotNull Style style) {
+  static <C> VirtualComponent virtual(final Class<C> contextType, final VirtualComponentRenderer<C> renderer, final Style style) {
     requireNonNull(contextType, "context type");
     requireNonNull(renderer, "renderer");
     return VirtualComponentImpl.createVirtual(contextType, renderer, Collections.emptyList(), style);
@@ -1296,7 +1295,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.18.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static <C> @NotNull VirtualComponent virtual(final @NotNull Class<C> contextType, final @NotNull VirtualComponentRenderer<C> renderer, final @NotNull StyleBuilderApplicable... style) {
+  static <C> VirtualComponent virtual(final Class<C> contextType, final VirtualComponentRenderer<C> renderer, final StyleBuilderApplicable... style) {
     requireNonNull(contextType, "context type");
     requireNonNull(renderer, "renderer");
     return VirtualComponentImpl.createVirtual(contextType, renderer, Collections.emptyList(), Style.style(style));
@@ -1313,7 +1312,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.18.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static <C> @NotNull VirtualComponent virtual(final @NotNull Class<C> contextType, final @NotNull VirtualComponentRenderer<C> renderer, final @NotNull Iterable<StyleBuilderApplicable> style) {
+  static <C> VirtualComponent virtual(final Class<C> contextType, final VirtualComponentRenderer<C> renderer, final Iterable<StyleBuilderApplicable> style) {
     requireNonNull(contextType, "context type");
     requireNonNull(renderer, "renderer");
     return VirtualComponentImpl.createVirtual(contextType, renderer, Collections.emptyList(), Style.style(style));
@@ -1332,7 +1331,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  static TranslatableComponent.@NotNull Builder translatable() {
+  static TranslatableComponent.Builder translatable() {
     return new TranslatableComponentImpl.BuilderImpl();
   }
 
@@ -1344,7 +1343,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract("_ -> new")
-  static @NotNull TranslatableComponent translatable(final @NotNull Consumer<? super TranslatableComponent.Builder> consumer) {
+  static TranslatableComponent translatable(final Consumer<? super TranslatableComponent.Builder> consumer) {
     return AbstractBuilder.configureAndBuild(translatable(), consumer);
   }
 
@@ -1356,7 +1355,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key) {
+  static TranslatableComponent translatable(final String key) {
     return translatable(key, Style.empty());
   }
 
@@ -1368,7 +1367,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable) {
+  static TranslatableComponent translatable(final Translatable translatable) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), Style.empty());
   }
 
@@ -1382,7 +1381,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback) {
+  static TranslatableComponent translatable(final String key, final @Nullable String fallback) {
     return translatable(key, fallback, Style.empty());
   }
 
@@ -1396,7 +1395,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable String fallback) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, Style.empty());
   }
 
@@ -1409,7 +1408,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style) {
+  static TranslatableComponent translatable(final String key, final Style style) {
     return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, null, Collections.emptyList());
   }
 
@@ -1422,7 +1421,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull Style style) {
+  static TranslatableComponent translatable(final Translatable translatable, final Style style) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), style);
   }
 
@@ -1437,7 +1436,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style) {
+  static TranslatableComponent translatable(final String key, final @Nullable String fallback, final Style style) {
     return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, fallback, Collections.emptyList());
   }
 
@@ -1452,7 +1451,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable String fallback, final Style style) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style);
   }
 
@@ -1467,7 +1466,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull StyleBuilderApplicable... style) {
+  static TranslatableComponent translatable(final String key, final @Nullable String fallback, final StyleBuilderApplicable... style) {
     return translatable(requireNonNull(key, "key"), fallback, Style.style(style));
   }
 
@@ -1482,7 +1481,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Iterable<StyleBuilderApplicable> style) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable String fallback, final Iterable<StyleBuilderApplicable> style) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, Style.style(style));
   }
 
@@ -1497,7 +1496,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final String key, final @Nullable String fallback, final ComponentLike... args) {
     return translatable(key, fallback, Style.empty(), args);
   }
 
@@ -1512,7 +1511,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable String fallback, final ComponentLike... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args);
   }
 
@@ -1528,7 +1527,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final String key, final @Nullable String fallback, final Style style, final ComponentLike... args) {
     return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, fallback, requireNonNull(args, "args"));
   }
 
@@ -1544,7 +1543,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable String fallback, final Style style, final ComponentLike... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style, args);
   }
 
@@ -1560,7 +1559,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final String key, final @Nullable String fallback, final Style style, final List<? extends ComponentLike> args) {
     return TranslatableComponentImpl.create(Collections.emptyList(), style, key, fallback, requireNonNull(args, "args"));
   }
 
@@ -1576,7 +1575,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable String fallback, final Style style, final List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, style, args);
   }
 
@@ -1592,7 +1591,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull Iterable<StyleBuilderApplicable> style) {
+  static TranslatableComponent translatable(final String key, final @Nullable String fallback, final List<? extends ComponentLike> args, final Iterable<StyleBuilderApplicable> style) {
     return TranslatableComponentImpl.create(Collections.emptyList(), Style.style(style), key, fallback, requireNonNull(args, "args"));
   }
 
@@ -1608,7 +1607,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull Iterable<StyleBuilderApplicable> style) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable String fallback, final List<? extends ComponentLike> args, final Iterable<StyleBuilderApplicable> style) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args, style);
   }
 
@@ -1624,7 +1623,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull StyleBuilderApplicable... style) {
+  static TranslatableComponent translatable(final String key, final @Nullable String fallback, final List<? extends ComponentLike> args, final StyleBuilderApplicable... style) {
     return TranslatableComponentImpl.create(Collections.emptyList(), Style.style(style), key, fallback, requireNonNull(args, "args"));
   }
 
@@ -1640,7 +1639,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @sinceMinecraft 1.19.4
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args, final @NotNull StyleBuilderApplicable... style) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable String fallback, final List<? extends ComponentLike> args, final StyleBuilderApplicable... style) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), fallback, args, style);
   }
 
@@ -1653,7 +1652,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color) {
+  static TranslatableComponent translatable(final String key, final @Nullable TextColor color) {
     return translatable(key, Style.style(color));
   }
 
@@ -1666,7 +1665,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable TextColor color) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color);
   }
 
@@ -1680,7 +1679,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TranslatableComponent translatable(final String key, final @Nullable TextColor color, final TextDecoration... decorations) {
     return translatable(key, Style.style(color, decorations));
   }
 
@@ -1694,7 +1693,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable TextColor color, final TextDecoration... decorations) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, decorations);
   }
 
@@ -1708,7 +1707,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TranslatableComponent translatable(final String key, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return translatable(key, Style.style(color, decorations));
   }
 
@@ -1722,7 +1721,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, decorations);
   }
 
@@ -1735,7 +1734,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final String key, final ComponentLike... args) {
     return translatable(key, Style.empty(), args);
   }
 
@@ -1748,7 +1747,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final Translatable translatable, final ComponentLike... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), args);
   }
 
@@ -1762,7 +1761,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final String key, final Style style, final ComponentLike... args) {
     return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, null, requireNonNull(args, "args"));
   }
 
@@ -1776,7 +1775,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull Style style, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final Translatable translatable, final Style style, final ComponentLike... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), style, args);
   }
 
@@ -1790,7 +1789,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final String key, final @Nullable TextColor color, final ComponentLike... args) {
     return translatable(key, Style.style(color), args);
   }
 
@@ -1804,7 +1803,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable TextColor color, final ComponentLike... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, args);
   }
 
@@ -1819,7 +1818,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final String key, final @Nullable TextColor color, final Set<TextDecoration> decorations, final ComponentLike... args) {
     return translatable(key, Style.style(color, decorations), args);
   }
 
@@ -1834,7 +1833,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull ComponentLike@NotNull... args) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable TextColor color, final Set<TextDecoration> decorations, final ComponentLike... args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, decorations, args);
   }
 
@@ -1847,7 +1846,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final String key, final List<? extends ComponentLike> args) {
     return TranslatableComponentImpl.create(Collections.emptyList(), Style.empty(), key, null, requireNonNull(args, "args"));
   }
 
@@ -1860,7 +1859,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final Translatable translatable, final List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), args);
   }
 
@@ -1874,7 +1873,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final String key, final Style style, final List<? extends ComponentLike> args) {
     return TranslatableComponentImpl.create(Collections.emptyList(), requireNonNull(style, "style"), key, null, requireNonNull(args, "args"));
   }
 
@@ -1888,7 +1887,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @NotNull Style style, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final Translatable translatable, final Style style, final List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), style, args);
   }
 
@@ -1902,7 +1901,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final String key, final @Nullable TextColor color, final List<? extends ComponentLike> args) {
     return translatable(key, Style.style(color), args);
   }
 
@@ -1916,7 +1915,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable TextColor color, final List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, args);
   }
 
@@ -1931,7 +1930,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull String key, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final String key, final @Nullable TextColor color, final Set<TextDecoration> decorations, final List<? extends ComponentLike> args) {
     return translatable(key, Style.style(color, decorations), args);
   }
 
@@ -1946,7 +1945,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.8.0
    */
   @Contract(value = "_, _, _, _ -> new", pure = true)
-  static @NotNull TranslatableComponent translatable(final @NotNull Translatable translatable, final @Nullable TextColor color, final @NotNull Set<TextDecoration> decorations, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent translatable(final Translatable translatable, final @Nullable TextColor color, final Set<TextDecoration> decorations, final List<? extends ComponentLike> args) {
     return translatable(requireNonNull(translatable, "translatable").translationKey(), color, decorations, args);
   }
 
@@ -1956,7 +1955,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the unmodifiable list of children
    * @since 4.0.0
    */
-  @Unmodifiable @NotNull List<Component> children();
+  @Unmodifiable List<Component> children();
 
   /**
    * Sets the list of children.
@@ -1968,7 +1967,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull Component children(final @NotNull List<? extends ComponentLike> children);
+  Component children(final List<? extends ComponentLike> children);
 
   /**
    * Checks if this component contains a component.
@@ -1981,7 +1980,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    *     component, {@code false} otherwise
    * @since 4.0.0
    */
-  default boolean contains(final @NotNull Component that) {
+  default boolean contains(final Component that) {
     return this.contains(that, EQUALS_IDENTITY);
   }
 
@@ -1994,7 +1993,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    *     component, {@code false} otherwise
    * @since 4.8.0
    */
-  default boolean contains(final @NotNull Component that, final @NotNull BiPredicate<? super Component, ? super Component> equals) {
+  default boolean contains(final Component that, final BiPredicate<? super Component, ? super Component> equals) {
     if (equals.test(this, that)) return true;
     for (final Component child : this.children()) {
       if (child.contains(that, equals)) return true;
@@ -2026,7 +2025,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull Component append(final @NotNull Component component) {
+  default Component append(final Component component) {
     return this.append((ComponentLike) component);
   }
 
@@ -2037,7 +2036,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return a component with the component added
    * @since 4.0.0
    */
-  default @NotNull Component append(final @NotNull ComponentLike like) {
+  default Component append(final ComponentLike like) {
     requireNonNull(like, "like");
     final Component component = like.asComponent();
     requireNonNull(component, "component");
@@ -2054,7 +2053,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull Component append(final @NotNull ComponentBuilder<?, ?> builder) {
+  default Component append(final ComponentBuilder<?, ?> builder) {
     return this.append(builder.build());
   }
 
@@ -2065,7 +2064,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.12.0
    */
   @Contract(pure = true)
-  default @NotNull Component appendNewline() {
+  default Component appendNewline() {
     return this.append(newline());
   }
 
@@ -2076,7 +2075,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.12.0
    */
   @Contract(pure = true)
-  default @NotNull Component appendSpace() {
+  default Component appendSpace() {
     return this.append(space());
   }
 
@@ -2088,7 +2087,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.20.0
    */
   @Contract(pure = true)
-  default @NotNull Component append(final @NotNull ComponentLike @NotNull... components) {
+  default Component append(final ComponentLike ... components) {
     if (components.length == 0) return this;
 
     final List<ComponentLike> newChildren = new ArrayList<>(components.length + this.children().size());
@@ -2105,7 +2104,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.20.0
    */
   @Contract(pure = true)
-  default @NotNull Component append(final @NotNull List<? extends ComponentLike> components) {
+  default Component append(final List<? extends ComponentLike> components) {
     if (components.isEmpty()) return this;
     if (this.children().isEmpty()) return this.children(components);
 
@@ -2125,7 +2124,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.10.0
    */
   @Contract(pure = true)
-  default @NotNull Component applyFallbackStyle(final @NotNull Style style) {
+  default Component applyFallbackStyle(final Style style) {
     Objects.requireNonNull(style, "style");
     return this.style(this.style().merge(style, Style.Merge.Strategy.IF_ABSENT_ON_TARGET));
   }
@@ -2140,7 +2139,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.10.0
    */
   @Contract(pure = true)
-  default @NotNull Component applyFallbackStyle(final @NotNull StyleBuilderApplicable@NotNull... style) {
+  default Component applyFallbackStyle(final StyleBuilderApplicable... style) {
     return this.applyFallbackStyle(Style.style(style));
   }
 
@@ -2150,7 +2149,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the style of this component
    * @since 4.0.0
    */
-  @NotNull Style style();
+  Style style();
 
   /**
    * Sets the style of this component.
@@ -2160,7 +2159,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull Component style(final @NotNull Style style);
+  Component style(final Style style);
 
   /**
    * Sets the style of this component.
@@ -2170,7 +2169,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull Component style(final @NotNull Consumer<Style.Builder> consumer) {
+  default Component style(final Consumer<Style.Builder> consumer) {
     return this.style(this.style().edit(consumer));
   }
 
@@ -2183,7 +2182,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull Component style(final @NotNull Consumer<Style.Builder> consumer, final Style.Merge.@NotNull Strategy strategy) {
+  default Component style(final Consumer<Style.Builder> consumer, final Style.Merge.Strategy strategy) {
     return this.style(this.style().edit(consumer, strategy));
   }
 
@@ -2195,7 +2194,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull Component style(final Style.@NotNull Builder style) {
+  default Component style(final Style.Builder style) {
     return this.style(style.build());
   }
 
@@ -2207,7 +2206,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull Component mergeStyle(final @NotNull Component that) {
+  default Component mergeStyle(final Component that) {
     return this.mergeStyle(that, Style.Merge.all());
   }
 
@@ -2220,7 +2219,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull Component mergeStyle(final @NotNull Component that, final Style.@NotNull Merge@NotNull... merges) {
+  default Component mergeStyle(final Component that, final Style.Merge... merges) {
     return this.mergeStyle(that, Style.Merge.merges(merges));
   }
 
@@ -2233,7 +2232,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Contract(pure = true)
-  default @NotNull Component mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges) {
+  default Component mergeStyle(final Component that, final Set<Style.Merge> merges) {
     return this.style(this.style().merge(that.style(), merges));
   }
 
@@ -2256,7 +2255,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.10.0
    */
   @Override
-  default @NotNull Component font(final @Nullable Key key) {
+  default Component font(final @Nullable Key key) {
     return this.style(this.style().font(key));
   }
 
@@ -2285,7 +2284,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component color(final @Nullable TextColor color) {
+  default Component color(final @Nullable TextColor color) {
     return this.style(this.style().color(color));
   }
 
@@ -2298,7 +2297,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component colorIfAbsent(final @Nullable TextColor color) {
+  default Component colorIfAbsent(final @Nullable TextColor color) {
     if (this.color() == null) return this.color(color);
     return this;
   }
@@ -2312,7 +2311,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component shadowColor(final @Nullable ARGBLike argb) {
+  default Component shadowColor(final @Nullable ARGBLike argb) {
     return this.style(this.style().shadowColor(argb));
   }
 
@@ -2325,7 +2324,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component shadowColorIfAbsent(final @Nullable ARGBLike argb) {
+  default Component shadowColorIfAbsent(final @Nullable ARGBLike argb) {
     if (this.shadowColor() == null) return this.shadowColor(argb);
     return this;
   }
@@ -2339,7 +2338,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Override
-  default boolean hasDecoration(final @NotNull TextDecoration decoration) {
+  default boolean hasDecoration(final TextDecoration decoration) {
     return StyleGetter.super.hasDecoration(decoration);
   }
 
@@ -2352,7 +2351,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component decorate(final @NotNull TextDecoration decoration) {
+  default Component decorate(final TextDecoration decoration) {
     return StyleSetter.super.decorate(decoration);
   }
 
@@ -2366,7 +2365,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Override
-  default TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
+  default TextDecoration.State decoration(final TextDecoration decoration) {
     return this.style().decoration(decoration);
   }
 
@@ -2381,7 +2380,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component decoration(final @NotNull TextDecoration decoration, final boolean flag) {
+  default Component decoration(final TextDecoration decoration, final boolean flag) {
     return StyleSetter.super.decoration(decoration, flag);
   }
 
@@ -2398,7 +2397,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  default Component decoration(final TextDecoration decoration, final TextDecoration.State state) {
     return this.style(this.style().decoration(decoration, state));
   }
 
@@ -2412,10 +2411,10 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.12.0
    */
   @Override
-  default @NotNull Component decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  default Component decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state) {
     requireNonNull(state, "state");
     // Not delegating this method prevents object creation if decoration is NOT absent
-    final TextDecoration.@NotNull State oldState = this.decoration(decoration);
+    final TextDecoration.State oldState = this.decoration(decoration);
     if (oldState == TextDecoration.State.NOT_SET) {
       return this.style(this.style().decoration(decoration, state));
     }
@@ -2429,7 +2428,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.0.0
    */
   @Override
-  default @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
+  default Map<TextDecoration, TextDecoration.State> decorations() {
     return this.style().decorations();
   }
 
@@ -2444,7 +2443,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
+  default Component decorations(final Map<TextDecoration, TextDecoration.State> decorations) {
     return this.style(this.style().decorations(decorations));
   }
 
@@ -2468,7 +2467,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component clickEvent(final @Nullable ClickEvent<?> event) {
+  default Component clickEvent(final @Nullable ClickEvent<?> event) {
     return this.style(this.style().clickEvent(event));
   }
 
@@ -2492,7 +2491,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component hoverEvent(final @Nullable HoverEventSource<?> source) {
+  default Component hoverEvent(final @Nullable HoverEventSource<?> source) {
     return this.style(this.style().hoverEvent(source));
   }
 
@@ -2516,7 +2515,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @Override
-  default @NotNull Component insertion(final @Nullable String insertion) {
+  default Component insertion(final @Nullable String insertion) {
     return this.style(this.style().insertion(insertion));
   }
 
@@ -2540,7 +2539,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @ScopedComponentOverrideNotRequired
-  default @NotNull Component replaceText(final @NotNull Consumer<TextReplacementConfig.Builder> configurer) {
+  default Component replaceText(final Consumer<TextReplacementConfig.Builder> configurer) {
     requireNonNull(configurer, "configurer");
     return this.replaceText(AbstractBuilder.configureAndBuild(TextReplacementConfig.builder(), configurer));
   }
@@ -2554,7 +2553,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    */
   @Contract(pure = true)
   @ScopedComponentOverrideNotRequired
-  default @NotNull Component replaceText(final @NotNull TextReplacementConfig config) {
+  default Component replaceText(final TextReplacementConfig config) {
     requireNonNull(config, "replacement");
     return TextReplacementRenderer.INSTANCE.render(this, ((TextReplacementConfigImpl) config).createState());
   }
@@ -2566,7 +2565,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.9.0
    */
   @ScopedComponentOverrideNotRequired
-  default @NotNull Component compact() {
+  default Component compact() {
     return this.compact(null);
   }
 
@@ -2579,7 +2578,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @since 4.25.0
    */
   @ScopedComponentOverrideNotRequired
-  default @NotNull Component compact(final @Nullable Style parentStyle) {
+  default Component compact(final @Nullable Style parentStyle) {
     return ComponentCompaction.compact(this, parentStyle);
   }
 
@@ -2591,7 +2590,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the iterable
    * @since 4.9.0
    */
-  default @NotNull Iterable<Component> iterable(final @NotNull ComponentIteratorType type, final @NotNull ComponentIteratorFlag@Nullable... flags) {
+  default Iterable<Component> iterable(final ComponentIteratorType type, final ComponentIteratorFlag@Nullable... flags) {
     return this.iterable(type, flags == null ? Collections.emptySet() : MonkeyBars.enumSet(ComponentIteratorFlag.class, flags));
   }
 
@@ -2603,7 +2602,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the iterable
    * @since 4.9.0
    */
-  default @NotNull Iterable<Component> iterable(final @NotNull ComponentIteratorType type, final @NotNull Set<ComponentIteratorFlag> flags) {
+  default Iterable<Component> iterable(final ComponentIteratorType type, final Set<ComponentIteratorFlag> flags) {
     requireNonNull(type, "type");
     requireNonNull(flags, "flags");
     return new ForwardingIterator<>(() -> this.iterator(type, flags), () -> this.spliterator(type, flags));
@@ -2619,7 +2618,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the iterator
    * @since 4.9.0
    */
-  default @NotNull Iterator<Component> iterator(final @NotNull ComponentIteratorType type, final @NotNull ComponentIteratorFlag@Nullable... flags) {
+  default Iterator<Component> iterator(final ComponentIteratorType type, final ComponentIteratorFlag@Nullable... flags) {
     return this.iterator(type, flags == null ? Collections.emptySet() : MonkeyBars.enumSet(ComponentIteratorFlag.class, flags));
   }
 
@@ -2633,7 +2632,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the iterator
    * @since 4.9.0
    */
-  default @NotNull Iterator<Component> iterator(final @NotNull ComponentIteratorType type, final @NotNull Set<ComponentIteratorFlag> flags) {
+  default Iterator<Component> iterator(final ComponentIteratorType type, final Set<ComponentIteratorFlag> flags) {
     return new ComponentIterator(this, requireNonNull(type, "type"), requireNonNull(flags, "flags"));
   }
 
@@ -2647,7 +2646,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the spliterator
    * @since 4.9.0
    */
-  default @NotNull Spliterator<Component> spliterator(final @NotNull ComponentIteratorType type, final @NotNull ComponentIteratorFlag@Nullable... flags) {
+  default Spliterator<Component> spliterator(final ComponentIteratorType type, final ComponentIteratorFlag@Nullable... flags) {
     return this.spliterator(type, flags == null ? Collections.emptySet() : MonkeyBars.enumSet(ComponentIteratorFlag.class, flags));
   }
 
@@ -2661,7 +2660,7 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the spliterator
    * @since 4.9.0
    */
-  default @NotNull Spliterator<Component> spliterator(final @NotNull ComponentIteratorType type, final @NotNull Set<ComponentIteratorFlag> flags) {
+  default Spliterator<Component> spliterator(final ComponentIteratorType type, final Set<ComponentIteratorFlag> flags) {
     return Spliterators.spliteratorUnknownSize(this.iterator(type, flags), Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED);
   }
 
@@ -2671,25 +2670,25 @@ public sealed interface Component extends ComponentBuilderApplicable, ComponentL
    * @return the builder
    * @since 5.0.0
    */
-  @NotNull ComponentBuilder<?, ?> toBuilder();
+  ComponentBuilder<?, ?> toBuilder();
 
   @Override
-  default void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component) {
+  default void componentBuilderApply(final ComponentBuilder<?, ?> component) {
     component.append(this);
   }
 
   @Override
-  default @NotNull Component asComponent() {
+  default Component asComponent() {
     return this;
   }
 
   @Override
-  default @NotNull HoverEvent<Component> asHoverEvent(final @NotNull UnaryOperator<Component> op) {
+  default HoverEvent<Component> asHoverEvent(final UnaryOperator<Component> op) {
     return HoverEvent.showText(op.apply(this));
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("style", this.style()),
       ExaminableProperty.of("children", this.children())

--- a/api/src/main/java/net/kyori/adventure/text/ComponentApplicable.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentApplicable.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.text;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Something that can be applied to a {@link Component}.
  *
@@ -39,5 +37,5 @@ public interface ComponentApplicable {
    * @return a component with something applied.
    * @since 4.0.0
    */
-  @NotNull Component componentApply(final @NotNull Component component);
+  Component componentApply(final Component component);
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentBuilder.java
@@ -38,8 +38,7 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A component builder.
@@ -58,7 +57,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B append(final @NotNull Component component);
+  B append(final Component component);
 
   /**
    * Appends a component to this component.
@@ -68,7 +67,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  default @NotNull B append(final @NotNull ComponentLike component) {
+  default B append(final ComponentLike component) {
     return this.append(component.asComponent());
   }
 
@@ -80,7 +79,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  default @NotNull B append(final @NotNull ComponentBuilder<?, ?> builder) {
+  default B append(final ComponentBuilder<?, ?> builder) {
     return this.append(builder.build());
   }
 
@@ -92,7 +91,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B append(final @NotNull Component@NotNull... components);
+  B append(final Component... components);
 
   /**
    * Appends components to this component.
@@ -102,7 +101,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B append(final @NotNull ComponentLike@NotNull... components);
+  B append(final ComponentLike... components);
 
   /**
    * Appends components to this component.
@@ -112,7 +111,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B append(final @NotNull Iterable<? extends ComponentLike> components);
+  B append(final Iterable<? extends ComponentLike> components);
 
   /**
    * Appends a newline to this component.
@@ -120,7 +119,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @return this builder
    * @since 4.12.0
    */
-  default @NotNull B appendNewline() {
+  default B appendNewline() {
     return this.append(Component.newline());
   }
 
@@ -130,7 +129,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @return this builder
    * @since 4.12.0
    */
-  default @NotNull B appendSpace() {
+  default B appendSpace() {
     return this.append(Component.space());
   }
 
@@ -143,7 +142,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @SuppressWarnings("unchecked")
-  default @NotNull B apply(final @NotNull Consumer<? super ComponentBuilder<?, ?>> consumer) {
+  default B apply(final Consumer<? super ComponentBuilder<?, ?>> consumer) {
     consumer.accept(this);
     return (B) this;
   }
@@ -156,7 +155,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B applyDeep(final @NotNull Consumer<? super ComponentBuilder<?, ?>> action);
+  B applyDeep(final Consumer<? super ComponentBuilder<?, ?>> action);
 
   /**
    * Replaces each child of this component with the resultant component from the function.
@@ -166,7 +165,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B mapChildren(final @NotNull Function<Component, ? extends Component> function);
+  B mapChildren(final Function<Component, ? extends Component> function);
 
   /**
    * Replaces each child and sub-child of this component with the resultant
@@ -177,7 +176,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B mapChildrenDeep(final @NotNull Function<Component, ? extends Component> function);
+  B mapChildrenDeep(final Function<Component, ? extends Component> function);
 
   /**
    * Get an unmodifiable list containing all children currently in this builder.
@@ -185,7 +184,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @return the list of children
    * @since 4.6.0
    */
-  @NotNull List<Component> children();
+  List<Component> children();
 
   /**
    * Sets the style.
@@ -195,7 +194,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B style(final @NotNull Style style);
+  B style(final Style style);
 
   /**
    * Configures the style.
@@ -205,7 +204,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B style(final @NotNull Consumer<Style.Builder> consumer);
+  B style(final Consumer<Style.Builder> consumer);
 
   /**
    * Sets the font of this component.
@@ -216,7 +215,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  @NotNull B font(final @Nullable Key font);
+  B font(final @Nullable Key font);
 
   /**
    * Sets the color of this component.
@@ -227,7 +226,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  @NotNull B color(final @Nullable TextColor color);
+  B color(final @Nullable TextColor color);
 
   /**
    * Sets the color of this component if there isn't one set already.
@@ -238,7 +237,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  @NotNull B colorIfAbsent(final @Nullable TextColor color);
+  B colorIfAbsent(final @Nullable TextColor color);
 
   /**
    * Sets the state of a set of decorations to {@code flag} on this component.
@@ -251,7 +250,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_, _ -> this")
   @Override
-  default @NotNull B decorations(final @NotNull Set<TextDecoration> decorations, final boolean flag) {
+  default B decorations(final Set<TextDecoration> decorations, final boolean flag) {
     return MutableStyleSetter.super.decorations(decorations, flag);
   }
 
@@ -264,7 +263,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  default @NotNull B decorate(final @NotNull TextDecoration decoration) {
+  default B decorate(final TextDecoration decoration) {
     return this.decoration(decoration, TextDecoration.State.TRUE);
   }
 
@@ -277,7 +276,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  default @NotNull B decorate(final @NotNull TextDecoration@NotNull... decorations) {
+  default B decorate(final TextDecoration... decorations) {
     return MutableStyleSetter.super.decorate(decorations);
   }
 
@@ -292,7 +291,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_, _ -> this")
   @Override
-  default @NotNull B decoration(final @NotNull TextDecoration decoration, final boolean flag) {
+  default B decoration(final TextDecoration decoration, final boolean flag) {
     return this.decoration(decoration, TextDecoration.State.byBoolean(flag));
   }
 
@@ -307,7 +306,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  default @NotNull B decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
+  default B decorations(final Map<TextDecoration, TextDecoration.State> decorations) {
     return MutableStyleSetter.super.decorations(decorations);
   }
 
@@ -324,7 +323,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_, _ -> this")
   @Override
-  @NotNull B decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+  B decoration(final TextDecoration decoration, final TextDecoration.State state);
 
   /**
    * Sets the state of a decoration on this component to {@code state} if the current state of
@@ -337,7 +336,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_, _ -> this")
   @Override
-  @NotNull B decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+  B decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state);
 
   /**
    * Sets the click event of this component.
@@ -348,7 +347,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  @NotNull B clickEvent(final @Nullable ClickEvent event);
+  B clickEvent(final @Nullable ClickEvent event);
 
   /**
    * Sets the hover event of this component.
@@ -359,7 +358,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  @NotNull B hoverEvent(final @Nullable HoverEventSource<?> source);
+  B hoverEvent(final @Nullable HoverEventSource<?> source);
 
   /**
    * Sets the string to be inserted when this component is shift-clicked.
@@ -370,7 +369,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @Override
-  @NotNull B insertion(final @Nullable String insertion);
+  B insertion(final @Nullable String insertion);
 
   /**
    * Merges styling from another component into this component.
@@ -380,7 +379,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  default @NotNull B mergeStyle(final @NotNull Component that) {
+  default B mergeStyle(final Component that) {
     return this.mergeStyle(that, Style.Merge.all());
   }
 
@@ -393,7 +392,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_, _ -> this")
-  default @NotNull B mergeStyle(final @NotNull Component that, final Style.@NotNull Merge@NotNull... merges) {
+  default B mergeStyle(final Component that, final Style.Merge... merges) {
     return this.mergeStyle(that, Style.Merge.merges(merges));
   }
 
@@ -406,7 +405,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @since 4.0.0
    */
   @Contract("_, _ -> this")
-  @NotNull B mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges);
+  B mergeStyle(final Component that, final Set<Style.Merge> merges);
 
   /**
    * Resets all styling on this component.
@@ -414,7 +413,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @return this builder
    * @since 4.0.0
    */
-  @NotNull B resetStyle();
+  B resetStyle();
 
   /**
    * Build a component.
@@ -422,7 +421,7 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    * @return the component
    */
   @Override
-  @NotNull C build();
+  C build();
 
   /**
    * Applies {@code applicable}.
@@ -433,18 +432,18 @@ public sealed interface ComponentBuilder<C extends Component, B extends Componen
    */
   @Contract("_ -> this")
   @SuppressWarnings("unchecked")
-  default @NotNull B applicableApply(final @NotNull ComponentBuilderApplicable applicable) {
+  default B applicableApply(final ComponentBuilderApplicable applicable) {
     applicable.componentBuilderApply(this);
     return (B) this;
   }
 
   @Override
-  default void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component) {
+  default void componentBuilderApply(final ComponentBuilder<?, ?> component) {
     component.append(this);
   }
 
   @Override
-  default @NotNull Component asComponent() {
+  default Component asComponent() {
     return this.build();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentBuilderApplicable.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentBuilderApplicable.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text;
 
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can be applied to a {@link ComponentBuilder}.
@@ -42,5 +41,5 @@ public interface ComponentBuilderApplicable {
    * @since 4.0.0
    */
   @Contract(mutates = "param")
-  void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component);
+  void componentBuilderApply(final ComponentBuilder<?, ?> component);
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentCompaction.java
@@ -29,9 +29,8 @@ import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.jspecify.annotations.Nullable;
 
 final class ComponentCompaction {
   @VisibleForTesting
@@ -40,7 +39,7 @@ final class ComponentCompaction {
   private ComponentCompaction() {
   }
 
-  static Component compact(final @NotNull Component self, final @Nullable Style parentStyle) {
+  static Component compact(final Component self, final @Nullable Style parentStyle) {
     final List<Component> children = self.children();
     Component optimized = self.children(Collections.emptyList());
     if (parentStyle != null) {
@@ -183,7 +182,7 @@ final class ComponentCompaction {
   * @param parentStyle style from component's parents, for context
   * @return a new, simplified style
   */
-  private static @NotNull Style simplifyStyleForBlank(final @NotNull Style style, final @Nullable Style parentStyle) {
+  private static Style simplifyStyleForBlank(final Style style, final @Nullable Style parentStyle) {
     if (!SIMPLIFY_STYLE_FOR_BLANK_COMPONENTS) {
       // todo: can this be fixed a better way?
       // https://github.com/KyoriPowered/adventure/issues/849

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIterator.java
@@ -28,7 +28,6 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import org.jetbrains.annotations.NotNull;
 
 final class ComponentIterator implements Iterator<Component> {
   private Component component;
@@ -36,7 +35,7 @@ final class ComponentIterator implements Iterator<Component> {
   private final Set<ComponentIteratorFlag> flags;
   private final Deque<Component> deque;
 
-  ComponentIterator(final @NotNull Component component, final @NotNull ComponentIteratorType type, final @NotNull Set<ComponentIteratorFlag> flags) {
+  ComponentIterator(final Component component, final ComponentIteratorType type, final Set<ComponentIteratorFlag> flags) {
     this.component = component;
     this.type = type;
     this.flags = flags;

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorType.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text;
 
 import java.util.Deque;
 import java.util.Set;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * The iterator types.
@@ -57,5 +56,5 @@ public sealed interface ComponentIteratorType permits ComponentIteratorTypeImpl.
    * @param flags the flags
    * @since 4.9.0
    */
-  void populate(final @NotNull Component component, final @NotNull Deque<Component> deque, final @NotNull Set<ComponentIteratorFlag> flags);
+  void populate(final Component component, final Deque<Component> deque, final Set<ComponentIteratorFlag> flags);
 }

--- a/api/src/main/java/net/kyori/adventure/text/ComponentIteratorTypeImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentIteratorTypeImpl.java
@@ -1,10 +1,32 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package net.kyori.adventure.text;
 
 import java.util.Deque;
 import java.util.List;
 import java.util.Set;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.jetbrains.annotations.NotNull;
 
 class ComponentIteratorTypeImpl {
   private ComponentIteratorTypeImpl() {
@@ -14,7 +36,7 @@ class ComponentIteratorTypeImpl {
     static final ComponentIteratorType INSTANCE = new DepthFirst();
 
     @Override
-    public void populate(@NotNull Component component, @NotNull Deque<Component> deque, @NotNull Set<ComponentIteratorFlag> flags) {
+    public void populate(Component component, Deque<Component> deque, Set<ComponentIteratorFlag> flags) {
       if (flags.contains(ComponentIteratorFlag.INCLUDE_TRANSLATABLE_COMPONENT_ARGUMENTS) && component instanceof TranslatableComponent translatable) {
         final List<? extends ComponentLike> args = translatable.arguments();
 
@@ -45,7 +67,7 @@ class ComponentIteratorTypeImpl {
     static final ComponentIteratorType INSTANCE = new BreadthFirst();
 
     @Override
-    public void populate(@NotNull Component component, @NotNull Deque<Component> deque, @NotNull Set<ComponentIteratorFlag> flags) {
+    public void populate(Component component, Deque<Component> deque, Set<ComponentIteratorFlag> flags) {
       if (flags.contains(ComponentIteratorFlag.INCLUDE_TRANSLATABLE_COMPONENT_ARGUMENTS) && component instanceof TranslatableComponent) {
         for (final TranslationArgument argument : ((TranslatableComponent) component).arguments()) {
           deque.add(argument.asComponent());

--- a/api/src/main/java/net/kyori/adventure/text/ComponentLike.java
+++ b/api/src/main/java/net/kyori/adventure/text/ComponentLike.java
@@ -28,8 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -47,7 +46,7 @@ public interface ComponentLike {
    * @return the components
    * @since 4.8.0
    */
-  static @NotNull List<Component> asComponents(final @NotNull List<? extends ComponentLike> likes) {
+  static List<Component> asComponents(final List<? extends ComponentLike> likes) {
     return asComponents(likes, null);
   }
 
@@ -61,7 +60,7 @@ public interface ComponentLike {
    * @return the components
    * @since 4.8.0
    */
-  static @NotNull List<Component> asComponents(final @NotNull List<? extends ComponentLike> likes, final @Nullable Predicate<? super Component> filter) {
+  static List<Component> asComponents(final List<? extends ComponentLike> likes, final @Nullable Predicate<? super Component> filter) {
     requireNonNull(likes, "likes");
     final int size = likes.size();
     if (size == 0) {
@@ -109,5 +108,5 @@ public interface ComponentLike {
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull Component asComponent();
+  Component asComponent();
 }

--- a/api/src/main/java/net/kyori/adventure/text/EntityNBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/EntityNBTComponent.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Given a Minecraft selector, this component reads the NBT of the associated entity and displays that information.
@@ -50,7 +49,7 @@ public sealed interface EntityNBTComponent extends NBTComponent<EntityNBTCompone
    * @return the entity selector
    * @since 4.0.0
    */
-  @NotNull String selector();
+  String selector();
 
   /**
    * Sets the entity selector.
@@ -60,10 +59,10 @@ public sealed interface EntityNBTComponent extends NBTComponent<EntityNBTCompone
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull EntityNBTComponent selector(final @NotNull String selector);
+  EntityNBTComponent selector(final String selector);
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("selector", this.selector())
@@ -86,6 +85,6 @@ public sealed interface EntityNBTComponent extends NBTComponent<EntityNBTCompone
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder selector(final @NotNull String selector);
+    Builder selector(final String selector);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/EntityNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/EntityNBTComponentImpl.java
@@ -27,8 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -40,7 +39,7 @@ record EntityNBTComponentImpl(
   Component separator,
   String selector
 ) implements EntityNBTComponent {
-  static EntityNBTComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final String selector) {
+  static EntityNBTComponent create(final List<? extends ComponentLike> children, final Style style, final String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final String selector) {
     return new EntityNBTComponentImpl(
       ComponentLike.asComponents(children, IS_NOT_EMPTY),
       requireNonNull(style, "style"),
@@ -52,45 +51,45 @@ record EntityNBTComponentImpl(
   }
 
   @Override
-  public @NotNull EntityNBTComponent nbtPath(final @NotNull String nbtPath) {
+  public EntityNBTComponent nbtPath(final String nbtPath) {
     if (Objects.equals(this.nbtPath, nbtPath)) return this;
     return create(this.children, this.style, nbtPath, this.interpret, this.separator, this.selector);
   }
 
   @Override
-  public @NotNull EntityNBTComponent interpret(final boolean interpret) {
+  public EntityNBTComponent interpret(final boolean interpret) {
     if (this.interpret == interpret) return this;
     return create(this.children, this.style, this.nbtPath, interpret, this.separator, this.selector);
   }
 
   @Override
-  public @NotNull EntityNBTComponent separator(final @Nullable ComponentLike separator) {
+  public EntityNBTComponent separator(final @Nullable ComponentLike separator) {
     return create(this.children, this.style, this.nbtPath, this.interpret, separator, this.selector);
   }
 
   @Override
-  public @NotNull EntityNBTComponent selector(final @NotNull String selector) {
+  public EntityNBTComponent selector(final String selector) {
     if (Objects.equals(this.selector, selector)) return this;
     return create(this.children, this.style, this.nbtPath, this.interpret, this.separator, selector);
   }
 
   @Override
-  public @NotNull EntityNBTComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public EntityNBTComponent children(final List<? extends ComponentLike> children) {
     return create(children, this.style, this.nbtPath, this.interpret, this.separator, this.selector);
   }
 
   @Override
-  public @NotNull EntityNBTComponent style(final @NotNull Style style) {
+  public EntityNBTComponent style(final Style style) {
     return create(this.children, style, this.nbtPath, this.interpret, this.separator, this.selector);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -100,19 +99,19 @@ record EntityNBTComponentImpl(
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull EntityNBTComponent component) {
+    BuilderImpl(final EntityNBTComponent component) {
       super(component);
       this.selector = component.selector();
     }
 
     @Override
-    public @NotNull Builder selector(final @NotNull String selector) {
+    public Builder selector(final String selector) {
       this.selector = requireNonNull(selector, "selector");
       return this;
     }
 
     @Override
-    public @NotNull EntityNBTComponent build() {
+    public EntityNBTComponent build() {
       if (this.nbtPath == null) throw new IllegalStateException("nbt path must be set");
       if (this.selector == null) throw new IllegalStateException("selector must be set");
       return create(this.children, this.buildStyle(), this.nbtPath, this.interpret, this.separator, this.selector);

--- a/api/src/main/java/net/kyori/adventure/text/JoinConfiguration.java
+++ b/api/src/main/java/net/kyori/adventure/text/JoinConfiguration.java
@@ -29,8 +29,7 @@ import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A configuration for how a series of components can be joined.
@@ -88,7 +87,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return a new builder
    * @since 4.9.0
    */
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new JoinConfigurationImpl.BuilderImpl();
   }
 
@@ -98,7 +97,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the join configuration
    * @since 4.9.0
    */
-  static @NotNull JoinConfiguration noSeparators() {
+  static JoinConfiguration noSeparators() {
     return JoinConfigurationImpl.NULL;
   }
 
@@ -111,7 +110,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the join configuration
    * @since 4.10.0
    */
-  static @NotNull JoinConfiguration newlines() {
+  static JoinConfiguration newlines() {
     return JoinConfigurationImpl.STANDARD_NEW_LINES;
   }
 
@@ -124,7 +123,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the join configuration
    * @since 4.15.0
    */
-  static @NotNull JoinConfiguration spaces() {
+  static JoinConfiguration spaces() {
     return JoinConfigurationImpl.STANDARD_SPACES;
   }
 
@@ -138,7 +137,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the join configuration
    * @since 4.10.0
    */
-  static @NotNull JoinConfiguration commas(final boolean spaces) {
+  static JoinConfiguration commas(final boolean spaces) {
     return spaces ? JoinConfigurationImpl.STANDARD_COMMA_SPACE_SEPARATED : JoinConfigurationImpl.STANDARD_COMMA_SEPARATED;
   }
 
@@ -153,7 +152,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the join configuration
    * @since 4.10.0
    */
-  static @NotNull JoinConfiguration arrayLike() {
+  static JoinConfiguration arrayLike() {
     return JoinConfigurationImpl.STANDARD_ARRAY_LIKE;
   }
 
@@ -164,7 +163,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the join configuration
    * @since 4.9.0
    */
-  static @NotNull JoinConfiguration separator(final @Nullable ComponentLike separator) {
+  static JoinConfiguration separator(final @Nullable ComponentLike separator) {
     if (separator == null) return JoinConfigurationImpl.NULL;
     return builder().separator(separator).build();
   }
@@ -177,7 +176,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the join configuration
    * @since 4.9.0
    */
-  static @NotNull JoinConfiguration separators(final @Nullable ComponentLike separator, final @Nullable ComponentLike lastSeparator) {
+  static JoinConfiguration separators(final @Nullable ComponentLike separator, final @Nullable ComponentLike lastSeparator) {
     if (separator == null && lastSeparator == null) return JoinConfigurationImpl.NULL;
     return builder().separator(separator).lastSeparator(lastSeparator).build();
   }
@@ -231,7 +230,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the operator
    * @since 4.9.0
    */
-  @NotNull Function<ComponentLike, Component> convertor();
+  Function<ComponentLike, Component> convertor();
 
   /**
    * Gets the predicate of this join configuration.
@@ -241,7 +240,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the predicate
    * @since 4.9.0
    */
-  @NotNull Predicate<ComponentLike> predicate();
+  Predicate<ComponentLike> predicate();
 
   /**
    * Gets the style of the parent component that contains the joined components.
@@ -249,7 +248,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
    * @return the style
    * @since 4.11.0
    */
-  @NotNull Style parentStyle();
+  Style parentStyle();
 
   /**
    * A builder for join configurations.
@@ -265,7 +264,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
      * @since 4.9.0
      */
     @Contract("_ -> this")
-    @NotNull Builder prefix(final @Nullable ComponentLike prefix);
+    Builder prefix(final @Nullable ComponentLike prefix);
 
     /**
      * Sets the suffix of this join configuration builder.
@@ -275,7 +274,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
      * @since 4.9.0
      */
     @Contract("_ -> this")
-    @NotNull Builder suffix(final @Nullable ComponentLike suffix);
+    Builder suffix(final @Nullable ComponentLike suffix);
 
     /**
      * Sets the separator of this join configuration builder.
@@ -285,7 +284,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
      * @since 4.9.0
      */
     @Contract("_ -> this")
-    @NotNull Builder separator(final @Nullable ComponentLike separator);
+    Builder separator(final @Nullable ComponentLike separator);
 
     /**
      * Sets the last separator of this join configuration builder.
@@ -295,7 +294,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
      * @since 4.9.0
      */
     @Contract("_ -> this")
-    @NotNull Builder lastSeparator(final @Nullable ComponentLike lastSeparator);
+    Builder lastSeparator(final @Nullable ComponentLike lastSeparator);
 
     /**
      * Sets the last separator that will be used instead of the normal last separator in the case where there
@@ -308,7 +307,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
      * @since 4.9.0
      */
     @Contract("_ -> this")
-    @NotNull Builder lastSeparatorIfSerial(final @Nullable ComponentLike lastSeparatorIfSerial);
+    Builder lastSeparatorIfSerial(final @Nullable ComponentLike lastSeparatorIfSerial);
 
     /**
      * Sets the convertor of this join configuration builder.
@@ -320,7 +319,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
      * @since 4.9.0
      */
     @Contract("_ -> this")
-    @NotNull Builder convertor(final @NotNull Function<ComponentLike, Component> convertor);
+    Builder convertor(final Function<ComponentLike, Component> convertor);
 
     /**
      * Sets the predicate of this join configuration builder.
@@ -332,7 +331,7 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
      * @since 4.9.0
      */
     @Contract("_ -> this")
-    @NotNull Builder predicate(final @NotNull Predicate<ComponentLike> predicate);
+    Builder predicate(final Predicate<ComponentLike> predicate);
 
     /**
      * Sets the style of the parent component that contains the joined components.
@@ -342,6 +341,6 @@ public sealed interface JoinConfiguration extends Examinable permits JoinConfigu
      * @since 4.11.0
      */
     @Contract("_ -> this")
-    @NotNull Builder parentStyle(final @NotNull Style parentStyle);
+    Builder parentStyle(final Style parentStyle);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/JoinConfigurationImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/JoinConfigurationImpl.java
@@ -32,8 +32,7 @@ import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 record JoinConfigurationImpl(Component prefix, Component suffix, Component separator, Component lastSeparator, Component lastSeparatorIfSerial, Function<ComponentLike, Component> convertor, Predicate<ComponentLike> predicate, Style parentStyle) implements JoinConfiguration {
   static final Function<ComponentLike, Component> DEFAULT_CONVERTOR = ComponentLike::asComponent;
@@ -50,12 +49,12 @@ record JoinConfigurationImpl(Component prefix, Component suffix, Component separ
     .suffix(Component.text("]"))
     .build();
 
-  private JoinConfigurationImpl(final @NotNull BuilderImpl builder) {
+  private JoinConfigurationImpl(final BuilderImpl builder) {
     this(ComponentLike.unbox(builder.prefix), ComponentLike.unbox(builder.suffix), ComponentLike.unbox(builder.separator), ComponentLike.unbox(builder.lastSeparator), ComponentLike.unbox(builder.lastSeparatorIfSerial), builder.convertor, builder.predicate, builder.parentStyle);
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("prefix", this.prefix),
       ExaminableProperty.of("suffix", this.suffix),
@@ -69,12 +68,12 @@ record JoinConfigurationImpl(Component prefix, Component suffix, Component separ
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Contract(pure = true)
-  static @NotNull Component join(final @NotNull JoinConfiguration config, final @NotNull Iterable<? extends ComponentLike> components) {
+  static Component join(final JoinConfiguration config, final Iterable<? extends ComponentLike> components) {
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(components, "components");
 
@@ -146,7 +145,7 @@ record JoinConfigurationImpl(Component prefix, Component suffix, Component separ
     return builder.build();
   }
 
-  static @NotNull Component singleElementJoin(final @NotNull JoinConfiguration config, final @Nullable ComponentLike component) {
+  static Component singleElementJoin(final JoinConfiguration config, final @Nullable ComponentLike component) {
     final Component prefix = config.prefix();
     final Component suffix = config.suffix();
     final Function<ComponentLike, Component> convertor = config.convertor();
@@ -185,7 +184,7 @@ record JoinConfigurationImpl(Component prefix, Component suffix, Component separ
       this(JoinConfigurationImpl.NULL);
     }
 
-    private BuilderImpl(final @NotNull JoinConfigurationImpl joinConfig) {
+    private BuilderImpl(final JoinConfigurationImpl joinConfig) {
       this.separator = joinConfig.separator;
       this.lastSeparator = joinConfig.lastSeparator;
       this.prefix = joinConfig.prefix;
@@ -197,55 +196,55 @@ record JoinConfigurationImpl(Component prefix, Component suffix, Component separ
     }
 
     @Override
-    public @NotNull Builder prefix(final @Nullable ComponentLike prefix) {
+    public Builder prefix(final @Nullable ComponentLike prefix) {
       this.prefix = prefix;
       return this;
     }
 
     @Override
-    public @NotNull Builder suffix(final @Nullable ComponentLike suffix) {
+    public Builder suffix(final @Nullable ComponentLike suffix) {
       this.suffix = suffix;
       return this;
     }
 
     @Override
-    public @NotNull Builder separator(final @Nullable ComponentLike separator) {
+    public Builder separator(final @Nullable ComponentLike separator) {
       this.separator = separator;
       return this;
     }
 
     @Override
-    public @NotNull Builder lastSeparator(final @Nullable ComponentLike lastSeparator) {
+    public Builder lastSeparator(final @Nullable ComponentLike lastSeparator) {
       this.lastSeparator = lastSeparator;
       return this;
     }
 
     @Override
-    public @NotNull Builder lastSeparatorIfSerial(final @Nullable ComponentLike lastSeparatorIfSerial) {
+    public Builder lastSeparatorIfSerial(final @Nullable ComponentLike lastSeparatorIfSerial) {
       this.lastSeparatorIfSerial = lastSeparatorIfSerial;
       return this;
     }
 
     @Override
-    public @NotNull Builder convertor(final @NotNull Function<ComponentLike, Component> convertor) {
+    public Builder convertor(final Function<ComponentLike, Component> convertor) {
       this.convertor = Objects.requireNonNull(convertor, "convertor");
       return this;
     }
 
     @Override
-    public @NotNull Builder predicate(final @NotNull Predicate<ComponentLike> predicate) {
+    public Builder predicate(final Predicate<ComponentLike> predicate) {
       this.predicate = Objects.requireNonNull(predicate, "predicate");
       return this;
     }
 
     @Override
-    public @NotNull Builder parentStyle(final @NotNull Style parentStyle) {
+    public Builder parentStyle(final Style parentStyle) {
       this.parentStyle = Objects.requireNonNull(parentStyle, "parentStyle");
       return this;
     }
 
     @Override
-    public @NotNull JoinConfiguration build() {
+    public JoinConfiguration build() {
       return new JoinConfigurationImpl(this);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A {@link Component} that displays the client's current keybind for the supplied action.
@@ -48,7 +47,7 @@ public sealed interface KeybindComponent extends ScopedComponent<KeybindComponen
    * @return the keybind
    * @since 4.0.0
    */
-  @NotNull String keybind();
+  String keybind();
 
   /**
    * Sets the keybind.
@@ -58,7 +57,7 @@ public sealed interface KeybindComponent extends ScopedComponent<KeybindComponen
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull KeybindComponent keybind(final @NotNull String keybind);
+  KeybindComponent keybind(final String keybind);
 
   /**
    * Sets the keybind.
@@ -68,12 +67,12 @@ public sealed interface KeybindComponent extends ScopedComponent<KeybindComponen
    * @since 4.9.0
    */
   @Contract(pure = true)
-  default @NotNull KeybindComponent keybind(final @NotNull KeybindLike keybind) {
+  default KeybindComponent keybind(final KeybindLike keybind) {
     return this.keybind(Objects.requireNonNull(keybind, "keybind").asKeybind());
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("keybind", this.keybind())
@@ -94,7 +93,7 @@ public sealed interface KeybindComponent extends ScopedComponent<KeybindComponen
      * @return the keybind identifier
      * @since 4.9.0
      */
-    @NotNull String asKeybind();
+    String asKeybind();
   }
 
   /**
@@ -111,7 +110,7 @@ public sealed interface KeybindComponent extends ScopedComponent<KeybindComponen
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder keybind(final @NotNull String keybind);
+    Builder keybind(final String keybind);
 
     /**
      * Sets the keybind.
@@ -121,7 +120,7 @@ public sealed interface KeybindComponent extends ScopedComponent<KeybindComponen
      * @since 4.9.0
      */
     @Contract(pure = true)
-    default @NotNull Builder keybind(final @NotNull KeybindLike keybind) {
+    default Builder keybind(final KeybindLike keybind) {
       return this.keybind(Objects.requireNonNull(keybind, "keybind").asKeybind());
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponentImpl.java
@@ -27,13 +27,12 @@ import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 record KeybindComponentImpl(List<Component> children, Style style, String keybind) implements KeybindComponent {
-  static KeybindComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String keybind) {
+  static KeybindComponent create(final List<? extends ComponentLike> children, final Style style, final String keybind) {
     return new KeybindComponentImpl(
       ComponentLike.asComponents(children, IS_NOT_EMPTY),
       requireNonNull(style, "style"),
@@ -42,28 +41,28 @@ record KeybindComponentImpl(List<Component> children, Style style, String keybin
   }
 
   @Override
-  public @NotNull KeybindComponent keybind(final @NotNull String keybind) {
+  public KeybindComponent keybind(final String keybind) {
     if (Objects.equals(this.keybind, keybind)) return this;
     return create(this.children, this.style, keybind);
   }
 
   @Override
-  public @NotNull KeybindComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public KeybindComponent children(final List<? extends ComponentLike> children) {
     return create(children, this.style, this.keybind);
   }
 
   @Override
-  public @NotNull KeybindComponent style(final @NotNull Style style) {
+  public KeybindComponent style(final Style style) {
     return create(this.children, style, this.keybind);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -73,19 +72,19 @@ record KeybindComponentImpl(List<Component> children, Style style, String keybin
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull KeybindComponent component) {
+    BuilderImpl(final KeybindComponent component) {
       super(component);
       this.keybind = component.keybind();
     }
 
     @Override
-    public @NotNull Builder keybind(final @NotNull String keybind) {
+    public Builder keybind(final String keybind) {
       this.keybind = requireNonNull(keybind, "keybind");
       return this;
     }
 
     @Override
-    public @NotNull KeybindComponent build() {
+    public KeybindComponent build() {
       if (this.keybind == null) throw new IllegalStateException("keybind must be set");
       return create(this.children, this.buildStyle(), this.keybind);
     }

--- a/api/src/main/java/net/kyori/adventure/text/LinearComponents.java
+++ b/api/src/main/java/net/kyori/adventure/text/LinearComponents.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text;
 
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A utility class that allows {@link Component components} to be created where {@link Style styles} can be specified inline.
@@ -51,7 +50,7 @@ public final class LinearComponents {
    * @return a component
    * @since 4.0.0
    */
-  public static @NotNull Component linear(final @NotNull ComponentBuilderApplicable@NotNull... applicables) {
+  public static Component linear(final ComponentBuilderApplicable... applicables) {
     final int length = applicables.length;
     if (length == 0) return Component.empty();
     if (length == 1) {

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponent.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.text;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A component that can display NBT fetched from different locations, optionally trying to interpret the NBT as JSON
@@ -65,7 +64,7 @@ public sealed interface NBTComponent<C extends NBTComponent<C>> extends Componen
    * @return the NBT path
    * @since 4.0.0
    */
-  @NotNull String nbtPath();
+  String nbtPath();
 
   /**
    * Sets the NBT path.
@@ -75,7 +74,7 @@ public sealed interface NBTComponent<C extends NBTComponent<C>> extends Componen
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull C nbtPath(final @NotNull String nbtPath);
+  C nbtPath(final String nbtPath);
 
   /**
    * Gets if we should be interpreting.
@@ -93,7 +92,7 @@ public sealed interface NBTComponent<C extends NBTComponent<C>> extends Componen
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull C interpret(final boolean interpret);
+  C interpret(final boolean interpret);
 
   /**
    * Gets the separator.
@@ -110,10 +109,10 @@ public sealed interface NBTComponent<C extends NBTComponent<C>> extends Componen
    * @return the separator
    * @since 4.8.0
    */
-  @NotNull C separator(final @Nullable ComponentLike separator);
+  C separator(final @Nullable ComponentLike separator);
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("nbtPath", this.nbtPath()),

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponentBuilder.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponentBuilder.java
@@ -24,8 +24,7 @@
 package net.kyori.adventure.text;
 
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /*
  * This can't be a child of NBTComponent.
@@ -47,7 +46,7 @@ public sealed interface NBTComponentBuilder<C extends NBTComponent<C>, B extends
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B nbtPath(final @NotNull String nbtPath);
+  B nbtPath(final String nbtPath);
 
   /**
    * Sets whether to interpret.
@@ -57,7 +56,7 @@ public sealed interface NBTComponentBuilder<C extends NBTComponent<C>, B extends
    * @since 4.0.0
    */
   @Contract("_ -> this")
-  @NotNull B interpret(final boolean interpret);
+  B interpret(final boolean interpret);
 
   /**
    * Sets the separator.
@@ -67,5 +66,5 @@ public sealed interface NBTComponentBuilder<C extends NBTComponent<C>, B extends
    * @since 4.8.0
    */
   @Contract("_ -> this")
-  @NotNull B separator(final @Nullable ComponentLike separator);
+  B separator(final @Nullable ComponentLike separator);
 }

--- a/api/src/main/java/net/kyori/adventure/text/ObjectComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ObjectComponent.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.object.ObjectContents;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Displays a non-text object.
@@ -41,7 +40,7 @@ public sealed interface ObjectComponent extends ScopedComponent<ObjectComponent>
    * @return the contents
    * @since 4.25.0
    */
-  @NotNull ObjectContents contents();
+  ObjectContents contents();
 
   /**
    * Creates a copy of this object component with the given contents.
@@ -50,10 +49,10 @@ public sealed interface ObjectComponent extends ScopedComponent<ObjectComponent>
    * @return new object component
    * @since 4.25.0
    */
-  @NotNull ObjectComponent contents(@NotNull ObjectContents contents);
+  ObjectComponent contents(ObjectContents contents);
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(ExaminableProperty.of("contents", this.contents())),
       ScopedComponent.super.examinableProperties()
@@ -73,6 +72,6 @@ public sealed interface ObjectComponent extends ScopedComponent<ObjectComponent>
      * @return this builder
      * @since 4.25.0
      */
-    @NotNull Builder contents(@NotNull ObjectContents objectContents);
+    Builder contents(ObjectContents objectContents);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ObjectComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/ObjectComponentImpl.java
@@ -27,13 +27,12 @@ import java.util.List;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.object.ObjectContents;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
 record ObjectComponentImpl(List<Component> children, Style style, ObjectContents contents) implements ObjectComponent {
 
-  static @NotNull ObjectComponentImpl create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull ObjectContents objectContents) {
+  static ObjectComponentImpl create(final List<? extends ComponentLike> children, final Style style, final ObjectContents objectContents) {
     return new ObjectComponentImpl(
       ComponentLike.asComponents(children, IS_NOT_EMPTY),
       requireNonNull(style, "style"),
@@ -42,27 +41,27 @@ record ObjectComponentImpl(List<Component> children, Style style, ObjectContents
   }
 
   @Override
-  public @NotNull ObjectComponent contents(final @NotNull ObjectContents contents) {
+  public ObjectComponent contents(final ObjectContents contents) {
     return create(this.children, this.style, contents);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
   @Override
-  public @NotNull ObjectComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public ObjectComponent children(final List<? extends ComponentLike> children) {
     return create(children, this.style, this.contents);
   }
 
   @Override
-  public @NotNull ObjectComponent style(final @NotNull Style style) {
+  public ObjectComponent style(final Style style) {
     return create(this.children, style, this.contents);
   }
 
@@ -72,19 +71,19 @@ record ObjectComponentImpl(List<Component> children, Style style, ObjectContents
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull ObjectComponent component) {
+    BuilderImpl(final ObjectComponent component) {
       super(component);
       this.objectContents = component.contents();
     }
 
     @Override
-    public @NotNull Builder contents(final @NotNull ObjectContents objectContents) {
+    public Builder contents(final ObjectContents objectContents) {
       this.objectContents = requireNonNull(objectContents, "contents");
       return this;
     }
 
     @Override
-    public @NotNull ObjectComponent build() {
+    public ObjectComponent build() {
       if (this.objectContents == null) throw new IllegalStateException("contents must be set");
       return create(this.children, this.buildStyle(), this.objectContents);
     }

--- a/api/src/main/java/net/kyori/adventure/text/ScopedComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScopedComponent.java
@@ -35,8 +35,7 @@ import net.kyori.adventure.text.format.StyleBuilderApplicable;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.util.ARGBLike;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Some magic to change return types.
@@ -47,181 +46,181 @@ import org.jetbrains.annotations.Nullable;
 public sealed interface ScopedComponent<C extends Component> extends Component permits BlockNBTComponent, EntityNBTComponent, KeybindComponent, ObjectComponent, ScoreComponent, SelectorComponent, StorageNBTComponent, TextComponent, TranslatableComponent {
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C asComponent() {
+  default C asComponent() {
     return (C) Component.super.asComponent();
   }
 
   @Override
-  @NotNull C children(final @NotNull List<? extends ComponentLike> children);
+  C children(final List<? extends ComponentLike> children);
 
   @Override
-  @NotNull C style(final @NotNull Style style);
+  C style(final Style style);
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C style(final @NotNull Consumer<Style.Builder> style) {
+  default C style(final Consumer<Style.Builder> style) {
     return (C) Component.super.style(style);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C style(final Style.@NotNull Builder style) {
+  default C style(final Style.Builder style) {
     return (C) Component.super.style(style);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C style(final @NotNull Consumer<Style.Builder> consumer, final Style.Merge.@NotNull Strategy strategy) {
+  default C style(final Consumer<Style.Builder> consumer, final Style.Merge.Strategy strategy) {
     return (C) Component.super.style(consumer, strategy);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C mergeStyle(final @NotNull Component that) {
+  default C mergeStyle(final Component that) {
     return (C) Component.super.mergeStyle(that);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C mergeStyle(final @NotNull Component that, final Style.@NotNull Merge@NotNull... merges) {
+  default C mergeStyle(final Component that, final Style.Merge... merges) {
     return (C) Component.super.mergeStyle(that, merges);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C append(final @NotNull Component component) {
+  default C append(final Component component) {
     return (C) Component.super.append(component);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C append(final @NotNull ComponentLike like) {
+  default C append(final ComponentLike like) {
     return (C) Component.super.append(like);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C append(final @NotNull ComponentBuilder<?, ?> builder) {
+  default C append(final ComponentBuilder<?, ?> builder) {
     return (C) Component.super.append(builder);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C append(final @NotNull List<? extends ComponentLike> components) {
+  default C append(final List<? extends ComponentLike> components) {
     return (C) Component.super.append(components);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C append(final @NotNull ComponentLike @NotNull... components) {
+  default C append(final ComponentLike ... components) {
     return (C) Component.super.append(components);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C appendNewline() {
+  default C appendNewline() {
     return (C) Component.super.appendNewline();
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C appendSpace() {
+  default C appendSpace() {
     return (C) Component.super.appendSpace();
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C applyFallbackStyle(final @NotNull StyleBuilderApplicable @NotNull ... style) {
+  default C applyFallbackStyle(final StyleBuilderApplicable ... style) {
     return (C) Component.super.applyFallbackStyle(style);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C applyFallbackStyle(final @NotNull Style style) {
+  default C applyFallbackStyle(final Style style) {
     return (C) Component.super.applyFallbackStyle(style);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C mergeStyle(final @NotNull Component that, final @NotNull Set<Style.Merge> merges) {
+  default C mergeStyle(final Component that, final Set<Style.Merge> merges) {
     return (C) Component.super.mergeStyle(that, merges);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C color(final @Nullable TextColor color) {
+  default C color(final @Nullable TextColor color) {
     return (C) Component.super.color(color);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C colorIfAbsent(final @Nullable TextColor color) {
+  default C colorIfAbsent(final @Nullable TextColor color) {
     return (C) Component.super.colorIfAbsent(color);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C shadowColor(final @Nullable ARGBLike argb) {
+  default C shadowColor(final @Nullable ARGBLike argb) {
     return (C) Component.super.shadowColor(argb);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C shadowColorIfAbsent(final @Nullable ARGBLike argb) {
+  default C shadowColorIfAbsent(final @Nullable ARGBLike argb) {
     return (C) Component.super.shadowColorIfAbsent(argb);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C decorate(final @NotNull TextDecoration decoration) {
+  default C decorate(final TextDecoration decoration) {
     return (C) Component.super.decorate(decoration);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C decoration(final @NotNull TextDecoration decoration, final boolean flag) {
+  default C decoration(final TextDecoration decoration, final boolean flag) {
     return (C) Component.super.decoration(decoration, flag);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  default C decoration(final TextDecoration decoration, final TextDecoration.State state) {
     return (C) Component.super.decoration(decoration, state);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  default C decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state) {
     return (C) Component.super.decorationIfAbsent(decoration, state);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
+  default C decorations(final Map<TextDecoration, TextDecoration.State> decorations) {
     return (C) Component.super.decorations(decorations);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C clickEvent(final @Nullable ClickEvent<?> event) {
+  default C clickEvent(final @Nullable ClickEvent<?> event) {
     return (C) Component.super.clickEvent(event);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C hoverEvent(final @Nullable HoverEventSource<?> event) {
+  default C hoverEvent(final @Nullable HoverEventSource<?> event) {
     return (C) Component.super.hoverEvent(event);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C insertion(final @Nullable String insertion) {
+  default C insertion(final @Nullable String insertion) {
     return (C) Component.super.insertion(insertion);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  default @NotNull C font(final @Nullable Key key) {
+  default C font(final @Nullable Key key) {
     return (C) Component.super.font(key);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponent.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A component that can display a player's score from a scoreboard objective,
@@ -57,7 +56,7 @@ public sealed interface ScoreComponent extends ScopedComponent<ScoreComponent> p
    * @return the score name
    * @since 4.0.0
    */
-  @NotNull String name();
+  String name();
 
   /**
    * Sets the score name.
@@ -67,7 +66,7 @@ public sealed interface ScoreComponent extends ScopedComponent<ScoreComponent> p
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull ScoreComponent name(final @NotNull String name);
+  ScoreComponent name(final String name);
 
   /**
    * Gets the objective name.
@@ -75,7 +74,7 @@ public sealed interface ScoreComponent extends ScopedComponent<ScoreComponent> p
    * @return the objective name
    * @since 4.0.0
    */
-  @NotNull String objective();
+  String objective();
 
   /**
    * Sets the score objective.
@@ -85,10 +84,10 @@ public sealed interface ScoreComponent extends ScopedComponent<ScoreComponent> p
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull ScoreComponent objective(final @NotNull String objective);
+  ScoreComponent objective(final String objective);
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("name", this.name()),
@@ -112,7 +111,7 @@ public sealed interface ScoreComponent extends ScopedComponent<ScoreComponent> p
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder name(final @NotNull String name);
+    Builder name(final String name);
 
     /**
      * Sets the score objective.
@@ -122,6 +121,6 @@ public sealed interface ScoreComponent extends ScopedComponent<ScoreComponent> p
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder objective(final @NotNull String objective);
+    Builder objective(final String objective);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponentImpl.java
@@ -27,13 +27,12 @@ import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 record ScoreComponentImpl(List<Component> children, Style style, String name, String objective) implements ScoreComponent {
-  static ScoreComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String name, final @NotNull String objective) {
+  static ScoreComponent create(final List<? extends ComponentLike> children, final Style style, final String name, final String objective) {
     return new ScoreComponentImpl(
       ComponentLike.asComponents(children, IS_NOT_EMPTY),
       requireNonNull(style, "style"),
@@ -43,34 +42,34 @@ record ScoreComponentImpl(List<Component> children, Style style, String name, St
   }
 
   @Override
-  public @NotNull ScoreComponent name(final @NotNull String name) {
+  public ScoreComponent name(final String name) {
     if (Objects.equals(this.name, name)) return this;
     return create(this.children, this.style, name, this.objective);
   }
 
   @Override
-  public @NotNull ScoreComponent objective(final @NotNull String objective) {
+  public ScoreComponent objective(final String objective) {
     if (Objects.equals(this.objective, objective)) return this;
     return create(this.children, this.style, this.name, objective);
   }
 
   @Override
-  public @NotNull ScoreComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public ScoreComponent children(final List<? extends ComponentLike> children) {
     return create(children, this.style, this.name, this.objective);
   }
 
   @Override
-  public @NotNull ScoreComponent style(final @NotNull Style style) {
+  public ScoreComponent style(final Style style) {
     return create(this.children, style, this.name, this.objective);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -81,26 +80,26 @@ record ScoreComponentImpl(List<Component> children, Style style, String name, St
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull ScoreComponent component) {
+    BuilderImpl(final ScoreComponent component) {
       super(component);
       this.name = component.name();
       this.objective = component.objective();
     }
 
     @Override
-    public @NotNull Builder name(final @NotNull String name) {
+    public Builder name(final String name) {
       this.name = requireNonNull(name, "name");
       return this;
     }
 
     @Override
-    public @NotNull Builder objective(final @NotNull String objective) {
+    public Builder objective(final String objective) {
       this.objective = requireNonNull(objective, "objective");
       return this;
     }
 
     @Override
-    public @NotNull ScoreComponent build() {
+    public ScoreComponent build() {
       if (this.name == null) throw new IllegalStateException("name must be set");
       if (this.objective == null) throw new IllegalStateException("objective must be set");
       return create(this.children, this.buildStyle(), this.name, this.objective);

--- a/api/src/main/java/net/kyori/adventure/text/SelectorComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/SelectorComponent.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.text;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A component that can display the name of entities found with a given selector.
@@ -51,7 +50,7 @@ public sealed interface SelectorComponent extends ScopedComponent<SelectorCompon
    * @return the selector pattern
    * @since 4.0.0
    */
-  @NotNull String pattern();
+  String pattern();
 
   /**
    * Sets the selector pattern.
@@ -61,7 +60,7 @@ public sealed interface SelectorComponent extends ScopedComponent<SelectorCompon
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull SelectorComponent pattern(final @NotNull String pattern);
+  SelectorComponent pattern(final String pattern);
 
   /**
    * Gets the separator.
@@ -78,10 +77,10 @@ public sealed interface SelectorComponent extends ScopedComponent<SelectorCompon
    * @return the separator
    * @since 4.8.0
    */
-  @NotNull SelectorComponent separator(final @Nullable ComponentLike separator);
+  SelectorComponent separator(final @Nullable ComponentLike separator);
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("pattern", this.pattern()),
@@ -105,7 +104,7 @@ public sealed interface SelectorComponent extends ScopedComponent<SelectorCompon
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder pattern(final @NotNull String pattern);
+    Builder pattern(final String pattern);
 
     /**
      * Sets the separator.
@@ -115,6 +114,6 @@ public sealed interface SelectorComponent extends ScopedComponent<SelectorCompon
      * @since 4.8.0
      */
     @Contract("_ -> this")
-    @NotNull Builder separator(final @Nullable ComponentLike separator);
+    Builder separator(final @Nullable ComponentLike separator);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/SelectorComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/SelectorComponentImpl.java
@@ -27,13 +27,12 @@ import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 record SelectorComponentImpl(List<Component> children, Style style, String pattern, @Nullable Component separator) implements SelectorComponent {
-  static SelectorComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String pattern, final @Nullable ComponentLike separator) {
+  static SelectorComponent create(final List<? extends ComponentLike> children, final Style style, final String pattern, final @Nullable ComponentLike separator) {
     return new SelectorComponentImpl(
       ComponentLike.asComponents(children, IS_NOT_EMPTY),
       requireNonNull(style, "style"),
@@ -43,33 +42,33 @@ record SelectorComponentImpl(List<Component> children, Style style, String patte
   }
 
   @Override
-  public @NotNull SelectorComponent pattern(final @NotNull String pattern) {
+  public SelectorComponent pattern(final String pattern) {
     if (Objects.equals(this.pattern, pattern)) return this;
     return create(this.children, this.style, pattern, this.separator);
   }
 
   @Override
-  public @NotNull SelectorComponent separator(final @Nullable ComponentLike separator) {
+  public SelectorComponent separator(final @Nullable ComponentLike separator) {
     return create(this.children, this.style, this.pattern, separator);
   }
 
   @Override
-  public @NotNull SelectorComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public SelectorComponent children(final List<? extends ComponentLike> children) {
     return create(children, this.style, this.pattern, this.separator);
   }
 
   @Override
-  public @NotNull SelectorComponent style(final @NotNull Style style) {
+  public SelectorComponent style(final Style style) {
     return create(this.children, style, this.pattern, this.separator);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -80,26 +79,26 @@ record SelectorComponentImpl(List<Component> children, Style style, String patte
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull SelectorComponent component) {
+    BuilderImpl(final SelectorComponent component) {
       super(component);
       this.pattern = component.pattern();
       this.separator = component.separator();
     }
 
     @Override
-    public @NotNull Builder pattern(final @NotNull String pattern) {
+    public Builder pattern(final String pattern) {
       this.pattern = requireNonNull(pattern, "pattern");
       return this;
     }
 
     @Override
-    public @NotNull Builder separator(final @Nullable ComponentLike separator) {
+    public Builder separator(final @Nullable ComponentLike separator) {
       this.separator = ComponentLike.unbox(separator);
       return this;
     }
 
     @Override
-    public @NotNull SelectorComponent build() {
+    public SelectorComponent build() {
       if (this.pattern == null) throw new IllegalStateException("pattern must be set");
       return create(this.children, this.buildStyle(), this.pattern, this.separator);
     }

--- a/api/src/main/java/net/kyori/adventure/text/StorageNBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/StorageNBTComponent.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Given a {@link Key}, this component reads the NBT of the associated command storage and displays that information.
@@ -51,7 +50,7 @@ public interface StorageNBTComponent extends NBTComponent<StorageNBTComponent>, 
    * @return the NBT storage
    * @since 4.0.0
    */
-  @NotNull Key storage();
+  Key storage();
 
   /**
    * Sets the NBT storage.
@@ -61,10 +60,10 @@ public interface StorageNBTComponent extends NBTComponent<StorageNBTComponent>, 
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull StorageNBTComponent storage(final @NotNull Key storage);
+  StorageNBTComponent storage(final Key storage);
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("storage", this.storage())
@@ -87,6 +86,6 @@ public interface StorageNBTComponent extends NBTComponent<StorageNBTComponent>, 
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder storage(final @NotNull Key storage);
+    Builder storage(final Key storage);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/StorageNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/StorageNBTComponentImpl.java
@@ -28,8 +28,7 @@ import java.util.Objects;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,7 +40,7 @@ record StorageNBTComponentImpl(
   @Nullable Component separator,
   Key storage
 ) implements StorageNBTComponent {
-  static @NotNull StorageNBTComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final @NotNull Key storage) {
+  static StorageNBTComponent create(final List<? extends ComponentLike> children, final Style style, final String nbtPath, final boolean interpret, final @Nullable ComponentLike separator, final Key storage) {
     return new StorageNBTComponentImpl(
       ComponentLike.asComponents(children, IS_NOT_EMPTY),
       requireNonNull(style, "style"),
@@ -53,45 +52,45 @@ record StorageNBTComponentImpl(
   }
 
   @Override
-  public @NotNull StorageNBTComponent nbtPath(final @NotNull String nbtPath) {
+  public StorageNBTComponent nbtPath(final String nbtPath) {
     if (Objects.equals(this.nbtPath, nbtPath)) return this;
     return create(this.children, this.style, nbtPath, this.interpret, this.separator, this.storage);
   }
 
   @Override
-  public @NotNull StorageNBTComponent interpret(final boolean interpret) {
+  public StorageNBTComponent interpret(final boolean interpret) {
     if (this.interpret == interpret) return this;
     return create(this.children, this.style, this.nbtPath, interpret, this.separator, this.storage);
   }
 
   @Override
-  public @NotNull StorageNBTComponent separator(final @Nullable ComponentLike separator) {
+  public StorageNBTComponent separator(final @Nullable ComponentLike separator) {
     return create(this.children, this.style, this.nbtPath, this.interpret, separator, this.storage);
   }
 
   @Override
-  public @NotNull StorageNBTComponent storage(final @NotNull Key storage) {
+  public StorageNBTComponent storage(final Key storage) {
     if (Objects.equals(this.storage, storage)) return this;
     return create(this.children, this.style, this.nbtPath, this.interpret, this.separator, storage);
   }
 
   @Override
-  public @NotNull StorageNBTComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public StorageNBTComponent children(final List<? extends ComponentLike> children) {
     return create(children, this.style, this.nbtPath, this.interpret, this.separator, this.storage);
   }
 
   @Override
-  public @NotNull StorageNBTComponent style(final @NotNull Style style) {
+  public StorageNBTComponent style(final Style style) {
     return create(this.children, style, this.nbtPath, this.interpret, this.separator, this.storage);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -101,19 +100,19 @@ record StorageNBTComponentImpl(
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull StorageNBTComponent component) {
+    BuilderImpl(final StorageNBTComponent component) {
       super(component);
       this.storage = component.storage();
     }
 
     @Override
-    public @NotNull Builder storage(final @NotNull Key storage) {
+    public Builder storage(final Key storage) {
       this.storage = requireNonNull(storage, "storage");
       return this;
     }
 
     @Override
-    public @NotNull StorageNBTComponent build() {
+    public StorageNBTComponent build() {
       if (this.nbtPath == null) throw new IllegalStateException("nbt path must be set");
       if (this.storage == null) throw new IllegalStateException("storage must be set");
       return create(this.children, this.buildStyle(), this.nbtPath, this.interpret, this.separator, this.storage);

--- a/api/src/main/java/net/kyori/adventure/text/TextComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponent.java
@@ -25,9 +25,7 @@ package net.kyori.adventure.text;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A component that displays a string.
@@ -47,7 +45,7 @@ public sealed interface TextComponent extends ScopedComponent<TextComponent> per
    * @return the plain text content
    * @since 4.0.0
    */
-  @NotNull String content();
+  String content();
 
   /**
    * Sets the plain text content.
@@ -57,10 +55,10 @@ public sealed interface TextComponent extends ScopedComponent<TextComponent> per
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull TextComponent content(final @NotNull String content);
+  TextComponent content(final String content);
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("content", this.content())
@@ -81,7 +79,7 @@ public sealed interface TextComponent extends ScopedComponent<TextComponent> per
      * @return the plain text content
      * @since 4.0.0
      */
-    @NotNull String content();
+    String content();
 
     /**
      * Sets the plain text content.
@@ -91,6 +89,6 @@ public sealed interface TextComponent extends ScopedComponent<TextComponent> per
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder content(final @NotNull String content);
+    Builder content(final String content);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponentImpl.java
@@ -30,10 +30,9 @@ import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.internal.properties.AdventureProperties;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.util.Nag;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -46,7 +45,7 @@ sealed class TextComponentImpl implements TextComponent permits VirtualComponent
   static final TextComponent NEWLINE = createDirect("\n");
   static final TextComponent SPACE = createDirect(" ");
 
-  static TextComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String content) {
+  static TextComponent create(final List<? extends ComponentLike> children, final Style style, final String content) {
     final List<Component> filteredChildren = ComponentLike.asComponents(children, IS_NOT_EMPTY);
     if (filteredChildren.isEmpty() && style.isEmpty() && content.isEmpty()) return Component.empty();
 
@@ -57,11 +56,11 @@ sealed class TextComponentImpl implements TextComponent permits VirtualComponent
     );
   }
 
-  TextComponent create0(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String content) {
+  TextComponent create0(final List<? extends ComponentLike> children, final Style style, final String content) {
     return create(children, style, content);
   }
 
-  private static @NotNull TextComponent createDirect(final @NotNull String content) {
+  private static TextComponent createDirect(final String content) {
     return new TextComponentImpl(Collections.emptyList(), Style.empty(), content);
   }
 
@@ -69,7 +68,7 @@ sealed class TextComponentImpl implements TextComponent permits VirtualComponent
   private final List<Component> children;
   private final Style style;
 
-  TextComponentImpl(final @NotNull List<Component> children, final @NotNull Style style, final @NotNull String content) {
+  TextComponentImpl(final List<Component> children, final Style style, final String content) {
     this.content = content;
     this.children = children;
     this.style = style;
@@ -91,33 +90,33 @@ sealed class TextComponentImpl implements TextComponent permits VirtualComponent
   }
 
   @Override
-  public @Unmodifiable @NotNull List<Component> children() {
+  public @Unmodifiable List<Component> children() {
     return this.children;
   }
 
   @Override
-  public @NotNull Style style() {
+  public Style style() {
     return this.style;
   }
 
   @Override
-  public @NotNull String content() {
+  public String content() {
     return this.content;
   }
 
   @Override
-  public @NotNull TextComponent content(final @NotNull String content) {
+  public TextComponent content(final String content) {
     if (Objects.equals(this.content, content)) return this;
     return this.create0(this.children, this.style, content);
   }
 
   @Override
-  public @NotNull TextComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public TextComponent children(final List<? extends ComponentLike> children) {
     return this.create0(children, this.style, this.content);
   }
 
   @Override
-  public @NotNull TextComponent style(final @NotNull Style style) {
+  public TextComponent style(final Style style) {
     return this.create0(this.children, style, this.content);
   }
 
@@ -142,7 +141,7 @@ sealed class TextComponentImpl implements TextComponent permits VirtualComponent
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -157,24 +156,24 @@ sealed class TextComponentImpl implements TextComponent permits VirtualComponent
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull TextComponent component) {
+    BuilderImpl(final TextComponent component) {
       super(component);
       this.content = component.content();
     }
 
     @Override
-    public @NotNull Builder content(final @NotNull String content) {
+    public Builder content(final String content) {
       this.content = requireNonNull(content, "content");
       return this;
     }
 
     @Override
-    public @NotNull String content() {
+    public String content() {
       return this.content;
     }
 
     @Override
-    public @NotNull TextComponent build() {
+    public TextComponent build() {
       if (this.isEmpty()) {
         return Component.empty();
       }

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfig.java
@@ -33,8 +33,7 @@ import net.kyori.adventure.util.IntFunction2;
 import net.kyori.examination.Examinable;
 import org.intellij.lang.annotations.RegExp;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -53,7 +52,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
    * @return a new builder
    * @since 4.2.0
    */
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new TextReplacementConfigImpl.Builder();
   }
 
@@ -63,7 +62,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
    * @return the match pattern
    * @since 4.2.0
    */
-  @NotNull Pattern matchPattern();
+  Pattern matchPattern();
 
   /**
    * A builder for replacement configurations.
@@ -99,7 +98,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NotNull Builder match(final @NotNull @RegExp String pattern) {
+    default Builder match(final @RegExp String pattern) {
       return this.match(Pattern.compile(pattern));
     }
 
@@ -111,7 +110,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    @NotNull Builder match(final @NotNull Pattern pattern);
+    Builder match(final Pattern pattern);
 
     /*
      * ---------------------------
@@ -125,7 +124,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @return this builder
      * @since 4.2.0
      */
-    default @NotNull Builder once() {
+    default Builder once() {
       return this.times(1);
     }
 
@@ -137,7 +136,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NotNull Builder times(final int times) {
+    default Builder times(final int times) {
       return this.condition((index, replaced) -> replaced < times ? PatternReplacementResult.REPLACE : PatternReplacementResult.STOP);
     }
 
@@ -150,7 +149,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NotNull Builder condition(final @NotNull IntFunction2<PatternReplacementResult> condition) {
+    default Builder condition(final IntFunction2<PatternReplacementResult> condition) {
       return this.condition((result, matchCount, replaced) -> condition.apply(matchCount, replaced));
     }
 
@@ -163,7 +162,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.8.0
      */
     @Contract("_ -> this")
-    @NotNull Builder condition(final @NotNull Condition condition);
+    Builder condition(final Condition condition);
 
     /*
      * -------------------------
@@ -179,7 +178,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NotNull Builder replacement(final @NotNull String replacement) {
+    default Builder replacement(final String replacement) {
       requireNonNull(replacement, "replacement");
       return this.replacement(builder -> builder.content(replacement));
     }
@@ -192,7 +191,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NotNull Builder replacement(final @Nullable ComponentLike replacement) {
+    default Builder replacement(final @Nullable ComponentLike replacement) {
       final @Nullable Component baked = ComponentLike.unbox(replacement);
       return this.replacement((result, input) -> baked);
     }
@@ -205,7 +204,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    default @NotNull Builder replacement(final @NotNull Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
+    default Builder replacement(final Function<TextComponent.Builder, @Nullable ComponentLike> replacement) {
       requireNonNull(replacement, "replacement");
       return this.replacement((result, input) -> replacement.apply(input));
 
@@ -219,7 +218,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.2.0
      */
     @Contract("_ -> this")
-    @NotNull Builder replacement(final @NotNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement);
+    Builder replacement(final BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement);
 
     /**
      * Set if the replacement should replace inside {@link HoverEvent hover events}.
@@ -231,7 +230,7 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @since 4.19.0
      */
     @Contract("_ -> this")
-    @NotNull Builder replaceInsideHoverEvents(final boolean replace);
+    Builder replaceInsideHoverEvents(final boolean replace);
   }
 
   /**
@@ -250,6 +249,6 @@ public sealed interface TextReplacementConfig extends Examinable permits TextRep
      * @return whether a certain match should
      * @since 4.8.0
      */
-    @NotNull PatternReplacementResult shouldReplace(final @NotNull MatchResult result, final int matchCount, final int replaced);
+    PatternReplacementResult shouldReplace(final MatchResult result, final int matchCount, final int replaced);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementConfigImpl.java
@@ -29,8 +29,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -42,7 +41,7 @@ record TextReplacementConfigImpl(
 ) implements TextReplacementConfig {
 
   @Override
-  public @NotNull Pattern matchPattern() {
+  public Pattern matchPattern() {
     return this.matchPattern;
   }
 
@@ -51,7 +50,7 @@ record TextReplacementConfigImpl(
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("matchPattern", this.matchPattern),
       ExaminableProperty.of("replacement", this.replacement),
@@ -60,7 +59,7 @@ record TextReplacementConfigImpl(
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
@@ -74,31 +73,31 @@ record TextReplacementConfigImpl(
     }
 
     @Override
-    public @NotNull Builder match(final @NotNull Pattern pattern) {
+    public Builder match(final Pattern pattern) {
       this.matchPattern = requireNonNull(pattern, "pattern");
       return this;
     }
 
     @Override
-    public @NotNull Builder condition(final @NotNull Condition condition) {
+    public Builder condition(final Condition condition) {
       this.continuer = requireNonNull(condition, "continuation");
       return this;
     }
 
     @Override
-    public @NotNull Builder replacement(final @NotNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement) {
+    public Builder replacement(final BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement) {
       this.replacement = requireNonNull(replacement, "replacement");
       return this;
     }
 
     @Override
-    public TextReplacementConfig.@NotNull Builder replaceInsideHoverEvents(final boolean replace) {
+    public TextReplacementConfig.Builder replaceInsideHoverEvents(final boolean replace) {
       this.replaceInsideHoverEvents = replace;
       return this;
     }
 
     @Override
-    public @NotNull TextReplacementConfig build() {
+    public TextReplacementConfig build() {
       if (this.matchPattern == null) throw new IllegalStateException("A pattern must be provided to match against");
       if (this.replacement == null) throw new IllegalStateException("A replacement action must be provided");
       return new TextReplacementConfigImpl(this.matchPattern, this.replacement, this.continuer, this.replaceInsideHoverEvents);

--- a/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextReplacementRenderer.java
@@ -32,8 +32,7 @@ import java.util.regex.Pattern;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.renderer.ComponentRenderer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A renderer performing a replacement on every {@link TextComponent} element of a component tree.
@@ -45,7 +44,7 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
   }
 
   @Override
-  public @NotNull Component render(final @NotNull Component component, final @NotNull State state) {
+  public Component render(final Component component, final State state) {
     if (!state.running) return component;
     final boolean prevFirstMatch = state.firstMatch;
     state.firstMatch = true;
@@ -208,7 +207,7 @@ final class TextReplacementRenderer implements ComponentRenderer<TextReplacement
     int replaceCount = 0;
     boolean firstMatch = true;
 
-    State(final @NotNull Pattern pattern, final @NotNull BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement, final TextReplacementConfig.@NotNull Condition continuer, final boolean replaceInsideHoverEvents) {
+    State(final Pattern pattern, final BiFunction<MatchResult, TextComponent.Builder, @Nullable ComponentLike> replacement, final TextReplacementConfig.Condition continuer, final boolean replaceInsideHoverEvents) {
       this.pattern = pattern;
       this.replacement = replacement;
       this.continuer = continuer;

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -33,8 +33,7 @@ import net.kyori.adventure.translation.Translatable;
 import net.kyori.adventure.translation.TranslationStore;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A component that can display translated text.
@@ -68,7 +67,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
    * @return the translation key
    * @since 4.0.0
    */
-  @NotNull String key();
+  String key();
 
   /**
    * Sets the translation key.
@@ -78,7 +77,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
    * @since 4.8.0
    */
   @Contract(pure = true)
-  default @NotNull TranslatableComponent key(final @NotNull Translatable translatable) {
+  default TranslatableComponent key(final Translatable translatable) {
     return this.key(Objects.requireNonNull(translatable, "translatable").translationKey());
   }
 
@@ -90,7 +89,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull TranslatableComponent key(final @NotNull String key);
+  TranslatableComponent key(final String key);
 
   /**
    * Gets the unmodifiable list of translation arguments.
@@ -98,7 +97,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
    * @return the unmodifiable list of translation arguments
    * @since 4.0.0
    */
-  @NotNull List<TranslationArgument> arguments();
+  List<TranslationArgument> arguments();
 
   /**
    * Sets the translation arguments for this component.
@@ -111,7 +110,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
    * @since 4.15.0
    */
   @Contract(pure = true)
-  @NotNull TranslatableComponent arguments(final @NotNull ComponentLike@NotNull... args);
+  TranslatableComponent arguments(final ComponentLike... args);
 
   /**
    * Sets the translation arguments for this component.
@@ -123,7 +122,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
    * @since 4.15.0
    */
   @Contract(pure = true)
-  @NotNull TranslatableComponent arguments(final @NotNull List<? extends ComponentLike> args);
+  TranslatableComponent arguments(final List<? extends ComponentLike> args);
 
   /**
    * Gets the translation fallback text for this component.
@@ -147,10 +146,10 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
    * @sinceMinecraft 1.19.4
    */
   @Contract(pure = true)
-  @NotNull TranslatableComponent fallback(final @Nullable String fallback);
+  TranslatableComponent fallback(final @Nullable String fallback);
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       Stream.of(
         ExaminableProperty.of("key", this.key()),
@@ -175,7 +174,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
      * @since 4.8.0
      */
     @Contract(pure = true)
-    default @NotNull Builder key(final @NotNull Translatable translatable) {
+    default Builder key(final Translatable translatable) {
       return this.key(Objects.requireNonNull(translatable, "translatable").translationKey());
     }
 
@@ -187,7 +186,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    @NotNull Builder key(final @NotNull String key);
+    Builder key(final String key);
 
     /**
      * Sets the translation args.
@@ -199,7 +198,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder arguments(final @NotNull ComponentLike@NotNull... args);
+    Builder arguments(final ComponentLike... args);
 
     /**
      * Sets the translation args.
@@ -211,7 +210,7 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
      * @since 4.15.0
      */
     @Contract("_ -> this")
-    @NotNull Builder arguments(final @NotNull List<? extends ComponentLike> args);
+    Builder arguments(final List<? extends ComponentLike> args);
 
     /**
      * Sets the translation fallback text.
@@ -224,6 +223,6 @@ public sealed interface TranslatableComponent extends ScopedComponent<Translatab
      * @sinceMinecraft 1.19.4
      */
     @Contract("_ -> this")
-    @NotNull Builder fallback(final @Nullable String fallback);
+    Builder fallback(final @Nullable String fallback);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponentImpl.java
@@ -30,18 +30,17 @@ import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 record TranslatableComponentImpl(List<Component> children, Style style, String key, @Nullable String fallback, List<TranslationArgument> args) implements TranslatableComponent {
-  static TranslatableComponent create(final @NotNull List<Component> children, final @NotNull Style style, final @NotNull String key, final @Nullable String fallback, final @NotNull ComponentLike @NotNull [] args) {
+  static TranslatableComponent create(final List<Component> children, final Style style, final String key, final @Nullable String fallback, final ComponentLike [] args) {
     requireNonNull(args, "args");
     return create(children, style, key, fallback, Arrays.asList(args));
   }
 
-  static TranslatableComponent create(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String key, final @Nullable String fallback, final @NotNull List<? extends ComponentLike> args) {
+  static TranslatableComponent create(final List<? extends ComponentLike> children, final Style style, final String key, final @Nullable String fallback, final List<? extends ComponentLike> args) {
     return new TranslatableComponentImpl(
       ComponentLike.asComponents(children, IS_NOT_EMPTY),
       requireNonNull(style, "style"),
@@ -52,53 +51,53 @@ record TranslatableComponentImpl(List<Component> children, Style style, String k
   }
 
   @Override
-  public @NotNull String key() {
+  public String key() {
     return this.key;
   }
 
   @Override
-  public @NotNull TranslatableComponent key(final @NotNull String key) {
+  public TranslatableComponent key(final String key) {
     if (Objects.equals(this.key, key)) return this;
     return create(this.children, this.style, key, this.fallback, this.args);
   }
 
   @Override
-  public @NotNull List<TranslationArgument> arguments() {
+  public List<TranslationArgument> arguments() {
     return this.args;
   }
 
   @Override
-  public @NotNull TranslatableComponent arguments(final @NotNull ComponentLike @NotNull ... args) {
+  public TranslatableComponent arguments(final ComponentLike ... args) {
     return create(this.children, this.style, this.key, this.fallback, args);
   }
 
   @Override
-  public @NotNull TranslatableComponent arguments(final @NotNull List<? extends ComponentLike> args) {
+  public TranslatableComponent arguments(final List<? extends ComponentLike> args) {
     return create(this.children, this.style, this.key, this.fallback, args);
   }
 
   @Override
-  public @NotNull TranslatableComponent fallback(final @Nullable String fallback) {
+  public TranslatableComponent fallback(final @Nullable String fallback) {
     return create(this.children, this.style, this.key, fallback, this.args);
   }
 
   @Override
-  public @NotNull TranslatableComponent children(final @NotNull List<? extends ComponentLike> children) {
+  public TranslatableComponent children(final List<? extends ComponentLike> children) {
     return create(children, this.style, this.key, this.fallback, this.args);
   }
 
   @Override
-  public @NotNull TranslatableComponent style(final @NotNull Style style) {
+  public TranslatableComponent style(final Style style) {
     return create(this.children, style, this.key, this.fallback, this.args);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -110,7 +109,7 @@ record TranslatableComponentImpl(List<Component> children, Style style, String k
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull TranslatableComponent component) {
+    BuilderImpl(final TranslatableComponent component) {
       super(component);
       this.key = component.key();
       this.args = component.arguments();
@@ -118,38 +117,38 @@ record TranslatableComponentImpl(List<Component> children, Style style, String k
     }
 
     @Override
-    public @NotNull Builder key(final @NotNull String key) {
+    public Builder key(final String key) {
       this.key = key;
       return this;
     }
 
     @Override
-    public @NotNull Builder arguments(final @NotNull ComponentLike @NotNull ... args) {
+    public Builder arguments(final ComponentLike ... args) {
       requireNonNull(args, "args");
       if (args.length == 0) return this.arguments(Collections.emptyList());
       return this.arguments(Arrays.asList(args));
     }
 
     @Override
-    public @NotNull Builder arguments(final @NotNull List<? extends ComponentLike> args) {
+    public Builder arguments(final List<? extends ComponentLike> args) {
       this.args = asArguments(requireNonNull(args, "args"));
       return this;
     }
 
     @Override
-    public @NotNull Builder fallback(final @Nullable String fallback) {
+    public Builder fallback(final @Nullable String fallback) {
       this.fallback = fallback;
       return this;
     }
 
     @Override
-    public @NotNull TranslatableComponent build() {
+    public TranslatableComponent build() {
       if (this.key == null) throw new IllegalStateException("key must be set");
       return create(this.children, this.buildStyle(), this.key, this.fallback, this.args);
     }
   }
 
-  static List<TranslationArgument> asArguments(final @NotNull List<? extends ComponentLike> likes) {
+  static List<TranslationArgument> asArguments(final List<? extends ComponentLike> likes) {
     if (likes.isEmpty()) {
       return Collections.emptyList();
     }

--- a/api/src/main/java/net/kyori/adventure/text/TranslationArgument.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslationArgument.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text;
 
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -42,7 +41,7 @@ public sealed interface TranslationArgument extends TranslationArgumentLike, Exa
    * @since 4.15.0
    * @sinceMinecraft 1.20.3
    */
-  static @NotNull TranslationArgument bool(final boolean value) {
+  static TranslationArgument bool(final boolean value) {
     return new TranslationArgumentImpl(value);
   }
 
@@ -54,7 +53,7 @@ public sealed interface TranslationArgument extends TranslationArgumentLike, Exa
    * @since 4.15.0
    * @sinceMinecraft 1.20.3
    */
-  static @NotNull TranslationArgument numeric(final @NotNull Number value) {
+  static TranslationArgument numeric(final Number value) {
     return new TranslationArgumentImpl(requireNonNull(value, "value"));
   }
 
@@ -66,7 +65,7 @@ public sealed interface TranslationArgument extends TranslationArgumentLike, Exa
    * @since 4.15.0
    * @sinceMinecraft 1.20.3
    */
-  static @NotNull TranslationArgument component(final @NotNull ComponentLike value) {
+  static TranslationArgument component(final ComponentLike value) {
     if (value instanceof TranslationArgumentLike) return ((TranslationArgumentLike) value).asTranslationArgument();
     return new TranslationArgumentImpl(requireNonNull(requireNonNull(value, "value").asComponent(), "value.asComponent()"));
   }
@@ -77,10 +76,10 @@ public sealed interface TranslationArgument extends TranslationArgumentLike, Exa
    * @return the argument value
    * @since 4.15.0
    */
-  @NotNull Object value();
+  Object value();
 
   @Override
-  default @NotNull TranslationArgument asTranslationArgument() {
+  default TranslationArgument asTranslationArgument() {
     return this;
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/TranslationArgumentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslationArgumentImpl.java
@@ -26,14 +26,13 @@ package net.kyori.adventure.text;
 import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 record TranslationArgumentImpl(Object value) implements TranslationArgument {
   private static final Component TRUE = Component.text("true");
   private static final Component FALSE = Component.text("false");
 
   @Override
-  public @NotNull Component asComponent() {
+  public Component asComponent() {
     if (this.value instanceof Component) {
       return (Component) this.value;
     } else if (this.value instanceof Boolean) {
@@ -44,12 +43,12 @@ record TranslationArgumentImpl(Object value) implements TranslationArgument {
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("value", this.value)
     );

--- a/api/src/main/java/net/kyori/adventure/text/TranslationArgumentLike.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslationArgumentLike.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.text;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Represents anything that can be represented as a non-{@link Component} {@link TranslationArgument}.
  *
@@ -39,10 +37,10 @@ public interface TranslationArgumentLike extends ComponentLike {
    * @return the argument representation
    * @since 4.15.0
    */
-  @NotNull TranslationArgument asTranslationArgument();
+  TranslationArgument asTranslationArgument();
 
   @Override
-  default @NotNull Component asComponent() {
+  default Component asComponent() {
     return this.asTranslationArgument().asComponent();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/VirtualComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/VirtualComponent.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.text;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A virtual component.
  *
@@ -40,7 +38,7 @@ public sealed interface VirtualComponent extends TextComponent permits VirtualCo
    * @return the renderer context type
    * @since 4.18.0
    */
-  @NotNull Class<?> contextType();
+  Class<?> contextType();
 
   /**
    * Gets the renderer.
@@ -48,5 +46,5 @@ public sealed interface VirtualComponent extends TextComponent permits VirtualCo
    * @return the renderer
    * @since 4.18.0
    */
-  @NotNull VirtualComponentRenderer<?> renderer();
+  VirtualComponentRenderer<?> renderer();
 }

--- a/api/src/main/java/net/kyori/adventure/text/VirtualComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/VirtualComponentImpl.java
@@ -27,15 +27,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class VirtualComponentImpl<C> extends TextComponentImpl implements VirtualComponent {
-  static <C> VirtualComponent createVirtual(final @NotNull Class<C> contextType, final @NotNull VirtualComponentRenderer<C> renderer) {
+  static <C> VirtualComponent createVirtual(final Class<C> contextType, final VirtualComponentRenderer<C> renderer) {
     return createVirtual(contextType, renderer, Collections.emptyList(), Style.empty());
   }
 
-  static <C> VirtualComponent createVirtual(final @NotNull Class<C> contextType, final @NotNull VirtualComponentRenderer<C> renderer, final List<? extends ComponentLike> children, final Style style) {
+  static <C> VirtualComponent createVirtual(final Class<C> contextType, final VirtualComponentRenderer<C> renderer, final List<? extends ComponentLike> children, final Style style) {
     final List<Component> filteredChildren = ComponentLike.asComponents(children, IS_NOT_EMPTY);
 
     return new VirtualComponentImpl<>(filteredChildren, style, "", contextType, renderer);
@@ -44,34 +43,34 @@ final class VirtualComponentImpl<C> extends TextComponentImpl implements Virtual
   private final Class<C> contextType;
   private final VirtualComponentRenderer<C> renderer;
 
-  private VirtualComponentImpl(final @NotNull List<Component> children, final @NotNull Style style, final @NotNull String content, final @NotNull Class<C> contextType, final @NotNull VirtualComponentRenderer<C> renderer) {
+  private VirtualComponentImpl(final List<Component> children, final Style style, final String content, final Class<C> contextType, final VirtualComponentRenderer<C> renderer) {
     super(children, style, content);
     this.contextType = contextType;
     this.renderer = renderer;
   }
 
   @Override
-  VirtualComponent create0(final @NotNull List<? extends ComponentLike> children, final @NotNull Style style, final @NotNull String content) {
+  VirtualComponent create0(final List<? extends ComponentLike> children, final Style style, final String content) {
     return new VirtualComponentImpl<>(ComponentLike.asComponents(children, IS_NOT_EMPTY), style, content, this.contextType, this.renderer);
   }
 
   @Override
-  public @NotNull Class<C> contextType() {
+  public Class<C> contextType() {
     return this.contextType;
   }
 
   @Override
-  public @NotNull VirtualComponentRenderer<C> renderer() {
+  public VirtualComponentRenderer<C> renderer() {
     return this.renderer;
   }
 
   @Override
-  public @NotNull String content() {
+  public String content() {
     return this.renderer.fallbackString();
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl<>(this);
   }
 
@@ -102,7 +101,7 @@ final class VirtualComponentImpl<C> extends TextComponentImpl implements Virtual
     }
 
     @Override
-    public @NotNull TextComponent build() {
+    public TextComponent build() {
       return createVirtual(this.contextType, this.renderer, this.children, this.buildStyle());
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/VirtualComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/VirtualComponentRenderer.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.adventure.text;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnknownNullability;
 
 /**
@@ -40,7 +39,7 @@ public interface VirtualComponentRenderer<C> {
    * @return the rendered value
    * @since 4.18.0
    */
-  @UnknownNullability ComponentLike apply(final @NotNull C context);
+  @UnknownNullability ComponentLike apply(final C context);
 
   /**
    * Get a fallback value for when this component has been serialized without being rendered.
@@ -50,7 +49,7 @@ public interface VirtualComponentRenderer<C> {
    * @return the fallback string
    * @since 4.18.0
    */
-  default @NotNull String fallbackString() {
+  default String fallbackString() {
     return "";
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/event/ClickCallback.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickCallback.java
@@ -35,8 +35,7 @@ import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.CheckReturnValue;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A handler for callback click events.
@@ -73,7 +72,7 @@ public interface ClickCallback<T extends Audience> {
    */
   @CheckReturnValue
   @Contract(pure = true)
-  static <W extends Audience, N extends W> @NotNull ClickCallback<W> widen(final @NotNull ClickCallback<N> original, final @NotNull Class<N> type, final @Nullable Consumer<? super Audience> otherwise) {
+  static <W extends Audience, N extends W> ClickCallback<W> widen(final ClickCallback<N> original, final Class<N> type, final @Nullable Consumer<? super Audience> otherwise) {
     return audience -> {
       if (type.isInstance(audience)) {
         original.accept(type.cast(audience));
@@ -97,7 +96,7 @@ public interface ClickCallback<T extends Audience> {
    */
   @CheckReturnValue
   @Contract(pure = true)
-  static <W extends Audience, N extends W> @NotNull ClickCallback<W> widen(final @NotNull ClickCallback<N> original, final @NotNull Class<N> type) {
+  static <W extends Audience, N extends W> ClickCallback<W> widen(final ClickCallback<N> original, final Class<N> type) {
     return widen(original, type, null);
   }
 
@@ -107,7 +106,7 @@ public interface ClickCallback<T extends Audience> {
    * @param audience the single-user audience who is attempting to execute this callback function.
    * @since 4.13.0
    */
-  void accept(final @NotNull T audience);
+  void accept(final T audience);
 
   /**
    * Filter audiences that receive this click callback.
@@ -120,7 +119,7 @@ public interface ClickCallback<T extends Audience> {
    */
   @CheckReturnValue
   @Contract(pure = true)
-  default @NotNull ClickCallback<T> filter(final @NotNull Predicate<T> filter) {
+  default ClickCallback<T> filter(final Predicate<T> filter) {
     return this.filter(filter, null);
   }
 
@@ -134,7 +133,7 @@ public interface ClickCallback<T extends Audience> {
    */
   @CheckReturnValue
   @Contract(pure = true)
-  default @NotNull ClickCallback<T> filter(final @NotNull Predicate<T> filter, final @Nullable Consumer<? super Audience> otherwise) {
+  default ClickCallback<T> filter(final Predicate<T> filter, final @Nullable Consumer<? super Audience> otherwise) {
     return audience -> {
       if (filter.test(audience)) {
         this.accept(audience);
@@ -157,7 +156,7 @@ public interface ClickCallback<T extends Audience> {
    */
   @CheckReturnValue
   @Contract(pure = true)
-  default @NotNull ClickCallback<T> requiringPermission(final @NotNull String permission) {
+  default ClickCallback<T> requiringPermission(final String permission) {
     return this.requiringPermission(permission, null);
   }
 
@@ -173,7 +172,7 @@ public interface ClickCallback<T extends Audience> {
    */
   @CheckReturnValue
   @Contract(pure = true)
-  default @NotNull ClickCallback<T> requiringPermission(final @NotNull String permission, final @Nullable Consumer<? super Audience> otherwise) {
+  default ClickCallback<T> requiringPermission(final String permission, final @Nullable Consumer<? super Audience> otherwise) {
     return this.filter(audience -> audience.getOrDefault(PermissionChecker.POINTER, ClickCallbackInternals.ALWAYS_FALSE).test(permission), otherwise);
   }
 
@@ -189,7 +188,7 @@ public interface ClickCallback<T extends Audience> {
      * @return the new builder
      * @since 4.13.0
      */
-    static @NotNull Builder builder() {
+    static Builder builder() {
       return new ClickCallbackOptionsImpl.BuilderImpl();
     }
 
@@ -200,7 +199,7 @@ public interface ClickCallback<T extends Audience> {
      * @return the new builder
      * @since 4.13.0
      */
-    static @NotNull Builder builder(final @NotNull Options existing) {
+    static Builder builder(final Options existing) {
       return new ClickCallbackOptionsImpl.BuilderImpl(existing);
     }
 
@@ -222,7 +221,7 @@ public interface ClickCallback<T extends Audience> {
      * @return the duration of this callback
      * @since 4.13.0
      */
-    @NotNull Duration lifetime();
+    Duration lifetime();
 
     /**
      * A builder for callback options.
@@ -237,7 +236,7 @@ public interface ClickCallback<T extends Audience> {
        * @return this builder
        * @since 4.13.0
        */
-      @NotNull Builder uses(int useCount);
+      Builder uses(int useCount);
 
       /**
        * Set how long the callback should last from sending.
@@ -246,7 +245,7 @@ public interface ClickCallback<T extends Audience> {
        * @return this builder
        * @since 4.13.0
        */
-      @NotNull Builder lifetime(final @NotNull TemporalAmount duration);
+      Builder lifetime(final TemporalAmount duration);
     }
   }
 
@@ -266,6 +265,6 @@ public interface ClickCallback<T extends Audience> {
      * @return a created click event that will execute the provided callback with options
      * @since 4.13.0
      */
-    @NotNull ClickEvent<?> create(final @NotNull ClickCallback<Audience> callback, final @NotNull Options options);
+    ClickEvent<?> create(final ClickCallback<Audience> callback, final Options options);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/event/ClickCallbackInternals.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickCallbackInternals.java
@@ -27,7 +27,6 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.permission.PermissionChecker;
 import net.kyori.adventure.util.Services;
 import net.kyori.adventure.util.TriState;
-import org.jetbrains.annotations.NotNull;
 
 final class ClickCallbackInternals {
   private ClickCallbackInternals() {
@@ -40,7 +39,7 @@ final class ClickCallbackInternals {
 
   static final class Fallback implements ClickCallback.Provider {
     @Override
-    public @NotNull ClickEvent<?> create(final @NotNull ClickCallback<Audience> callback, final ClickCallback.@NotNull Options options) {
+    public ClickEvent<?> create(final ClickCallback<Audience> callback, final ClickCallback.Options options) {
       return ClickEvent.suggestCommand("Callbacks are not supported on this platform!");
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/event/ClickCallbackOptionsImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickCallbackOptionsImpl.java
@@ -28,7 +28,6 @@ import java.time.temporal.TemporalAmount;
 import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -36,7 +35,7 @@ record ClickCallbackOptionsImpl(int uses, Duration lifetime) implements ClickCal
   static final ClickCallback.Options DEFAULT = new BuilderImpl().build();
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("uses", this.uses),
       ExaminableProperty.of("expiration", this.lifetime)
@@ -44,7 +43,7 @@ record ClickCallbackOptionsImpl(int uses, Duration lifetime) implements ClickCal
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
@@ -59,24 +58,24 @@ record ClickCallbackOptionsImpl(int uses, Duration lifetime) implements ClickCal
       this.lifetime = ClickCallback.DEFAULT_LIFETIME;
     }
 
-    BuilderImpl(final ClickCallback.@NotNull Options existing) {
+    BuilderImpl(final ClickCallback.Options existing) {
       this.uses = existing.uses();
       this.lifetime = existing.lifetime();
     }
 
     @Override
-    public ClickCallback.@NotNull Options build() {
+    public ClickCallback.Options build() {
       return new ClickCallbackOptionsImpl(this.uses, this.lifetime);
     }
 
     @Override
-    public @NotNull Builder uses(final int uses) {
+    public Builder uses(final int uses) {
       this.uses = uses;
       return this;
     }
 
     @Override
-    public @NotNull Builder lifetime(final @NotNull TemporalAmount lifetime) {
+    public Builder lifetime(final TemporalAmount lifetime) {
       this.lifetime = lifetime instanceof Duration ? (Duration) lifetime : Duration.from(requireNonNull(lifetime, "lifetime"));
       return this;
     }

--- a/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickEvent.java
@@ -34,7 +34,6 @@ import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
 import net.kyori.adventure.util.Index;
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -56,7 +55,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a click event
    * @since 4.0.0
    */
-  static @NotNull ClickEvent<Payload.Text> openUrl(@NotNull String url) {
+  static ClickEvent<Payload.Text> openUrl(String url) {
     return ClickEventImpl.create(Action.OPEN_URL, Payload.string(url));
   }
 
@@ -67,7 +66,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a click event
    * @since 4.0.0
    */
-  static @NotNull ClickEvent<Payload.Text> openUrl(@NotNull URL url) {
+  static ClickEvent<Payload.Text> openUrl(URL url) {
     return openUrl(url.toExternalForm());
   }
 
@@ -80,7 +79,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a click event
    * @since 4.0.0
    */
-  static @NotNull ClickEvent<Payload.Text> openFile(@NotNull String file) {
+  static ClickEvent<Payload.Text> openFile(String file) {
     return ClickEventImpl.create(Action.OPEN_FILE, Payload.string(file));
   }
 
@@ -91,7 +90,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a click event
    * @since 4.0.0
    */
-  static @NotNull ClickEvent<Payload.Text> runCommand(@NotNull String command) {
+  static ClickEvent<Payload.Text> runCommand(String command) {
     return ClickEventImpl.create(Action.RUN_COMMAND, Payload.string(command));
   }
 
@@ -102,7 +101,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a click event
    * @since 4.0.0
    */
-  static @NotNull ClickEvent<Payload.Text> suggestCommand(@NotNull String command) {
+  static ClickEvent<Payload.Text> suggestCommand(String command) {
     return ClickEventImpl.create(Action.SUGGEST_COMMAND, Payload.string(command));
   }
 
@@ -113,7 +112,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a click event
    * @since 4.0.0
    */
-  static @NotNull ClickEvent<Payload.Int> changePage(int page) {
+  static ClickEvent<Payload.Int> changePage(int page) {
     return ClickEventImpl.create(Action.CHANGE_PAGE, Payload.integer(page));
   }
 
@@ -125,7 +124,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @sinceMinecraft 1.15
    * @since 4.0.0
    */
-  static @NotNull ClickEvent<Payload.Text> copyToClipboard(@NotNull String text) {
+  static ClickEvent<Payload.Text> copyToClipboard(String text) {
     return ClickEventImpl.create(Action.COPY_TO_CLIPBOARD, Payload.string(text));
   }
 
@@ -138,7 +137,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a callback click event
    * @since 4.13.0
    */
-  static @NotNull ClickEvent<?> callback(@NotNull ClickCallback<Audience> function) {
+  static ClickEvent<?> callback(ClickCallback<Audience> function) {
     return ClickCallbackInternals.PROVIDER.create(requireNonNull(function, "function"), ClickCallbackOptionsImpl.DEFAULT);
   }
 
@@ -150,7 +149,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a callback click event
    * @since 4.13.0
    */
-  static @NotNull ClickEvent<?> callback(@NotNull ClickCallback<Audience> function, ClickCallback.@NotNull Options options) {
+  static ClickEvent<?> callback(ClickCallback<Audience> function, ClickCallback.Options options) {
     return ClickCallbackInternals.PROVIDER.create(requireNonNull(function, "function"), requireNonNull(options, "options"));
   }
 
@@ -162,7 +161,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return a callback click event
    * @since 4.13.0
    */
-  static @NotNull ClickEvent<?> callback(@NotNull ClickCallback<Audience> function, @NotNull Consumer<ClickCallback.Options.@NotNull Builder> optionsBuilder) {
+  static ClickEvent<?> callback(ClickCallback<Audience> function, Consumer<ClickCallback.Options.Builder> optionsBuilder) {
     return ClickCallbackInternals.PROVIDER.create(
       requireNonNull(function, "function"),
       AbstractBuilder.configureAndBuild(ClickCallback.Options.builder(), requireNonNull(optionsBuilder, "optionsBuilder"))
@@ -176,7 +175,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return the click event
    * @since 4.22.0
    */
-  static @NotNull ClickEvent<Payload.Dialog> showDialog(@NotNull DialogLike dialog) {
+  static ClickEvent<Payload.Dialog> showDialog(DialogLike dialog) {
     requireNonNull(dialog, "dialog");
     return ClickEventImpl.create(Action.SHOW_DIALOG, Payload.dialog(dialog));
   }
@@ -192,7 +191,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return the click event
    * @since 4.23.0
    */
-  static @NotNull ClickEvent<Payload.Custom> custom(@NotNull Key key, @NotNull BinaryTagHolder nbt) {
+  static ClickEvent<Payload.Custom> custom(Key key, BinaryTagHolder nbt) {
     requireNonNull(key, "key");
     requireNonNull(nbt, "nbt");
     return ClickEventImpl.create(Action.CUSTOM, Payload.custom(key, nbt));
@@ -207,7 +206,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @throws IllegalArgumentException if the action does not support that payload
    * @since 4.25.0
    */
-  static <T extends ClickEvent.Payload> @NotNull ClickEvent<T> clickEvent(final @NotNull Action<T> action, final @NotNull T payload) {
+  static <T extends ClickEvent.Payload> ClickEvent<T> clickEvent(final Action<T> action, final T payload) {
     return ClickEventImpl.create(action, payload);
   }
 
@@ -217,7 +216,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return the click event action
    * @since 4.0.0
    */
-  @NotNull Action<T> action();
+  Action<T> action();
 
   /**
    * Gets the payload associated with this click event.
@@ -225,7 +224,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
    * @return the payload
    * @since 4.22.0
    */
-  @NotNull Payload payload();
+  Payload payload();
 
   /**
    * An enumeration of click event actions.
@@ -320,7 +319,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
      * @return {@code true} if this action supports the payload
      * @since 4.22.0
      */
-    boolean supports(final @NotNull Payload payload);
+    boolean supports(final Payload payload);
 
     /**
      * The type of the payload this click event supports.
@@ -330,7 +329,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
      * @deprecated For removal, action now supports generics.
      */
     @Deprecated(since = "5.0.0", forRemoval = true)
-    @NotNull Class<? extends Payload> payloadType();
+    Class<? extends Payload> payloadType();
   }
 
   /**
@@ -346,7 +345,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
      * @return the payload
      * @since 4.22.0
      */
-    static ClickEvent.Payload.@NotNull Text string(final @NotNull String value) {
+    static ClickEvent.Payload.Text string(final String value) {
       requireNonNull(value, "value");
       return new PayloadImpl.TextImpl(value);
     }
@@ -358,7 +357,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
      * @return the payload
      * @since 4.22.0
      */
-    static ClickEvent.Payload.@NotNull Int integer(final int integer) {
+    static ClickEvent.Payload.Int integer(final int integer) {
       return new PayloadImpl.IntImpl(integer);
     }
 
@@ -369,7 +368,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
      * @return the payload
      * @since 4.22.0
      */
-    static ClickEventImpl.Payload.@NotNull Dialog dialog(final @NotNull DialogLike dialog) {
+    static ClickEventImpl.Payload.Dialog dialog(final DialogLike dialog) {
       requireNonNull(dialog, "dialog");
       return new PayloadImpl.DialogImpl(dialog);
     }
@@ -385,7 +384,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
      * @return the payload
      * @since 4.23.0
      */
-    static ClickEventImpl.Payload.@NotNull Custom custom(final @NotNull Key key, final @NotNull BinaryTagHolder nbt) {
+    static ClickEventImpl.Payload.Custom custom(final Key key, final BinaryTagHolder nbt) {
       requireNonNull(key, "key");
       requireNonNull(nbt, "nbt");
       return new PayloadImpl.CustomImpl(key, nbt);
@@ -403,7 +402,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
        * @return the string
        * @since 4.22.0
        */
-      @NotNull String value();
+      String value();
     }
 
     /**
@@ -434,7 +433,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
        * @return the dialog
        * @since 4.22.0
        */
-      @NotNull DialogLike dialog();
+      DialogLike dialog();
     }
 
     /**
@@ -452,7 +451,7 @@ public sealed interface ClickEvent<T extends ClickEvent.Payload> extends Examina
        * @return the data
        * @since 4.23.0
        */
-      @NotNull BinaryTagHolder nbt();
+      BinaryTagHolder nbt();
     }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/event/ClickEventImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/ClickEventImpl.java
@@ -27,23 +27,22 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
 record ClickEventImpl<T extends ClickEvent.Payload>(Action<T> action, Payload payload) implements ClickEvent<T> {
 
-  static <T extends ClickEvent.Payload> ClickEvent<T> create(final @NotNull Action<T> action, final @NotNull T payload) {
+  static <T extends ClickEvent.Payload> ClickEvent<T> create(final Action<T> action, final T payload) {
     return new ClickEventImpl<>(requireNonNull(action, "action"), requireNonNull(payload, "payload"));
   }
 
   @Override
-  public void styleApply(final Style.@NotNull Builder style) {
+  public void styleApply(final Style.Builder style) {
     style.clickEvent(this);
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("action", this.action),
       ExaminableProperty.of("payload", this.payload)
@@ -51,13 +50,13 @@ record ClickEventImpl<T extends ClickEvent.Payload>(Action<T> action, Payload pa
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   record ActionImpl<T extends Payload>(String name, boolean readable, Class<? extends Payload> payloadType) implements ClickEvent.Action<T> {
     @Override
-    public boolean supports(final @NotNull Payload payload) {
+    public boolean supports(final Payload payload) {
       return payload.getClass() == this.payloadType;
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/event/DataComponentValue.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/DataComponentValue.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.event;
 
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A holder for the value of an item's data component.
@@ -45,7 +44,7 @@ public interface DataComponentValue extends Examinable {
    * @since 4.17.0
    * @sinceMinecraft 1.20.5
    */
-  static DataComponentValue.@NotNull Removed removed() {
+  static DataComponentValue.Removed removed() {
     return RemovedDataComponentValueImpl.REMOVED;
   }
 
@@ -64,7 +63,7 @@ public interface DataComponentValue extends Examinable {
      * @since 4.17.0
      * @sinceMinecraft 1.20.5
      */
-    @NotNull BinaryTagHolder asBinaryTag();
+    BinaryTagHolder asBinaryTag();
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConversionImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConversionImpl.java
@@ -28,19 +28,18 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
 record DataComponentValueConversionImpl<I, O>(Class<I> source, Class<O> destination, BiFunction<Key, I, O> conversion) implements DataComponentValueConverterRegistry.Conversion<I, O> {
 
   @Override
-  public @NotNull O convert(final @NotNull Key key, final @NotNull I input) {
+  public O convert(final Key key, final I input) {
     return this.conversion.apply(requireNonNull(key, "key"), requireNonNull(input, "input"));
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("source", this.source),
       ExaminableProperty.of("destination", this.destination),
@@ -49,7 +48,7 @@ record DataComponentValueConversionImpl<I, O>(Class<I> source, Class<O> destinat
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistry.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/DataComponentValueConverterRegistry.java
@@ -40,8 +40,7 @@ import net.kyori.adventure.util.Services;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -64,7 +63,7 @@ public final class DataComponentValueConverterRegistry {
    * @return an unmodifiable set of the known provider ids
    * @since 4.1.7.0
    */
-  public static @NotNull Set<Key> knownProviders() {
+  public static Set<Key> knownProviders() {
     return PROVIDERS.stream()
       .map(Provider::id)
       .collect(Collectors.toUnmodifiableSet());
@@ -81,7 +80,7 @@ public final class DataComponentValueConverterRegistry {
    * @since 4.17.0
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public static <O extends DataComponentValue> @NotNull O convert(final @NotNull Class<O> target, final @NotNull Key key, final @NotNull DataComponentValue in) {
+  public static <O extends DataComponentValue> O convert(final Class<O> target, final Key key, final DataComponentValue in) {
     if (target.isInstance(in)) {
       return target.cast(in);
     }
@@ -112,7 +111,7 @@ public final class DataComponentValueConverterRegistry {
      * @return the provider id
      * @since 4.17.0
      */
-    @NotNull Key id();
+    Key id();
 
     /**
      * Return conversions available from this provider.
@@ -122,7 +121,7 @@ public final class DataComponentValueConverterRegistry {
      * @return the conversions available
      * @since 4.17.0
      */
-    @NotNull Iterable<Conversion<?, ?>> conversions();
+    Iterable<Conversion<?, ?>> conversions();
   }
 
   /**
@@ -144,7 +143,7 @@ public final class DataComponentValueConverterRegistry {
      * @return a conversion object
      * @since 4.17.0
      */
-    static <I1, O1> @NotNull Conversion<I1, O1> convert(final @NotNull Class<I1> src, final @NotNull Class<O1> dst, final @NotNull BiFunction<Key, I1, O1> op) {
+    static <I1, O1> Conversion<I1, O1> convert(final Class<I1> src, final Class<O1> dst, final BiFunction<Key, I1, O1> op) {
       return new DataComponentValueConversionImpl<>(
         requireNonNull(src, "src"),
         requireNonNull(dst, "dst"),
@@ -159,7 +158,7 @@ public final class DataComponentValueConverterRegistry {
      * @since 4.17.0
      */
     @Contract(pure = true)
-    @NotNull Class<I> source();
+    Class<I> source();
 
     /**
      * The destination type.
@@ -168,7 +167,7 @@ public final class DataComponentValueConverterRegistry {
      * @since 4.17.0
      */
     @Contract(pure = true)
-    @NotNull Class<O> destination();
+    Class<O> destination();
 
     /**
      * Perform the actual conversion.
@@ -178,7 +177,7 @@ public final class DataComponentValueConverterRegistry {
      * @return a data holder of the destination type
      * @since 4.17.0
      */
-    @NotNull O convert(final @NotNull Key key, final @NotNull I input);
+    O convert(final Key key, final I input);
   }
 
   static final class ConversionCache {
@@ -189,7 +188,7 @@ public final class DataComponentValueConverterRegistry {
     private static Map<Class<?>, Set<RegisteredConversion>> collectConversions() {
       final Map<Class<?>, Set<RegisteredConversion>> collected = new ConcurrentHashMap<>();
       for (final Provider provider : PROVIDERS) {
-        final @NotNull Key id = requireNonNull(provider.id(), () -> "ID of provider " + provider + " is null");
+        final Key id = requireNonNull(provider.id(), () -> "ID of provider " + provider + " is null");
         for (final Conversion<?, ?> conv : provider.conversions()) {
           collected.computeIfAbsent(conv.source(), $ -> ConcurrentHashMap.newKeySet()).add(new RegisteredConversion(id, conv));
         }

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEvent.java
@@ -37,9 +37,8 @@ import net.kyori.adventure.util.Index;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,7 +59,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a hover event
    * @since 4.2.0
    */
-  static @NotNull HoverEvent<Component> showText(@NotNull ComponentLike text) {
+  static HoverEvent<Component> showText(ComponentLike text) {
     return showText(text.asComponent());
   }
 
@@ -71,7 +70,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a hover event
    * @since 4.0.0
    */
-  static @NotNull HoverEvent<Component> showText(@NotNull Component text) {
+  static HoverEvent<Component> showText(Component text) {
     return new HoverEventImpl<>(Action.SHOW_TEXT, text);
   }
 
@@ -83,7 +82,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a hover event
    * @since 4.0.0
    */
-  static @NotNull HoverEvent<ShowItem> showItem(@NotNull Key item, @Range(from = 0, to = Integer.MAX_VALUE) int count) {
+  static HoverEvent<ShowItem> showItem(Key item, @Range(from = 0, to = Integer.MAX_VALUE) int count) {
     return showItem(item, count, Collections.emptyMap());
   }
 
@@ -95,7 +94,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a hover event
    * @since 4.6.0
    */
-  static @NotNull HoverEvent<ShowItem> showItem(@NotNull Keyed item, @Range(from = 0, to = Integer.MAX_VALUE) int count) {
+  static HoverEvent<ShowItem> showItem(Keyed item, @Range(from = 0, to = Integer.MAX_VALUE) int count) {
     return showItem(item, count, Collections.emptyMap());
   }
 
@@ -110,7 +109,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
    */
   @Deprecated
-  static @NotNull HoverEvent<ShowItem> showItem(@NotNull Key item, @Range(from = 0, to = Integer.MAX_VALUE) int count, @Nullable BinaryTagHolder nbt) {
+  static HoverEvent<ShowItem> showItem(Key item, @Range(from = 0, to = Integer.MAX_VALUE) int count, @Nullable BinaryTagHolder nbt) {
     return showItem(ShowItem.showItem(item, count, nbt));
   }
 
@@ -125,7 +124,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
    */
   @Deprecated
-  static @NotNull HoverEvent<ShowItem> showItem(@NotNull Keyed item, @Range(from = 0, to = Integer.MAX_VALUE) int count, @Nullable BinaryTagHolder nbt) {
+  static HoverEvent<ShowItem> showItem(Keyed item, @Range(from = 0, to = Integer.MAX_VALUE) int count, @Nullable BinaryTagHolder nbt) {
     return showItem(ShowItem.showItem(item, count, nbt));
   }
 
@@ -138,7 +137,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a hover event
    * @since 4.17.0
    */
-  static @NotNull HoverEvent<ShowItem> showItem(@NotNull Keyed item, @Range(from = 0, to = Integer.MAX_VALUE) int count, @NotNull Map<Key, ? extends DataComponentValue> dataComponents) {
+  static HoverEvent<ShowItem> showItem(Keyed item, @Range(from = 0, to = Integer.MAX_VALUE) int count, Map<Key, ? extends DataComponentValue> dataComponents) {
     return showItem(ShowItem.showItem(item, count, dataComponents));
   }
 
@@ -149,7 +148,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a hover event
    * @since 4.0.0
    */
-  static @NotNull HoverEvent<ShowItem> showItem(@NotNull ShowItem item) {
+  static HoverEvent<ShowItem> showItem(ShowItem item) {
     return new HoverEventImpl<>(Action.SHOW_ITEM, item);
   }
 
@@ -163,7 +162,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a {@code ShowEntity}
    * @since 4.0.0
    */
-  static @NotNull HoverEvent<ShowEntity> showEntity(@NotNull Key type, @NotNull UUID id) {
+  static HoverEvent<ShowEntity> showEntity(Key type, UUID id) {
     return showEntity(type, id, null);
   }
 
@@ -177,7 +176,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a {@code ShowEntity}
    * @since 4.6.0
    */
-  static @NotNull HoverEvent<ShowEntity> showEntity(@NotNull Keyed type, @NotNull UUID id) {
+  static HoverEvent<ShowEntity> showEntity(Keyed type, UUID id) {
     return showEntity(type, id, null);
   }
 
@@ -192,7 +191,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a {@code ShowEntity}
    * @since 4.0.0
    */
-  static @NotNull HoverEvent<ShowEntity> showEntity(@NotNull Key type, @NotNull UUID id, @Nullable Component name) {
+  static HoverEvent<ShowEntity> showEntity(Key type, UUID id, @Nullable Component name) {
     return showEntity(ShowEntity.showEntity(type, id, name));
   }
 
@@ -207,7 +206,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a {@code ShowEntity}
    * @since 4.6.0
    */
-  static @NotNull HoverEvent<ShowEntity> showEntity(@NotNull Keyed type, @NotNull UUID id, @Nullable Component name) {
+  static HoverEvent<ShowEntity> showEntity(Keyed type, UUID id, @Nullable Component name) {
     return showEntity(ShowEntity.showEntity(type, id, name));
   }
 
@@ -220,7 +219,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a hover event
    * @since 4.0.0
    */
-  static @NotNull HoverEvent<ShowEntity> showEntity(@NotNull ShowEntity entity) {
+  static HoverEvent<ShowEntity> showEntity(ShowEntity entity) {
     return new HoverEventImpl<>(Action.SHOW_ENTITY, entity);
   }
 
@@ -233,7 +232,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @deprecated Removed in Vanilla 1.12, but we keep it for backwards compatibility
    */
   @Deprecated
-  static @NotNull HoverEvent<String> showAchievement(@NotNull String value) {
+  static HoverEvent<String> showAchievement(String value) {
     return new HoverEventImpl<>(Action.SHOW_ACHIEVEMENT, value);
   }
 
@@ -246,7 +245,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a click event
    * @since 4.0.0
    */
-  static <V> @NotNull HoverEvent<V> hoverEvent(@NotNull Action<V> action, @NotNull V value) {
+  static <V> HoverEvent<V> hoverEvent(Action<V> action, V value) {
     return new HoverEventImpl<>(action, value);
   }
 
@@ -256,7 +255,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return the hover event action
    * @since 4.0.0
    */
-  @NotNull Action<V> action();
+  Action<V> action();
 
   /**
    * Gets the hover event value.
@@ -264,7 +263,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return the hover event value
    * @since 4.0.0
    */
-  @NotNull V value();
+  V value();
 
   /**
    * Sets the hover event value.
@@ -274,7 +273,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @since 4.0.0
    */
   @Contract(pure = true)
-  @NotNull HoverEvent<V> value(final @NotNull V value);
+  HoverEvent<V> value(final V value);
 
   /**
    * Returns a hover event with the value rendered using {@code renderer} when possible.
@@ -285,7 +284,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
    * @return a hover event
    * @since 4.0.0
    */
-  <C> @NotNull HoverEvent<V> withRenderedValue(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context);
+  <C> HoverEvent<V> withRenderedValue(final ComponentRenderer<C> renderer, final C context);
 
   /**
    * The value of a {@link Action#SHOW_ITEM show_item} hover event.
@@ -301,7 +300,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowItem}
      * @since 4.14.0
      */
-    static @NotNull ShowItem showItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
+    static ShowItem showItem(final Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
       return ShowItem.showItem(item, count, Collections.emptyMap());
     }
 
@@ -313,7 +312,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowItem}
      * @since 4.14.0
      */
-    static @NotNull ShowItem showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
+    static ShowItem showItem(final Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
       return ShowItem.showItem(item, count, Collections.emptyMap());
     }
 
@@ -328,7 +327,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
      */
     @Deprecated
-    static @NotNull ShowItem showItem(final @NotNull Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
+    static ShowItem showItem(final Key item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
       return new HoverEventImpl.ShowItemImpl(requireNonNull(item, "item"), count, nbt, Collections.emptyMap());
     }
 
@@ -343,7 +342,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
      */
     @Deprecated
-    static @NotNull ShowItem showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
+    static ShowItem showItem(final Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @Nullable BinaryTagHolder nbt) {
       return new HoverEventImpl.ShowItemImpl(requireNonNull(item, "item").key(), count, nbt, Collections.emptyMap());
     }
 
@@ -357,7 +356,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @sinceMinecraft 1.20.5
      * @since 4.17.0
      */
-    static @NotNull ShowItem showItem(final @NotNull Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final @NotNull Map<Key, ? extends DataComponentValue> dataComponents) {
+    static ShowItem showItem(final Keyed item, final @Range(from = 0, to = Integer.MAX_VALUE) int count, final Map<Key, ? extends DataComponentValue> dataComponents) {
       return new HoverEventImpl.ShowItemImpl(requireNonNull(item, "item").key(), count, null, Map.copyOf(requireNonNull(dataComponents, "dataComponents")));
     }
 
@@ -367,7 +366,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return the item
      * @since 4.0.0
      */
-    @NotNull Key item();
+    Key item();
 
     /**
      * Sets the item.
@@ -376,7 +375,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowItem}
      * @since 4.0.0
      */
-    @NotNull ShowItem item(final @NotNull Key item);
+    ShowItem item(final Key item);
 
     /**
      * Gets the count.
@@ -393,7 +392,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowItem}
      * @since 4.0.0
      */
-    @NotNull ShowItem count(final @Range(from = 0, to = Integer.MAX_VALUE) int count);
+    ShowItem count(final @Range(from = 0, to = Integer.MAX_VALUE) int count);
 
     /**
      * Gets the nbt.
@@ -418,7 +417,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @deprecated since Minecraft 1.20.5 and replaced with data components, not scheduled for removal
      */
     @Deprecated
-    @NotNull ShowItem nbt(final @Nullable BinaryTagHolder nbt);
+    ShowItem nbt(final @Nullable BinaryTagHolder nbt);
 
     /**
      * Get the data components used for this item.
@@ -429,7 +428,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @sinceMinecraft 1.20.5
      * @since 4.17.0
      */
-    @NotNull Map<Key, DataComponentValue> dataComponents();
+    Map<Key, DataComponentValue> dataComponents();
 
     /**
      * Set the data components used on this item.
@@ -440,7 +439,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a show item data object that has the provided components
      * @sinceMinecraft 1.20.5
      */
-    @NotNull ShowItem dataComponents(final @NotNull Map<Key, DataComponentValue> holder);
+    ShowItem dataComponents(final Map<Key, DataComponentValue> holder);
 
     /**
      * Return an unmodifiable map of data components coerced to the target type.
@@ -452,7 +451,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return the unmodifiable map
      * @since 4.17.0
      */
-    <V extends DataComponentValue> @NotNull Map<Key, V> dataComponentsAs(final @NotNull Class<V> targetType);
+    <V extends DataComponentValue> Map<Key, V> dataComponentsAs(final Class<V> targetType);
   }
 
   /**
@@ -469,7 +468,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowEntity}
      * @since 4.14.0
      */
-    static @NotNull ShowEntity showEntity(final @NotNull Key type, final @NotNull UUID id) {
+    static ShowEntity showEntity(final Key type, final UUID id) {
       return ShowEntity.showEntity(type, id, null);
     }
 
@@ -481,7 +480,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowEntity}
      * @since 4.14.0
      */
-    static @NotNull ShowEntity showEntity(final @NotNull Keyed type, final @NotNull UUID id) {
+    static ShowEntity showEntity(final Keyed type, final UUID id) {
       return ShowEntity.showEntity(type, id, null);
     }
 
@@ -494,7 +493,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowEntity}
      * @since 4.14.0
      */
-    static @NotNull ShowEntity showEntity(final @NotNull Key type, final @NotNull UUID id, final @Nullable Component name) {
+    static ShowEntity showEntity(final Key type, final UUID id, final @Nullable Component name) {
       return new HoverEventImpl.ShowEntityImpl(requireNonNull(type, "type"), requireNonNull(id, "id"), name);
     }
 
@@ -507,7 +506,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowEntity}
      * @since 4.14.0
      */
-    static @NotNull ShowEntity showEntity(final @NotNull Keyed type, final @NotNull UUID id, final @Nullable Component name) {
+    static ShowEntity showEntity(final Keyed type, final UUID id, final @Nullable Component name) {
       return new HoverEventImpl.ShowEntityImpl(requireNonNull(type, "type").key(), requireNonNull(id, "id"), name);
     }
 
@@ -517,7 +516,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return the type
      * @since 4.0.0
      */
-    @NotNull Key type();
+    Key type();
 
     /**
      * Sets the type.
@@ -526,7 +525,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowEntity}
      * @since 4.0.0
      */
-    @NotNull ShowEntity type(final @NotNull Key type);
+    ShowEntity type(final Key type);
 
     /**
      * Sets the type.
@@ -535,7 +534,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowEntity}
      * @since 4.6.0
      */
-    default @NotNull ShowEntity type(final @NotNull Keyed type) {
+    default ShowEntity type(final Keyed type) {
       return this.type(requireNonNull(type, "type").key());
     }
 
@@ -545,7 +544,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return the id
      * @since 4.0.0
      */
-    @NotNull UUID id();
+    UUID id();
 
     /**
      * Sets the id.
@@ -554,7 +553,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowEntity}
      * @since 4.0.0
      */
-    @NotNull ShowEntity id(final @NotNull UUID id);
+    ShowEntity id(final UUID id);
 
     /**
      * Gets the name.
@@ -571,7 +570,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return a {@code ShowEntity}
      * @since 4.0.0
      */
-    @NotNull ShowEntity name(final @Nullable Component name);
+    ShowEntity name(final @Nullable Component name);
   }
 
   /**
@@ -588,7 +587,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      */
     Action<Component> SHOW_TEXT = new HoverEventImpl.ActionImpl<>("show_text", Component.class, true, new Renderer<>() {
       @Override
-      public <C> @NotNull Component render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull Component value) {
+      public <C> Component render(final ComponentRenderer<C> renderer, final C context, final Component value) {
         return renderer.render(value, context);
       }
     });
@@ -599,7 +598,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      */
     Action<ShowItem> SHOW_ITEM = new HoverEventImpl.ActionImpl<>("show_item", ShowItem.class, true, new Renderer<>() {
       @Override
-      public <C> @NotNull ShowItem render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull ShowItem value) {
+      public <C> ShowItem render(final ComponentRenderer<C> renderer, final C context, final ShowItem value) {
         return value;
       }
     });
@@ -610,7 +609,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      */
     Action<ShowEntity> SHOW_ENTITY = new HoverEventImpl.ActionImpl<>("show_entity", ShowEntity.class, true, new Renderer<>() {
       @Override
-      public <C> @NotNull ShowEntity render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull ShowEntity value) {
+      public <C> ShowEntity render(final ComponentRenderer<C> renderer, final C context, final ShowEntity value) {
         final Component name = value.name();
         if (name == null) return value;
         return value.name(renderer.render(name, context));
@@ -625,7 +624,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
     @Deprecated
     Action<String> SHOW_ACHIEVEMENT = new HoverEventImpl.ActionImpl<>("show_achievement", String.class, true, new Renderer<>() {
       @Override
-      public <C> @NotNull String render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull String value) {
+      public <C> String render(final ComponentRenderer<C> renderer, final C context, final String value) {
         return value;
       }
     });
@@ -643,7 +642,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return the value type
      * @since 4.0.0
      */
-    @NotNull Class<V> type();
+    Class<V> type();
 
     /**
      * Tests if this action is readable.
@@ -660,7 +659,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
      * @return the renderer
      * @since 5.0.0
      */
-    @NotNull Renderer<V> renderer();
+    Renderer<V> renderer();
 
     /**
      * Type-specific renderer.
@@ -681,7 +680,7 @@ public sealed interface HoverEvent<V> extends Examinable, HoverEventSource<V>, S
        * @param <C> the type of the context
        * @since 4.0.0
        */
-      <C> @NotNull V render(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context, final @NotNull V value);
+      <C> V render(final ComponentRenderer<C> renderer, final C context, final V value);
     }
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEventImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEventImpl.java
@@ -37,21 +37,20 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.renderer.ComponentRenderer;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 record HoverEventImpl<V>(Action<V> action, V value) implements HoverEvent<V> {
 
-  public HoverEventImpl(final @NotNull Action<V> action, final @NotNull V value) {
+  public HoverEventImpl(final Action<V> action, final V value) {
     this.action = requireNonNull(action, "action");
     this.value = requireNonNull(value, "value");
   }
 
   @Override
-  public @NotNull HoverEvent<V> value(final @NotNull V value) {
+  public HoverEvent<V> value(final V value) {
     return new HoverEventImpl<>(this.action, value);
   }
 
@@ -65,7 +64,7 @@ record HoverEventImpl<V>(Action<V> action, V value) implements HoverEvent<V> {
    * @since 4.0.0
    */
   @Override
-  public <C> @NotNull HoverEvent<V> withRenderedValue(final @NotNull ComponentRenderer<C> renderer, final @NotNull C context) {
+  public <C> HoverEvent<V> withRenderedValue(final ComponentRenderer<C> renderer, final C context) {
     final V oldValue = this.value;
     final V newValue = this.action.renderer().render(renderer, context, oldValue);
     if (newValue != oldValue) return new HoverEventImpl<>(this.action, newValue);
@@ -73,53 +72,53 @@ record HoverEventImpl<V>(Action<V> action, V value) implements HoverEvent<V> {
   }
 
   @Override
-  public @NotNull HoverEvent<V> asHoverEvent() {
+  public HoverEvent<V> asHoverEvent() {
     return this; // i already am a hover event! hehehehe
   }
 
   @Override
-  public @NotNull HoverEvent<V> asHoverEvent(final @NotNull UnaryOperator<V> op) {
+  public HoverEvent<V> asHoverEvent(final UnaryOperator<V> op) {
     if (op == UnaryOperator.<V>identity()) return this; // nothing to do, can return ourself
     return new HoverEventImpl<>(this.action, op.apply(this.value));
   }
 
   @Override
-  public void styleApply(final Style.@NotNull Builder style) {
+  public void styleApply(final Style.Builder style) {
     style.hoverEvent(this);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   record ShowItemImpl(Key item, int count, BinaryTagHolder nbt, Map<Key, DataComponentValue> dataComponents) implements ShowItem {
     @Override
-    public @NotNull ShowItem item(final @NotNull Key item) {
+    public ShowItem item(final Key item) {
       if (requireNonNull(item, "item").equals(this.item)) return this;
       return new ShowItemImpl(item, this.count, this.nbt, this.dataComponents);
     }
 
     @Override
-    public @NotNull ShowItem count(final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
+    public ShowItem count(final @Range(from = 0, to = Integer.MAX_VALUE) int count) {
       if (count == this.count) return this;
       return new ShowItemImpl(this.item, count, this.nbt, this.dataComponents);
     }
 
     @Override
-    public @NotNull ShowItem nbt(final @Nullable BinaryTagHolder nbt) {
+    public ShowItem nbt(final @Nullable BinaryTagHolder nbt) {
       if (Objects.equals(nbt, this.nbt)) return this;
       return new ShowItemImpl(this.item, this.count, nbt, Collections.emptyMap());
     }
 
     @Override
-    public @NotNull ShowItem dataComponents(final @NotNull Map<Key, DataComponentValue> holder) {
+    public ShowItem dataComponents(final Map<Key, DataComponentValue> holder) {
       if (Objects.equals(this.dataComponents, holder)) return this;
       return new ShowItemImpl(this.item, this.count, null, holder.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(holder)));
     }
 
     @Override
-    public <V extends DataComponentValue> @NotNull Map<Key, V> dataComponentsAs(final @NotNull Class<V> targetType) {
+    public <V extends DataComponentValue> Map<Key, V> dataComponentsAs(final Class<V> targetType) {
       if (this.dataComponents.isEmpty()) {
         return Collections.emptyMap();
       } else {
@@ -132,7 +131,7 @@ record HoverEventImpl<V>(Action<V> action, V value) implements HoverEvent<V> {
     }
 
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("item", this.item),
         ExaminableProperty.of("count", this.count),
@@ -142,32 +141,32 @@ record HoverEventImpl<V>(Action<V> action, V value) implements HoverEvent<V> {
     }
 
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return Internals.toString(this);
     }
   }
 
   record ShowEntityImpl(Key type, UUID id, Component name) implements ShowEntity {
     @Override
-    public @NotNull ShowEntity type(final @NotNull Key type) {
+    public ShowEntity type(final Key type) {
       if (requireNonNull(type, "type").equals(this.type)) return this;
       return new ShowEntityImpl(type, this.id, this.name);
     }
 
     @Override
-    public @NotNull ShowEntity id(final @NotNull UUID id) {
+    public ShowEntity id(final UUID id) {
       if (requireNonNull(id).equals(this.id)) return this;
       return new ShowEntityImpl(this.type, id, this.name);
     }
 
     @Override
-    public @NotNull ShowEntity name(final @Nullable Component name) {
+    public ShowEntity name(final @Nullable Component name) {
       if (Objects.equals(name, this.name)) return this;
       return new ShowEntityImpl(this.type, this.id, name);
     }
 
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("type", this.type),
         ExaminableProperty.of("id", this.id),
@@ -176,14 +175,14 @@ record HoverEventImpl<V>(Action<V> action, V value) implements HoverEvent<V> {
     }
 
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return Internals.toString(this);
     }
   }
 
   record ActionImpl<V>(String name, Class<V> type, boolean readable, Renderer<V> renderer) implements Action<V> {
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return this.name;
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/event/HoverEventSource.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/HoverEventSource.java
@@ -24,8 +24,7 @@
 package net.kyori.adventure.text.event;
 
 import java.util.function.UnaryOperator;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Something that can provide a {@link HoverEvent}.
@@ -52,7 +51,7 @@ public interface HoverEventSource<V> {
    * @return a hover event
    * @since 4.0.0
    */
-  default @NotNull HoverEvent<V> asHoverEvent() {
+  default HoverEvent<V> asHoverEvent() {
     return this.asHoverEvent(UnaryOperator.identity());
   }
 
@@ -66,5 +65,5 @@ public interface HoverEventSource<V> {
    * @return a hover event
    * @since 4.0.0
    */
-  @NotNull HoverEvent<V> asHoverEvent(final @NotNull UnaryOperator<V> op);
+  HoverEvent<V> asHoverEvent(final UnaryOperator<V> op);
 }

--- a/api/src/main/java/net/kyori/adventure/text/event/PayloadImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/event/PayloadImpl.java
@@ -29,7 +29,6 @@ import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 final class PayloadImpl {
   private PayloadImpl() {
@@ -37,49 +36,49 @@ final class PayloadImpl {
 
   record TextImpl(String value) implements ClickEventImpl.Payload.Text {
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("value", this.value)
       );
     }
 
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return Internals.toString(this);
     }
   }
 
   record IntImpl(int integer) implements ClickEventImpl.Payload.Int {
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("integer", this.integer)
       );
     }
 
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return Internals.toString(this);
     }
   }
 
   record DialogImpl(DialogLike dialog) implements ClickEventImpl.Payload.Dialog {
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("dialog", this.dialog)
       );
     }
 
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return Internals.toString(this);
     }
   }
 
   record CustomImpl(Key key, BinaryTagHolder nbt) implements ClickEventImpl.Payload.Custom {
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("key", this.key),
         ExaminableProperty.of("nbt", this.nbt)
@@ -87,7 +86,7 @@ final class PayloadImpl {
     }
 
     @Override
-    public @NotNull String toString() {
+    public String toString() {
       return Internals.toString(this);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattener.java
+++ b/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattener.java
@@ -28,9 +28,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A 'flattener' to convert a component tree to a linear string for display.
@@ -51,7 +50,7 @@ public sealed interface ComponentFlattener permits ComponentFlattenerImpl {
    * @return a new builder
    * @since 4.7.0
    */
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new ComponentFlattenerImpl.BuilderImpl();
   }
 
@@ -64,7 +63,7 @@ public sealed interface ComponentFlattener permits ComponentFlattenerImpl {
    * @return a basic flattener
    * @since 4.7.0
    */
-  static @NotNull ComponentFlattener basic() {
+  static ComponentFlattener basic() {
     return ComponentFlattenerImpl.BASIC;
   }
 
@@ -76,7 +75,7 @@ public sealed interface ComponentFlattener permits ComponentFlattenerImpl {
    * @return a text-only flattener
    * @since 4.7.0
    */
-  static @NotNull ComponentFlattener textOnly() {
+  static ComponentFlattener textOnly() {
     return ComponentFlattenerImpl.TEXT_ONLY;
   }
 
@@ -87,10 +86,10 @@ public sealed interface ComponentFlattener permits ComponentFlattenerImpl {
    * @param listener the listener that will receive flattened component state
    * @since 4.7.0
    */
-  void flatten(final @NotNull Component input, final @NotNull FlattenerListener listener);
+  void flatten(final Component input, final FlattenerListener listener);
 
   // TODO: common builder interface?
-  @NotNull Builder toBuilder();
+  Builder toBuilder();
 
   /**
    * A builder for a component flattener.
@@ -110,7 +109,7 @@ public sealed interface ComponentFlattener permits ComponentFlattenerImpl {
      * @see #complexMapper(Class, BiConsumer) for component types that are too complex to be directly rendered to a string
      * @since 4.7.0
      */
-    <T extends Component> @NotNull Builder mapper(final @NotNull Class<T> type, final @NotNull Function<T, String> converter);
+    <T extends Component> Builder mapper(final Class<T> type, final Function<T, String> converter);
 
     /**
      * Register a type of component that needs to be flattened to an intermediate stage.
@@ -121,7 +120,7 @@ public sealed interface ComponentFlattener permits ComponentFlattenerImpl {
      * @return this builder
      * @since 4.7.0
      */
-    <T extends Component> @NotNull Builder complexMapper(final @NotNull Class<T> type, final @NotNull BiConsumer<T, Consumer<Component>> converter);
+    <T extends Component> Builder complexMapper(final Class<T> type, final BiConsumer<T, Consumer<Component>> converter);
 
     /**
      * Register a handler for unknown component types.
@@ -132,7 +131,7 @@ public sealed interface ComponentFlattener permits ComponentFlattenerImpl {
      * @return this builder
      * @since 4.7.0
      */
-    @NotNull Builder unknownMapper(final @Nullable Function<Component, String> converter);
+    Builder unknownMapper(final @Nullable Function<Component, String> converter);
 
     /**
      * Sets the limit of nested flatten calls.
@@ -144,6 +143,6 @@ public sealed interface ComponentFlattener permits ComponentFlattenerImpl {
      * @return this builder
      * @since 4.22.0
      */
-    @NotNull Builder nestingLimit(final @Range(from = 1, to = Integer.MAX_VALUE) int limit);
+    Builder nestingLimit(final @Range(from = 1, to = Integer.MAX_VALUE) int limit);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattenerImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/flattener/ComponentFlattenerImpl.java
@@ -42,9 +42,8 @@ import net.kyori.adventure.text.object.ObjectContents;
 import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import net.kyori.adventure.text.object.SpriteObjectContents;
 import net.kyori.adventure.util.InheritanceAwareMap;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -80,11 +79,11 @@ record ComponentFlattenerImpl(InheritanceAwareMap<Component, Handler> flatteners
   }
 
   @Override
-  public void flatten(final @NotNull Component input, final @NotNull FlattenerListener listener) {
+  public void flatten(final Component input, final FlattenerListener listener) {
     this.flatten0(input, listener, 0, 0);
   }
 
-  private void flatten0(final @NotNull Component input, final @NotNull FlattenerListener listener, final int depth, final int nestedDepth) {
+  private void flatten0(final Component input, final FlattenerListener listener, final int depth, final int nestedDepth) {
     requireNonNull(input, "input");
     requireNonNull(listener, "listener");
     if (input == Component.empty()) return;
@@ -178,32 +177,32 @@ record ComponentFlattenerImpl(InheritanceAwareMap<Component, Handler> flatteners
     }
 
     @Override
-    public @NotNull ComponentFlattener build() {
+    public ComponentFlattener build() {
       return new ComponentFlattenerImpl(this.flatteners.build(), this.unknownHandler, this.maxNestedDepth);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public @NotNull <T extends Component> Builder mapper(final @NotNull Class<T> type, final @NotNull Function<T, String> converter) {
+    public <T extends Component> Builder mapper(final Class<T> type, final Function<T, String> converter) {
       this.flatteners.put(type, (self, component, listener, depth, nestedDepth) -> listener.component(converter.apply((T) component)));
       return this;
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public @NotNull <T extends Component> Builder complexMapper(final @NotNull Class<T> type, final @NotNull BiConsumer<T, Consumer<Component>> converter) {
+    public <T extends Component> Builder complexMapper(final Class<T> type, final BiConsumer<T, Consumer<Component>> converter) {
       this.flatteners.put(type, (self, component, listener, depth, nestedDepth) -> converter.accept((T) component, c -> self.flatten0(c, listener, depth, nestedDepth + 1)));
       return this;
     }
 
     @Override
-    public @NotNull Builder unknownMapper(final @Nullable Function<Component, String> converter) {
+    public Builder unknownMapper(final @Nullable Function<Component, String> converter) {
       this.unknownHandler = converter;
       return this;
     }
 
     @Override
-    public @NotNull Builder nestingLimit(final @Range(from = 1, to = Integer.MAX_VALUE) int limit) {
+    public Builder nestingLimit(final @Range(from = 1, to = Integer.MAX_VALUE) int limit) {
       // noinspection ConstantValue (the Range annotation tells IDEA this will never happen, but API users could ignore that)
       if (limit != ComponentFlattener.NO_NESTING_LIMIT && limit < 1) throw new IllegalArgumentException("limit must be positive or ComponentFlattener.NO_NESTING_LIMIT");
       this.maxNestedDepth = limit;

--- a/api/src/main/java/net/kyori/adventure/text/flattener/FlattenerListener.java
+++ b/api/src/main/java/net/kyori/adventure/text/flattener/FlattenerListener.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.flattener;
 
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A listener accepting styled information from flattened components.
@@ -39,7 +38,7 @@ public interface FlattenerListener {
    * @param style the style to push
    * @since 4.7.0
    */
-  default void pushStyle(final @NotNull Style style) {
+  default void pushStyle(final Style style) {
   }
 
   /**
@@ -48,7 +47,7 @@ public interface FlattenerListener {
    * @param text the component text
    * @since 4.7.0
    */
-  void component(final @NotNull String text);
+  void component(final String text);
 
   /**
    * Determine if the flattener should continue running.
@@ -68,6 +67,6 @@ public interface FlattenerListener {
    * @param style the style popped, as passed to {@link #pushStyle(Style)}
    * @since 4.7.0
    */
-  default void popStyle(final @NotNull Style style) {
+  default void popStyle(final Style style) {
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -37,7 +37,6 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
 /**
@@ -125,7 +124,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
     this.bitSet = bitSet;
   }
 
-  public @NotNull DecorationMap with(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  public DecorationMap with(final TextDecoration decoration, final TextDecoration.State state) {
     Objects.requireNonNull(state, "state");
     Objects.requireNonNull(decoration, "decoration");
     final int offset = offset(decoration);
@@ -134,7 +133,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Arrays.stream(DECORATIONS)
       .map(decoration -> ExaminableProperty.of(decoration.toString(), this.get(decoration)));
   }
@@ -164,7 +163,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
   }
 
   @Override
-  public @NotNull Set<Entry<TextDecoration, TextDecoration.State>> entrySet() {
+  public Set<Entry<TextDecoration, TextDecoration.State>> entrySet() {
     if (this.entrySet == null) {
       synchronized (this) {
         // re-check for lost race condition
@@ -177,12 +176,12 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
   }
 
   @Override
-  public @NotNull Set<TextDecoration> keySet() {
+  public Set<TextDecoration> keySet() {
     return KEY_SET;
   }
 
   @Override
-  public @NotNull Collection<TextDecoration.State> values() {
+  public Collection<TextDecoration.State> values() {
     if (this.values == null) {
       synchronized (this) {
         // re-check for lost race condition
@@ -208,7 +207,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
 
   final class EntrySet extends AbstractSet<Entry<TextDecoration, TextDecoration.State>> {
     @Override
-    public @NotNull Iterator<Entry<TextDecoration, TextDecoration.State>> iterator() {
+    public Iterator<Entry<TextDecoration, TextDecoration.State>> iterator() {
       return new Iterator<>() {
         private final Iterator<TextDecoration> decorations = KEY_SET.iterator();
         private final Iterator<TextDecoration.State> states = DecorationMap.this.values().iterator();
@@ -236,7 +235,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
 
   final class Values extends AbstractCollection<TextDecoration.State> {
     @Override
-    public @NotNull Iterator<TextDecoration.State> iterator() {
+    public Iterator<TextDecoration.State> iterator() {
       return Spliterators.iterator(Arrays.spliterator(this.toArray(EMPTY_STATE_ARRAY)));
     }
 
@@ -246,7 +245,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
     }
 
     @Override
-    public Object @NotNull [] toArray() {
+    public Object [] toArray() {
       final Object[] states = new Object[MAP_SIZE];
       for (int i = 0; i < MAP_SIZE; i++) {
         states[i] = DecorationMap.this.get(DECORATIONS[i]);
@@ -256,7 +255,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T @NotNull [] toArray(final T @NotNull [] dest) {
+    public <T> T [] toArray(final T [] dest) {
       if (dest.length < MAP_SIZE) {
         return (T[]) Arrays.copyOf(this.toArray(), MAP_SIZE, dest.getClass());
       }
@@ -291,13 +290,13 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
     }
 
     @Override
-    public Object @NotNull [] toArray() {
+    public Object [] toArray() {
       return Arrays.copyOf(DECORATIONS, MAP_SIZE, Object[].class);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T @NotNull [] toArray(final T @NotNull [] dest) {
+    public <T> T [] toArray(final T [] dest) {
       if (dest.length < MAP_SIZE) {
         return (T[]) Arrays.copyOf(DECORATIONS, MAP_SIZE, dest.getClass());
       }
@@ -309,7 +308,7 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
     }
 
     @Override
-    public @NotNull Iterator<TextDecoration> iterator() {
+    public Iterator<TextDecoration> iterator() {
       return Spliterators.iterator(Arrays.spliterator(DECORATIONS));
     }
 

--- a/api/src/main/java/net/kyori/adventure/text/format/MutableStyleSetter.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/MutableStyleSetter.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +51,7 @@ public interface MutableStyleSetter<T extends MutableStyleSetter<?>> extends Sty
   @Override
   @Contract("_ -> this")
   @SuppressWarnings("unchecked")
-  default @NotNull T decorate(final @NotNull TextDecoration@NotNull... decorations) {
+  default T decorate(final TextDecoration... decorations) {
     for (final TextDecoration decoration : decorations) {
       this.decorate(decoration);
     }
@@ -71,7 +70,7 @@ public interface MutableStyleSetter<T extends MutableStyleSetter<?>> extends Sty
   @Override
   @Contract("_ -> this")
   @SuppressWarnings("unchecked")
-  default @NotNull T decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
+  default T decorations(final Map<TextDecoration, TextDecoration.State> decorations) {
     requireNonNull(decorations, "decorations");
     for (final Map.Entry<TextDecoration, TextDecoration.State> entry : decorations.entrySet()) {
       this.decoration(entry.getKey(), entry.getValue());
@@ -91,7 +90,7 @@ public interface MutableStyleSetter<T extends MutableStyleSetter<?>> extends Sty
   @Override
   @Contract("_, _ -> this")
   @SuppressWarnings("unchecked")
-  default @NotNull T decorations(final @NotNull Set<TextDecoration> decorations, final boolean flag) {
+  default T decorations(final Set<TextDecoration> decorations, final boolean flag) {
     final TextDecoration.State state = TextDecoration.State.byBoolean(flag);
     decorations.forEach(decoration -> this.decoration(decoration, state));
     return (T) this;

--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java
@@ -24,8 +24,7 @@
 package net.kyori.adventure.text.format;
 
 import net.kyori.adventure.util.Index;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The named text colours in Minecraft: Java Edition.
@@ -172,7 +171,7 @@ public sealed interface NamedTextColor extends TextColor permits NamedTextColorI
    * @return nearest named colour. will always return a value
    * @since 4.0.0
    */
-  static @NotNull NamedTextColor nearestTo(final @NotNull TextColor any) {
+  static NamedTextColor nearestTo(final TextColor any) {
     if (any instanceof final NamedTextColor namedTextColor) return namedTextColor;
     return TextColor.nearestColorTo(NamedTextColorImpl.VALUES, any);
   }

--- a/api/src/main/java/net/kyori/adventure/text/format/NamedTextColorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/NamedTextColorImpl.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.stream.Stream;
 import net.kyori.adventure.util.HSVLike;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 public record NamedTextColorImpl(String name, int value) implements NamedTextColor {
   static final int BLACK_VALUE = 0x000000;
@@ -50,17 +49,17 @@ public record NamedTextColorImpl(String name, int value) implements NamedTextCol
   static final List<NamedTextColor> VALUES = List.of(BLACK, DARK_BLUE, DARK_GREEN, DARK_AQUA, DARK_RED, DARK_PURPLE, GOLD, GRAY, DARK_GRAY, BLUE, GREEN, AQUA, RED, LIGHT_PURPLE, YELLOW, WHITE);
 
   @Override
-  public @NotNull HSVLike asHSV() {
+  public HSVLike asHSV() {
     return HSVLike.fromRGB(this.red(), this.green(), this.blue());
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return this.name;
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("name", this.name));
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/ShadowColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/ShadowColor.java
@@ -27,9 +27,8 @@ import net.kyori.adventure.util.ARGBLike;
 import net.kyori.adventure.util.RGBLike;
 import org.intellij.lang.annotations.Pattern;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A shadow color which may be applied to a {@link Style}.
@@ -51,7 +50,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @return the interpolated value, a color between the two input colors {@code a} and {@code b}
    * @since 4.18.0
    */
-  static @NotNull ShadowColor lerp(final float t, final @NotNull ARGBLike a, final @NotNull ARGBLike b) {
+  static ShadowColor lerp(final float t, final ARGBLike a, final ARGBLike b) {
     final float clampedT = Math.min(1.0f, Math.max(0.0f, t)); // clamp between 0 and 1
     final int ar = a.red();
     final int br = b.red();
@@ -75,7 +74,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @return a disabling shadow color
    * @since 4.18.0
    */
-  static @NotNull ShadowColor none() {
+  static ShadowColor none() {
     return ShadowColorImpl.NONE;
   }
 
@@ -89,7 +88,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @since 4.18.0
    */
   @Contract(pure = true)
-  static @NotNull ShadowColor shadowColor(final int argb) {
+  static ShadowColor shadowColor(final int argb) {
     if (argb == ShadowColorImpl.NONE_VALUE) return none();
 
     return new ShadowColorImpl(argb);
@@ -106,7 +105,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @since 4.18.0
    */
   @Contract(pure = true)
-  static @NotNull ShadowColor shadowColor(
+  static ShadowColor shadowColor(
     final @Range(from = 0x0, to = 0xff) int red,
     final @Range(from = 0x0, to = 0xff) int green,
     final @Range(from = 0x0, to = 0xff) int blue,
@@ -130,7 +129,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @since 4.18.0
    */
   @Contract(pure = true)
-  static @NotNull ShadowColor shadowColor(final @NotNull RGBLike rgb, final @Range(from = 0x0, to = 0xff) int alpha) {
+  static ShadowColor shadowColor(final RGBLike rgb, final @Range(from = 0x0, to = 0xff) int alpha) {
     return shadowColor(rgb.red(), rgb.green(), rgb.blue(), alpha);
   }
 
@@ -141,7 +140,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @return a shadow colour
    * @since 4.18.0
    */
-  static @NotNull ShadowColor shadowColor(final @NotNull ARGBLike argb) {
+  static ShadowColor shadowColor(final ARGBLike argb) {
     if (argb instanceof ShadowColor) {
       return (ShadowColor) argb;
     }
@@ -159,7 +158,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @since 4.18.0
    */
   @Contract(pure = true)
-  static @Nullable ShadowColor fromHexString(@Pattern("#[0-9a-fA-F]{8}") final @NotNull String hex) {
+  static @Nullable ShadowColor fromHexString(@Pattern("#[0-9a-fA-F]{8}") final String hex) {
     if (hex.length() != 9) return null;
     if (!hex.startsWith("#")) return null;
 
@@ -182,7 +181,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @return the hex string representation of this shadow colour
    * @since 4.18.0
    */
-  default @NotNull String asHexString() {
+  default String asHexString() {
     final int argb = this.value();
     final int a = (argb >> 24) & 0xFF;
     final int r = (argb >> 16) & 0xFF;
@@ -244,7 +243,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
   int value();
 
   @Override
-  default void styleApply(final Style.@NotNull Builder style) {
+  default void styleApply(final Style.Builder style) {
     style.shadowColor(this);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/ShadowColorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/ShadowColorImpl.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * @param value ARGB
@@ -37,12 +36,12 @@ record ShadowColorImpl(int value) implements ShadowColor, Examinable {
   static final ShadowColorImpl NONE = new ShadowColorImpl(NONE_VALUE);
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("value", this.value) // todo: represent as hex?
     );

--- a/api/src/main/java/net/kyori/adventure/text/format/Style.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/Style.java
@@ -37,10 +37,9 @@ import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.util.MonkeyBars;
 import net.kyori.examination.Examinable;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A style applies visual effects or extra functionality to {@link Component}s,
@@ -73,7 +72,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return empty style
    * @since 4.0.0
    */
-  static @NotNull Style empty() {
+  static Style empty() {
     return StyleImpl.EMPTY;
   }
 
@@ -83,7 +82,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a builder
    * @since 4.0.0
    */
-  static @NotNull Builder style() {
+  static Builder style() {
     return new StyleImpl.BuilderImpl();
   }
 
@@ -94,7 +93,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  static @NotNull Style style(final @NotNull Consumer<Builder> consumer) {
+  static Style style(final Consumer<Builder> consumer) {
     return AbstractBuilder.configureAndBuild(style(), consumer);
   }
 
@@ -105,7 +104,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  static @NotNull Style style(final @Nullable TextColor color) {
+  static Style style(final @Nullable TextColor color) {
     return empty().color(color);
   }
 
@@ -116,7 +115,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  static @NotNull Style style(final @NotNull TextDecoration decoration) {
+  static Style style(final TextDecoration decoration) {
     return style().decoration(decoration, true).build();
   }
 
@@ -128,7 +127,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  static @NotNull Style style(final @Nullable TextColor color, final TextDecoration@NotNull... decorations) {
+  static Style style(final @Nullable TextColor color, final TextDecoration... decorations) {
     final Builder builder = style();
     builder.color(color);
     builder.decorate(decorations);
@@ -143,7 +142,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  static @NotNull Style style(final @Nullable TextColor color, final Set<TextDecoration> decorations) {
+  static Style style(final @Nullable TextColor color, final Set<TextDecoration> decorations) {
     final Builder builder = style();
     builder.color(color);
     if (!decorations.isEmpty()) {
@@ -161,7 +160,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  static @NotNull Style style(final @UnknownNullability StyleBuilderApplicable@NotNull... applicables) {
+  static Style style(final @UnknownNullability StyleBuilderApplicable... applicables) {
     final int length = applicables.length;
     if (length == 0) return empty();
     final Builder builder = style();
@@ -180,7 +179,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  static @NotNull Style style(final @NotNull Iterable<? extends StyleBuilderApplicable> applicables) {
+  static Style style(final Iterable<? extends StyleBuilderApplicable> applicables) {
     final Builder builder = style();
     for (final StyleBuilderApplicable applicable : applicables) {
       applicable.styleApply(builder);
@@ -197,7 +196,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a new style
    * @since 4.0.0
    */
-  default @NotNull Style edit(final @NotNull Consumer<Builder> consumer) {
+  default Style edit(final Consumer<Builder> consumer) {
     return this.edit(consumer, Merge.Strategy.ALWAYS);
   }
 
@@ -209,7 +208,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a new style
    * @since 4.0.0
    */
-  default @NotNull Style edit(final @NotNull Consumer<Builder> consumer, final Merge.@NotNull Strategy strategy) {
+  default Style edit(final Consumer<Builder> consumer, final Merge.Strategy strategy) {
     return style(style -> {
       if (strategy == Merge.Strategy.ALWAYS) {
         style.merge(this, strategy);
@@ -241,7 +240,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @sinceMinecraft 1.16
    */
   @Override
-  @NotNull Style font(final @Nullable Key font);
+  Style font(final @Nullable Key font);
 
   /**
    * Gets the color.
@@ -260,7 +259,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  @NotNull Style color(final @Nullable TextColor color);
+  Style color(final @Nullable TextColor color);
 
   /**
    * Sets the color if there isn't one set already.
@@ -270,7 +269,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  @NotNull Style colorIfAbsent(final @Nullable TextColor color);
+  Style colorIfAbsent(final @Nullable TextColor color);
 
   /**
    * Tests if this style has a decoration.
@@ -281,7 +280,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  default boolean hasDecoration(final @NotNull TextDecoration decoration) {
+  default boolean hasDecoration(final TextDecoration decoration) {
     return StyleGetter.super.hasDecoration(decoration);
   }
 
@@ -295,7 +294,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration);
+  TextDecoration.State decoration(final TextDecoration decoration);
 
   /**
    * Sets the state of {@code decoration} to {@link TextDecoration.State#TRUE} on this style.
@@ -305,7 +304,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  default @NotNull Style decorate(final @NotNull TextDecoration decoration) {
+  default Style decorate(final TextDecoration decoration) {
     return StyleSetter.super.decorate(decoration);
   }
 
@@ -319,7 +318,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  default @NotNull Style decoration(final @NotNull TextDecoration decoration, final boolean flag) {
+  default Style decoration(final TextDecoration decoration, final boolean flag) {
     return StyleSetter.super.decoration(decoration, flag);
   }
 
@@ -335,7 +334,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  @NotNull Style decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+  Style decoration(final TextDecoration decoration, final TextDecoration.State state);
 
   /**
    * Sets the state of a decoration on this style to {@code state} if the current state of
@@ -347,7 +346,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.12.0
    */
   @Override
-  @NotNull Style decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+  Style decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state);
 
   /**
    * Gets a map of decorations this style has.
@@ -356,7 +355,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  default @Unmodifiable @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
+  default @Unmodifiable Map<TextDecoration, TextDecoration.State> decorations() {
     return StyleGetter.super.decorations();
   }
 
@@ -370,7 +369,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations);
+  Style decorations(final Map<TextDecoration, TextDecoration.State> decorations);
 
   /**
    * Gets the click event.
@@ -389,7 +388,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  @NotNull Style clickEvent(final @Nullable ClickEvent<?> event);
+  Style clickEvent(final @Nullable ClickEvent<?> event);
 
   /**
    * Gets the hover event.
@@ -408,7 +407,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  @NotNull Style hoverEvent(final @Nullable HoverEventSource<?> source);
+  Style hoverEvent(final @Nullable HoverEventSource<?> source);
 
   /**
    * Gets the string to be inserted when this style is shift-clicked.
@@ -427,7 +426,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @since 4.0.0
    */
   @Override
-  @NotNull Style insertion(final @Nullable String insertion);
+  Style insertion(final @Nullable String insertion);
 
   /**
    * Merges from another style into this style.
@@ -436,7 +435,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  default @NotNull Style merge(final @NotNull Style that) {
+  default Style merge(final Style that) {
     return this.merge(that, Merge.all());
   }
 
@@ -448,7 +447,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  default @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy) {
+  default Style merge(final Style that, final Merge.Strategy strategy) {
     return this.merge(that, strategy, Merge.all());
   }
 
@@ -460,7 +459,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  default @NotNull Style merge(final @NotNull Style that, final @NotNull Merge merge) {
+  default Style merge(final Style that, final Merge merge) {
     return this.merge(that, Collections.singleton(merge));
   }
 
@@ -473,7 +472,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  default @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Merge merge) {
+  default Style merge(final Style that, final Merge.Strategy strategy, final Merge merge) {
     return this.merge(that, strategy, Collections.singleton(merge));
   }
 
@@ -485,7 +484,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  default @NotNull Style merge(final @NotNull Style that, final @NotNull Merge@NotNull... merges) {
+  default Style merge(final Style that, final Merge... merges) {
     return this.merge(that, Merge.merges(merges));
   }
 
@@ -498,7 +497,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  default @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Merge@NotNull... merges) {
+  default Style merge(final Style that, final Merge.Strategy strategy, final Merge... merges) {
     return this.merge(that, strategy, Merge.merges(merges));
   }
 
@@ -510,7 +509,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  default @NotNull Style merge(final @NotNull Style that, final @NotNull Set<Merge> merges) {
+  default Style merge(final Style that, final Set<Merge> merges) {
     return this.merge(that, Merge.Strategy.ALWAYS, merges);
   }
 
@@ -523,7 +522,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a style
    * @since 4.0.0
    */
-  @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges);
+  Style merge(final Style that, final Merge.Strategy strategy, final Set<Merge> merges);
 
   /**
    * Simplify this style to remove any information that is redundant.
@@ -532,7 +531,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    * @return a new, simplified style
    * @since 4.12.0
    */
-  @NotNull Style unmerge(final @NotNull Style that);
+  Style unmerge(final Style that);
 
   /**
    * Tests if this style is empty.
@@ -548,7 +547,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
    *
    * @return a builder
    */
-  @NotNull Builder toBuilder();
+  Builder toBuilder();
 
   /**
    * A merge choice.
@@ -602,7 +601,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @return a merge set
      * @since 4.0.0
      */
-    public static @Unmodifiable @NotNull Set<Merge> all() {
+    public static @Unmodifiable Set<Merge> all() {
       return ALL;
     }
 
@@ -612,7 +611,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @return a merge set
      * @since 4.0.0
      */
-    public static @Unmodifiable @NotNull Set<Merge> colorAndDecorations() {
+    public static @Unmodifiable Set<Merge> colorAndDecorations() {
       return COLOR_AND_DECORATIONS;
     }
 
@@ -623,11 +622,11 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @return a merge set
      * @since 4.10.0
      */
-    public static @Unmodifiable @NotNull Set<Merge> merges(final Merge@NotNull... merges) {
+    public static @Unmodifiable Set<Merge> merges(final Merge... merges) {
       return MonkeyBars.enumSet(Merge.class, merges);
     }
 
-    static boolean hasAll(final @NotNull Set<Merge> merges) {
+    static boolean hasAll(final Set<Merge> merges) {
       return merges.size() == ALL.size();
     }
 
@@ -674,7 +673,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    @NotNull Builder font(final @Nullable Key font);
+    Builder font(final @Nullable Key font);
 
     /**
      * Sets the color.
@@ -685,7 +684,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    @NotNull Builder color(final @Nullable TextColor color);
+    Builder color(final @Nullable TextColor color);
 
     /**
      * Sets the color if there isn't one set already.
@@ -696,7 +695,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    @NotNull Builder colorIfAbsent(final @Nullable TextColor color);
+    Builder colorIfAbsent(final @Nullable TextColor color);
 
     /**
      * Sets {@code decoration} to {@link TextDecoration.State#TRUE}.
@@ -707,7 +706,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    default @NotNull Builder decorate(final @NotNull TextDecoration decoration) {
+    default Builder decorate(final TextDecoration decoration) {
       return MutableStyleSetter.super.decorate(decoration);
     }
 
@@ -720,7 +719,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    default @NotNull Builder decorate(final @NotNull TextDecoration@NotNull... decorations) {
+    default Builder decorate(final TextDecoration... decorations) {
       return MutableStyleSetter.super.decorate(decorations);
     }
 
@@ -735,7 +734,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_, _ -> this")
-    default @NotNull Builder decoration(final @NotNull TextDecoration decoration, final boolean flag) {
+    default Builder decoration(final TextDecoration decoration, final boolean flag) {
       return MutableStyleSetter.super.decoration(decoration, flag);
     }
 
@@ -750,7 +749,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    default @NotNull Builder decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
+    default Builder decorations(final Map<TextDecoration, TextDecoration.State> decorations) {
       return MutableStyleSetter.super.decorations(decorations);
     }
 
@@ -767,7 +766,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_, _ -> this")
-    @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+    Builder decoration(final TextDecoration decoration, final TextDecoration.State state);
 
     /**
      * Sets the state of a decoration on this style to {@code state} if the current state of the decoration is {@link TextDecoration.State#NOT_SET}.
@@ -779,7 +778,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_, _ -> this")
-    @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+    Builder decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state);
 
     /**
      * Sets the click event.
@@ -790,7 +789,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    @NotNull Builder clickEvent(final @Nullable ClickEvent<?> event);
+    Builder clickEvent(final @Nullable ClickEvent<?> event);
 
     /**
      * Sets the hover event.
@@ -801,7 +800,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    @NotNull Builder hoverEvent(final @Nullable HoverEventSource<?> source);
+    Builder hoverEvent(final @Nullable HoverEventSource<?> source);
 
     /**
      * Sets the string to be inserted.
@@ -812,7 +811,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      */
     @Override
     @Contract("_ -> this")
-    @NotNull Builder insertion(final @Nullable String insertion);
+    Builder insertion(final @Nullable String insertion);
 
     /**
      * Merges from another style into this style.
@@ -822,7 +821,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    default @NotNull Builder merge(final @NotNull Style that) {
+    default Builder merge(final Style that) {
       return this.merge(that, Merge.all());
     }
 
@@ -835,7 +834,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @since 4.0.0
      */
     @Contract("_, _ -> this")
-    default @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy) {
+    default Builder merge(final Style that, final Merge.Strategy strategy) {
       return this.merge(that, strategy, Merge.all());
     }
 
@@ -848,7 +847,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @since 4.0.0
      */
     @Contract("_, _ -> this")
-    default @NotNull Builder merge(final @NotNull Style that, final @NotNull Merge@NotNull... merges) {
+    default Builder merge(final Style that, final Merge... merges) {
       if (merges.length == 0) return this;
       return this.merge(that, Merge.merges(merges));
     }
@@ -863,7 +862,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    default @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Merge@NotNull... merges) {
+    default Builder merge(final Style that, final Merge.Strategy strategy, final Merge... merges) {
       if (merges.length == 0) return this;
       return this.merge(that, strategy, Merge.merges(merges));
     }
@@ -877,7 +876,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @since 4.0.0
      */
     @Contract("_, _ -> this")
-    default @NotNull Builder merge(final @NotNull Style that, final @NotNull Set<Merge> merges) {
+    default Builder merge(final Style that, final Set<Merge> merges) {
       return this.merge(that, Merge.Strategy.ALWAYS, merges);
     }
 
@@ -891,7 +890,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @since 4.0.0
      */
     @Contract("_, _, _ -> this")
-    @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges);
+    Builder merge(final Style that, final Merge.Strategy strategy, final Set<Merge> merges);
 
     /**
      * Applies {@code applicable} to this builder.
@@ -901,7 +900,7 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @since 4.0.0
      */
     @Contract("_ -> this")
-    default @NotNull Builder apply(final @NotNull StyleBuilderApplicable applicable) {
+    default Builder apply(final StyleBuilderApplicable applicable) {
       applicable.styleApply(this);
       return this;
     }
@@ -912,6 +911,6 @@ public sealed interface Style extends Examinable, StyleGetter, StyleSetter<Style
      * @return the style
      */
     @Override
-    @NotNull Style build();
+    Style build();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleBuilderApplicable.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleBuilderApplicable.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.format;
 import net.kyori.adventure.text.ComponentBuilder;
 import net.kyori.adventure.text.ComponentBuilderApplicable;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can be applied to a {@link Style}.
@@ -42,10 +41,10 @@ public interface StyleBuilderApplicable extends ComponentBuilderApplicable {
    * @since 4.0.0
    */
   @Contract(mutates = "param")
-  void styleApply(final Style.@NotNull Builder style);
+  void styleApply(final Style.Builder style);
 
   @Override
-  default void componentBuilderApply(final @NotNull ComponentBuilder<?, ?> component) {
+  default void componentBuilderApply(final ComponentBuilder<?, ?> component) {
     component.style(this::styleApply);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleGetter.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleGetter.java
@@ -29,9 +29,8 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Reads style properties from an object.
@@ -74,7 +73,7 @@ public interface StyleGetter {
    *     stylable does not have the decoration
    * @since 4.10.0
    */
-  default boolean hasDecoration(final @NotNull TextDecoration decoration) {
+  default boolean hasDecoration(final TextDecoration decoration) {
     return this.decoration(decoration) == TextDecoration.State.TRUE;
   }
 
@@ -87,7 +86,7 @@ public interface StyleGetter {
    *     and {@link TextDecoration.State#NOT_SET} if not set
    * @since 4.10.0
    */
-  TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration);
+  TextDecoration.State decoration(final TextDecoration decoration);
 
   /**
    * Gets a map of decorations this stylable has.
@@ -96,7 +95,7 @@ public interface StyleGetter {
    * @since 4.10.0
    */
   @SuppressWarnings("Duplicates")
-  default @Unmodifiable @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
+  default @Unmodifiable Map<TextDecoration, TextDecoration.State> decorations() {
     final Map<TextDecoration, TextDecoration.State> decorations = new EnumMap<>(TextDecoration.class);
     for (int i = 0, length = DecorationMap.DECORATIONS.length; i < length; i++) {
       final TextDecoration decoration = DecorationMap.DECORATIONS[i];

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleImpl.java
@@ -34,8 +34,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.util.ARGBLike;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -45,7 +44,7 @@ final class StyleImpl implements Style {
   final @Nullable Key font;
   final @Nullable TextColor color;
   final @Nullable ShadowColor shadowColor;
-  final @NotNull DecorationMap decorations;
+  final DecorationMap decorations;
   final @Nullable ClickEvent clickEvent;
   final @Nullable HoverEvent<?> hoverEvent;
   final @Nullable String insertion;
@@ -54,7 +53,7 @@ final class StyleImpl implements Style {
     final @Nullable Key font,
     final @Nullable TextColor color,
     final @Nullable ShadowColor shadowColor,
-    final @NotNull Map<TextDecoration, TextDecoration.State> decorations,
+    final Map<TextDecoration, TextDecoration.State> decorations,
     final @Nullable ClickEvent clickEvent,
     final @Nullable HoverEvent<?> hoverEvent,
     final @Nullable String insertion
@@ -74,7 +73,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Style font(final @Nullable Key font) {
+  public Style font(final @Nullable Key font) {
     if (Objects.equals(this.font, font)) return this;
     return new StyleImpl(font, this.color, this.shadowColor, this.decorations, this.clickEvent, this.hoverEvent, this.insertion);
   }
@@ -85,13 +84,13 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Style color(final @Nullable TextColor color) {
+  public Style color(final @Nullable TextColor color) {
     if (Objects.equals(this.color, color)) return this;
     return new StyleImpl(this.font, color, this.shadowColor, this.decorations, this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
-  public @NotNull Style colorIfAbsent(final @Nullable TextColor color) {
+  public Style colorIfAbsent(final @Nullable TextColor color) {
     if (this.color == null) {
       return this.color(color);
     }
@@ -104,13 +103,13 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Style shadowColor(final @Nullable ARGBLike argb) {
+  public Style shadowColor(final @Nullable ARGBLike argb) {
     if (Objects.equals(this.shadowColor, argb)) return this;
     return new StyleImpl(this.font, this.color, argb == null ? null : ShadowColor.shadowColor(argb), this.decorations, this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
-  public @NotNull Style shadowColorIfAbsent(final @Nullable ARGBLike argb) {
+  public Style shadowColorIfAbsent(final @Nullable ARGBLike argb) {
     if (this.shadowColor == null) {
       return this.shadowColor(argb);
     }
@@ -118,7 +117,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public TextDecoration.@NotNull State decoration(final @NotNull TextDecoration decoration) {
+  public TextDecoration.State decoration(final TextDecoration decoration) {
     // null -> null
     final TextDecoration.@Nullable State state = this.decorations.get(decoration);
     if (state != null) {
@@ -128,14 +127,14 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Style decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  public Style decoration(final TextDecoration decoration, final TextDecoration.State state) {
     requireNonNull(state, "state");
     if (this.decoration(decoration) == state) return this;
     return new StyleImpl(this.font, this.color, this.shadowColor, this.decorations.with(decoration, state), this.clickEvent, this.hoverEvent, this.insertion);
   }
 
   @Override
-  public @NotNull Style decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+  public Style decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state) {
     requireNonNull(state, "state");
     final TextDecoration.@Nullable State oldState = this.decorations.get(decoration);
     if (oldState == TextDecoration.State.NOT_SET) {
@@ -148,12 +147,12 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Map<TextDecoration, TextDecoration.State> decorations() {
+  public Map<TextDecoration, TextDecoration.State> decorations() {
     return this.decorations;
   }
 
   @Override
-  public @NotNull Style decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations) {
+  public Style decorations(final Map<TextDecoration, TextDecoration.State> decorations) {
     return new StyleImpl(this.font, this.color, this.shadowColor, DecorationMap.merge(decorations, this.decorations), this.clickEvent, this.hoverEvent, this.insertion);
   }
 
@@ -163,7 +162,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Style clickEvent(final @Nullable ClickEvent event) {
+  public Style clickEvent(final @Nullable ClickEvent event) {
     return new StyleImpl(this.font, this.color, this.shadowColor, this.decorations, event, this.hoverEvent, this.insertion);
   }
 
@@ -173,7 +172,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Style hoverEvent(final @Nullable HoverEventSource<?> source) {
+  public Style hoverEvent(final @Nullable HoverEventSource<?> source) {
     return new StyleImpl(this.font, this.color, this.shadowColor, this.decorations, this.clickEvent, HoverEventSource.unbox(source), this.insertion);
   }
 
@@ -183,13 +182,13 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Style insertion(final @Nullable String insertion) {
+  public Style insertion(final @Nullable String insertion) {
     if (Objects.equals(this.insertion, insertion)) return this;
     return new StyleImpl(this.font, this.color, this.shadowColor, this.decorations, this.clickEvent, this.hoverEvent, insertion);
   }
 
   @Override
-  public @NotNull Style merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges) {
+  public Style merge(final Style that, final Merge.Strategy strategy, final Set<Merge> merges) {
     if (nothingToMerge(that, strategy, merges)) {
       return this;
     }
@@ -206,7 +205,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Style unmerge(final @NotNull Style that) {
+  public Style unmerge(final Style that) {
     if (this.isEmpty()) {
       // the target style is empty, so there is nothing to simplify
       return this;
@@ -249,7 +248,7 @@ final class StyleImpl implements Style {
   }
 
   @SuppressWarnings("RedundantIfStatement")
-  static boolean nothingToMerge(final @NotNull Style mergeFrom, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges) {
+  static boolean nothingToMerge(final Style mergeFrom, final Merge.Strategy strategy, final Set<Merge> merges) {
     if (strategy == Merge.Strategy.NEVER) return true;
     if (mergeFrom.isEmpty()) return true;
     if (merges.isEmpty()) return true;
@@ -262,12 +261,12 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.concat(
       this.decorations.examinableProperties(),
       Stream.of(
@@ -282,7 +281,7 @@ final class StyleImpl implements Style {
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
@@ -324,7 +323,7 @@ final class StyleImpl implements Style {
       this.decorations = DecorationMap.EMPTY;
     }
 
-    BuilderImpl(final @NotNull StyleImpl style) {
+    BuilderImpl(final StyleImpl style) {
       this.color = style.color;
       this.shadowColor = style.shadowColor;
       this.decorations = style.decorations;
@@ -335,19 +334,19 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NotNull Builder font(final @Nullable Key font) {
+    public Builder font(final @Nullable Key font) {
       this.font = font;
       return this;
     }
 
     @Override
-    public @NotNull Builder color(final @Nullable TextColor color) {
+    public Builder color(final @Nullable TextColor color) {
       this.color = color;
       return this;
     }
 
     @Override
-    public @NotNull Builder colorIfAbsent(final @Nullable TextColor color) {
+    public Builder colorIfAbsent(final @Nullable TextColor color) {
       if (this.color == null) {
         this.color = color;
       }
@@ -355,13 +354,13 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NotNull Builder shadowColor(final @Nullable ARGBLike argb) {
+    public Builder shadowColor(final @Nullable ARGBLike argb) {
       this.shadowColor = argb == null ? null : ShadowColor.shadowColor(argb);
       return this;
     }
 
     @Override
-    public @NotNull Builder shadowColorIfAbsent(final @Nullable ARGBLike argb) {
+    public Builder shadowColorIfAbsent(final @Nullable ARGBLike argb) {
       if (this.shadowColor == null) {
         this.shadowColor = argb == null ? null : ShadowColor.shadowColor(argb);
       }
@@ -369,7 +368,7 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NotNull Builder decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+    public Builder decoration(final TextDecoration decoration, final TextDecoration.State state) {
       requireNonNull(state, "state");
       requireNonNull(decoration, "decoration");
       this.decorations = this.decorations.with(decoration, state);
@@ -377,7 +376,7 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NotNull Builder decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state) {
+    public Builder decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state) {
       requireNonNull(state, "state");
       final TextDecoration.@Nullable State oldState = this.decorations.get(decoration);
       if (oldState == TextDecoration.State.NOT_SET) {
@@ -390,25 +389,25 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NotNull Builder clickEvent(final @Nullable ClickEvent event) {
+    public Builder clickEvent(final @Nullable ClickEvent event) {
       this.clickEvent = event;
       return this;
     }
 
     @Override
-    public @NotNull Builder hoverEvent(final @Nullable HoverEventSource<?> source) {
+    public Builder hoverEvent(final @Nullable HoverEventSource<?> source) {
       this.hoverEvent = HoverEventSource.unbox(source);
       return this;
     }
 
     @Override
-    public @NotNull Builder insertion(final @Nullable String insertion) {
+    public Builder insertion(final @Nullable String insertion) {
       this.insertion = insertion;
       return this;
     }
 
     @Override
-    public @NotNull Builder merge(final @NotNull Style that, final Merge.@NotNull Strategy strategy, final @NotNull Set<Merge> merges) {
+    public Builder merge(final Style that, final Merge.Strategy strategy, final Set<Merge> merges) {
       requireNonNull(that, "style");
       requireNonNull(strategy, "strategy");
       requireNonNull(merges, "merges");
@@ -487,7 +486,7 @@ final class StyleImpl implements Style {
     }
 
     @Override
-    public @NotNull StyleImpl build() {
+    public StyleImpl build() {
       if (this.isEmpty()) {
         return EMPTY;
       }

--- a/api/src/main/java/net/kyori/adventure/text/format/StyleSetter.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/StyleSetter.java
@@ -34,8 +34,7 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
 import net.kyori.adventure.util.ARGBLike;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Writes style properties to an object.
@@ -54,7 +53,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @since 4.10.0
    * @sinceMinecraft 1.16
    */
-  @NotNull T font(final @Nullable Key font);
+  T font(final @Nullable Key font);
 
   /**
    * Sets the color.
@@ -63,7 +62,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  @NotNull T color(final @Nullable TextColor color);
+  T color(final @Nullable TextColor color);
 
   /**
    * Sets the color if there isn't one set already.
@@ -72,7 +71,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  @NotNull T colorIfAbsent(final @Nullable TextColor color);
+  T colorIfAbsent(final @Nullable TextColor color);
 
   /**
    * Sets the shadow color.
@@ -84,7 +83,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.18.0
    */
-  @NotNull T shadowColor(final @Nullable ARGBLike argb);
+  T shadowColor(final @Nullable ARGBLike argb);
 
   /**
    * Sets the shadow color if there isn't one set already.
@@ -96,7 +95,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.18.0
    */
-  @NotNull T shadowColorIfAbsent(final @Nullable ARGBLike argb);
+  T shadowColorIfAbsent(final @Nullable ARGBLike argb);
 
   /**
    * Sets the state of {@code decoration} to {@link TextDecoration.State#TRUE}.
@@ -105,7 +104,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  default @NotNull T decorate(final @NotNull TextDecoration decoration) {
+  default T decorate(final TextDecoration decoration) {
     return this.decoration(decoration, TextDecoration.State.TRUE);
   }
 
@@ -116,7 +115,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  default @NotNull T decorate(final @NotNull TextDecoration@NotNull... decorations) {
+  default T decorate(final TextDecoration... decorations) {
     final Map<TextDecoration, TextDecoration.State> map = new EnumMap<>(TextDecoration.class);
     for (final TextDecoration decoration : decorations) {
       map.put(decoration, TextDecoration.State.TRUE);
@@ -133,7 +132,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  default @NotNull T decoration(final @NotNull TextDecoration decoration, final boolean flag) {
+  default T decoration(final TextDecoration decoration, final boolean flag) {
     return this.decoration(decoration, TextDecoration.State.byBoolean(flag));
   }
 
@@ -148,7 +147,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  @NotNull T decoration(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+  T decoration(final TextDecoration decoration, final TextDecoration.State state);
 
   /**
    * Sets the state of a decoration to {@code state} if the current state of the decoration is {@link TextDecoration.State#NOT_SET}.
@@ -158,7 +157,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.12.0
    */
-  @NotNull T decorationIfAbsent(final @NotNull TextDecoration decoration, final TextDecoration.@NotNull State state);
+  T decorationIfAbsent(final TextDecoration decoration, final TextDecoration.State state);
 
   /**
    * Sets decorations using the specified {@code decorations} map.
@@ -169,7 +168,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  @NotNull T decorations(final @NotNull Map<TextDecoration, TextDecoration.State> decorations);
+  T decorations(final Map<TextDecoration, TextDecoration.State> decorations);
 
   /**
    * Sets the state of a set of decorations to {@code flag}.
@@ -180,7 +179,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  default @NotNull T decorations(final @NotNull Set<TextDecoration> decorations, final boolean flag) {
+  default T decorations(final Set<TextDecoration> decorations, final boolean flag) {
     return this.decorations(decorations.stream().collect(Collectors.toMap(Function.identity(), decoration -> TextDecoration.State.byBoolean(flag))));
   }
 
@@ -191,7 +190,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  @NotNull T clickEvent(final @Nullable ClickEvent<?> event);
+  T clickEvent(final @Nullable ClickEvent<?> event);
 
   /**
    * Sets the hover event.
@@ -200,7 +199,7 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  @NotNull T hoverEvent(final @Nullable HoverEventSource<?> source);
+  T hoverEvent(final @Nullable HoverEventSource<?> source);
 
   /**
    * Sets the string to be inserted when this object ({@code T}) is shift-clicked.
@@ -209,5 +208,5 @@ public interface StyleSetter<T extends StyleSetter<?>> {
    * @return an object ({@code T})
    * @since 4.10.0
    */
-  @NotNull T insertion(final @Nullable String insertion);
+  T insertion(final @Nullable String insertion);
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -30,9 +30,8 @@ import net.kyori.adventure.util.HSVLike;
 import net.kyori.adventure.util.RGBLike;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -68,7 +67,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @NotNull TextColor color(final int value) {
+  static TextColor color(final int value) {
     final int truncatedValue = value & 0xffffff;
     final NamedTextColor named = NamedTextColor.namedColor(truncatedValue);
     return named != null ? named : new TextColorImpl(truncatedValue);
@@ -81,7 +80,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @NotNull TextColor color(final @NotNull RGBLike rgb) {
+  static TextColor color(final RGBLike rgb) {
     if (rgb instanceof TextColor) return (TextColor) rgb;
     return color(rgb.red(), rgb.green(), rgb.blue());
   }
@@ -94,7 +93,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @see <a href="https://en.wikipedia.org/wiki/HSL_and_HSV">https://en.wikipedia.org/wiki/HSL_and_HSV</a>
    * @since 4.6.0
    */
-  static @NotNull TextColor color(final @NotNull HSVLike hsv) {
+  static TextColor color(final HSVLike hsv) {
     final float s = hsv.s();
     final float v = hsv.v();
     if (s == 0) {
@@ -133,7 +132,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @NotNull TextColor color(final @Range(from = 0x0, to = 0xff) int r, final @Range(from = 0x0, to = 0xff) int g, final @Range(from = 0x0, to = 0xff) int b) {
+  static TextColor color(final @Range(from = 0x0, to = 0xff) int r, final @Range(from = 0x0, to = 0xff) int g, final @Range(from = 0x0, to = 0xff) int b) {
     return color((r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff));
   }
 
@@ -146,7 +145,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @NotNull TextColor color(final float r, final float g, final float b) {
+  static TextColor color(final float r, final float g, final float b) {
     return color((int) (r * 0xff), (int) (g * 0xff), (int) (b * 0xff));
   }
 
@@ -157,7 +156,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @Nullable TextColor fromHexString(final @NotNull String string) {
+  static @Nullable TextColor fromHexString(final String string) {
     if (string.startsWith(HEX_PREFIX)) {
       try {
         final int hex = Integer.parseInt(string.substring(1), 16);
@@ -176,7 +175,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a new text colour
    * @since 4.0.0
    */
-  static @Nullable TextColor fromCSSHexString(final @NotNull String string) {
+  static @Nullable TextColor fromCSSHexString(final String string) {
     if (string.startsWith(HEX_PREFIX)) {
       final String hexString = string.substring(1);
       if (hexString.length() != 3 && hexString.length() != 6) {
@@ -215,7 +214,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return a hex string
    * @since 4.0.0
    */
-  default @NotNull String asHexString() {
+  default String asHexString() {
     final StringBuilder result = new StringBuilder();
     result.append(HEX_PREFIX);
     final String hex = Integer.toHexString(this.value());
@@ -270,7 +269,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return the interpolated value, a color between the two input colors {@code a} and {@code b}
    * @since 4.8.0
    */
-  static @NotNull TextColor lerp(final float t, final @NotNull RGBLike a, final @NotNull RGBLike b) {
+  static TextColor lerp(final float t, final RGBLike a, final RGBLike b) {
     final float clampedT = Math.min(1.0f, Math.max(0.0f, t)); // clamp between 0 and 1
     final int ar = a.red();
     final int br = b.red();
@@ -294,7 +293,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
    * @return nearest named colour. will always return a value
    * @since 4.14.0
    */
-  static <C extends TextColor> @NotNull C nearestColorTo(final @NotNull List<C> values, final @NotNull TextColor any) {
+  static <C extends TextColor> C nearestColorTo(final List<C> values, final TextColor any) {
     requireNonNull(any, "color");
 
     float matchedDistance = Float.MAX_VALUE;
@@ -313,7 +312,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
   }
 
   @Override
-  default void styleApply(final Style.@NotNull Builder style) {
+  default void styleApply(final Style.Builder style) {
     style.color(this);
   }
 
@@ -323,7 +322,7 @@ public interface TextColor extends Comparable<TextColor>, Examinable, RGBLike, S
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.asHexString()));
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
@@ -25,13 +25,12 @@ package net.kyori.adventure.text.format;
 
 import net.kyori.adventure.util.HSVLike;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
 
 @Debug.Renderer(text = "asHexString()")
 record TextColorImpl(int value) implements TextColor {
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return this.asHexString();
   }
 
@@ -44,7 +43,7 @@ record TextColorImpl(int value) implements TextColor {
    * @param other colour to compare to
    * @return distance metric
    */
-  static float distance(final @NotNull HSVLike self, final @NotNull HSVLike other) {
+  static float distance(final HSVLike self, final HSVLike other) {
     // weight hue more heavily than saturation and brightness. kind of magic numbers, but is fine for our use case of downsampling to a set of colors
     final float hueDistance = 3 * Math.min(Math.abs(self.h() - other.h()), 1f - Math.abs(self.h() - other.h()));
     final float saturationDiff = self.s() - other.s();

--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecoration.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.text.format;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Index;
 import net.kyori.adventure.util.TriState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -87,7 +86,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    * @return a {@link TextDecorationAndState}
    * @since 4.10.0
    */
-  public final @NotNull TextDecorationAndState withState(final boolean state) {
+  public final TextDecorationAndState withState(final boolean state) {
     return new TextDecorationAndStateImpl(this, State.byBoolean(state));
   }
 
@@ -98,7 +97,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    * @return a {@link TextDecorationAndState}
    * @since 4.10.0
    */
-  public final @NotNull TextDecorationAndState withState(final @NotNull State state) {
+  public final TextDecorationAndState withState(final State state) {
     return new TextDecorationAndStateImpl(this, state);
   }
 
@@ -109,17 +108,17 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
    * @return a {@link TextDecorationAndState}
    * @since 4.10.0
    */
-  public final @NotNull TextDecorationAndState withState(final @NotNull TriState state) {
+  public final TextDecorationAndState withState(final TriState state) {
     return new TextDecorationAndStateImpl(this, State.byTriState(state));
   }
 
   @Override
-  public void styleApply(final Style.@NotNull Builder style) {
+  public void styleApply(final Style.Builder style) {
     style.decorate(this);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return this.name;
   }
 
@@ -166,7 +165,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
      * @return the state
      * @since 4.0.0
      */
-    public static @NotNull State byBoolean(final boolean flag) {
+    public static State byBoolean(final boolean flag) {
       return flag ? TRUE : FALSE;
     }
 
@@ -177,7 +176,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
      * @return the state
      * @since 4.0.0
      */
-    public static @NotNull State byBoolean(final @Nullable Boolean flag) {
+    public static State byBoolean(final @Nullable Boolean flag) {
       return flag == null ? NOT_SET : byBoolean(flag.booleanValue());
     }
 
@@ -188,7 +187,7 @@ public enum TextDecoration implements StyleBuilderApplicable, TextFormat {
      * @return the state
      * @since 4.10.0
      */
-    public static @NotNull State byTriState(final @NotNull TriState flag) {
+    public static State byTriState(final TriState flag) {
       return switch (requireNonNull(flag, "flag")) {
         case TRUE -> TRUE;
         case FALSE -> FALSE;

--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecorationAndState.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecorationAndState.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.format;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A combination of a {@link TextDecoration} and a {@link TextDecoration.State}.
@@ -40,7 +39,7 @@ public sealed interface TextDecorationAndState extends Examinable, StyleBuilderA
    * @return the decoration
    * @since 4.8.0
    */
-  @NotNull TextDecoration decoration();
+  TextDecoration decoration();
 
   /**
    * Gets the state.
@@ -48,15 +47,15 @@ public sealed interface TextDecorationAndState extends Examinable, StyleBuilderA
    * @return the state
    * @since 4.8.0
    */
-  TextDecoration.@NotNull State state();
+  TextDecoration.State state();
 
   @Override
-  default void styleApply(final Style.@NotNull Builder style) {
+  default void styleApply(final Style.Builder style) {
     style.decoration(this.decoration(), this.state());
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("decoration", this.decoration()),
       ExaminableProperty.of("state", this.state())

--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecorationAndStateImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecorationAndStateImpl.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.format;
 
 import net.kyori.adventure.internal.Internals;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -37,7 +36,7 @@ record TextDecorationAndStateImpl(TextDecoration decoration, TextDecoration.Stat
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/object/ObjectContents.java
+++ b/api/src/main/java/net/kyori/adventure/text/object/ObjectContents.java
@@ -27,9 +27,7 @@ import java.util.Collections;
 import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -49,7 +47,7 @@ public sealed interface ObjectContents extends Examinable permits SpriteObjectCo
    * @since 4.25.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static @NotNull SpriteObjectContents sprite(final @NotNull Key atlas, final @NotNull Key sprite) {
+  static SpriteObjectContents sprite(final Key atlas, final Key sprite) {
     return new SpriteObjectContentsImpl(requireNonNull(atlas, "atlas"), requireNonNull(sprite, "sprite"));
   }
 
@@ -61,7 +59,7 @@ public sealed interface ObjectContents extends Examinable permits SpriteObjectCo
    * @since 4.25.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull SpriteObjectContents sprite(final @NotNull Key sprite) {
+  static SpriteObjectContents sprite(final Key sprite) {
     return new SpriteObjectContentsImpl(SpriteObjectContents.DEFAULT_ATLAS, requireNonNull(sprite, "sprite"));
   }
 
@@ -72,7 +70,7 @@ public sealed interface ObjectContents extends Examinable permits SpriteObjectCo
    * @since 4.25.0
    */
   @Contract(value = "-> new", pure = true)
-  static PlayerHeadObjectContents.@NotNull Builder playerHead() {
+  static PlayerHeadObjectContents.Builder playerHead() {
     return new PlayerHeadObjectContentsImpl.BuilderImpl();
   }
 
@@ -84,7 +82,7 @@ public sealed interface ObjectContents extends Examinable permits SpriteObjectCo
    * @since 4.25.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull PlayerHeadObjectContents playerHead(final @NotNull String name) {
+  static PlayerHeadObjectContents playerHead(final String name) {
     return new PlayerHeadObjectContentsImpl(name, null, Collections.emptyList(), true, null);
   }
 
@@ -96,7 +94,7 @@ public sealed interface ObjectContents extends Examinable permits SpriteObjectCo
    * @since 4.25.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull PlayerHeadObjectContents playerHead(final @NotNull UUID id) {
+  static PlayerHeadObjectContents playerHead(final UUID id) {
     return new PlayerHeadObjectContentsImpl(null, id, Collections.emptyList(), true, null);
   }
 
@@ -108,7 +106,7 @@ public sealed interface ObjectContents extends Examinable permits SpriteObjectCo
    * @since 4.25.0
    */
   @Contract(value = "_ -> new", pure = true)
-  static @NotNull PlayerHeadObjectContents playerHead(final PlayerHeadObjectContents.@NotNull SkinSource skinSource) {
+  static PlayerHeadObjectContents playerHead(final PlayerHeadObjectContents.SkinSource skinSource) {
     return playerHead().skin(skinSource).build();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContents.java
+++ b/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContents.java
@@ -33,9 +33,8 @@ import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -81,7 +80,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
    * @since 4.25.0
    */
   @Unmodifiable
-  @NotNull List<ProfileProperty> profileProperties();
+  List<ProfileProperty> profileProperties();
 
   /**
    * Whether the player head should render the player's hat layer.
@@ -111,7 +110,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
    * @since 4.25.0
    */
   @Contract(value = "-> new", pure = true)
-  @NotNull Builder toBuilder();
+  Builder toBuilder();
 
   /**
    * Creates a profile property with the given value and no signature.
@@ -122,7 +121,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
    * @since 4.25.0
    */
   @Contract(value = "_, _ -> new", pure = true)
-  static ProfileProperty property(final @NotNull String name, final @NotNull String value) {
+  static ProfileProperty property(final String name, final String value) {
     return new PlayerHeadObjectContentsImpl.ProfilePropertyImpl(requireNonNull(name, "name"), requireNonNull(value, "value"), null);
   }
 
@@ -136,7 +135,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
    * @since 4.25.0
    */
   @Contract(value = "_, _, _ -> new", pure = true)
-  static ProfileProperty property(final @NotNull String name, final @NotNull String value, final @Nullable String signature) {
+  static ProfileProperty property(final String name, final String value, final @Nullable String signature) {
     return new PlayerHeadObjectContentsImpl.ProfilePropertyImpl(requireNonNull(name, "name"), requireNonNull(value, "value"), signature);
   }
 
@@ -152,7 +151,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @return the name
      * @since 4.25.0
      */
-    @NotNull String name();
+    String name();
 
     /**
      * Gets the value of the property.
@@ -160,7 +159,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @return the value
      * @since 4.25.0
      */
-    @NotNull String value();
+    String value();
 
     /**
      * Gets the signature of the property, if present.
@@ -171,7 +170,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
     @Nullable String signature();
 
     @Override
-    default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    default Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("name", this.name()),
         ExaminableProperty.of("value", this.value()),
@@ -181,7 +180,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("name", this.name()),
       ExaminableProperty.of("id", this.id()),
@@ -205,7 +204,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "_ -> this")
-    @NotNull Builder name(final @Nullable String name);
+    Builder name(final @Nullable String name);
 
     /**
      * Sets the UUID of the player.
@@ -215,7 +214,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "_ -> this")
-    @NotNull Builder id(final @Nullable UUID id);
+    Builder id(final @Nullable UUID id);
 
     /**
      * Sets a profile property.
@@ -225,7 +224,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "_ -> this")
-    @NotNull Builder profileProperty(final @NotNull ProfileProperty property);
+    Builder profileProperty(final ProfileProperty property);
 
     /**
      * Sets multiple profile properties.
@@ -235,7 +234,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "_ -> this")
-    @NotNull Builder profileProperties(final @NotNull Collection<ProfileProperty> properties);
+    Builder profileProperties(final Collection<ProfileProperty> properties);
 
     /**
      * Sets the skin (name, id, properties, and texture) from the given source, overriding any existing values.
@@ -245,7 +244,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "_ -> this")
-    @NotNull Builder skin(final @NotNull SkinSource skinSource);
+    Builder skin(final SkinSource skinSource);
 
     /**
      * Sets whether the player head should render the player's hat layer.
@@ -257,7 +256,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "_ -> this")
-    @NotNull Builder hat(final boolean hat);
+    Builder hat(final boolean hat);
 
     /**
      * Sets the optional namespaced ID of the skin texture to use for rendering.
@@ -272,7 +271,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "_ -> this")
-    @NotNull Builder texture(final @Nullable Key texture);
+    Builder texture(final @Nullable Key texture);
 
     /**
      * Builds the player head contents.
@@ -281,7 +280,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "-> new", pure = true)
-    @NotNull PlayerHeadObjectContents build();
+    PlayerHeadObjectContents build();
   }
 
   /**
@@ -301,6 +300,6 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      */
     @PlatformAPI
     @ApiStatus.Internal
-    void applySkinToPlayerHeadContents(@NotNull Builder builder);
+    void applySkinToPlayerHeadContents(Builder builder);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContentsImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContentsImpl.java
@@ -29,20 +29,19 @@ import java.util.List;
 import java.util.UUID;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-record PlayerHeadObjectContentsImpl(@Nullable String name, @Nullable UUID id, @NotNull List<ProfileProperty> profileProperties, boolean hat, @Nullable Key texture) implements PlayerHeadObjectContents {
+record PlayerHeadObjectContentsImpl(@Nullable String name, @Nullable UUID id, List<ProfileProperty> profileProperties, boolean hat, @Nullable Key texture) implements PlayerHeadObjectContents {
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
@@ -63,7 +62,7 @@ record PlayerHeadObjectContentsImpl(@Nullable String name, @Nullable UUID id, @N
     BuilderImpl() {
     }
 
-    BuilderImpl(final @NotNull PlayerHeadObjectContentsImpl playerHeadObjectContents) {
+    BuilderImpl(final PlayerHeadObjectContentsImpl playerHeadObjectContents) {
       this.name = playerHeadObjectContents.name;
       this.id = playerHeadObjectContents.id;
       this.properties.addAll(playerHeadObjectContents.profileProperties);
@@ -72,25 +71,25 @@ record PlayerHeadObjectContentsImpl(@Nullable String name, @Nullable UUID id, @N
     }
 
     @Override
-    public @NotNull Builder name(final @Nullable String name) {
+    public Builder name(final @Nullable String name) {
       this.name = name;
       return this;
     }
 
     @Override
-    public @NotNull Builder id(final @Nullable UUID id) {
+    public Builder id(final @Nullable UUID id) {
       this.id = id;
       return this;
     }
 
     @Override
-    public @NotNull Builder profileProperty(final @NotNull ProfileProperty property) {
+    public Builder profileProperty(final ProfileProperty property) {
       this.properties.add(requireNonNull(property, "property"));
       return this;
     }
 
     @Override
-    public @NotNull Builder profileProperties(final @NotNull Collection<ProfileProperty> properties) {
+    public Builder profileProperties(final Collection<ProfileProperty> properties) {
       for (final ProfileProperty property : requireNonNull(properties, "properties")) {
         this.profileProperty(property);
       }
@@ -105,26 +104,26 @@ record PlayerHeadObjectContentsImpl(@Nullable String name, @Nullable UUID id, @N
     }
 
     @Override
-    public @NotNull Builder skin(final @NotNull SkinSource skinSource) {
+    public Builder skin(final SkinSource skinSource) {
       this.clearProfile(); // intent of this method is to override any existing profile data
       requireNonNull(skinSource, "skinSource").applySkinToPlayerHeadContents(this);
       return this;
     }
 
     @Override
-    public @NotNull Builder hat(final boolean hat) {
+    public Builder hat(final boolean hat) {
       this.hat = hat;
       return this;
     }
 
     @Override
-    public @NotNull Builder texture(final @Nullable Key texture) {
+    public Builder texture(final @Nullable Key texture) {
       this.texture = texture;
       return this;
     }
 
     @Override
-    public @NotNull PlayerHeadObjectContents build() {
+    public PlayerHeadObjectContents build() {
       return new PlayerHeadObjectContentsImpl(this.name, this.id, List.copyOf(this.properties), this.hat, this.texture);
     }
   }

--- a/api/src/main/java/net/kyori/adventure/text/object/SpriteObjectContents.java
+++ b/api/src/main/java/net/kyori/adventure/text/object/SpriteObjectContents.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.object;
 import java.util.stream.Stream;
 import net.kyori.adventure.key.Key;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A sprite contents.
@@ -50,7 +49,7 @@ public sealed interface SpriteObjectContents extends ObjectContents permits Spri
    * @return the atlas key
    * @since 4.25.0
    */
-  @NotNull Key atlas();
+  Key atlas();
 
   /**
    * Gets the sprite key.
@@ -58,10 +57,10 @@ public sealed interface SpriteObjectContents extends ObjectContents permits Spri
    * @return the sprite key
    * @since 4.25.0
    */
-  @NotNull Key sprite();
+  Key sprite();
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("atlas", this.atlas()),
       ExaminableProperty.of("sprite", this.sprite())

--- a/api/src/main/java/net/kyori/adventure/text/object/SpriteObjectContentsImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/object/SpriteObjectContentsImpl.java
@@ -25,11 +25,10 @@ package net.kyori.adventure.text.object;
 
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.key.Key;
-import org.jetbrains.annotations.NotNull;
 
 record SpriteObjectContentsImpl(Key atlas, Key sprite) implements SpriteObjectContents {
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/text/renderer/AbstractComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/AbstractComponentRenderer.java
@@ -34,7 +34,6 @@ import net.kyori.adventure.text.StorageNBTComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.VirtualComponent;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An abstract implementation of a component renderer.
@@ -44,7 +43,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<C> {
   @Override
-  public @NotNull Component render(@NotNull Component component, final @NotNull C context) {
+  public Component render(Component component, final C context) {
     if (component instanceof VirtualComponent vc) {
       component = this.renderVirtual(vc, context);
     }
@@ -76,7 +75,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NotNull Component renderBlockNbt(final @NotNull BlockNBTComponent component, final @NotNull C context);
+  protected abstract Component renderBlockNbt(final BlockNBTComponent component, final C context);
 
   /**
    * Renders an entity NBT component.
@@ -85,7 +84,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NotNull Component renderEntityNbt(final @NotNull EntityNBTComponent component, final @NotNull C context);
+  protected abstract Component renderEntityNbt(final EntityNBTComponent component, final C context);
 
   /**
    * Renders a storage NBT component.
@@ -94,7 +93,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NotNull Component renderStorageNbt(final @NotNull StorageNBTComponent component, final @NotNull C context);
+  protected abstract Component renderStorageNbt(final StorageNBTComponent component, final C context);
 
   /**
    * Renders a keybind component.
@@ -103,7 +102,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NotNull Component renderKeybind(final @NotNull KeybindComponent component, final @NotNull C context);
+  protected abstract Component renderKeybind(final KeybindComponent component, final C context);
 
   /**
    * Renders a score component.
@@ -112,7 +111,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NotNull Component renderScore(final @NotNull ScoreComponent component, final @NotNull C context);
+  protected abstract Component renderScore(final ScoreComponent component, final C context);
 
   /**
    * Renders a selector component.
@@ -121,7 +120,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NotNull Component renderSelector(final @NotNull SelectorComponent component, final @NotNull C context);
+  protected abstract Component renderSelector(final SelectorComponent component, final C context);
 
   /**
    * Renders a text component.
@@ -130,7 +129,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NotNull Component renderText(final @NotNull TextComponent component, final @NotNull C context);
+  protected abstract Component renderText(final TextComponent component, final C context);
 
   /**
    * Renders a virtual component.
@@ -140,7 +139,7 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @return the rendered component
    * @since 4.18.0
    */
-  protected @NotNull Component renderVirtual(final @NotNull VirtualComponent component, final @NotNull C context) {
+  protected Component renderVirtual(final VirtualComponent component, final C context) {
     return component;
   }
 
@@ -151,5 +150,5 @@ public abstract class AbstractComponentRenderer<C> implements ComponentRenderer<
    * @param context the context
    * @return the rendered component
    */
-  protected abstract @NotNull Component renderTranslatable(final @NotNull TranslatableComponent component, final @NotNull C context);
+  protected abstract Component renderTranslatable(final TranslatableComponent component, final C context);
 }

--- a/api/src/main/java/net/kyori/adventure/text/renderer/ComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/ComponentRenderer.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.renderer;
 
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A component renderer.
@@ -42,7 +41,7 @@ public interface ComponentRenderer<C> {
    * @return the rendered component
    * @since 4.0.0
    */
-  @NotNull Component render(final @NotNull Component component, final @NotNull C context);
+  Component render(final Component component, final C context);
 
   /**
    * Return a {@link ComponentRenderer} that takes a different context type.

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -49,8 +49,7 @@ import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.translation.Translator;
 import net.kyori.adventure.util.TriState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -79,16 +78,16 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
    * @return the renderer
    * @since 4.0.0
    */
-  public static @NotNull TranslatableComponentRenderer<Locale> usingTranslationSource(final @NotNull Translator source) {
+  public static TranslatableComponentRenderer<Locale> usingTranslationSource(final Translator source) {
     requireNonNull(source, "source");
     return new TranslatableComponentRenderer<>() {
       @Override
-      protected @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale context) {
+      protected @Nullable MessageFormat translate(final String key, final Locale context) {
         return source.translate(key, context);
       }
 
       @Override
-      protected @NotNull Component renderTranslatableInner(final @NotNull TranslatableComponent component, final @NotNull Locale context) {
+      protected Component renderTranslatableInner(final TranslatableComponent component, final Locale context) {
         final TriState anyTranslations = source.hasAnyTranslations();
         if (anyTranslations == TriState.FALSE) return component;
 
@@ -110,7 +109,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
    * @param context a context
    * @return a message format or {@code null} to skip translation
    */
-  protected @Nullable MessageFormat translate(final @NotNull String key, final @NotNull C context) {
+  protected @Nullable MessageFormat translate(final String key, final C context) {
     return null;
   }
 
@@ -122,32 +121,32 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
    * @param context a context
    * @return a message format or {@code null} to skip translation
    */
-  protected @Nullable MessageFormat translate(final @NotNull String key, final @Nullable String fallback, final @NotNull C context) {
+  protected @Nullable MessageFormat translate(final String key, final @Nullable String fallback, final C context) {
     return this.translate(key, context);
   }
 
   @Override
-  protected @NotNull Component renderBlockNbt(final @NotNull BlockNBTComponent component, final @NotNull C context) {
+  protected Component renderBlockNbt(final BlockNBTComponent component, final C context) {
     final BlockNBTComponent.Builder builder = this.nbt(context, Component.blockNBT(), component)
       .pos(component.pos());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
-  protected @NotNull Component renderEntityNbt(final @NotNull EntityNBTComponent component, final @NotNull C context) {
+  protected Component renderEntityNbt(final EntityNBTComponent component, final C context) {
     final EntityNBTComponent.Builder builder = this.nbt(context, Component.entityNBT(), component)
       .selector(component.selector());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
-  protected @NotNull Component renderStorageNbt(final @NotNull StorageNBTComponent component, final @NotNull C context) {
+  protected Component renderStorageNbt(final StorageNBTComponent component, final C context) {
     final StorageNBTComponent.Builder builder = this.nbt(context, Component.storageNBT(), component)
       .storage(component.storage());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
-  protected <O extends NBTComponent<O, B>, B extends NBTComponentBuilder<O, B>> B nbt(final @NotNull C context, final B builder, final O oldComponent) {
+  protected <O extends NBTComponent<O, B>, B extends NBTComponentBuilder<O, B>> B nbt(final C context, final B builder, final O oldComponent) {
     builder
       .nbtPath(oldComponent.nbtPath())
       .interpret(oldComponent.interpret());
@@ -159,14 +158,14 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   }
 
   @Override
-  protected @NotNull Component renderKeybind(final @NotNull KeybindComponent component, final @NotNull C context) {
+  protected Component renderKeybind(final KeybindComponent component, final C context) {
     final KeybindComponent.Builder builder = Component.keybind().keybind(component.keybind());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
   @SuppressWarnings("deprecation")
-  protected @NotNull Component renderScore(final @NotNull ScoreComponent component, final @NotNull C context) {
+  protected Component renderScore(final ScoreComponent component, final C context) {
     final ScoreComponent.Builder builder = Component.score()
       .name(component.name())
       .objective(component.objective())
@@ -175,19 +174,19 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   }
 
   @Override
-  protected @NotNull Component renderSelector(final @NotNull SelectorComponent component, final @NotNull C context) {
+  protected Component renderSelector(final SelectorComponent component, final C context) {
     final SelectorComponent.Builder builder = Component.selector().pattern(component.pattern());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
-  protected @NotNull Component renderText(final @NotNull TextComponent component, final @NotNull C context) {
+  protected Component renderText(final TextComponent component, final C context) {
     final TextComponent.Builder builder = Component.text().content(component.content());
     return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
   }
 
   @Override
-  protected @NotNull Component renderTranslatable(@NotNull TranslatableComponent component, final @NotNull C context) {
+  protected Component renderTranslatable(TranslatableComponent component, final C context) {
     final List<TranslationArgument> arguments = component.arguments();
     final List<Component> children = component.children();
 
@@ -213,7 +212,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
   }
 
   @SuppressWarnings("JdkObsolete") // MessageFormat requires StringBuffer in its api
-  protected @NotNull Component renderTranslatableInner(final @NotNull TranslatableComponent component, final @NotNull C context) {
+  protected Component renderTranslatableInner(final TranslatableComponent component, final C context) {
     final @Nullable MessageFormat format = this.translate(component.key(), component.fallback(), context);
     if (format == null) return this.optionallyRenderChildrenAndStyle(component, context);
 

--- a/api/src/main/java/net/kyori/adventure/text/serializer/ComponentDecoder.java
+++ b/api/src/main/java/net/kyori/adventure/text/serializer/ComponentDecoder.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.text.serializer;
 
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A {@link Component} decoder, which provides deserialization, but without serialization.
@@ -45,7 +44,7 @@ public interface ComponentDecoder<S, O extends Component> {
    * @return the component
    * @since 4.16.0
    */
-  @NotNull O deserialize(final @NotNull S input);
+  O deserialize(final S input);
 
   /**
    * Deserialize a component from input of type {@code S}.

--- a/api/src/main/java/net/kyori/adventure/text/serializer/ComponentEncoder.java
+++ b/api/src/main/java/net/kyori/adventure/text/serializer/ComponentEncoder.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.text.serializer;
 
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A {@link Component} encoder, which provides serialization, but without deserialization.
@@ -45,7 +44,7 @@ public interface ComponentEncoder<I extends Component, R> {
    * @return the output
    * @since 4.14.0
    */
-  @NotNull R serialize(final @NotNull I component);
+  R serialize(final I component);
 
   /**
    * Serializes a component into an output of type {@code R}.

--- a/api/src/main/java/net/kyori/adventure/text/serializer/ComponentSerializer.java
+++ b/api/src/main/java/net/kyori/adventure/text/serializer/ComponentSerializer.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.text.serializer;
 
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A {@link Component} serializer and deserializer.
@@ -45,7 +44,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @since 4.0.0
    */
   @Override
-  @NotNull O deserialize(final @NotNull R input);
+  O deserialize(final R input);
 
   /**
    * Deserialize a component from input of type {@code R}.
@@ -86,7 +85,7 @@ public interface ComponentSerializer<I extends Component, O extends Component, R
    * @since 4.0.0
    */
   @Override
-  @NotNull R serialize(final @NotNull I component);
+  R serialize(final I component);
 
   /**
    * Serializes a component into an output of type {@code R}.

--- a/api/src/main/java/net/kyori/adventure/title/Title.java
+++ b/api/src/main/java/net/kyori/adventure/title/Title.java
@@ -27,9 +27,8 @@ import java.time.Duration;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.Ticks;
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents an in-game title, which can be displayed across the centre of the screen.
@@ -53,7 +52,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
    * @return the title
    * @since 4.0.0
    */
-  static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle) {
+  static Title title(final Component title, final Component subtitle) {
     return title(title, subtitle, DEFAULT_TIMES);
   }
 
@@ -66,7 +65,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
    * @return the title
    * @since 4.0.0
    */
-  static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle, final @Nullable Times times) {
+  static Title title(final Component title, final Component subtitle, final @Nullable Times times) {
     return new TitleImpl(title, subtitle, times);
   }
 
@@ -81,7 +80,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
    * @return the title
    * @since 4.24.0
    */
-  static @NotNull Title title(final @NotNull Component title, final @NotNull Component subtitle, final int fadeInTicks, final int stayTicks, final int fadeOutTicks) {
+  static Title title(final Component title, final Component subtitle, final int fadeInTicks, final int stayTicks, final int fadeOutTicks) {
     return new TitleImpl(title, subtitle, Times.times(Ticks.duration(fadeInTicks), Ticks.duration(stayTicks), Ticks.duration(fadeOutTicks)));
   }
 
@@ -91,7 +90,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
    * @return the title
    * @since 4.0.0
    */
-  @NotNull Component title();
+  Component title();
 
   /**
    * Gets the subtitle.
@@ -99,7 +98,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
    * @return the subtitle
    * @since 4.0.0
    */
-  @NotNull Component subtitle();
+  Component subtitle();
 
   /**
    * Gets the times.
@@ -117,7 +116,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
    * @return the value
    * @since 4.9.0
    */
-  <T> @UnknownNullability T part(final @NotNull TitlePart<T> part);
+  <T> @UnknownNullability T part(final TitlePart<T> part);
 
   /**
    * Title times.
@@ -134,7 +133,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
      * @return times
      * @since 4.10.0
      */
-    static @NotNull Times times(final @NotNull Duration fadeIn, final @NotNull Duration stay, final @NotNull Duration fadeOut) {
+    static Times times(final Duration fadeIn, final Duration stay, final Duration fadeOut) {
       return new TitleImpl.TimesImpl(fadeIn, stay, fadeOut);
     }
 
@@ -144,7 +143,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
      * @return the time the title will fade-in
      * @since 4.0.0
      */
-    @NotNull Duration fadeIn();
+    Duration fadeIn();
 
     /**
      * Gets the time the title will stay.
@@ -152,7 +151,7 @@ public sealed interface Title extends Examinable permits TitleImpl {
      * @return the time the title will stay
      * @since 4.0.0
      */
-    @NotNull Duration stay();
+    Duration stay();
 
     /**
      * Gets the time the title will fade-out.
@@ -160,6 +159,6 @@ public sealed interface Title extends Examinable permits TitleImpl {
      * @return the time the title will fade-out
      * @since 4.0.0
      */
-    @NotNull Duration fadeOut();
+    Duration fadeOut();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/title/TitleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/title/TitleImpl.java
@@ -28,14 +28,13 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 record TitleImpl(Component title, Component subtitle, @Nullable Times times) implements Title {
-  TitleImpl(final @NotNull Component title, final @NotNull Component subtitle, final @Nullable Times times) {
+  TitleImpl(final Component title, final Component subtitle, final @Nullable Times times) {
     this.title = requireNonNull(title, "title");
     this.subtitle = requireNonNull(subtitle, "subtitle");
     this.times = times;
@@ -43,7 +42,7 @@ record TitleImpl(Component title, Component subtitle, @Nullable Times times) imp
 
   @Override
   @SuppressWarnings("unchecked") // compared with parts directly
-  public <T> @UnknownNullability T part(final @NotNull TitlePart<T> part) {
+  public <T> @UnknownNullability T part(final TitlePart<T> part) {
     requireNonNull(part, "part");
     if (part == TitlePart.TITLE) {
       return (T) this.title;
@@ -57,7 +56,7 @@ record TitleImpl(Component title, Component subtitle, @Nullable Times times) imp
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("title", this.title),
       ExaminableProperty.of("subtitle", this.subtitle),
@@ -66,19 +65,19 @@ record TitleImpl(Component title, Component subtitle, @Nullable Times times) imp
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 
   record TimesImpl(Duration fadeIn, Duration stay, Duration fadeOut) implements Times {
-      TimesImpl(final @NotNull Duration fadeIn, final @NotNull Duration stay, final @NotNull Duration fadeOut) {
+      TimesImpl(final Duration fadeIn, final Duration stay, final Duration fadeOut) {
         this.fadeIn = requireNonNull(fadeIn, "fadeIn");
         this.stay = requireNonNull(stay, "stay");
         this.fadeOut = requireNonNull(fadeOut, "fadeOut");
       }
 
     @Override
-      public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+      public Stream<? extends ExaminableProperty> examinableProperties() {
         return Stream.of(
           ExaminableProperty.of("fadeIn", this.fadeIn),
           ExaminableProperty.of("stay", this.stay),
@@ -87,7 +86,7 @@ record TitleImpl(Component title, Component subtitle, @Nullable Times times) imp
       }
 
       @Override
-      public @NotNull String toString() {
+      public String toString() {
         return Internals.toString(this);
       }
     }

--- a/api/src/main/java/net/kyori/adventure/title/TitlePartImpl.java
+++ b/api/src/main/java/net/kyori/adventure/title/TitlePartImpl.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.title;
 
-import org.jetbrains.annotations.NotNull;
-
 record TitlePartImpl<T>(String part) implements TitlePart<T> {
   @Override
   public boolean equals(final Object o) {
@@ -32,7 +30,7 @@ record TitlePartImpl<T>(String part) implements TitlePart<T> {
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return "TitlePart." + this.part();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java
+++ b/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java
@@ -43,8 +43,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.util.TriState;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -55,9 +54,9 @@ import static java.util.Objects.requireNonNull;
  * @since 4.20.0
  */
 public abstract class AbstractTranslationStore<T> implements Examinable, TranslationStore<T> {
-  private final @NotNull Key name;
+  private final Key name;
   private final Map<String, Translation> translations = new ConcurrentHashMap<>();
-  private volatile @NotNull Locale defaultLocale = Locale.US;
+  private volatile Locale defaultLocale = Locale.US;
 
   /**
    * Creates a new abstract translation store with a given name.
@@ -65,7 +64,7 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
    * @param name the name
    * @since 4.20.0
    */
-  protected AbstractTranslationStore(final @NotNull Key name) {
+  protected AbstractTranslationStore(final Key name) {
     this.name = Objects.requireNonNull(name, "name");
   }
 
@@ -77,48 +76,48 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
    * @return the translation, or {@code null} if none exists for this key
    * @since 4.20.0
    */
-  protected @Nullable T translationValue(final @NotNull String key, final @NotNull Locale locale) {
+  protected @Nullable T translationValue(final String key, final Locale locale) {
     final Translation translation = this.translations.get(requireNonNull(key, "key"));
     if (translation == null) return null;
     return translation.translate(requireNonNull(locale, "locale"));
   }
 
   @Override
-  public final boolean contains(final @NotNull String key) {
+  public final boolean contains(final String key) {
     return this.translations.containsKey(key);
   }
 
   @Override
-  public final boolean contains(final @NotNull String key, final @NotNull Locale locale) {
+  public final boolean contains(final String key, final Locale locale) {
     final Translation translation = this.translations.get(requireNonNull(key, "key"));
     if (translation == null) return false;
     return translation.translations.get(requireNonNull(locale, "locale")) != null;
   }
 
   @Override
-  public final boolean canTranslate(final @NotNull String key, final @NotNull Locale locale) {
+  public final boolean canTranslate(final String key, final Locale locale) {
     final Translation translation = this.translations.get(requireNonNull(key, "key"));
     if (translation == null) return false;
     return translation.translate(requireNonNull(locale, "locale")) != null;
   }
 
   @Override
-  public final void defaultLocale(final @NotNull Locale locale) {
+  public final void defaultLocale(final Locale locale) {
     this.defaultLocale = requireNonNull(locale, "locale");
   }
 
   @Override
-  public final void register(final @NotNull String key, final @NotNull Locale locale, final @NotNull T translation) {
+  public final void register(final String key, final Locale locale, final T translation) {
     this.translations.computeIfAbsent(key, Translation::new).register(locale, translation);
   }
 
   @Override
-  public final void registerAll(final @NotNull Locale locale, final @NotNull Map<String, T> translations) {
+  public final void registerAll(final Locale locale, final Map<String, T> translations) {
     this.registerAll(locale, translations.keySet(), translations::get);
   }
 
   @Override
-  public final void registerAll(final @NotNull Locale locale, final @NotNull Set<String> keys, final Function<String, T> function) {
+  public final void registerAll(final Locale locale, final Set<String> keys, final Function<String, T> function) {
     IllegalArgumentException firstError = null;
     int errorCount = 0;
     for (final String key : keys) {
@@ -141,22 +140,22 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
   }
 
   @Override
-  public final void unregister(final @NotNull String key) {
+  public final void unregister(final String key) {
     this.translations.remove(key);
   }
 
   @Override
-  public final @NotNull Key name() {
+  public final Key name() {
     return this.name;
   }
 
   @Override
-  public final @NotNull TriState hasAnyTranslations() {
+  public final TriState hasAnyTranslations() {
     return TriState.byBoolean(!this.translations.isEmpty());
   }
 
   @Override
-  public final @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public final Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("translations", this.translations));
   }
 
@@ -174,7 +173,7 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
   }
 
   @Override
-  public final @NotNull String toString() {
+  public final String toString() {
     return Internals.toString(this);
   }
 
@@ -182,12 +181,12 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
     private final String key;
     private final Map<Locale, T> translations;
 
-    private Translation(final @NotNull String key) {
+    private Translation(final String key) {
       this.key = requireNonNull(key, "key");
       this.translations = new ConcurrentHashMap<>();
     }
 
-    private @Nullable T translate(final @NotNull Locale locale) {
+    private @Nullable T translate(final Locale locale) {
       T format = this.translations.get(requireNonNull(locale, "locale"));
       if (format == null) {
         format = this.translations.get(Locale.of(locale.getLanguage())); // try without country
@@ -201,14 +200,14 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
       return format;
     }
 
-    private void register(final @NotNull Locale locale, final @NotNull T translation) {
+    private void register(final Locale locale, final T translation) {
       if (this.translations.putIfAbsent(requireNonNull(locale, "locale"), requireNonNull(translation, "translation")) != null) {
         throw new IllegalArgumentException(String.format("Translation already exists: %s for %s", this.key, locale));
       }
     }
 
     @Override
-    public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+    public Stream<? extends ExaminableProperty> examinableProperties() {
       return Stream.of(
         ExaminableProperty.of("key", this.key),
         ExaminableProperty.of("translations", this.translations)
@@ -251,7 +250,7 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
      * @param name the name
      * @since 4.20.0
      */
-    protected StringBased(final @NotNull Key name) {
+    protected StringBased(final Key name) {
       super(name);
     }
 
@@ -263,10 +262,10 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
      * @return the parsed type
      * @since 4.20.0
      */
-    protected abstract @NotNull T parse(final @NotNull String string, final @NotNull Locale locale);
+    protected abstract T parse(final String string, final Locale locale);
 
     @Override
-    public final void registerAll(final @NotNull Locale locale, final @NotNull Path path, final boolean escapeSingleQuotes) {
+    public final void registerAll(final Locale locale, final Path path, final boolean escapeSingleQuotes) {
       try (final BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
         this.registerAll(locale, new PropertyResourceBundle(reader), escapeSingleQuotes);
       } catch (final IOException e) {
@@ -275,7 +274,7 @@ public abstract class AbstractTranslationStore<T> implements Examinable, Transla
     }
 
     @Override
-    public final void registerAll(final @NotNull Locale locale, final @NotNull ResourceBundle bundle, final boolean escapeSingleQuotes) {
+    public final void registerAll(final Locale locale, final ResourceBundle bundle, final boolean escapeSingleQuotes) {
       this.registerAll(locale, bundle.keySet(), key -> {
         final String format = bundle.getString(key);
         return this.parse(

--- a/api/src/main/java/net/kyori/adventure/translation/ComponentTranslationStore.java
+++ b/api/src/main/java/net/kyori/adventure/translation/ComponentTranslationStore.java
@@ -28,22 +28,21 @@ import java.util.Locale;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class ComponentTranslationStore extends AbstractTranslationStore<Component> {
 
-  ComponentTranslationStore(final @NotNull Key name) {
+  ComponentTranslationStore(final Key name) {
     super(name);
   }
 
   @Override
-  public @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
+  public @Nullable MessageFormat translate(final String key, final Locale locale) {
     return null;
   }
 
   @Override
-  public @Nullable Component translate(final @NotNull TranslatableComponent component, final @NotNull Locale locale) {
+  public @Nullable Component translate(final TranslatableComponent component, final Locale locale) {
     final Component translatedComponent = this.translationValue(component.key(), locale);
     if (translatedComponent == null) return null;
     return translatedComponent.append(component.children());

--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslator.java
@@ -29,7 +29,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A global source of translations. The global source is the default source used by adventure platforms
@@ -47,7 +46,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return the source
    * @since 4.10.0
    */
-  static @NotNull GlobalTranslator translator() {
+  static GlobalTranslator translator() {
     return GlobalTranslatorImpl.INSTANCE;
   }
 
@@ -57,7 +56,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return a renderer
    * @since 4.0.0
    */
-  static @NotNull TranslatableComponentRenderer<Locale> renderer() {
+  static TranslatableComponentRenderer<Locale> renderer() {
     return GlobalTranslatorImpl.INSTANCE.renderer;
   }
 
@@ -69,7 +68,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return the rendered component
    * @since 4.0.0
    */
-  static @NotNull Component render(final @NotNull Component component, final @NotNull Locale locale) {
+  static Component render(final Component component, final Locale locale) {
     return renderer().render(component, locale);
   }
 
@@ -79,7 +78,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return the sources
    * @since 4.0.0
    */
-  @NotNull Iterable<? extends Translator> sources();
+  Iterable<? extends Translator> sources();
 
   /**
    * Adds a translation source.
@@ -91,7 +90,7 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @throws IllegalArgumentException if source is {@link GlobalTranslator}
    * @since 4.0.0
    */
-  boolean addSource(final @NotNull Translator source);
+  boolean addSource(final Translator source);
 
   /**
    * Removes a translation source.
@@ -100,5 +99,5 @@ public interface GlobalTranslator extends Translator, Examinable {
    * @return {@code true} if unregistered, {@code false} otherwise
    * @since 4.0.0
    */
-  boolean removeSource(final @NotNull Translator source);
+  boolean removeSource(final Translator source);
 }

--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
@@ -35,8 +35,7 @@ import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import net.kyori.adventure.util.TriState;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,30 +49,30 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
   }
 
   @Override
-  public @NotNull Key name() {
+  public Key name() {
     return NAME;
   }
 
   @Override
-  public @NotNull Iterable<? extends Translator> sources() {
+  public Iterable<? extends Translator> sources() {
     return Collections.unmodifiableSet(this.sources);
   }
 
   @Override
-  public boolean addSource(final @NotNull Translator source) {
+  public boolean addSource(final Translator source) {
     requireNonNull(source, "source");
     if (source == this) throw new IllegalArgumentException("GlobalTranslationSource");
     return this.sources.add(source);
   }
 
   @Override
-  public boolean removeSource(final @NotNull Translator source) {
+  public boolean removeSource(final Translator source) {
     requireNonNull(source, "source");
     return this.sources.remove(source);
   }
 
   @Override
-  public @NotNull TriState hasAnyTranslations() {
+  public TriState hasAnyTranslations() {
     if (!this.sources.isEmpty()) {
       return TriState.TRUE;
     }
@@ -81,7 +80,7 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
   }
 
   @Override
-  public boolean canTranslate(final @NotNull String key, final @NotNull Locale locale) {
+  public boolean canTranslate(final String key, final Locale locale) {
     requireNonNull(key, "key");
     requireNonNull(locale, "locale");
     for (final Translator source : this.sources) {
@@ -91,7 +90,7 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
   }
 
   @Override
-  public @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
+  public @Nullable MessageFormat translate(final String key, final Locale locale) {
     requireNonNull(key, "key");
     requireNonNull(locale, "locale");
     for (final Translator source : this.sources) {
@@ -102,7 +101,7 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
   }
 
   @Override
-  public @Nullable Component translate(final @NotNull TranslatableComponent component, final @NotNull Locale locale) {
+  public @Nullable Component translate(final TranslatableComponent component, final Locale locale) {
     requireNonNull(component, "component");
     requireNonNull(locale, "locale");
     for (final Translator source : this.sources) {
@@ -113,7 +112,7 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("sources", this.sources));
   }
 }

--- a/api/src/main/java/net/kyori/adventure/translation/MessageFormatTranslationStore.java
+++ b/api/src/main/java/net/kyori/adventure/translation/MessageFormatTranslationStore.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.translation;
 import java.text.MessageFormat;
 import java.util.Locale;
 import net.kyori.adventure.key.Key;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class MessageFormatTranslationStore extends AbstractTranslationStore.StringBased<MessageFormat> {
 
@@ -36,12 +35,12 @@ final class MessageFormatTranslationStore extends AbstractTranslationStore.Strin
   }
 
   @Override
-  protected @NotNull MessageFormat parse(final @NotNull String string, final @NotNull Locale locale) {
+  protected MessageFormat parse(final String string, final Locale locale) {
     return new MessageFormat(string, locale);
   }
 
   @Override
-  public @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
+  public @Nullable MessageFormat translate(final String key, final Locale locale) {
     return this.translationValue(key, locale);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/translation/Translatable.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translatable.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.translation;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Something that has a translation key.
  *
@@ -37,5 +35,5 @@ public interface Translatable {
    * @return the translation key
    * @since 4.8.0
    */
-  @NotNull String translationKey();
+  String translationKey();
 }

--- a/api/src/main/java/net/kyori/adventure/translation/TranslationLocales.java
+++ b/api/src/main/java/net/kyori/adventure/translation/TranslationLocales.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.translation;
 import java.util.Locale;
 import java.util.function.Supplier;
 import net.kyori.adventure.internal.properties.AdventureProperties;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class TranslationLocales {
   private static final Supplier<Locale> GLOBAL;

--- a/api/src/main/java/net/kyori/adventure/translation/TranslationStore.java
+++ b/api/src/main/java/net/kyori/adventure/translation/TranslationStore.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.UTF8ResourceBundleControl;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A store of translation values.
@@ -57,7 +56,7 @@ public interface TranslationStore<T> extends Translator {
    * @return the translation store
    * @since 4.20.0
    */
-  static @NotNull TranslationStore<Component> component(final @NotNull Key name) {
+  static TranslationStore<Component> component(final Key name) {
     return new ComponentTranslationStore(Objects.requireNonNull(name, "name"));
   }
 
@@ -68,7 +67,7 @@ public interface TranslationStore<T> extends Translator {
    * @return the translation store
    * @since 4.20.0
    */
-  static TranslationStore.@NotNull StringBased<MessageFormat> messageFormat(final @NotNull Key name) {
+  static TranslationStore.StringBased<MessageFormat> messageFormat(final Key name) {
     return new MessageFormatTranslationStore(Objects.requireNonNull(name, "name"));
   }
 
@@ -79,7 +78,7 @@ public interface TranslationStore<T> extends Translator {
    * @return whether the store contains a value for the translation key
    * @since 4.20.0
    */
-  boolean contains(final @NotNull String key);
+  boolean contains(final String key);
 
   /**
    * Checks if any translations are explicitly registered for the specified key and locale.
@@ -97,7 +96,7 @@ public interface TranslationStore<T> extends Translator {
    * @see #canTranslate(String, Locale)
    * @since 4.20.0
    */
-  boolean contains(final @NotNull String key, final @NotNull Locale locale);
+  boolean contains(final String key, final Locale locale);
 
   /**
    * {@inheritDoc}
@@ -115,7 +114,7 @@ public interface TranslationStore<T> extends Translator {
    * @since 4.20.0
    */
   @Override
-  default boolean canTranslate(final @NotNull String key, final @NotNull Locale locale) {
+  default boolean canTranslate(final String key, final Locale locale) {
     return Translator.super.canTranslate(key, locale);
   }
 
@@ -125,7 +124,7 @@ public interface TranslationStore<T> extends Translator {
    * @param locale the locale to use a default
    * @since 4.20.0
    */
-  void defaultLocale(final @NotNull Locale locale);
+  void defaultLocale(final Locale locale);
 
   /**
    * Registers a translation.
@@ -136,7 +135,7 @@ public interface TranslationStore<T> extends Translator {
    * @throws IllegalArgumentException if the translation key already exists
    * @since 4.20.0
    */
-  void register(final @NotNull String key, final @NotNull Locale locale, final T translation);
+  void register(final String key, final Locale locale, final T translation);
 
   /**
    * Registers a map of translations.
@@ -147,7 +146,7 @@ public interface TranslationStore<T> extends Translator {
    * @see #register(String, Locale, T)
    * @since 4.20.0
    */
-  void registerAll(final @NotNull Locale locale, final @NotNull Map<String, T> translations);
+  void registerAll(final Locale locale, final Map<String, T> translations);
 
   /**
    * Registers translations with a set of keys and a mapping function to produce the translation from the key.
@@ -158,7 +157,7 @@ public interface TranslationStore<T> extends Translator {
    * @throws IllegalArgumentException if a translation key already exists
    * @since 4.20.0
    */
-  void registerAll(final @NotNull Locale locale, final @NotNull Set<String> keys, Function<String, T> function);
+  void registerAll(final Locale locale, final Set<String> keys, Function<String, T> function);
 
   /**
    * Unregisters a translation key.
@@ -166,7 +165,7 @@ public interface TranslationStore<T> extends Translator {
    * @param key a translation key
    * @since 4.0.0
    */
-  void unregister(final @NotNull String key);
+  void unregister(final String key);
 
   /**
    * An abstract, string-based translation store.
@@ -188,7 +187,7 @@ public interface TranslationStore<T> extends Translator {
      * @see #registerAll(Locale, ResourceBundle, boolean)
      * @since 4.20.0
      */
-    void registerAll(final @NotNull Locale locale, final @NotNull Path path, final boolean escapeSingleQuotes);
+    void registerAll(final Locale locale, final Path path, final boolean escapeSingleQuotes);
 
     /**
      * Registers a resource bundle of translations.
@@ -208,6 +207,6 @@ public interface TranslationStore<T> extends Translator {
      * @see UTF8ResourceBundleControl
      * @since 4.20.0
      */
-    void registerAll(final @NotNull Locale locale, final @NotNull ResourceBundle bundle, final boolean escapeSingleQuotes);
+    void registerAll(final Locale locale, final ResourceBundle bundle, final boolean escapeSingleQuotes);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/translation/Translator.java
+++ b/api/src/main/java/net/kyori/adventure/translation/Translator.java
@@ -31,8 +31,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.util.TriState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A message translator.
@@ -57,7 +56,7 @@ public interface Translator {
    * @return a locale
    * @since 4.0.0
    */
-  static @Nullable Locale parseLocale(final @NotNull String string) {
+  static @Nullable Locale parseLocale(final String string) {
     final String[] segments = string.split("_", 3); // language_country_variant
     final int length = segments.length;
     if (length == 1) {
@@ -78,7 +77,7 @@ public interface Translator {
    * @return an identifier for this translation source
    * @since 4.0.0
    */
-  @NotNull Key name();
+  Key name();
 
   /**
    * Checks if this translator has any translations.
@@ -86,7 +85,7 @@ public interface Translator {
    * @return {@link TriState#TRUE} if any, {@link TriState#NOT_SET} if unknown, or {@link TriState#FALSE} if none
    * @since 4.15.0
    */
-  default @NotNull TriState hasAnyTranslations() {
+  default TriState hasAnyTranslations() {
     return TriState.NOT_SET;
   }
 
@@ -99,7 +98,7 @@ public interface Translator {
    *     the two {@code translate} methods
    * @since 4.20.0
    */
-  default boolean canTranslate(final @NotNull String key, final @NotNull Locale locale) {
+  default boolean canTranslate(final String key, final Locale locale) {
     final Component translatedValue = this.translate(Component.translatable(Objects.requireNonNull(key, "key")), Objects.requireNonNull(locale, "locale"));
     if (translatedValue != null) return true;
     return this.translate(key, locale) != null;
@@ -116,7 +115,7 @@ public interface Translator {
    * @return a message format or {@code null} to skip translation
    * @since 4.0.0
    */
-  @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale);
+  @Nullable MessageFormat translate(final String key, final Locale locale);
 
   /**
    * Gets a translated component from a translatable component and locale.
@@ -136,7 +135,7 @@ public interface Translator {
    * @return a translated component or {@code null} to use {@link #translate(String, Locale)} instead (if available)
    * @since 4.13.0
    */
-  default @Nullable Component translate(final @NotNull TranslatableComponent component, final @NotNull Locale locale) {
+  default @Nullable Component translate(final TranslatableComponent component, final Locale locale) {
     return null;
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/Buildable.java
+++ b/api/src/main/java/net/kyori/adventure/util/Buildable.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.util;
 
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that can be built.
@@ -40,5 +39,5 @@ public interface Buildable<B> {
    * @since 4.0.0
    */
   @Contract(value = "-> new", pure = true)
-  @NotNull B toBuilder();
+  B toBuilder();
 }

--- a/api/src/main/java/net/kyori/adventure/util/Codec.java
+++ b/api/src/main/java/net/kyori/adventure/util/Codec.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.util;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A combination encoder and decoder.
  *
@@ -47,15 +45,15 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
    * @return a codec
    * @since 4.10.0
    */
-  static <D, E, DX extends Throwable, EX extends Throwable> @NotNull Codec<D, E, DX, EX> codec(final @NotNull Decoder<D, E, DX> decoder, final @NotNull Encoder<D, E, EX> encoder) {
+  static <D, E, DX extends Throwable, EX extends Throwable> Codec<D, E, DX, EX> codec(final Decoder<D, E, DX> decoder, final Encoder<D, E, EX> encoder) {
     return new Codec<D, E, DX, EX>() {
       @Override
-      public @NotNull D decode(final @NotNull E encoded) throws DX {
+      public D decode(final E encoded) throws DX {
         return decoder.decode(encoded);
       }
 
       @Override
-      public @NotNull E encode(final @NotNull D decoded) throws EX {
+      public E encode(final D decoded) throws EX {
         return encoder.encode(decoded);
       }
     };
@@ -69,7 +67,7 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
    * @throws DX if an exception is encountered while decoding
    * @since 4.0.0
    */
-  @NotNull D decode(final @NotNull E encoded) throws DX;
+  D decode(final E encoded) throws DX;
 
   /**
    * A decoder.
@@ -88,7 +86,7 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
      * @throws X if an exception is encountered while decoding
      * @since 4.0.0
      */
-    @NotNull D decode(final @NotNull E encoded) throws X;
+    D decode(final E encoded) throws X;
   }
 
   /**
@@ -99,7 +97,7 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
    * @throws EX if an exception is encountered while encoding
    * @since 4.0.0
    */
-  @NotNull E encode(final @NotNull D decoded) throws EX;
+  E encode(final D decoded) throws EX;
 
   /**
    * An encoder.
@@ -118,6 +116,6 @@ public interface Codec<D, E, DX extends Throwable, EX extends Throwable> {
      * @throws X if an exception is encountered while encoding
      * @since 4.0.0
      */
-    @NotNull E encode(final @NotNull D decoded) throws X;
+    E encode(final D decoded) throws X;
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/ComponentMessageThrowable.java
+++ b/api/src/main/java/net/kyori/adventure/util/ComponentMessageThrowable.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.util;
 
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An extension interface for {@link Throwable}s to provide a {@link Component}-based message.

--- a/api/src/main/java/net/kyori/adventure/util/ForwardingIterator.java
+++ b/api/src/main/java/net/kyori/adventure/util/ForwardingIterator.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.function.Supplier;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An iterable that forwards the {@link #iterator()} and {@link #spliterator()} calls to some {@link Supplier suppliers}.
@@ -46,18 +45,18 @@ public final class ForwardingIterator<T> implements Iterable<T> {
    * @param spliterator the spliterator supplier
    * @since 4.9.0
    */
-  public ForwardingIterator(final @NotNull Supplier<Iterator<T>> iterator, final @NotNull Supplier<Spliterator<T>> spliterator) {
+  public ForwardingIterator(final Supplier<Iterator<T>> iterator, final Supplier<Spliterator<T>> spliterator) {
     this.iterator = Objects.requireNonNull(iterator, "iterator");
     this.spliterator = Objects.requireNonNull(spliterator, "spliterator");
   }
 
   @Override
-  public @NotNull Iterator<T> iterator() {
+  public Iterator<T> iterator() {
     return this.iterator.get();
   }
 
   @Override
-  public @NotNull Spliterator<T> spliterator() {
+  public Spliterator<T> spliterator() {
     return this.spliterator.get();
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/HSVLike.java
+++ b/api/src/main/java/net/kyori/adventure/util/HSVLike.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.util;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 
 /**
@@ -46,7 +45,7 @@ public interface HSVLike extends Examinable {
    * @return a new HSVLike
    * @since 4.10.0
    */
-  static @NotNull HSVLike hsvLike(final float h, final float s, final float v) {
+  static HSVLike hsvLike(final float h, final float s, final float v) {
     return new HSVLikeImpl(h, s, v);
   }
 
@@ -59,7 +58,7 @@ public interface HSVLike extends Examinable {
    * @return a new HSVLike
    * @since 4.6.0
    */
-  static @NotNull HSVLike fromRGB(@Range(from = 0x0, to = 0xff) final int red, @Range(from = 0x0, to = 0xff) final int green, @Range(from = 0x0, to = 0xff) final int blue) {
+  static HSVLike fromRGB(@Range(from = 0x0, to = 0xff) final int red, @Range(from = 0x0, to = 0xff) final int green, @Range(from = 0x0, to = 0xff) final int blue) {
     final float r = red / 255.0f;
     final float g = green / 255.0f;
     final float b = blue / 255.0f;
@@ -120,7 +119,7 @@ public interface HSVLike extends Examinable {
   float v();
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("h", this.h()),
       ExaminableProperty.of("s", this.s()),

--- a/api/src/main/java/net/kyori/adventure/util/HSVLikeImpl.java
+++ b/api/src/main/java/net/kyori/adventure/util/HSVLikeImpl.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.util;
 
 import net.kyori.adventure.internal.Internals;
-import org.jetbrains.annotations.NotNull;
 
 record HSVLikeImpl(float h, float s, float v) implements HSVLike {
   HSVLikeImpl {
@@ -41,7 +40,7 @@ record HSVLikeImpl(float h, float s, float v) implements HSVLike {
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/Index.java
+++ b/api/src/main/java/net/kyori/adventure/util/Index.java
@@ -34,8 +34,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A bi-directional map in which keys and values must be unique.
@@ -63,7 +62,7 @@ public final class Index<K, V> {
    * @return the key map
    * @since 4.0.0
    */
-  public static <K, V extends Enum<V>> @NotNull Index<K, V> create(final Class<V> type, final @NotNull Function<? super V, ? extends K> keyFunction) {
+  public static <K, V extends Enum<V>> Index<K, V> create(final Class<V> type, final Function<? super V, ? extends K> keyFunction) {
     return create(type, keyFunction, type.getEnumConstants());
   }
 
@@ -80,7 +79,7 @@ public final class Index<K, V> {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <K, V extends Enum<V>> @NotNull Index<K, V> create(final Class<V> type, final @NotNull Function<? super V, ? extends K> keyFunction, final @NotNull V@NotNull... values) {
+  public static <K, V extends Enum<V>> Index<K, V> create(final Class<V> type, final Function<? super V, ? extends K> keyFunction, final V... values) {
     return create(values, length -> new EnumMap<>(type), keyFunction);
   }
 
@@ -96,7 +95,7 @@ public final class Index<K, V> {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <K, V> @NotNull Index<K, V> create(final @NotNull Function<? super V, ? extends K> keyFunction, final @NotNull V@NotNull... values) {
+  public static <K, V> Index<K, V> create(final Function<? super V, ? extends K> keyFunction, final V... values) {
     return create(values, HashMap::new, keyFunction);
   }
 
@@ -110,15 +109,15 @@ public final class Index<K, V> {
    * @return the key map
    * @since 4.0.0
    */
-  public static <K, V> @NotNull Index<K, V> create(final @NotNull Function<? super V, ? extends K> keyFunction, final @NotNull List<V> constants) {
+  public static <K, V> Index<K, V> create(final Function<? super V, ? extends K> keyFunction, final List<V> constants) {
     return create(constants, HashMap::new, keyFunction);
   }
 
-  private static <K, V> @NotNull Index<K, V> create(final V[] values, final IntFunction<Map<V, K>> valueToKeyFactory, final @NotNull Function<? super V, ? extends K> keyFunction) {
+  private static <K, V> Index<K, V> create(final V[] values, final IntFunction<Map<V, K>> valueToKeyFactory, final Function<? super V, ? extends K> keyFunction) {
     return create(Arrays.asList(values), valueToKeyFactory, keyFunction);
   }
 
-  private static <K, V> @NotNull Index<K, V> create(final List<V> values, final IntFunction<Map<V, K>> valueToKeyFactory, final @NotNull Function<? super V, ? extends K> keyFunction) {
+  private static <K, V> Index<K, V> create(final List<V> values, final IntFunction<Map<V, K>> valueToKeyFactory, final Function<? super V, ? extends K> keyFunction) {
     final int length = values.size();
     final Map<K, V> keyToValue = new HashMap<>(length);
     final Map<V, K> valueToKey = valueToKeyFactory.apply(length); // to support using EnumMap instead of HashMap when possible
@@ -141,7 +140,7 @@ public final class Index<K, V> {
    * @return the keys
    * @since 4.0.0
    */
-  public @NotNull Set<K> keys() {
+  public Set<K> keys() {
     return Collections.unmodifiableSet(this.keyToValue.keySet());
   }
 
@@ -152,7 +151,7 @@ public final class Index<K, V> {
    * @return the key
    * @since 4.0.0
    */
-  public @Nullable K key(final @NotNull V value) {
+  public @Nullable K key(final V value) {
     return this.valueToKey.get(value);
   }
 
@@ -164,7 +163,7 @@ public final class Index<K, V> {
    * @throws NoSuchElementException if there is no key for the value
    * @since 4.11.0
    */
-  public @NotNull K keyOrThrow(final @NotNull V value) {
+  public K keyOrThrow(final V value) {
     final K key = this.key(value);
     if (key == null) {
       throw new NoSuchElementException("There is no key for value " + value);
@@ -181,7 +180,7 @@ public final class Index<K, V> {
    * @since 4.11.0
    */
   @Contract("_, null -> null; _, !null -> !null")
-  public K keyOr(final @NotNull V value, final @Nullable K defaultKey) {
+  public K keyOr(final V value, final @Nullable K defaultKey) {
     final K key = this.key(value);
     return key == null ? defaultKey : key;
   }
@@ -192,7 +191,7 @@ public final class Index<K, V> {
    * @return the keys
    * @since 4.0.0
    */
-  public @NotNull Set<V> values() {
+  public Set<V> values() {
     return Collections.unmodifiableSet(this.valueToKey.keySet());
   }
 
@@ -203,7 +202,7 @@ public final class Index<K, V> {
    * @return the value
    * @since 4.0.0
    */
-  public @Nullable V value(final @NotNull K key) {
+  public @Nullable V value(final K key) {
     return this.keyToValue.get(key);
   }
 
@@ -215,7 +214,7 @@ public final class Index<K, V> {
    * @throws NoSuchElementException if there is no value for the key
    * @since 4.11.0
    */
-  public @NotNull V valueOrThrow(final @NotNull K key) {
+  public V valueOrThrow(final K key) {
     final V value = this.value(key);
     if (value == null) {
       throw new NoSuchElementException("There is no value for key " + key);
@@ -232,7 +231,7 @@ public final class Index<K, V> {
    * @since 4.11.0
    */
   @Contract("_, null -> null; _, !null -> !null")
-  public V valueOr(final @NotNull K key, final @Nullable V defaultValue) {
+  public V valueOr(final K key, final @Nullable V defaultValue) {
     final V value = this.value(key);
     return value == null ? defaultValue : value;
   }
@@ -243,7 +242,7 @@ public final class Index<K, V> {
    * @return a mapping from key to value in the index
    * @since 4.10.0
    */
-  public @NotNull Map<K, V> keyToValue() {
+  public Map<K, V> keyToValue() {
     return Collections.unmodifiableMap(this.keyToValue);
   }
 
@@ -253,7 +252,7 @@ public final class Index<K, V> {
    * @return a mapping from value to key in the index
    * @since 4.10.0
    */
-  public @NotNull Map<V, K> valueToKey() {
+  public Map<V, K> valueToKey() {
     return Collections.unmodifiableMap(this.valueToKey);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMap.java
+++ b/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMap.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.util;
 
 import net.kyori.adventure.builder.AbstractBuilder;
 import org.jetbrains.annotations.CheckReturnValue;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A map type that will traverse class hierarchy to find a value for a key.
@@ -52,7 +51,7 @@ public interface InheritanceAwareMap<C, V> {
    * @since 4.17.0
    */
   @SuppressWarnings("unchecked")
-  static <K, E> @NotNull InheritanceAwareMap<K, E> empty() {
+  static <K, E> InheritanceAwareMap<K, E> empty() {
     return InheritanceAwareMapImpl.EMPTY;
   }
 
@@ -64,7 +63,7 @@ public interface InheritanceAwareMap<C, V> {
    * @return a new builder
    * @since 4.17.0
    */
-  static <K, E> InheritanceAwareMap.@NotNull Builder<K, E> builder() {
+  static <K, E> InheritanceAwareMap.Builder<K, E> builder() {
     return new InheritanceAwareMapImpl.BuilderImpl<>();
   }
 
@@ -77,7 +76,7 @@ public interface InheritanceAwareMap<C, V> {
    * @return a new builder
    * @since 4.17.0
    */
-  static <K, E> InheritanceAwareMap.@NotNull Builder<K, E> builder(final InheritanceAwareMap<? extends K, ? extends E> existing) {
+  static <K, E> InheritanceAwareMap.Builder<K, E> builder(final InheritanceAwareMap<? extends K, ? extends E> existing) {
     return new InheritanceAwareMapImpl.BuilderImpl<K, E>()
       .putAll(existing);
   }
@@ -89,7 +88,7 @@ public interface InheritanceAwareMap<C, V> {
    * @return whether such a value is present
    * @since 4.17.0
    */
-  boolean containsKey(final @NotNull Class<? extends C> clazz);
+  boolean containsKey(final Class<? extends C> clazz);
 
   /**
    * Get the applicable value for the provided class.
@@ -100,7 +99,7 @@ public interface InheritanceAwareMap<C, V> {
    * @return the value, if any is available
    * @since 4.17.0
    */
-  @Nullable V get(final @NotNull Class<? extends C> clazz);
+  @Nullable V get(final Class<? extends C> clazz);
 
   /**
    * Get an updated inheritance aware map with the provided key changed.
@@ -111,7 +110,7 @@ public interface InheritanceAwareMap<C, V> {
    * @since 4.17.0
    */
   @CheckReturnValue
-  @NotNull InheritanceAwareMap<C, V> with(final @NotNull Class<? extends C> clazz, final @NotNull V value);
+  InheritanceAwareMap<C, V> with(final Class<? extends C> clazz, final V value);
 
   /**
    * Get an updated inheritance aware map with the provided key removed.
@@ -121,7 +120,7 @@ public interface InheritanceAwareMap<C, V> {
    * @since 4.17.0
    */
   @CheckReturnValue
-  @NotNull InheritanceAwareMap<C, V> without(final @NotNull Class<? extends C> clazz);
+  InheritanceAwareMap<C, V> without(final Class<? extends C> clazz);
 
   /**
    * A builder for inheritance-aware maps.
@@ -140,7 +139,7 @@ public interface InheritanceAwareMap<C, V> {
      * @return this builder
      * @since 4.17.0
      */
-    @NotNull Builder<C, V> strict(final boolean strict);
+    Builder<C, V> strict(final boolean strict);
 
     /**
      * Put another value in this map.
@@ -150,7 +149,7 @@ public interface InheritanceAwareMap<C, V> {
      * @return this builder
      * @since 4.17.0
      */
-    @NotNull Builder<C, V> put(final @NotNull Class<? extends C> clazz, final @NotNull V value);
+    Builder<C, V> put(final Class<? extends C> clazz, final V value);
 
     /**
      * Remove a value in this map.
@@ -159,7 +158,7 @@ public interface InheritanceAwareMap<C, V> {
      * @return this builder
      * @since 4.17.0
      */
-    @NotNull Builder<C, V> remove(final @NotNull Class<? extends C> clazz);
+    Builder<C, V> remove(final Class<? extends C> clazz);
 
     /**
      * Put values from an existing inheritance-aware map into this map.
@@ -168,7 +167,7 @@ public interface InheritanceAwareMap<C, V> {
      * @return this builder
      * @since 4.17.0
      */
-    @NotNull Builder<C, V> putAll(final @NotNull InheritanceAwareMap<? extends C, ? extends V> map);
+    Builder<C, V> putAll(final InheritanceAwareMap<? extends C, ? extends V> map);
   }
 
 }

--- a/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMapImpl.java
+++ b/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMapImpl.java
@@ -29,8 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -49,13 +48,13 @@ final class InheritanceAwareMapImpl<C, V> implements InheritanceAwareMap<C, V> {
   }
 
   @Override
-  public boolean containsKey(final @NotNull Class<? extends C> clazz) {
+  public boolean containsKey(final Class<? extends C> clazz) {
     return this.get(clazz) != null;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public @Nullable V get(final @NotNull Class<? extends C> clazz) {
+  public @Nullable V get(final Class<? extends C> clazz) {
     final Object ret = this.cache.computeIfAbsent(clazz, c -> {
       final @Nullable V value = this.declaredValues.get(c);
       if (value != null) return value;
@@ -73,7 +72,7 @@ final class InheritanceAwareMapImpl<C, V> implements InheritanceAwareMap<C, V> {
   }
 
   @Override
-  public @NotNull InheritanceAwareMap<C, V> with(final @NotNull Class<? extends C> clazz, final @NotNull V value) {
+  public InheritanceAwareMap<C, V> with(final Class<? extends C> clazz, final V value) {
     if (Objects.equals(this.declaredValues.get(clazz), value)) return this;
     if (this.strict) validateNoneInHierarchy(clazz, this.declaredValues);
 
@@ -83,7 +82,7 @@ final class InheritanceAwareMapImpl<C, V> implements InheritanceAwareMap<C, V> {
   }
 
   @Override
-  public @NotNull InheritanceAwareMap<C, V> without(final @NotNull Class<? extends C> clazz) {
+  public InheritanceAwareMap<C, V> without(final Class<? extends C> clazz) {
     if (!this.declaredValues.containsKey(clazz)) return this;
 
     final Map<Class<? extends C>, V> newValues = new LinkedHashMap<>(this.declaredValues);
@@ -96,12 +95,12 @@ final class InheritanceAwareMapImpl<C, V> implements InheritanceAwareMap<C, V> {
     private final Map<Class<? extends C>, V> values = new LinkedHashMap<>();
 
     @Override
-    public @NotNull InheritanceAwareMap<C, V> build() {
+    public InheritanceAwareMap<C, V> build() {
       return new InheritanceAwareMapImpl<>(this.strict, Collections.unmodifiableMap(new LinkedHashMap<>(this.values)));
     }
 
     @Override
-    public @NotNull Builder<C, V> strict(final boolean strict) {
+    public Builder<C, V> strict(final boolean strict) {
       if (strict && !this.strict) { // re-validate contents
         for (final Class<? extends C> clazz : this.values.keySet()) {
           validateNoneInHierarchy(clazz, this.values);
@@ -112,7 +111,7 @@ final class InheritanceAwareMapImpl<C, V> implements InheritanceAwareMap<C, V> {
     }
 
     @Override
-    public @NotNull Builder<C, V> put(final @NotNull Class<? extends C> clazz, final @NotNull V value) {
+    public Builder<C, V> put(final Class<? extends C> clazz, final V value) {
       if (this.strict) validateNoneInHierarchy(clazz, this.values);
       this.values.put(
         requireNonNull(clazz, "clazz"),
@@ -122,14 +121,14 @@ final class InheritanceAwareMapImpl<C, V> implements InheritanceAwareMap<C, V> {
     }
 
     @Override
-    public @NotNull Builder<C, V> remove(final @NotNull Class<? extends C> clazz) {
+    public Builder<C, V> remove(final Class<? extends C> clazz) {
       this.values.remove(requireNonNull(clazz, "clazz"));
       return this;
     }
 
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public @NotNull Builder<C, V> putAll(final @NotNull InheritanceAwareMap<? extends C, ? extends V> map) {
+    public Builder<C, V> putAll(final InheritanceAwareMap<? extends C, ? extends V> map) {
       final InheritanceAwareMapImpl<?, V> impl = (InheritanceAwareMapImpl<?, V>) map;
       if (this.strict) {
         if (!this.values.isEmpty() || !impl.strict) { // validate all

--- a/api/src/main/java/net/kyori/adventure/util/Listenable.java
+++ b/api/src/main/java/net/kyori/adventure/util/Listenable.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.util;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Something that has listeners.
@@ -43,7 +42,7 @@ public abstract class Listenable<L> {
    * @param consumer the consumer
    * @since 4.0.0
    */
-  protected final void forEachListener(final @NotNull Consumer<L> consumer) {
+  protected final void forEachListener(final Consumer<L> consumer) {
     for (final L listener : this.listeners) {
       consumer.accept(listener);
     }
@@ -55,7 +54,7 @@ public abstract class Listenable<L> {
    * @param listener the listener
    * @since 4.0.0
    */
-  protected final void addListener0(final @NotNull L listener) {
+  protected final void addListener0(final L listener) {
     this.listeners.add(listener);
   }
 
@@ -65,7 +64,7 @@ public abstract class Listenable<L> {
    * @param listener the listener
    * @since 4.0.0
    */
-  protected final void removeListener0(final @NotNull L listener) {
+  protected final void removeListener0(final L listener) {
     this.listeners.remove(listener);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/MonkeyBars.java
+++ b/api/src/main/java/net/kyori/adventure/util/MonkeyBars.java
@@ -30,7 +30,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -54,7 +53,7 @@ public final class MonkeyBars {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <E extends Enum<E>> @NotNull Set<E> enumSet(final Class<E> type, final E@NotNull... constants) {
+  public static <E extends Enum<E>> Set<E> enumSet(final Class<E> type, final E... constants) {
     final Set<E> set = EnumSet.noneOf(type);
     Collections.addAll(set, constants);
     return Collections.unmodifiableSet(set);
@@ -71,7 +70,7 @@ public final class MonkeyBars {
    * @return a list
    * @since 4.8.0
    */
-  public static <T> @NotNull List<T> addOne(final @NotNull List<T> oldList, final T newElement) {
+  public static <T> List<T> addOne(final List<T> oldList, final T newElement) {
     if (oldList.isEmpty()) return List.of(newElement);
     final List<T> newList = new ArrayList<>(oldList.size() + 1);
     newList.addAll(oldList);
@@ -93,7 +92,7 @@ public final class MonkeyBars {
    * @since 4.15.0
    */
   @SafeVarargs
-  public static <I, O> @NotNull List<O> nonEmptyArrayToList(final @NotNull Function<I, O> mapper, final @NotNull I first, final @NotNull I@NotNull... others) {
+  public static <I, O> List<O> nonEmptyArrayToList(final Function<I, O> mapper, final I first, final I... others) {
     final List<O> ret = new ArrayList<>(others.length + 1);
     ret.add(mapper.apply(first));
     for (final I other : others) {
@@ -114,7 +113,7 @@ public final class MonkeyBars {
    * @return a mapped list
    * @since 4.15.0
    */
-  public static <I, O> @NotNull List<O> toUnmodifiableList(final @NotNull Function<I, O> mapper, final @NotNull Iterable<? extends I> source) {
+  public static <I, O> List<O> toUnmodifiableList(final Function<I, O> mapper, final Iterable<? extends I> source) {
     final ArrayList<O> ret = source instanceof Collection<?> ? new ArrayList<>(((Collection<?>) source).size()) : new ArrayList<>();
     for (final I el : source) {
       ret.add(requireNonNull(mapper.apply(requireNonNull(el, "source[?]")), "mapper(source[?])"));

--- a/api/src/main/java/net/kyori/adventure/util/Nag.java
+++ b/api/src/main/java/net/kyori/adventure/util/Nag.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.util;
 
 import java.io.Serial;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A nag.
@@ -40,7 +39,7 @@ public abstract class Nag extends RuntimeException {
    * @param nag the nag
    * @since 4.7.0
    */
-  public static void print(final @NotNull Nag nag) {
+  public static void print(final Nag nag) {
     nag.printStackTrace();
   }
 

--- a/api/src/main/java/net/kyori/adventure/util/RGBLike.java
+++ b/api/src/main/java/net/kyori/adventure/util/RGBLike.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.adventure.util;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Range;
 
 /**
@@ -62,7 +61,7 @@ public interface RGBLike {
    * @return an HSVLike representing this RGBLike in the HSV color space
    * @since 4.6.0
    */
-  default @NotNull HSVLike asHSV() {
+  default HSVLike asHSV() {
     return HSVLike.fromRGB(this.red(), this.green(), this.blue());
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/Services.java
+++ b/api/src/main/java/net/kyori/adventure/util/Services.java
@@ -31,7 +31,6 @@ import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
 import net.kyori.adventure.internal.properties.AdventureProperties;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Tools for working with {@link ServiceLoader}s.
@@ -52,7 +51,7 @@ public final class Services {
    * @return a service, or {@link Optional#empty()}
    * @since 4.8.0
    */
-  public static <P> @NotNull Optional<P> service(final @NotNull Class<P> type) {
+  public static <P> Optional<P> service(final Class<P> type) {
     final ServiceLoader<P> loader = Services0.loader(type);
     final Iterator<P> it = loader.iterator();
     while (it.hasNext()) {
@@ -96,7 +95,7 @@ public final class Services {
    * @see Fallback
    * @since 4.14.0
    */
-  public static <P> @NotNull Optional<P> serviceWithFallback(final @NotNull Class<P> type) {
+  public static <P> Optional<P> serviceWithFallback(final Class<P> type) {
     final ServiceLoader<P> loader = Services0.loader(type);
     final Iterator<P> it = loader.iterator();
     P firstFallback = null;

--- a/api/src/main/java/net/kyori/adventure/util/Ticks.java
+++ b/api/src/main/java/net/kyori/adventure/util/Ticks.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.util;
 
 import java.time.Duration;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Standard game tick utilities.
@@ -53,7 +52,7 @@ public interface Ticks {
    * @return a duration
    * @since 4.0.0
    */
-  static @NotNull Duration duration(final long ticks) {
+  static Duration duration(final long ticks) {
     return Duration.ofMillis(ticks * SINGLE_TICK_DURATION_MS);
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/TriState.java
+++ b/api/src/main/java/net/kyori/adventure/util/TriState.java
@@ -24,8 +24,7 @@
 package net.kyori.adventure.util;
 
 import java.util.function.BooleanSupplier;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Similar to a {@code boolean} but with three states.
@@ -98,7 +97,7 @@ public enum TriState {
    * @return the boolean representing the tri-state or the result of the passed supplier if this state is {@link #NOT_SET}.
    * @since 4.10.0
    */
-  public boolean toBooleanOrElseGet(final @NotNull BooleanSupplier supplier) {
+  public boolean toBooleanOrElseGet(final BooleanSupplier supplier) {
     return switch (this) {
       case TRUE -> true;
       case FALSE -> false;
@@ -113,7 +112,7 @@ public enum TriState {
    * @return a tri-state
    * @since 4.8.0
    */
-  public static @NotNull TriState byBoolean(final boolean value) {
+  public static TriState byBoolean(final boolean value) {
     return value ? TRUE : FALSE;
   }
 
@@ -124,7 +123,7 @@ public enum TriState {
    * @return a tri-state
    * @since 4.8.0
    */
-  public static @NotNull TriState byBoolean(final @Nullable Boolean value) {
+  public static TriState byBoolean(final @Nullable Boolean value) {
     return value == null ? NOT_SET : byBoolean(value.booleanValue());
   }
 }

--- a/api/src/main/java/net/kyori/adventure/util/UTF8ResourceBundleControl.java
+++ b/api/src/main/java/net/kyori/adventure/util/UTF8ResourceBundleControl.java
@@ -32,7 +32,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A {@link ResourceBundle.Control} that enforces UTF-8 string encoding.
@@ -50,7 +49,7 @@ public final class UTF8ResourceBundleControl extends ResourceBundle.Control {
    * @return a resource bundle control
    * @since 4.24.0
    */
-  public static ResourceBundle.@NotNull Control utf8ResourceBundleControl() {
+  public static ResourceBundle.Control utf8ResourceBundleControl() {
     return INSTANCE;
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ option = { module = "net.kyori:option", version = "1.1.0" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava" }
 jetbrainsAnnotations = "org.jetbrains:annotations:26.0.2-1"
+jspecify = "org.jspecify:jspecify:1.0.0"
 
 # extra-kotlin
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }

--- a/key/build.gradle.kts
+++ b/key/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   api(libs.examination.api)
   api(libs.examination.string)
   compileOnlyApi(libs.jetbrainsAnnotations)
+  compileOnlyApi(libs.jspecify)
   testImplementation(libs.guava)
 }
 

--- a/key/src/main/java/module-info.java
+++ b/key/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A reference composed of a namespace and a path.
+ */
+@NullMarked
+module net.kyori.adventure.key {
+  requires transitive net.kyori.examination.string;
+  requires static org.jspecify;
+
+  exports net.kyori.adventure.key;
+}

--- a/key/src/main/java/net/kyori/adventure/key/InvalidKeyException.java
+++ b/key/src/main/java/net/kyori/adventure/key/InvalidKeyException.java
@@ -24,8 +24,7 @@
 package net.kyori.adventure.key;
 
 import java.io.Serial;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This exception is thrown when an invalid namespace and/or value has been detected while creating a {@link Key}.
@@ -38,7 +37,7 @@ public final class InvalidKeyException extends RuntimeException {
   private final String keyNamespace;
   private final String keyValue;
 
-  InvalidKeyException(final @NotNull String keyNamespace, final @NotNull String keyValue, final @Nullable String message) {
+  InvalidKeyException(final String keyNamespace, final String keyValue, final @Nullable String message) {
     super(message);
     this.keyNamespace = keyNamespace;
     this.keyValue = keyValue;
@@ -50,7 +49,7 @@ public final class InvalidKeyException extends RuntimeException {
    * @return a key
    * @since 4.0.0
    */
-  public @NotNull String keyNamespace() {
+  public String keyNamespace() {
     return this.keyNamespace;
   }
 
@@ -60,7 +59,7 @@ public final class InvalidKeyException extends RuntimeException {
    * @return a key
    * @since 4.0.0
    */
-  public @NotNull String keyValue() {
+  public String keyValue() {
     return this.keyValue;
   }
 }

--- a/key/src/main/java/net/kyori/adventure/key/Key.java
+++ b/key/src/main/java/net/kyori/adventure/key/Key.java
@@ -29,8 +29,7 @@ import java.util.OptionalInt;
 import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An identifying object used to fetch and/or store unique objects.
@@ -85,7 +84,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @throws InvalidKeyException if the namespace or value contains an invalid character
    * @since 4.0.0
    */
-  static @NotNull Key key(@KeyPattern final @NotNull String string) {
+  static Key key(@KeyPattern final String string) {
     return key(string, DEFAULT_SEPARATOR);
   }
 
@@ -105,7 +104,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @since 4.0.0
    */
   @SuppressWarnings("PatternValidation") // impossible to validate since the character is variable
-  static @NotNull Key key(final @NotNull String string, final char character) {
+  static Key key(final String string, final char character) {
     Objects.requireNonNull(string, "string");
     final int index = string.indexOf(character);
     final String namespace = index >= 1 ? string.substring(0, index) : MINECRAFT_NAMESPACE;
@@ -123,7 +122,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @since 4.4.0
    */
   @SuppressWarnings("PatternValidation") // The namespace is tested later.
-  static @NotNull Key key(final @NotNull Namespaced namespaced, @KeyPattern.Value final @NotNull String value) {
+  static Key key(final Namespaced namespaced, @KeyPattern.Value final String value) {
     return key(Objects.requireNonNull(namespaced, "namespaced").namespace(), value);
   }
 
@@ -136,7 +135,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @throws InvalidKeyException if the namespace or value contains an invalid character
    * @since 4.0.0
    */
-  static @NotNull Key key(@KeyPattern.Namespace final @NotNull String namespace, @KeyPattern.Value final @NotNull String value) {
+  static Key key(@KeyPattern.Namespace final String namespace, @KeyPattern.Value final String value) {
     KeyImpl.checkError("namespace", namespace, namespace, value, Key.checkNamespace(namespace), KeyImpl.NAMESPACE_PATTERN);
     KeyImpl.checkError("value", value, namespace, value, Key.checkValue(value), KeyImpl.VALUE_PATTERN);
     return new KeyImpl(namespace, value);
@@ -150,7 +149,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @return a comparator for keys
    * @since 4.10.0
    */
-  static @NotNull Comparator<? super Key> comparator() {
+  static Comparator<? super Key> comparator() {
     return KeyImpl.COMPARATOR;
   }
 
@@ -178,7 +177,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @return {@code true} if {@code value} is a valid namespace, {@code false} otherwise
    * @since 4.12.0
    */
-  static boolean parseableNamespace(final @NotNull String namespace) {
+  static boolean parseableNamespace(final String namespace) {
     return checkNamespace(namespace).isEmpty();
   }
 
@@ -189,7 +188,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @return {@link OptionalInt#empty()} if {@code value} is a valid namespace, otherwise an {@code OptionalInt} containing the index of an invalid character
    * @since 4.14.0
    */
-  static @NotNull OptionalInt checkNamespace(final @NotNull String namespace) {
+  static OptionalInt checkNamespace(final String namespace) {
     Objects.requireNonNull(namespace, "namespace");
     for (int i = 0, length = namespace.length(); i < length; i++) {
       if (!allowedInNamespace(namespace.charAt(i))) {
@@ -206,7 +205,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @return {@code true} if {@code value} is a valid value, {@code false} otherwise
    * @since 4.12.0
    */
-  static boolean parseableValue(final @NotNull String value) {
+  static boolean parseableValue(final String value) {
     return checkValue(value).isEmpty();
   }
 
@@ -217,7 +216,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @return {@link OptionalInt#empty()} if {@code value} is a valid value, otherwise an {@code OptionalInt} containing the index of an invalid character
    * @since 4.14.0
    */
-  static @NotNull OptionalInt checkValue(final @NotNull String value) {
+  static OptionalInt checkValue(final String value) {
     Objects.requireNonNull(value, "value");
     for (int i = 0, length = value.length(); i < length; i++) {
       if (!allowedInValue(value.charAt(i))) {
@@ -257,7 +256,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    */
   @KeyPattern.Namespace
   @Override
-  @NotNull String namespace();
+  String namespace();
 
   /**
    * Gets the value.
@@ -266,7 +265,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @since 4.0.0
    */
   @KeyPattern.Value
-  @NotNull String value();
+  String value();
 
   /**
    * Returns the string representation of this key.
@@ -274,7 +273,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @return the string representation
    * @since 4.0.0
    */
-  @NotNull String asString();
+  String asString();
 
   /**
    * Returns the string representation of this key in minimal form.
@@ -284,7 +283,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
    * @return the string representation
    * @since 4.15.0
    */
-  default @NotNull String asMinimalString() {
+  default String asMinimalString() {
     if (this.namespace().equals(MINECRAFT_NAMESPACE)) {
       return this.value();
     }
@@ -292,7 +291,7 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
   }
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("namespace", this.namespace()),
       ExaminableProperty.of("value", this.value())
@@ -300,12 +299,12 @@ public interface Key extends Comparable<Key>, Examinable, Namespaced, Keyed {
   }
 
   @Override
-  default int compareTo(final @NotNull Key that) {
+  default int compareTo(final Key that) {
     return comparator().compare(this, that);
   }
 
   @Override
-  default @NotNull Key key() {
+  default Key key() {
     return this;
   }
 }

--- a/key/src/main/java/net/kyori/adventure/key/KeyImpl.java
+++ b/key/src/main/java/net/kyori/adventure/key/KeyImpl.java
@@ -31,7 +31,6 @@ import java.util.OptionalInt;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.intellij.lang.annotations.RegExp;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -66,21 +65,21 @@ record KeyImpl(String namespace, String value) implements Key {
   }
 
   @Override
-  public @NotNull String asString() {
+  public String asString() {
     return asString(this.namespace, this.value);
   }
 
-  private static @NotNull String asString(final @NotNull String namespace, final @NotNull String value) {
+  private static String asString(final String namespace, final String value) {
     return namespace + ':' + value;
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return this.asString();
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("namespace", this.namespace),
       ExaminableProperty.of("value", this.value)
@@ -95,7 +94,7 @@ record KeyImpl(String namespace, String value) implements Key {
   }
 
   @Override
-  public int compareTo(final @NotNull Key that) {
+  public int compareTo(final Key that) {
     return Key.super.compareTo(that);
   }
 }

--- a/key/src/main/java/net/kyori/adventure/key/Keyed.java
+++ b/key/src/main/java/net/kyori/adventure/key/Keyed.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.key;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Something that has an associated {@link Key}.
  *
@@ -37,5 +35,5 @@ public interface Keyed {
    * @return the key
    * @since 4.0.0
    */
-  @NotNull Key key();
+  Key key();
 }

--- a/key/src/main/java/net/kyori/adventure/key/KeyedValue.java
+++ b/key/src/main/java/net/kyori/adventure/key/KeyedValue.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.key;
 
-import org.jetbrains.annotations.NotNull;
-
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -43,7 +41,7 @@ public interface KeyedValue<T> extends Keyed {
    * @return the keyed
    * @since 4.10.0
    */
-  static <T> @NotNull KeyedValue<T> keyedValue(final @NotNull Key key, final @NotNull T value) {
+  static <T> KeyedValue<T> keyedValue(final Key key, final T value) {
     return new KeyedValueImpl<>(key, requireNonNull(value, "value"));
   }
 
@@ -53,5 +51,5 @@ public interface KeyedValue<T> extends Keyed {
    * @return the value
    * @since 4.0.0
    */
-  @NotNull T value();
+  T value();
 }

--- a/key/src/main/java/net/kyori/adventure/key/KeyedValueImpl.java
+++ b/key/src/main/java/net/kyori/adventure/key/KeyedValueImpl.java
@@ -27,8 +27,7 @@ import java.util.stream.Stream;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 record KeyedValueImpl<T>(Key key, T value) implements Examinable, KeyedValue<T> {
 
@@ -40,7 +39,7 @@ record KeyedValueImpl<T>(Key key, T value) implements Examinable, KeyedValue<T> 
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("key", this.key),
       ExaminableProperty.of("value", this.value)
@@ -48,7 +47,7 @@ record KeyedValueImpl<T>(Key key, T value) implements Examinable, KeyedValue<T> 
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return this.examine(StringExaminer.simpleEscaping());
   }
 }

--- a/key/src/main/java/net/kyori/adventure/key/Namespaced.java
+++ b/key/src/main/java/net/kyori/adventure/key/Namespaced.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.key;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Something that has a namespace.
  *
@@ -38,5 +36,5 @@ public interface Namespaced {
    * @since 4.4.0
    */
   @KeyPattern.Namespace
-  @NotNull String namespace();
+  String namespace();
 }

--- a/nbt/build.gradle.kts
+++ b/nbt/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
   api(libs.examination.api)
   api(libs.examination.string)
   compileOnlyApi(libs.jetbrainsAnnotations)
+  compileOnlyApi(libs.jspecify)
 }
 
 applyJarMetadata("net.kyori.adventure.nbt")

--- a/nbt/src/main/java/module-info.java
+++ b/nbt/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * An implementation of the <a href="https://wiki.vg/NBT">NBT</a> format.
+ *
+ * <p>Adventure supports serializing to both binary and string representations
+ * of the tags, both through {@link net.kyori.adventure.nbt.BinaryTagIO}</p>
+ */
+@NullMarked
+module net.kyori.adventure.nbt {
+  requires transitive net.kyori.examination.string;
+  requires static org.jspecify;
+
+  exports net.kyori.adventure.nbt;
+}

--- a/nbt/src/main/java/net/kyori/adventure/nbt/AbstractBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/AbstractBinaryTag.java
@@ -24,11 +24,10 @@
 package net.kyori.adventure.nbt;
 
 import net.kyori.examination.string.StringExaminer;
-import org.jetbrains.annotations.NotNull;
 
 abstract class AbstractBinaryTag implements BinaryTag {
   @Override
-  public final @NotNull String examinableName() {
+  public final String examinableName() {
     return this.type().toString();
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ArrayBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * An array binary tag.
  *
@@ -32,5 +30,5 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface ArrayBinaryTag extends BinaryTag {
   @Override
-  @NotNull BinaryTagType<? extends ArrayBinaryTag> type();
+  BinaryTagType<? extends ArrayBinaryTag> type();
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTag.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.nbt;
 
 import net.kyori.examination.Examinable;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A binary tag.
@@ -38,10 +37,10 @@ public interface BinaryTag extends BinaryTagLike, Examinable {
    * @return the tag type
    * @since 4.0.0
    */
-  @NotNull BinaryTagType<? extends BinaryTag> type();
+  BinaryTagType<? extends BinaryTag> type();
 
   @Override
-  default @NotNull BinaryTag asBinaryTag() {
+  default BinaryTag asBinaryTag() {
     return this;
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagIO.java
@@ -34,7 +34,6 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.InflaterInputStream;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Serialization operations for binary tags.
@@ -57,7 +56,7 @@ public final class BinaryTagIO {
    * @return binary tag reader
    * @since 4.4.0
    */
-  public static @NotNull Reader unlimitedReader() {
+  public static Reader unlimitedReader() {
     return BinaryTagReaderImpl.UNLIMITED;
   }
 
@@ -69,7 +68,7 @@ public final class BinaryTagIO {
    * @return binary tag reader
    * @since 4.4.0
    */
-  public static @NotNull Reader reader() {
+  public static Reader reader() {
     return BinaryTagReaderImpl.DEFAULT_LIMIT;
   }
 
@@ -82,7 +81,7 @@ public final class BinaryTagIO {
    * @return binary tag reader
    * @since 4.4.0
    */
-  public static @NotNull Reader reader(final long sizeLimitBytes) {
+  public static Reader reader(final long sizeLimitBytes) {
     if (sizeLimitBytes <= 0) {
       throw new IllegalArgumentException("The size limit must be greater than zero");
     }
@@ -95,7 +94,7 @@ public final class BinaryTagIO {
    * @return binary tag writer
    * @since 4.4.0
    */
-  public static @NotNull Writer writer() {
+  public static Writer writer() {
     return BinaryTagWriterImpl.INSTANCE;
   }
 
@@ -117,7 +116,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default @NotNull CompoundBinaryTag read(final @NotNull Path path) throws IOException {
+    default CompoundBinaryTag read(final Path path) throws IOException {
       return this.read(path, Compression.NONE);
     }
 
@@ -132,7 +131,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    @NotNull CompoundBinaryTag read(final @NotNull Path path, final @NotNull Compression compression) throws IOException;
+    CompoundBinaryTag read(final Path path, final Compression compression) throws IOException;
 
     /**
      * Reads a binary tag from {@code input}.
@@ -146,7 +145,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default @NotNull CompoundBinaryTag read(final @NotNull InputStream input) throws IOException {
+    default CompoundBinaryTag read(final InputStream input) throws IOException {
       return this.read(input, Compression.NONE);
     }
 
@@ -161,7 +160,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    @NotNull CompoundBinaryTag read(final @NotNull InputStream input, final @NotNull Compression compression) throws IOException;
+    CompoundBinaryTag read(final InputStream input, final Compression compression) throws IOException;
 
     /**
      * Reads a binary tag from {@code input}.
@@ -173,7 +172,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    @NotNull CompoundBinaryTag read(final @NotNull DataInput input) throws IOException;
+    CompoundBinaryTag read(final DataInput input) throws IOException;
 
     /**
      * Reads a binary tag from {@code path}.
@@ -188,7 +187,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    default @NotNull CompoundBinaryTag readNameless(final @NotNull Path path) throws IOException {
+    default CompoundBinaryTag readNameless(final Path path) throws IOException {
       return this.readNameless(path, Compression.NONE);
     }
 
@@ -204,7 +203,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    @NotNull CompoundBinaryTag readNameless(final @NotNull Path path, final @NotNull Compression compression) throws IOException;
+    CompoundBinaryTag readNameless(final Path path, final Compression compression) throws IOException;
 
     /**
      * Reads a binary tag from {@code input}.
@@ -219,7 +218,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    default @NotNull CompoundBinaryTag readNameless(final @NotNull InputStream input) throws IOException {
+    default CompoundBinaryTag readNameless(final InputStream input) throws IOException {
       return this.readNameless(input, Compression.NONE);
     }
 
@@ -235,7 +234,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    @NotNull CompoundBinaryTag readNameless(final @NotNull InputStream input, final @NotNull Compression compression) throws IOException;
+    CompoundBinaryTag readNameless(final InputStream input, final Compression compression) throws IOException;
 
     /**
      * Reads a binary tag from {@code input}.
@@ -248,7 +247,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    @NotNull CompoundBinaryTag readNameless(final @NotNull DataInput input) throws IOException;
+    CompoundBinaryTag readNameless(final DataInput input) throws IOException;
 
     /**
      * Reads a binary tag, with a name, from {@code path}.
@@ -260,7 +259,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull Path path) throws IOException {
+    default Map.Entry<String, CompoundBinaryTag> readNamed(final Path path) throws IOException {
       return this.readNamed(path, Compression.NONE);
     }
 
@@ -273,7 +272,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull Path path, final @NotNull Compression compression) throws IOException;
+    Map.Entry<String, CompoundBinaryTag> readNamed(final Path path, final Compression compression) throws IOException;
 
     /**
      * Reads a binary tag, with a name, from {@code input}.
@@ -285,7 +284,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull InputStream input) throws IOException {
+    default Map.Entry<String, CompoundBinaryTag> readNamed(final InputStream input) throws IOException {
       return this.readNamed(input, Compression.NONE);
     }
 
@@ -298,7 +297,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull InputStream input, final @NotNull Compression compression) throws IOException;
+    Map.Entry<String, CompoundBinaryTag> readNamed(final InputStream input, final Compression compression) throws IOException;
 
     /**
      * Reads a binary tag, with a name, from {@code input}.
@@ -308,7 +307,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull DataInput input) throws IOException;
+    Map.Entry<String, CompoundBinaryTag> readNamed(final DataInput input) throws IOException;
   }
 
   /**
@@ -329,7 +328,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default void write(final @NotNull CompoundBinaryTag tag, final @NotNull Path path) throws IOException {
+    default void write(final CompoundBinaryTag tag, final Path path) throws IOException {
       this.write(tag, path, Compression.NONE);
     }
 
@@ -344,7 +343,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void write(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final @NotNull Compression compression) throws IOException;
+    void write(final CompoundBinaryTag tag, final Path path, final Compression compression) throws IOException;
 
     /**
      * Writes a binary tag to {@code output}.
@@ -358,7 +357,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default void write(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output) throws IOException {
+    default void write(final CompoundBinaryTag tag, final OutputStream output) throws IOException {
       this.write(tag, output, Compression.NONE);
     }
 
@@ -373,7 +372,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void write(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final @NotNull Compression compression) throws IOException;
+    void write(final CompoundBinaryTag tag, final OutputStream output, final Compression compression) throws IOException;
 
     /**
      * Writes a binary tag to {@code output}.
@@ -385,7 +384,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException;
+    void write(final CompoundBinaryTag tag, final DataOutput output) throws IOException;
 
     /**
      * Writes a binary tag to {@code path} with a {@code compression} type.
@@ -400,7 +399,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    default void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull Path path) throws IOException {
+    default void writeNameless(final CompoundBinaryTag tag, final Path path) throws IOException {
       this.writeNameless(tag, path, Compression.NONE);
     }
 
@@ -416,7 +415,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final @NotNull Compression compression) throws IOException;
+    void writeNameless(final CompoundBinaryTag tag, final Path path, final Compression compression) throws IOException;
 
     /**
      * Writes a binary tag to {@code output}.
@@ -431,7 +430,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    default void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output) throws IOException {
+    default void writeNameless(final CompoundBinaryTag tag, final OutputStream output) throws IOException {
       this.writeNameless(tag, output, Compression.NONE);
     }
 
@@ -447,7 +446,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final @NotNull Compression compression) throws IOException;
+    void writeNameless(final CompoundBinaryTag tag, final OutputStream output, final Compression compression) throws IOException;
 
     /**
      * Writes a binary tag to {@code output}.
@@ -460,7 +459,7 @@ public final class BinaryTagIO {
      * @since 4.15.0
      * @sinceMinecraft 1.20.2
      */
-    void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException;
+    void writeNameless(final CompoundBinaryTag tag, final DataOutput output) throws IOException;
 
     /**
      * Writes a binary tag, with a name, to {@code path}.
@@ -472,7 +471,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull Path path) throws IOException {
+    default void writeNamed(final Map.Entry<String, CompoundBinaryTag> tag, final Path path) throws IOException {
       this.writeNamed(tag, path, Compression.NONE);
     }
 
@@ -485,7 +484,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull Path path, final @NotNull Compression compression) throws IOException;
+    void writeNamed(final Map.Entry<String, CompoundBinaryTag> tag, final Path path, final Compression compression) throws IOException;
 
     /**
      * Writes a binary tag, with a name, to {@code output}.
@@ -497,7 +496,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    default void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull OutputStream output) throws IOException {
+    default void writeNamed(final Map.Entry<String, CompoundBinaryTag> tag, final OutputStream output) throws IOException {
       this.writeNamed(tag, output, Compression.NONE);
     }
 
@@ -510,7 +509,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull OutputStream output, final @NotNull Compression compression) throws IOException;
+    void writeNamed(final Map.Entry<String, CompoundBinaryTag> tag, final OutputStream output, final Compression compression) throws IOException;
 
     /**
      * Writes a binary tag, with a name, to {@code output}.
@@ -520,7 +519,7 @@ public final class BinaryTagIO {
      * @throws IOException if an exception was encountered while reading the tag
      * @since 4.4.0
      */
-    void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull DataOutput output) throws IOException;
+    void writeNamed(final Map.Entry<String, CompoundBinaryTag> tag, final DataOutput output) throws IOException;
   }
 
   /**
@@ -536,12 +535,12 @@ public final class BinaryTagIO {
      */
     public static final Compression NONE = new Compression() {
       @Override
-      @NotNull InputStream decompress(final @NotNull InputStream is) {
+      InputStream decompress(final InputStream is) {
         return is;
       }
 
       @Override
-      @NotNull OutputStream compress(final @NotNull OutputStream os) {
+      OutputStream compress(final OutputStream os) {
         return os;
       }
 
@@ -557,12 +556,12 @@ public final class BinaryTagIO {
      */
     public static final Compression GZIP = new Compression() {
       @Override
-      @NotNull InputStream decompress(final @NotNull InputStream is) throws IOException {
+      InputStream decompress(final InputStream is) throws IOException {
         return new GZIPInputStream(is);
       }
 
       @Override
-      @NotNull OutputStream compress(final @NotNull OutputStream os) throws IOException {
+      OutputStream compress(final OutputStream os) throws IOException {
         return new GZIPOutputStream(os);
       }
 
@@ -578,12 +577,12 @@ public final class BinaryTagIO {
      */
     public static final Compression ZLIB = new Compression() {
       @Override
-      @NotNull InputStream decompress(final @NotNull InputStream is) {
+      InputStream decompress(final InputStream is) {
         return new InflaterInputStream(is);
       }
 
       @Override
-      @NotNull OutputStream compress(final @NotNull OutputStream os) {
+      OutputStream compress(final OutputStream os) {
         return new DeflaterOutputStream(os);
       }
 
@@ -593,8 +592,8 @@ public final class BinaryTagIO {
       }
     };
 
-    abstract @NotNull InputStream decompress(final @NotNull InputStream is) throws IOException;
+    abstract InputStream decompress(final InputStream is) throws IOException;
 
-    abstract @NotNull OutputStream compress(final @NotNull OutputStream os) throws IOException;
+    abstract OutputStream compress(final OutputStream os) throws IOException;
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagLike.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagLike.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Something that can be represented as a binary tag.
  *
@@ -37,5 +35,5 @@ public interface BinaryTagLike {
    * @return a binary tag
    * @since 4.4.0
    */
-  @NotNull BinaryTag asBinaryTag();
+  BinaryTag asBinaryTag();
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagReaderImpl.java
@@ -32,7 +32,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.Map;
-import org.jetbrains.annotations.NotNull;
 
 import static net.kyori.adventure.nbt.IOStreamUtil.closeShield;
 
@@ -47,25 +46,25 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
   }
 
   @Override
-  public @NotNull CompoundBinaryTag read(final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public CompoundBinaryTag read(final Path path, final BinaryTagIO.Compression compression) throws IOException {
     try (final InputStream is = Files.newInputStream(path)) {
       return this.read(is, compression);
     }
   }
 
   @Override
-  public @NotNull CompoundBinaryTag read(final @NotNull InputStream input, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public CompoundBinaryTag read(final InputStream input, final BinaryTagIO.Compression compression) throws IOException {
     try (final DataInputStream dis = new DataInputStream(new BufferedInputStream(compression.decompress(closeShield(input))))) {
       return this.read((DataInput) dis);
     }
   }
 
   @Override
-  public @NotNull CompoundBinaryTag read(final @NotNull DataInput input) throws IOException {
+  public CompoundBinaryTag read(final DataInput input) throws IOException {
     return this.read(input, true);
   }
 
-  private @NotNull CompoundBinaryTag read(@NotNull DataInput input, final boolean named) throws IOException {
+  private CompoundBinaryTag read(DataInput input, final boolean named) throws IOException {
     if (!(input instanceof TrackingDataInput)) {
       input = new TrackingDataInput(input, this.maxBytes);
     }
@@ -79,40 +78,40 @@ final class BinaryTagReaderImpl implements BinaryTagIO.Reader {
   }
 
   @Override
-  public @NotNull CompoundBinaryTag readNameless(final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public CompoundBinaryTag readNameless(final Path path, final BinaryTagIO.Compression compression) throws IOException {
     try (final InputStream is = Files.newInputStream(path)) {
       return this.readNameless(is, compression);
     }
   }
 
   @Override
-  public @NotNull CompoundBinaryTag readNameless(final @NotNull InputStream input, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public CompoundBinaryTag readNameless(final InputStream input, final BinaryTagIO.Compression compression) throws IOException {
     try (final DataInputStream dis = new DataInputStream(new BufferedInputStream(compression.decompress(closeShield(input))))) {
       return this.readNameless((DataInput) dis);
     }
   }
 
   @Override
-  public @NotNull CompoundBinaryTag readNameless(final @NotNull DataInput input) throws IOException {
+  public CompoundBinaryTag readNameless(final DataInput input) throws IOException {
     return this.read(input, false);
   }
 
   @Override
-  public Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public Map.Entry<String, CompoundBinaryTag> readNamed(final Path path, final BinaryTagIO.Compression compression) throws IOException {
     try (final InputStream is = Files.newInputStream(path)) {
       return this.readNamed(is, compression);
     }
   }
 
   @Override
-  public Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull InputStream input, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public Map.Entry<String, CompoundBinaryTag> readNamed(final InputStream input, final BinaryTagIO.Compression compression) throws IOException {
     try (final DataInputStream dis = new DataInputStream(new BufferedInputStream(compression.decompress(closeShield(input))))) {
       return this.readNamed((DataInput) dis);
     }
   }
 
   @Override
-  public Map.@NotNull Entry<String, CompoundBinaryTag> readNamed(final @NotNull DataInput input) throws IOException {
+  public Map.Entry<String, CompoundBinaryTag> readNamed(final DataInput input) throws IOException {
     final BinaryTagType<? extends BinaryTag> type = BinaryTagType.binaryTagType(input.readByte());
     requireCompound(type);
     final String name = input.readUTF();

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagType.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagType.java
@@ -29,8 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A binary tag type.
@@ -59,7 +58,7 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @throws IOException if an exception was encountered while reading
    * @since 4.0.0
    */
-  public abstract @NotNull T read(final @NotNull DataInput input) throws IOException;
+  public abstract T read(final DataInput input) throws IOException;
 
   /**
    * Writes a tag.
@@ -69,14 +68,14 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @throws IOException if an exception was encountered while writing
    * @since 4.0.0
    */
-  public abstract void write(final @NotNull T tag, final @NotNull DataOutput output) throws IOException;
+  public abstract void write(final T tag, final DataOutput output) throws IOException;
 
   @SuppressWarnings("unchecked") // HACK: generics suck
   static <T extends BinaryTag> void writeUntyped(final BinaryTagType<? extends BinaryTag> type, final T tag, final DataOutput output) throws IOException {
     ((BinaryTagType<T>) type).write(tag, output);
   }
 
-  static @NotNull BinaryTagType<? extends BinaryTag> binaryTagType(final byte id) {
+  static BinaryTagType<? extends BinaryTag> binaryTagType(final byte id) {
     for (final BinaryTagType<? extends BinaryTag> type : TYPES) {
       if (type.id() == id) {
         return type;
@@ -85,11 +84,11 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
     throw new IllegalArgumentException(String.valueOf(id));
   }
 
-  static <T extends BinaryTag> @NotNull BinaryTagType<T> register(final Class<T> type, final byte id, final Reader<T> reader, final @Nullable Writer<T> writer) {
+  static <T extends BinaryTag> BinaryTagType<T> register(final Class<T> type, final byte id, final Reader<T> reader, final @Nullable Writer<T> writer) {
     return register(new Impl<>(type, id, reader, writer));
   }
 
-  static <T extends NumberBinaryTag> @NotNull BinaryTagType<T> registerNumeric(final Class<T> type, final byte id, final Reader<T> reader, final Writer<T> writer) {
+  static <T extends NumberBinaryTag> BinaryTagType<T> registerNumeric(final Class<T> type, final byte id, final Reader<T> reader, final Writer<T> writer) {
     return register(new Impl.Numeric<>(type, id, reader, writer));
   }
 
@@ -105,7 +104,7 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @since 4.0.0
    */
   interface Reader<T extends BinaryTag> {
-    @NotNull T read(final @NotNull DataInput input) throws IOException;
+    T read(final DataInput input) throws IOException;
   }
 
   /**
@@ -115,7 +114,7 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
    * @since 4.0.0
    */
   interface Writer<T extends BinaryTag> {
-    void write(final @NotNull T tag, final @NotNull DataOutput output) throws IOException;
+    void write(final T tag, final DataOutput output) throws IOException;
   }
 
   @Override
@@ -137,12 +136,12 @@ public abstract class BinaryTagType<T extends BinaryTag> implements Predicate<Bi
     }
 
     @Override
-    public final @NotNull T read(final @NotNull DataInput input) throws IOException {
+    public final T read(final DataInput input) throws IOException {
       return this.reader.read(input);
     }
 
     @Override
-    public final void write(final @NotNull T tag, final @NotNull DataOutput output) throws IOException {
+    public final void write(final T tag, final DataOutput output) throws IOException {
       if (this.writer != null) this.writer.write(tag, output);
     }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagWriterImpl.java
@@ -31,7 +31,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import org.jetbrains.annotations.NotNull;
 
 import static net.kyori.adventure.nbt.IOStreamUtil.closeShield;
 
@@ -39,25 +38,25 @@ final class BinaryTagWriterImpl implements BinaryTagIO.Writer {
   static final BinaryTagIO.Writer INSTANCE = new BinaryTagWriterImpl();
 
   @Override
-  public void write(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public void write(final CompoundBinaryTag tag, final Path path, final BinaryTagIO.Compression compression) throws IOException {
     try (final OutputStream os = Files.newOutputStream(path)) {
       this.write(tag, os, compression);
     }
   }
 
   @Override
-  public void write(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public void write(final CompoundBinaryTag tag, final OutputStream output, final BinaryTagIO.Compression compression) throws IOException {
     try (final DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(compression.compress(closeShield(output))))) {
       this.write(tag, (DataOutput) dos);
     }
   }
 
   @Override
-  public void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException {
+  public void write(final CompoundBinaryTag tag, final DataOutput output) throws IOException {
     this.write(tag, output, true);
   }
 
-  private void write(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output, final boolean named) throws IOException {
+  private void write(final CompoundBinaryTag tag, final DataOutput output, final boolean named) throws IOException {
     output.writeByte(BinaryTagTypes.COMPOUND.id());
     if (named) {
       output.writeUTF(""); // write empty name
@@ -66,40 +65,40 @@ final class BinaryTagWriterImpl implements BinaryTagIO.Writer {
   }
 
   @Override
-  public void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public void writeNameless(final CompoundBinaryTag tag, final Path path, final BinaryTagIO.Compression compression) throws IOException {
     try (final OutputStream os = Files.newOutputStream(path)) {
       this.writeNameless(tag, os, compression);
     }
   }
 
   @Override
-  public void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull OutputStream output, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public void writeNameless(final CompoundBinaryTag tag, final OutputStream output, final BinaryTagIO.Compression compression) throws IOException {
     try (final DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(compression.compress(closeShield(output))))) {
       this.writeNameless(tag, (DataOutput) dos);
     }
   }
 
   @Override
-  public void writeNameless(final @NotNull CompoundBinaryTag tag, final @NotNull DataOutput output) throws IOException {
+  public void writeNameless(final CompoundBinaryTag tag, final DataOutput output) throws IOException {
     this.write(tag, output, false);
   }
 
   @Override
-  public void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull Path path, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public void writeNamed(final Map.Entry<String, CompoundBinaryTag> tag, final Path path, final BinaryTagIO.Compression compression) throws IOException {
     try (final OutputStream os = Files.newOutputStream(path)) {
       this.writeNamed(tag, os, compression);
     }
   }
 
   @Override
-  public void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull OutputStream output, final BinaryTagIO.@NotNull Compression compression) throws IOException {
+  public void writeNamed(final Map.Entry<String, CompoundBinaryTag> tag, final OutputStream output, final BinaryTagIO.Compression compression) throws IOException {
     try (final DataOutputStream dos = new DataOutputStream(new BufferedOutputStream(compression.compress(closeShield(output))))) {
       this.writeNamed(tag, (DataOutput) dos);
     }
   }
 
   @Override
-  public void writeNamed(final Map.@NotNull Entry<String, CompoundBinaryTag> tag, final @NotNull DataOutput output) throws IOException {
+  public void writeNamed(final Map.Entry<String, CompoundBinaryTag> tag, final DataOutput output) throws IOException {
     output.writeByte(BinaryTagTypes.COMPOUND.id());
     output.writeUTF(tag.getKey());
     BinaryTagTypes.COMPOUND.write(tag.getValue(), output);

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A binary tag holding a {@code byte}-array value.
  *
@@ -38,12 +36,12 @@ public interface ByteArrayBinaryTag extends ArrayBinaryTag, Iterable<Byte> {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull ByteArrayBinaryTag byteArrayBinaryTag(final byte@NotNull... value) {
+  static ByteArrayBinaryTag byteArrayBinaryTag(final byte... value) {
     return new ByteArrayBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<ByteArrayBinaryTag> type() {
+  default BinaryTagType<ByteArrayBinaryTag> type() {
     return BinaryTagTypes.BYTE_ARRAY;
   }
 
@@ -55,7 +53,7 @@ public interface ByteArrayBinaryTag extends ArrayBinaryTag, Iterable<Byte> {
    * @return the value
    * @since 4.0.0
    */
-  byte@NotNull[] value();
+  byte[] value();
 
   /**
    * Get the size of the array.

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
@@ -28,8 +28,7 @@ import java.util.Iterator;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "\"byte[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class ByteArrayBinaryTagImpl extends ArrayBinaryTagImpl implements ByteArrayBinaryTag {
@@ -40,7 +39,7 @@ final class ByteArrayBinaryTagImpl extends ArrayBinaryTagImpl implements ByteArr
   }
 
   @Override
-  public byte@NotNull[] value() {
+  public byte[] value() {
     return Arrays.copyOf(this.value, this.value.length);
   }
 
@@ -74,12 +73,12 @@ final class ByteArrayBinaryTagImpl extends ArrayBinaryTagImpl implements ByteArr
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 
   @Override
-  public @NotNull Iterator<Byte> iterator() {
+  public Iterator<Byte> iterator() {
     return new Iterator<>() {
       private int index;
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A binary tag holding a {@code byte} value.
  *
@@ -52,7 +50,7 @@ public interface ByteBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull ByteBinaryTag byteBinaryTag(final byte value) {
+  static ByteBinaryTag byteBinaryTag(final byte value) {
     if (value == 0) {
       return ZERO;
     } else if (value == 1) {
@@ -63,7 +61,7 @@ public interface ByteBinaryTag extends NumberBinaryTag {
   }
 
   @Override
-  default @NotNull BinaryTagType<ByteBinaryTag> type() {
+  default BinaryTagType<ByteBinaryTag> type() {
     return BinaryTagTypes.BYTE;
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteBinaryTagImpl.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "\"0x\" + Integer.toString(this.value, 16)", hasChildren = "false")
 final class ByteBinaryTagImpl extends AbstractBinaryTag implements ByteBinaryTag {
@@ -73,7 +72,7 @@ final class ByteBinaryTagImpl extends AbstractBinaryTag implements ByteBinaryTag
   }
 
   @Override
-  public @NotNull Number numberValue() {
+  public Number numberValue() {
     return this.value;
   }
 
@@ -91,7 +90,7 @@ final class ByteBinaryTagImpl extends AbstractBinaryTag implements ByteBinaryTag
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -30,9 +30,8 @@ import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,7 +47,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return an empty tag
    * @since 4.0.0
    */
-  static @NotNull CompoundBinaryTag empty() {
+  static CompoundBinaryTag empty() {
     return CompoundBinaryTagImpl.EMPTY;
   }
 
@@ -61,7 +60,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a compound tag
    * @since 4.4.0
    */
-  static @NotNull CompoundBinaryTag from(final @NotNull Map<String, ? extends BinaryTag> tags) {
+  static CompoundBinaryTag from(final Map<String, ? extends BinaryTag> tags) {
     if (tags.isEmpty()) return empty();
     return new CompoundBinaryTagImpl(new HashMap<>(tags)); // explicitly copy
   }
@@ -74,7 +73,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a collector for map entries
    * @since 4.21.0
    */
-  static @NotNull Collector<Map.Entry<String, ? extends BinaryTag>, ?, CompoundBinaryTag> toCompoundTag() {
+  static Collector<Map.Entry<String, ? extends BinaryTag>, ?, CompoundBinaryTag> toCompoundTag() {
     return toCompoundTag(Map.Entry::getKey, Map.Entry::getValue);
   }
 
@@ -89,7 +88,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a collector creating compound tags
    * @since 4.21.0
    */
-  static <T> @NotNull Collector<T, ?, CompoundBinaryTag> toCompoundTag(final @NotNull Function<T, String> keyLens, final @NotNull Function<T, ? extends BinaryTag> valueLens) {
+  static <T> Collector<T, ?, CompoundBinaryTag> toCompoundTag(final Function<T, String> keyLens, final Function<T, ? extends BinaryTag> valueLens) {
     requireNonNull(keyLens, "keyLens");
     requireNonNull(valueLens, "valueLens");
 
@@ -111,7 +110,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a collector for map entries
    * @since 4.21.0
    */
-  static @NotNull Collector<Map.Entry<String, ? extends BinaryTag>, ?, CompoundBinaryTag> toCompoundTag(final @NotNull CompoundBinaryTag initial) {
+  static Collector<Map.Entry<String, ? extends BinaryTag>, ?, CompoundBinaryTag> toCompoundTag(final CompoundBinaryTag initial) {
     return toCompoundTag(initial, Map.Entry::getKey, Map.Entry::getValue);
   }
 
@@ -127,7 +126,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a collector creating compound tags
    * @since 4.21.0
    */
-  static <T> @NotNull Collector<T, ?, CompoundBinaryTag> toCompoundTag(final @NotNull CompoundBinaryTag initial, final @NotNull Function<T, String> keyLens, final @NotNull Function<T, ? extends BinaryTag> valueLens) {
+  static <T> Collector<T, ?, CompoundBinaryTag> toCompoundTag(final CompoundBinaryTag initial, final Function<T, String> keyLens, final Function<T, ? extends BinaryTag> valueLens) {
     requireNonNull(initial, "initial");
     requireNonNull(keyLens, "keyLens");
     requireNonNull(valueLens, "valueLens");
@@ -147,7 +146,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a new builder
    * @since 4.0.0
    */
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new CompoundTagBuilder();
   }
 
@@ -158,12 +157,12 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return a new builder
    * @since 4.25.0
    */
-  static @NotNull Builder builder(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
+  static Builder builder(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
     return new CompoundTagBuilder(initialCapacity);
   }
 
   @Override
-  default @NotNull BinaryTagType<CompoundBinaryTag> type() {
+  default BinaryTagType<CompoundBinaryTag> type() {
     return BinaryTagTypes.COMPOUND;
   }
 
@@ -174,7 +173,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return whether the compound contains the key
    * @since 4.25.0
    */
-  boolean contains(final @NotNull String key);
+  boolean contains(final String key);
 
   /**
    * Returns whether the compound contains a tag of a specific type with a key.
@@ -184,7 +183,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return whether there is a tag of {@code type} with {@code key}
    * @since 4.25.0
    */
-  boolean contains(final @NotNull String key, final @NotNull BinaryTagType<?> type);
+  boolean contains(final String key, final BinaryTagType<?> type);
 
   /**
    * Gets a set of all keys.
@@ -192,7 +191,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @return the keys
    * @since 4.0.0
    */
-  @NotNull Set<String> keySet();
+  Set<String> keySet();
 
   /**
    * Gets a tag.
@@ -229,7 +228,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default boolean getBoolean(final @NotNull String key) {
+  default boolean getBoolean(final String key) {
     return this.getBoolean(key, false);
   }
 
@@ -244,7 +243,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default boolean getBoolean(final @NotNull String key, final boolean defaultValue) {
+  default boolean getBoolean(final String key, final boolean defaultValue) {
     final BinaryTag tag = this.get(key);
     if (tag instanceof ByteBinaryTag) {
       // != 0 might look weird, but it is what vanilla does
@@ -261,7 +260,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default byte getByte(final @NotNull String key) {
+  default byte getByte(final String key) {
     return this.getByte(key, (byte) 0);
   }
 
@@ -274,7 +273,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  byte getByte(final @NotNull String key, final byte defaultValue);
+  byte getByte(final String key, final byte defaultValue);
 
   /**
    * Gets a short.
@@ -284,7 +283,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default short getShort(final @NotNull String key) {
+  default short getShort(final String key) {
     return this.getShort(key, (short) 0);
   }
 
@@ -297,7 +296,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  short getShort(final @NotNull String key, final short defaultValue);
+  short getShort(final String key, final short defaultValue);
 
   /**
    * Gets an int.
@@ -307,7 +306,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default int getInt(final @NotNull String key) {
+  default int getInt(final String key) {
     return this.getInt(key, 0);
   }
 
@@ -320,7 +319,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  int getInt(final @NotNull String key, final int defaultValue);
+  int getInt(final String key, final int defaultValue);
 
   /**
    * Gets a long.
@@ -330,7 +329,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default long getLong(final @NotNull String key) {
+  default long getLong(final String key) {
     return this.getLong(key, 0L);
   }
 
@@ -343,7 +342,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  long getLong(final @NotNull String key, final long defaultValue);
+  long getLong(final String key, final long defaultValue);
 
   /**
    * Gets a float.
@@ -353,7 +352,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default float getFloat(final @NotNull String key) {
+  default float getFloat(final String key) {
     return this.getFloat(key, 0f);
   }
 
@@ -366,7 +365,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  float getFloat(final @NotNull String key, final float defaultValue);
+  float getFloat(final String key, final float defaultValue);
 
   /**
    * Gets a double.
@@ -376,7 +375,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default double getDouble(final @NotNull String key) {
+  default double getDouble(final String key) {
     return this.getDouble(key, 0d);
   }
 
@@ -389,7 +388,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  double getDouble(final @NotNull String key, final double defaultValue);
+  double getDouble(final String key, final double defaultValue);
 
   /**
    * Gets an array of bytes.
@@ -399,7 +398,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  byte@NotNull[] getByteArray(final @NotNull String key);
+  byte[] getByteArray(final String key);
 
   /**
    * Gets an array of bytes.
@@ -410,7 +409,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   @Contract("_, !null -> !null")
-  byte@Nullable[] getByteArray(final @NotNull String key, final byte@Nullable[] defaultValue);
+  byte@Nullable[] getByteArray(final String key, final byte@Nullable[] defaultValue);
 
   /**
    * Gets a string.
@@ -420,7 +419,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default @NotNull String getString(final @NotNull String key) {
+  default String getString(final String key) {
     return this.getString(key, "");
   }
 
@@ -434,7 +433,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   @Contract("_, !null -> !null")
-  @Nullable String getString(final @NotNull String key, final @Nullable String defaultValue);
+  @Nullable String getString(final String key, final @Nullable String defaultValue);
 
   /**
    * Gets a list.
@@ -444,7 +443,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default @NotNull ListBinaryTag getList(final @NotNull String key) {
+  default ListBinaryTag getList(final String key) {
     return this.getList(key, ListBinaryTag.empty());
   }
 
@@ -458,7 +457,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   @Contract("_, !null -> !null")
-  @Nullable ListBinaryTag getList(final @NotNull String key, final @Nullable ListBinaryTag defaultValue);
+  @Nullable ListBinaryTag getList(final String key, final @Nullable ListBinaryTag defaultValue);
 
   /**
    * Gets a list, ensuring that the type is the same as {@code type}.
@@ -470,7 +469,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     does not match {@code expectedType}
    * @since 4.0.0
    */
-  default @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull BinaryTagType<? extends BinaryTag> expectedType) {
+  default ListBinaryTag getList(final String key, final BinaryTagType<? extends BinaryTag> expectedType) {
     return this.getList(key, expectedType, ListBinaryTag.empty());
   }
 
@@ -486,7 +485,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   @Contract("_, _, !null -> !null")
-  @Nullable ListBinaryTag getList(final @NotNull String key, final @NotNull BinaryTagType<? extends BinaryTag> expectedType, final @Nullable ListBinaryTag defaultValue);
+  @Nullable ListBinaryTag getList(final String key, final BinaryTagType<? extends BinaryTag> expectedType, final @Nullable ListBinaryTag defaultValue);
 
   /**
    * Gets a compound.
@@ -496,7 +495,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  default @NotNull CompoundBinaryTag getCompound(final @NotNull String key) {
+  default CompoundBinaryTag getCompound(final String key) {
     return this.getCompound(key, empty());
   }
 
@@ -510,7 +509,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   @Contract("_, !null -> !null")
-  @Nullable CompoundBinaryTag getCompound(final @NotNull String key, final @Nullable CompoundBinaryTag defaultValue);
+  @Nullable CompoundBinaryTag getCompound(final String key, final @Nullable CompoundBinaryTag defaultValue);
 
   /**
    * Gets an array of ints.
@@ -520,7 +519,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  int@NotNull[] getIntArray(final @NotNull String key);
+  int[] getIntArray(final String key);
 
   /**
    * Gets an array of ints.
@@ -531,7 +530,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   @Contract("_, !null -> !null")
-  int@Nullable[] getIntArray(final @NotNull String key, final int@Nullable[] defaultValue);
+  int@Nullable[] getIntArray(final String key, final int@Nullable[] defaultValue);
 
   /**
    * Gets an array of longs.
@@ -541,7 +540,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    *     with the specified key, or has a tag with a different type
    * @since 4.0.0
    */
-  long@NotNull[] getLongArray(final @NotNull String key);
+  long[] getLongArray(final String key);
 
   /**
    * Gets an array of longs.
@@ -552,7 +551,7 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
    * @since 4.0.0
    */
   @Contract("_, !null -> !null")
-  long@Nullable[] getLongArray(final @NotNull String key, final long@Nullable[] defaultValue);
+  long@Nullable[] getLongArray(final String key, final long@Nullable[] defaultValue);
 
   /**
    * Gets a stream of entries in this compound tag.
@@ -574,6 +573,6 @@ public interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<Compound
      * @return a compound tag
      * @since 4.0.0
      */
-    @NotNull CompoundBinaryTag build();
+    CompoundBinaryTag build();
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -33,8 +33,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -50,18 +49,18 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public boolean contains(final @NotNull String key) {
+  public boolean contains(final String key) {
     return this.tags.containsKey(key);
   }
 
   @Override
-  public boolean contains(final @NotNull String key, final @NotNull BinaryTagType<?> type) {
+  public boolean contains(final String key, final BinaryTagType<?> type) {
     final BinaryTag tag = this.tags.get(Objects.requireNonNull(key, "key"));
     return tag != null && Objects.requireNonNull(type, "type").test(tag.type());
   }
 
   @Override
-  public @NotNull Set<String> keySet() {
+  public Set<String> keySet() {
     return Collections.unmodifiableSet(this.tags.keySet());
   }
 
@@ -81,12 +80,12 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NotNull CompoundBinaryTag put(final @NotNull String key, final @NotNull BinaryTag tag) {
+  public CompoundBinaryTag put(final String key, final BinaryTag tag) {
     return this.edit(map -> map.put(key, tag));
   }
 
   @Override
-  public @NotNull CompoundBinaryTag put(final @NotNull CompoundBinaryTag tag) {
+  public CompoundBinaryTag put(final CompoundBinaryTag tag) {
     return this.edit(map -> {
       for (final String key : tag.keySet()) {
         map.put(key, tag.get(key));
@@ -95,12 +94,12 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NotNull CompoundBinaryTag put(final @NotNull Map<String, ? extends BinaryTag> tags) {
+  public CompoundBinaryTag put(final Map<String, ? extends BinaryTag> tags) {
     return this.edit(map -> map.putAll(tags));
   }
 
   @Override
-  public @NotNull CompoundBinaryTag remove(final @NotNull String key, final @Nullable Consumer<? super BinaryTag> removed) {
+  public CompoundBinaryTag remove(final String key, final @Nullable Consumer<? super BinaryTag> removed) {
     if (!this.tags.containsKey(key)) {
       return this;
     }
@@ -113,7 +112,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public byte getByte(final @NotNull String key, final byte defaultValue) {
+  public byte getByte(final String key, final byte defaultValue) {
     if (this.contains(key, BinaryTagTypes.BYTE)) {
       return ((NumberBinaryTag) this.tags.get(key)).byteValue();
     }
@@ -121,7 +120,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public short getShort(final @NotNull String key, final short defaultValue) {
+  public short getShort(final String key, final short defaultValue) {
     if (this.contains(key, BinaryTagTypes.SHORT)) {
       return ((NumberBinaryTag) this.tags.get(key)).shortValue();
     }
@@ -129,7 +128,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public int getInt(final @NotNull String key, final int defaultValue) {
+  public int getInt(final String key, final int defaultValue) {
     if (this.contains(key, BinaryTagTypes.INT)) {
       return ((NumberBinaryTag) this.tags.get(key)).intValue();
     }
@@ -137,7 +136,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public long getLong(final @NotNull String key, final long defaultValue) {
+  public long getLong(final String key, final long defaultValue) {
     if (this.contains(key, BinaryTagTypes.LONG)) {
       return ((NumberBinaryTag) this.tags.get(key)).longValue();
     }
@@ -145,7 +144,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public float getFloat(final @NotNull String key, final float defaultValue) {
+  public float getFloat(final String key, final float defaultValue) {
     if (this.contains(key, BinaryTagTypes.FLOAT)) {
       return ((NumberBinaryTag) this.tags.get(key)).floatValue();
     }
@@ -153,7 +152,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public double getDouble(final @NotNull String key, final double defaultValue) {
+  public double getDouble(final String key, final double defaultValue) {
     if (this.contains(key, BinaryTagTypes.DOUBLE)) {
       return ((NumberBinaryTag) this.tags.get(key)).doubleValue();
     }
@@ -161,7 +160,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public byte@NotNull[] getByteArray(final @NotNull String key) {
+  public byte[] getByteArray(final String key) {
     if (this.contains(key, BinaryTagTypes.BYTE_ARRAY)) {
       return ((ByteArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -169,7 +168,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public byte@NotNull[] getByteArray(final @NotNull String key, final byte@NotNull[] defaultValue) {
+  public byte[] getByteArray(final String key, final byte[] defaultValue) {
     if (this.contains(key, BinaryTagTypes.BYTE_ARRAY)) {
       return ((ByteArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -177,7 +176,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NotNull String getString(final @NotNull String key, final @NotNull String defaultValue) {
+  public String getString(final String key, final String defaultValue) {
     if (this.contains(key, BinaryTagTypes.STRING)) {
       return ((StringBinaryTag) this.tags.get(key)).value();
     }
@@ -185,7 +184,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull ListBinaryTag defaultValue) {
+  public ListBinaryTag getList(final String key, final ListBinaryTag defaultValue) {
     if (this.contains(key, BinaryTagTypes.LIST)) {
       return (ListBinaryTag) this.tags.get(key);
     }
@@ -193,7 +192,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NotNull ListBinaryTag getList(final @NotNull String key, final @NotNull BinaryTagType<? extends BinaryTag> expectedType, final @NotNull ListBinaryTag defaultValue) {
+  public ListBinaryTag getList(final String key, final BinaryTagType<? extends BinaryTag> expectedType, final ListBinaryTag defaultValue) {
     if (this.contains(key, BinaryTagTypes.LIST)) {
       final ListBinaryTag tag = (ListBinaryTag) this.tags.get(key);
       if (expectedType.test(tag.elementType())) {
@@ -204,7 +203,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NotNull CompoundBinaryTag getCompound(final @NotNull String key, final @NotNull CompoundBinaryTag defaultValue) {
+  public CompoundBinaryTag getCompound(final String key, final CompoundBinaryTag defaultValue) {
     if (this.contains(key, BinaryTagTypes.COMPOUND)) {
       return (CompoundBinaryTag) this.tags.get(key);
     }
@@ -212,7 +211,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public int@NotNull[] getIntArray(final @NotNull String key) {
+  public int[] getIntArray(final String key) {
     if (this.contains(key, BinaryTagTypes.INT_ARRAY)) {
       return ((IntArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -220,7 +219,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public int@NotNull[] getIntArray(final @NotNull String key, final int@NotNull[] defaultValue) {
+  public int[] getIntArray(final String key, final int[] defaultValue) {
     if (this.contains(key, BinaryTagTypes.INT_ARRAY)) {
       return ((IntArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -228,7 +227,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public long@NotNull[] getLongArray(final @NotNull String key) {
+  public long[] getLongArray(final String key) {
     if (this.contains(key, BinaryTagTypes.LONG_ARRAY)) {
       return ((LongArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -236,7 +235,7 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public long@NotNull[] getLongArray(final @NotNull String key, final long@NotNull[] defaultValue) {
+  public long[] getLongArray(final String key, final long[] defaultValue) {
     if (this.contains(key, BinaryTagTypes.LONG_ARRAY)) {
       return ((LongArrayBinaryTag) this.tags.get(key)).value();
     }
@@ -266,18 +265,18 @@ final class CompoundBinaryTagImpl extends AbstractBinaryTag implements CompoundB
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("tags", this.tags));
   }
 
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public @NotNull Iterator<Map.Entry<String, ? extends BinaryTag>> iterator() {
+  public Iterator<Map.Entry<String, ? extends BinaryTag>> iterator() {
     return (Iterator) this.tags.entrySet().iterator();
   }
 
   @Override
-  public void forEach(final @NotNull Consumer<? super Map.Entry<String, ? extends BinaryTag>> action) {
+  public void forEach(final Consumer<? super Map.Entry<String, ? extends BinaryTag>> action) {
     this.tags.entrySet().forEach(requireNonNull(action, "action"));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   private static final int DEFAULT_CAPACITY = -1;
@@ -56,13 +55,13 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   }
 
   @Override
-  public CompoundBinaryTag.@NotNull Builder put(final @NotNull String key, final @NotNull BinaryTag tag) {
+  public CompoundBinaryTag.Builder put(final String key, final BinaryTag tag) {
     this.tags().put(key, tag);
     return this;
   }
 
   @Override
-  public CompoundBinaryTag.@NotNull Builder put(final @NotNull CompoundBinaryTag tag) {
+  public CompoundBinaryTag.Builder put(final CompoundBinaryTag tag) {
     final Map<String, BinaryTag> tags = this.tags();
     for (final String key : tag.keySet()) {
       tags.put(key, tag.get(key));
@@ -71,13 +70,13 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   }
 
   @Override
-  public CompoundBinaryTag.@NotNull Builder put(final @NotNull Map<String, ? extends BinaryTag> tags) {
+  public CompoundBinaryTag.Builder put(final Map<String, ? extends BinaryTag> tags) {
     this.tags().putAll(tags);
     return this;
   }
 
   @Override
-  public CompoundBinaryTag.@NotNull Builder remove(final @NotNull String key, final @Nullable Consumer<? super BinaryTag> removed) {
+  public CompoundBinaryTag.Builder remove(final String key, final @Nullable Consumer<? super BinaryTag> removed) {
     if (this.tags != null) {
       final BinaryTag tag = this.tags.remove(key);
       if (removed != null) {
@@ -88,7 +87,7 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   }
 
   @Override
-  public @NotNull CompoundBinaryTag build() {
+  public CompoundBinaryTag build() {
     if (this.tags == null) return CompoundBinaryTag.empty();
     return new CompoundBinaryTagImpl(new HashMap<>(this.tags)); // explicitly copy
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagSetter.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagSetter.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.nbt;
 
 import java.util.Map;
 import java.util.function.Consumer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Common methods between {@link CompoundBinaryTag} and {@link CompoundBinaryTag.Builder}.
@@ -43,7 +42,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  @NotNull R put(final @NotNull String key, final @NotNull BinaryTag tag);
+  R put(final String key, final BinaryTag tag);
 
   /**
    * Inserts the tags in {@code tag}, overwriting any that are in {@code this}.
@@ -52,7 +51,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.6.0
    */
-  @NotNull R put(final @NotNull CompoundBinaryTag tag);
+  R put(final CompoundBinaryTag tag);
 
   /**
    * Inserts some tags.
@@ -61,7 +60,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.4.0
    */
-  @NotNull R put(final @NotNull Map<String, ? extends BinaryTag> tags);
+  R put(final Map<String, ? extends BinaryTag> tags);
 
   /**
    * Removes a tag.
@@ -70,7 +69,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.4.0
    */
-  default @NotNull R remove(final @NotNull String key) {
+  default R remove(final String key) {
     return this.remove(key, null);
   }
 
@@ -82,7 +81,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.4.0
    */
-  @NotNull R remove(final @NotNull String key, final @Nullable Consumer<? super BinaryTag> removed);
+  R remove(final String key, final @Nullable Consumer<? super BinaryTag> removed);
 
   /**
    * Inserts a boolean.
@@ -94,7 +93,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putBoolean(final @NotNull String key, final boolean value) {
+  default R putBoolean(final String key, final boolean value) {
     return this.put(key, value ? ByteBinaryTag.ONE : ByteBinaryTag.ZERO);
   }
 
@@ -106,7 +105,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putByte(final @NotNull String key, final byte value) {
+  default R putByte(final String key, final byte value) {
     return this.put(key, ByteBinaryTag.byteBinaryTag(value));
   }
 
@@ -118,7 +117,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putShort(final @NotNull String key, final short value) {
+  default R putShort(final String key, final short value) {
     return this.put(key, ShortBinaryTag.shortBinaryTag(value));
   }
 
@@ -130,7 +129,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putInt(final @NotNull String key, final int value) {
+  default R putInt(final String key, final int value) {
     return this.put(key, IntBinaryTag.intBinaryTag(value));
   }
 
@@ -142,7 +141,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putLong(final @NotNull String key, final long value) {
+  default R putLong(final String key, final long value) {
     return this.put(key, LongBinaryTag.longBinaryTag(value));
   }
 
@@ -154,7 +153,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putFloat(final @NotNull String key, final float value) {
+  default R putFloat(final String key, final float value) {
     return this.put(key, FloatBinaryTag.floatBinaryTag(value));
   }
 
@@ -166,7 +165,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putDouble(final @NotNull String key, final double value) {
+  default R putDouble(final String key, final double value) {
     return this.put(key, DoubleBinaryTag.doubleBinaryTag(value));
   }
 
@@ -178,7 +177,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putByteArray(final @NotNull String key, final byte@NotNull[] value) {
+  default R putByteArray(final String key, final byte[] value) {
     return this.put(key, ByteArrayBinaryTag.byteArrayBinaryTag(value));
   }
 
@@ -190,7 +189,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putString(final @NotNull String key, final @NotNull String value) {
+  default R putString(final String key, final String value) {
     return this.put(key, StringBinaryTag.stringBinaryTag(value));
   }
 
@@ -202,7 +201,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putIntArray(final @NotNull String key, final int@NotNull[] value) {
+  default R putIntArray(final String key, final int[] value) {
     return this.put(key, IntArrayBinaryTag.intArrayBinaryTag(value));
   }
 
@@ -214,7 +213,7 @@ public interface CompoundTagSetter<R> {
    * @return a compound tag
    * @since 4.0.0
    */
-  default @NotNull R putLongArray(final @NotNull String key, final long@NotNull[] value) {
+  default R putLongArray(final String key, final long[] value) {
     return this.put(key, LongArrayBinaryTag.longArrayBinaryTag(value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/DoubleBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/DoubleBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A binary tag holding a {@code double} value.
  *
@@ -38,12 +36,12 @@ public interface DoubleBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull DoubleBinaryTag doubleBinaryTag(final double value) {
+  static DoubleBinaryTag doubleBinaryTag(final double value) {
     return new DoubleBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<DoubleBinaryTag> type() {
+  default BinaryTagType<DoubleBinaryTag> type() {
     return BinaryTagTypes.DOUBLE;
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/DoubleBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/DoubleBinaryTagImpl.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "String.valueOf(this.value) + \"d\"", hasChildren = "false")
 final class DoubleBinaryTagImpl extends AbstractBinaryTag implements DoubleBinaryTag {
@@ -73,7 +72,7 @@ final class DoubleBinaryTagImpl extends AbstractBinaryTag implements DoubleBinar
   }
 
   @Override
-  public @NotNull Number numberValue() {
+  public Number numberValue() {
     return this.value;
   }
 
@@ -91,7 +90,7 @@ final class DoubleBinaryTagImpl extends AbstractBinaryTag implements DoubleBinar
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/EndBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/EndBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * An end tag.
  *
@@ -37,12 +35,12 @@ public interface EndBinaryTag extends BinaryTag {
    * @return the end tag
    * @since 4.14.0
    */
-  static @NotNull EndBinaryTag endBinaryTag() {
+  static EndBinaryTag endBinaryTag() {
     return EndBinaryTagImpl.INSTANCE;
   }
 
   @Override
-  default @NotNull BinaryTagType<EndBinaryTag> type() {
+  default BinaryTagType<EndBinaryTag> type() {
     return BinaryTagTypes.END;
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A binary tag holding a {@code float} value.
  *
@@ -38,12 +36,12 @@ public interface FloatBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull FloatBinaryTag floatBinaryTag(final float value) {
+  static FloatBinaryTag floatBinaryTag(final float value) {
     return new FloatBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<FloatBinaryTag> type() {
+  default BinaryTagType<FloatBinaryTag> type() {
     return BinaryTagTypes.FLOAT;
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/FloatBinaryTagImpl.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "String.valueOf(this.value) + \"f\"", hasChildren = "false")
 final class FloatBinaryTagImpl extends AbstractBinaryTag implements FloatBinaryTag {
@@ -73,7 +72,7 @@ final class FloatBinaryTagImpl extends AbstractBinaryTag implements FloatBinaryT
   }
 
   @Override
-  public @NotNull Number numberValue() {
+  public Number numberValue() {
     return this.value;
   }
 
@@ -91,7 +90,7 @@ final class FloatBinaryTagImpl extends AbstractBinaryTag implements FloatBinaryT
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTag.java
@@ -27,7 +27,6 @@ import java.util.PrimitiveIterator;
 import java.util.Spliterator;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A binary tag holding an {@code int}-array value.
@@ -43,12 +42,12 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull IntArrayBinaryTag intArrayBinaryTag(final int@NotNull... value) {
+  static IntArrayBinaryTag intArrayBinaryTag(final int... value) {
     return new IntArrayBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<IntArrayBinaryTag> type() {
+  default BinaryTagType<IntArrayBinaryTag> type() {
     return BinaryTagTypes.INT_ARRAY;
   }
 
@@ -60,7 +59,7 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @return the value
    * @since 4.0.0
    */
-  int@NotNull[] value();
+  int[] value();
 
   /**
    * Get the length of the array.
@@ -88,10 +87,10 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @since 4.2.0
    */
   @Override
-  PrimitiveIterator.@NotNull OfInt iterator();
+  PrimitiveIterator.OfInt iterator();
 
   @Override
-  Spliterator.@NotNull OfInt spliterator();
+  Spliterator.OfInt spliterator();
 
   /**
    * Create a stream whose elements are the elements of this array tag.
@@ -99,7 +98,7 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @return a new stream
    * @since 4.2.0
    */
-  @NotNull IntStream stream();
+  IntStream stream();
 
   /**
    * Perform an action for every int in the backing array.
@@ -107,5 +106,5 @@ public interface IntArrayBinaryTag extends ArrayBinaryTag, Iterable<Integer> {
    * @param action the action to perform
    * @since 4.2.0
    */
-  void forEachInt(final @NotNull IntConsumer action);
+  void forEachInt(final IntConsumer action);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
@@ -32,8 +32,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "\"int[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArrayBinaryTag {
@@ -44,7 +43,7 @@ final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArray
   }
 
   @Override
-  public int@NotNull[] value() {
+  public int[] value() {
     return Arrays.copyOf(this.value, this.value.length);
   }
 
@@ -60,7 +59,7 @@ final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArray
   }
 
   @Override
-  public PrimitiveIterator.@NotNull OfInt iterator() {
+  public PrimitiveIterator.OfInt iterator() {
     return new PrimitiveIterator.OfInt() {
       private int index;
 
@@ -80,17 +79,17 @@ final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArray
   }
 
   @Override
-  public Spliterator.@NotNull OfInt spliterator() {
+  public Spliterator.OfInt spliterator() {
     return Arrays.spliterator(this.value);
   }
 
   @Override
-  public @NotNull IntStream stream() {
+  public IntStream stream() {
     return Arrays.stream(this.value);
   }
 
   @Override
-  public void forEachInt(final @NotNull IntConsumer action) {
+  public void forEachInt(final IntConsumer action) {
     for (final int j : this.value) {
       action.accept(j);
     }
@@ -115,7 +114,7 @@ final class IntArrayBinaryTagImpl extends ArrayBinaryTagImpl implements IntArray
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A binary tag holding an {@code int} value.
  *
@@ -38,12 +36,12 @@ public interface IntBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull IntBinaryTag intBinaryTag(final int value) {
+  static IntBinaryTag intBinaryTag(final int value) {
     return new IntBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<IntBinaryTag> type() {
+  default BinaryTagType<IntBinaryTag> type() {
     return BinaryTagTypes.INT;
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntBinaryTagImpl.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "String.valueOf(this.value) + \"i\"", hasChildren = "false")
 final class IntBinaryTagImpl extends AbstractBinaryTag implements IntBinaryTag {
@@ -73,7 +72,7 @@ final class IntBinaryTagImpl extends AbstractBinaryTag implements IntBinaryTag {
   }
 
   @Override
-  public @NotNull Number numberValue() {
+  public Number numberValue() {
     return this.value;
   }
 
@@ -91,7 +90,7 @@ final class IntBinaryTagImpl extends AbstractBinaryTag implements IntBinaryTag {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
@@ -29,9 +29,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A list of zero or more values of a single tag type.
@@ -45,7 +44,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return an empty tag
    * @since 4.0.0
    */
-  static @NotNull ListBinaryTag empty() {
+  static ListBinaryTag empty() {
     return ListBinaryTagImpl.EMPTY;
   }
 
@@ -59,7 +58,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IllegalArgumentException if {@code tags} has different tag types within
    * @since 4.4.0
    */
-  static @NotNull ListBinaryTag from(final @NotNull Iterable<? extends BinaryTag> tags) {
+  static ListBinaryTag from(final Iterable<? extends BinaryTag> tags) {
     return builder().add(tags).build();
   }
 
@@ -69,7 +68,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a new builder
    * @since 4.0.0
    */
-  static @NotNull Builder<BinaryTag> builder() {
+  static Builder<BinaryTag> builder() {
     return new ListTagBuilder<>(false);
   }
 
@@ -80,7 +79,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a new builder
    * @since 4.25.0
    */
-  static @NotNull Builder<BinaryTag> builder(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
+  static Builder<BinaryTag> builder(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
     return new ListTagBuilder<>(false, initialCapacity);
   }
 
@@ -90,7 +89,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a new builder
    * @since 4.21.0
    */
-  static @NotNull Builder<BinaryTag> heterogeneousListBinaryTag() {
+  static Builder<BinaryTag> heterogeneousListBinaryTag() {
     return new ListTagBuilder<>(true);
   }
 
@@ -101,7 +100,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a new builder
    * @since 4.25.0
    */
-  static @NotNull Builder<BinaryTag> heterogeneousListBinaryTag(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
+  static Builder<BinaryTag> heterogeneousListBinaryTag(final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
     return new ListTagBuilder<>(true, initialCapacity);
   }
 
@@ -114,7 +113,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IllegalArgumentException if {@code type} is {@link BinaryTagTypes#END}
    * @since 4.0.0
    */
-  static <T extends BinaryTag> @NotNull Builder<T> builder(final @NotNull BinaryTagType<T> type) {
+  static <T extends BinaryTag> Builder<T> builder(final BinaryTagType<T> type) {
     if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);
     return new ListTagBuilder<>(false, type);
   }
@@ -129,7 +128,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IllegalArgumentException if {@code type} is {@link BinaryTagTypes#END}
    * @since 4.25.0
    */
-  static <T extends BinaryTag> @NotNull Builder<T> builder(final @NotNull BinaryTagType<T> type, final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
+  static <T extends BinaryTag> Builder<T> builder(final BinaryTagType<T> type, final @Range(from = 0, to = Integer.MAX_VALUE) int initialCapacity) {
     if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);
     return new ListTagBuilder<>(false, type, initialCapacity);
   }
@@ -145,7 +144,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IllegalArgumentException if {@code type} is {@link BinaryTagTypes#END}, or if elements are of different types
    * @since 4.14.0
    */
-  static @NotNull ListBinaryTag listBinaryTag(final @NotNull BinaryTagType<? extends BinaryTag> type, final @NotNull List<BinaryTag> tags) {
+  static ListBinaryTag listBinaryTag(final BinaryTagType<? extends BinaryTag> type, final List<BinaryTag> tags) {
     if (tags.isEmpty()) return empty();
     if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);
     ListBinaryTagImpl.validateTagType(tags, type == BinaryTagTypes.LIST_WILDCARD);
@@ -158,7 +157,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a collector of tags
    * @since 4.21.0
    */
-  static @NotNull Collector<BinaryTag, ?, ListBinaryTag> toListTag() {
+  static Collector<BinaryTag, ?, ListBinaryTag> toListTag() {
     return toListTag(null);
   }
 
@@ -171,7 +170,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a collector for map entries
    * @since 4.21.0
    */
-  static @NotNull Collector<BinaryTag, ?, ListBinaryTag> toListTag(final @Nullable ListBinaryTag initial) {
+  static Collector<BinaryTag, ?, ListBinaryTag> toListTag(final @Nullable ListBinaryTag initial) {
     return Collector.of(
       initial == null ? ListBinaryTag::builder : () -> ListBinaryTag.builder().add((Iterable<? extends BinaryTag>) initial),
       ListTagSetter::add,
@@ -181,7 +180,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
   }
 
   @Override
-  default @NotNull BinaryTagType<ListBinaryTag> type() {
+  default BinaryTagType<ListBinaryTag> type() {
     return BinaryTagTypes.LIST;
   }
 
@@ -191,7 +190,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the type
    * @since 4.4.0
    */
-  @NotNull BinaryTagType<? extends BinaryTag> elementType();
+  BinaryTagType<? extends BinaryTag> elementType();
 
   /**
    * Gets the size.
@@ -217,7 +216,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @throws IndexOutOfBoundsException if the index is out of range
    * @since 4.0.0
    */
-  @NotNull BinaryTag get(final @Range(from = 0, to = Integer.MAX_VALUE) int index);
+  BinaryTag get(final @Range(from = 0, to = Integer.MAX_VALUE) int index);
 
   /**
    * Sets the tag at index {@code index} to {@code tag}, optionally providing {@code removedConsumer} with the tag previously at index {@code index}.
@@ -228,7 +227,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a list tag
    * @since 4.0.0
    */
-  @NotNull ListBinaryTag set(final int index, final @NotNull BinaryTag tag, final @Nullable Consumer<? super BinaryTag> removed);
+  ListBinaryTag set(final int index, final BinaryTag tag, final @Nullable Consumer<? super BinaryTag> removed);
 
   /**
    * Removes the tag at index {@code index}, optionally providing {@code removedConsumer} with the tag previously at index {@code index}.
@@ -238,7 +237,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a list tag
    * @since 4.0.0
    */
-  @NotNull ListBinaryTag remove(final int index, final @Nullable Consumer<? super BinaryTag> removed);
+  ListBinaryTag remove(final int index, final @Nullable Consumer<? super BinaryTag> removed);
 
   /**
    * Gets a byte.
@@ -409,7 +408,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of bytes, or a zero-length array
    * @since 4.0.0
    */
-  default byte@NotNull[] getByteArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
+  default byte[] getByteArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.BYTE_ARRAY) {
       return ((ByteArrayBinaryTag) tag).value();
@@ -441,7 +440,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the string value, or {@code ""}
    * @since 4.0.0
    */
-  default @NotNull String getString(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
+  default String getString(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getString(index, "");
   }
 
@@ -469,7 +468,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the list, or an empty list if the tag at index {@code index} is not a list tag
    * @since 4.4.0
    */
-  default @NotNull ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
+  default ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getList(index, null, ListBinaryTag.empty());
   }
 
@@ -481,7 +480,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the list, or an empty list if the tag at index {@code index} is not a list tag, or if the list tag's element type is not {@code elementType}
    * @since 4.4.0
    */
-  default @NotNull ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable BinaryTagType<?> elementType) {
+  default ListBinaryTag getList(final @Range(from = 0, to = Integer.MAX_VALUE) int index, final @Nullable BinaryTagType<?> elementType) {
     return this.getList(index, elementType, ListBinaryTag.empty());
   }
 
@@ -528,7 +527,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the compound, or a new compound
    * @since 4.0.0
    */
-  default @NotNull CompoundBinaryTag getCompound(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
+  default CompoundBinaryTag getCompound(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     return this.getCompound(index, CompoundBinaryTag.empty());
   }
 
@@ -556,7 +555,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of ints, or a zero-length array
    * @since 4.0.0
    */
-  default int@NotNull[] getIntArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
+  default int[] getIntArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.INT_ARRAY) {
       return ((IntArrayBinaryTag) tag).value();
@@ -588,7 +587,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return the array of longs, or a zero-length array
    * @since 4.0.0
    */
-  default long@NotNull[] getLongArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
+  default long[] getLongArray(final @Range(from = 0, to = Integer.MAX_VALUE) int index) {
     final BinaryTag tag = this.get(index);
     if (tag.type() == BinaryTagTypes.LONG_ARRAY) {
       return ((LongArrayBinaryTag) tag).value();
@@ -619,7 +618,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a new stream
    * @since 4.2.0
    */
-  @NotNull Stream<BinaryTag> stream();
+  Stream<BinaryTag> stream();
 
   /**
    * Unwrap any compound-boxed heterogeneous values in this tag.
@@ -627,7 +626,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a list tag that permits heterogeneity
    * @since 4.21.0
    */
-  @NotNull ListBinaryTag unwrapHeterogeneity();
+  ListBinaryTag unwrapHeterogeneity();
 
   /**
    * Wrap any heterogeneous values in this tag into compound-tag boxes.
@@ -635,7 +634,7 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
    * @return a list tag that does not permit heterogeneity, with any heterogeneous values boxed if necessary
    * @since 4.21.0
    */
-  @NotNull ListBinaryTag wrapHeterogeneity();
+  ListBinaryTag wrapHeterogeneity();
 
   /**
    * A list tag builder.
@@ -650,6 +649,6 @@ public interface ListBinaryTag extends ListTagSetter<ListBinaryTag, BinaryTag>, 
      * @return a list tag
      * @since 4.0.0
      */
-    @NotNull ListBinaryTag build();
+    ListBinaryTag build();
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -35,9 +35,8 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "\"ListBinaryTag[type=\" + this.type.toString() + \"]\"", childrenArray = "this.tags.toArray()", hasChildren = "!this.tags.isEmpty()")
 final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag {
@@ -55,7 +54,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NotNull BinaryTagType<? extends BinaryTag> elementType() {
+  public BinaryTagType<? extends BinaryTag> elementType() {
     return this.elementType;
   }
 
@@ -70,12 +69,12 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NotNull BinaryTag get(@Range(from = 0, to = Integer.MAX_VALUE) final int index) {
+  public BinaryTag get(@Range(from = 0, to = Integer.MAX_VALUE) final int index) {
     return this.tags.get(index);
   }
 
   @Override
-  public @NotNull ListBinaryTag set(final int index, final @NotNull BinaryTag newTag, final @Nullable Consumer<? super BinaryTag> removed) {
+  public ListBinaryTag set(final int index, final BinaryTag newTag, final @Nullable Consumer<? super BinaryTag> removed) {
     final BinaryTagType<?> targetType = ListBinaryTagImpl.validateTagType(newTag, this.elementType, this.permitsHeterogeneity);
     return this.edit(tags -> {
       final BinaryTag oldTag = tags.set(index, newTag);
@@ -86,7 +85,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NotNull ListBinaryTag remove(final int index, final @Nullable Consumer<? super BinaryTag> removed) {
+  public ListBinaryTag remove(final int index, final @Nullable Consumer<? super BinaryTag> removed) {
     return this.edit(tags -> {
       final BinaryTag oldTag = tags.remove(index);
       if (removed != null) {
@@ -96,13 +95,13 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NotNull ListBinaryTag add(final BinaryTag tag) {
+  public ListBinaryTag add(final BinaryTag tag) {
     final BinaryTagType<?> targetType = validateTagType(tag, this.elementType, this.permitsHeterogeneity);
     return this.edit(tags -> tags.add(tag), targetType);
   }
 
   @Override
-  public @NotNull ListBinaryTag add(final Iterable<? extends BinaryTag> tagsToAdd) {
+  public ListBinaryTag add(final Iterable<? extends BinaryTag> tagsToAdd) {
     if (tagsToAdd instanceof Collection<?> && ((Collection<?>) tagsToAdd).isEmpty()) {
       return this;
     }
@@ -164,12 +163,12 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NotNull Stream<BinaryTag> stream() {
+  public Stream<BinaryTag> stream() {
     return this.tags.stream();
   }
 
   @Override
-  public @NotNull ListBinaryTag unwrapHeterogeneity() {
+  public ListBinaryTag unwrapHeterogeneity() {
     // Unlock where it makes sense
     if (!this.permitsHeterogeneity) {
       if (this.elementType != BinaryTagTypes.COMPOUND) {
@@ -201,7 +200,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NotNull ListBinaryTag wrapHeterogeneity() {
+  public ListBinaryTag wrapHeterogeneity() {
     if (this.elementType != BinaryTagTypes.LIST_WILDCARD) {
       return this;
     }
@@ -215,7 +214,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NotNull Iterator<BinaryTag> iterator() {
+  public Iterator<BinaryTag> iterator() {
     final Iterator<BinaryTag> iterator = this.tags.iterator();
     return new Iterator<>() {
       @Override
@@ -256,7 +255,7 @@ final class ListBinaryTagImpl extends AbstractBinaryTag implements ListBinaryTag
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("tags", this.tags),
       ExaminableProperty.of("type", this.elementType)

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.nbt;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder<T> {
   private static final int DEFAULT_CAPACITY = -1;
@@ -55,7 +54,7 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   }
 
   @Override
-  public ListBinaryTag.@NotNull Builder<T> add(final BinaryTag tag) {
+  public ListBinaryTag.Builder<T> add(final BinaryTag tag) {
     // check after changing from an empty tag
     this.elementType = ListBinaryTagImpl.validateTagType(tag, this.elementType, this.permitsHeterogeneity);
     if (this.tags == null) {
@@ -71,7 +70,7 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   }
 
   @Override
-  public ListBinaryTag.@NotNull Builder<T> add(final Iterable<? extends T> tagsToAdd) {
+  public ListBinaryTag.Builder<T> add(final Iterable<? extends T> tagsToAdd) {
     for (final T tag : tagsToAdd) {
       this.add(tag);
     }
@@ -79,7 +78,7 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   }
 
   @Override
-  public @NotNull ListBinaryTag build() {
+  public ListBinaryTag build() {
     if (this.tags == null) return ListBinaryTag.empty();
     return new ListBinaryTagImpl(this.elementType, this.permitsHeterogeneity, new ArrayList<>(this.tags)); // explicitly copy
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListTagSetter.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListTagSetter.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Common methods between {@link ListBinaryTag} and {@link ListBinaryTag.Builder}.
  *
@@ -40,7 +38,7 @@ public interface ListTagSetter<R, T extends BinaryTag> {
    * @return a list tag
    * @since 4.0.0
    */
-  @NotNull R add(final T tag);
+  R add(final T tag);
 
   /**
    * Adds multiple tags.
@@ -49,5 +47,5 @@ public interface ListTagSetter<R, T extends BinaryTag> {
    * @return a list tag
    * @since 4.4.0
    */
-  @NotNull R add(final Iterable<? extends T> tags);
+  R add(final Iterable<? extends T> tags);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTag.java
@@ -27,7 +27,6 @@ import java.util.PrimitiveIterator;
 import java.util.Spliterator;
 import java.util.function.LongConsumer;
 import java.util.stream.LongStream;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A binary tag holding a {@code long}-array value.
@@ -43,12 +42,12 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull LongArrayBinaryTag longArrayBinaryTag(final long@NotNull... value) {
+  static LongArrayBinaryTag longArrayBinaryTag(final long... value) {
     return new LongArrayBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<LongArrayBinaryTag> type() {
+  default BinaryTagType<LongArrayBinaryTag> type() {
     return BinaryTagTypes.LONG_ARRAY;
   }
 
@@ -60,7 +59,7 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @return the value
    * @since 4.0.0
    */
-  long@NotNull[] value();
+  long[] value();
 
   /**
    * Gets the length of the array.
@@ -88,10 +87,10 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @since 4.2.0
    */
   @Override
-  PrimitiveIterator.@NotNull OfLong iterator();
+  PrimitiveIterator.OfLong iterator();
 
   @Override
-  Spliterator.@NotNull OfLong spliterator();
+  Spliterator.OfLong spliterator();
 
   /**
    * Create a stream whose elements are the elements of this array tag.
@@ -99,7 +98,7 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @return a new stream
    * @since 4.2.0
    */
-  @NotNull LongStream stream();
+  LongStream stream();
 
   /**
    * Perform an action for every long in the backing array.
@@ -107,5 +106,5 @@ public interface LongArrayBinaryTag extends ArrayBinaryTag, Iterable<Long> {
    * @param action the action to perform
    * @since 4.2.0
    */
-  void forEachLong(final @NotNull LongConsumer action);
+  void forEachLong(final LongConsumer action);
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
@@ -32,8 +32,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "\"long[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArrayBinaryTag {
@@ -44,7 +43,7 @@ final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArr
   }
 
   @Override
-  public long@NotNull[] value() {
+  public long[] value() {
     return Arrays.copyOf(this.value, this.value.length);
   }
 
@@ -60,7 +59,7 @@ final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArr
   }
 
   @Override
-  public PrimitiveIterator.@NotNull OfLong iterator() {
+  public PrimitiveIterator.OfLong iterator() {
     return new PrimitiveIterator.OfLong() {
       private int index;
 
@@ -80,17 +79,17 @@ final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArr
   }
 
   @Override
-  public Spliterator.@NotNull OfLong spliterator() {
+  public Spliterator.OfLong spliterator() {
     return Arrays.spliterator(this.value);
   }
 
   @Override
-  public @NotNull LongStream stream() {
+  public LongStream stream() {
     return Arrays.stream(this.value);
   }
 
   @Override
-  public void forEachLong(final @NotNull LongConsumer action) {
+  public void forEachLong(final LongConsumer action) {
     for (final long l : this.value) {
       action.accept(l);
     }
@@ -115,7 +114,7 @@ final class LongArrayBinaryTagImpl extends ArrayBinaryTagImpl implements LongArr
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A binary tag holding a {@code long} value.
  *
@@ -38,12 +36,12 @@ public interface LongBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull LongBinaryTag longBinaryTag(final long value) {
+  static LongBinaryTag longBinaryTag(final long value) {
     return new LongBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<LongBinaryTag> type() {
+  default BinaryTagType<LongBinaryTag> type() {
     return BinaryTagTypes.LONG;
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongBinaryTagImpl.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "String.valueOf(this.value) + \"l\"", hasChildren = "false")
 final class LongBinaryTagImpl extends AbstractBinaryTag implements LongBinaryTag {
@@ -73,7 +72,7 @@ final class LongBinaryTagImpl extends AbstractBinaryTag implements LongBinaryTag
   }
 
   @Override
-  public @NotNull Number numberValue() {
+  public Number numberValue() {
     return this.value;
   }
 
@@ -91,7 +90,7 @@ final class LongBinaryTagImpl extends AbstractBinaryTag implements LongBinaryTag
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/NumberBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/NumberBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A numeric binary tag.
  *
@@ -32,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface NumberBinaryTag extends BinaryTag {
   @Override
-  @NotNull BinaryTagType<? extends NumberBinaryTag> type();
+  BinaryTagType<? extends NumberBinaryTag> type();
 
   /**
    * Gets the value as a {@code byte}.
@@ -88,5 +86,5 @@ public interface NumberBinaryTag extends BinaryTag {
    * @return the value as a {@link Number}
    * @since 4.21.0
    */
-  @NotNull Number numberValue();
+  Number numberValue();
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ShortBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ShortBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A binary tag holding a {@code short} value.
  *
@@ -38,12 +36,12 @@ public interface ShortBinaryTag extends NumberBinaryTag {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull ShortBinaryTag shortBinaryTag(final short value) {
+  static ShortBinaryTag shortBinaryTag(final short value) {
     return new ShortBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<ShortBinaryTag> type() {
+  default BinaryTagType<ShortBinaryTag> type() {
     return BinaryTagTypes.SHORT;
   }
 

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ShortBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ShortBinaryTagImpl.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "String.valueOf(this.value) + \"s\"", hasChildren = "false")
 final class ShortBinaryTagImpl extends AbstractBinaryTag implements ShortBinaryTag {
@@ -73,7 +72,7 @@ final class ShortBinaryTagImpl extends AbstractBinaryTag implements ShortBinaryT
   }
 
   @Override
-  public @NotNull Number numberValue() {
+  public Number numberValue() {
     return this.value;
   }
 
@@ -91,7 +90,7 @@ final class ShortBinaryTagImpl extends AbstractBinaryTag implements ShortBinaryT
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/StringBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/StringBinaryTag.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A binary tag holding a {@link String} value.
  *
@@ -38,12 +36,12 @@ public interface StringBinaryTag extends BinaryTag {
    * @return a binary tag
    * @since 4.14.0
    */
-  static @NotNull StringBinaryTag stringBinaryTag(final @NotNull String value) {
+  static StringBinaryTag stringBinaryTag(final String value) {
     return new StringBinaryTagImpl(value);
   }
 
   @Override
-  default @NotNull BinaryTagType<StringBinaryTag> type() {
+  default BinaryTagType<StringBinaryTag> type() {
     return BinaryTagTypes.STRING;
   }
 
@@ -53,5 +51,5 @@ public interface StringBinaryTag extends BinaryTag {
    * @return the value
    * @since 4.0.0
    */
-  @NotNull String value();
+  String value();
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/StringBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/StringBinaryTagImpl.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.nbt;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
 import org.jetbrains.annotations.Debug;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Debug.Renderer(text = "\"\\\"\" + this.value + \"\\\"\"", hasChildren = "false")
 final class StringBinaryTagImpl extends AbstractBinaryTag implements StringBinaryTag {
@@ -38,7 +37,7 @@ final class StringBinaryTagImpl extends AbstractBinaryTag implements StringBinar
   }
 
   @Override
-  public @NotNull String value() {
+  public String value() {
     return this.value;
   }
 
@@ -56,7 +55,7 @@ final class StringBinaryTagImpl extends AbstractBinaryTag implements StringBinar
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringIO.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringIO.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
 import java.util.Objects;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A holder for string tag format options.
@@ -43,7 +42,7 @@ public final class TagStringIO {
    * @return the basic instance
    * @since 4.22.0
    */
-  public static @NotNull TagStringIO tagStringIO() {
+  public static TagStringIO tagStringIO() {
     return INSTANCE;
   }
 
@@ -53,7 +52,7 @@ public final class TagStringIO {
    * @return a builder
    * @since 4.0.0
    */
-  public static @NotNull Builder builder() {
+  public static Builder builder() {
     return new Builder();
   }
 
@@ -63,7 +62,7 @@ public final class TagStringIO {
   private final boolean emitHeterogeneousLists;
   private final String indent;
 
-  private TagStringIO(final @NotNull Builder builder) {
+  private TagStringIO(final Builder builder) {
     this.acceptLegacy = builder.acceptLegacy;
     this.emitLegacy = builder.emitLegacy;
     this.acceptHeterogeneousLists = builder.acceptHeterogeneousLists;
@@ -82,7 +81,7 @@ public final class TagStringIO {
    * @throws IOException on any syntax errors
    * @since 4.0.0
    */
-  public @NotNull CompoundBinaryTag asCompound(final @NotNull String input) throws IOException {
+  public CompoundBinaryTag asCompound(final String input) throws IOException {
     Objects.requireNonNull(input, "input");
     try {
       final CharBuffer buffer = new CharBuffer(input);
@@ -110,7 +109,7 @@ public final class TagStringIO {
    * @throws IOException on any syntax errors
    * @since 4.22.0
    */
-  public @NotNull BinaryTag asTag(final @NotNull String input) throws IOException {
+  public BinaryTag asTag(final String input) throws IOException {
     Objects.requireNonNull(input, "input");
     try {
       final CharBuffer buffer = new CharBuffer(input);
@@ -136,7 +135,7 @@ public final class TagStringIO {
    * @throws IOException on any syntax errors
    * @since 4.22.0
    */
-  public @NotNull CompoundBinaryTag asCompound(final @NotNull String input, final @NotNull Appendable remainder) throws IOException {
+  public CompoundBinaryTag asCompound(final String input, final Appendable remainder) throws IOException {
     Objects.requireNonNull(input, "input");
     Objects.requireNonNull(remainder, "remainder");
     try {
@@ -161,7 +160,7 @@ public final class TagStringIO {
    * @throws IOException on any syntax errors
    * @since 4.22.0
    */
-  public @NotNull BinaryTag asTag(final @NotNull String input, final @NotNull Appendable remainder) throws IOException {
+  public BinaryTag asTag(final String input, final Appendable remainder) throws IOException {
     Objects.requireNonNull(input, "input");
     Objects.requireNonNull(remainder, "remainder");
     try {
@@ -185,7 +184,7 @@ public final class TagStringIO {
    * @throws IOException if any errors occur writing to string
    * @since 4.0.0
    */
-  public @NotNull String asString(final @NotNull CompoundBinaryTag input) throws IOException {
+  public String asString(final CompoundBinaryTag input) throws IOException {
     return this.asString((BinaryTag) input);
   }
 
@@ -197,7 +196,7 @@ public final class TagStringIO {
    * @throws IOException if any errors occur writing to string
    * @since 4.20.0
    */
-  public @NotNull String asString(final @NotNull BinaryTag input) throws IOException {
+  public String asString(final BinaryTag input) throws IOException {
     Objects.requireNonNull(input, "input");
     final StringBuilder sb = new StringBuilder();
     try (final TagStringWriter emit = new TagStringWriter(sb, this.indent)) {
@@ -218,7 +217,7 @@ public final class TagStringIO {
    * @throws IOException if any IO or syntax errors occur while parsing
    * @since 4.0.0
    */
-  public void toWriter(final @NotNull CompoundBinaryTag input, final @NotNull Writer dest) throws IOException {
+  public void toWriter(final CompoundBinaryTag input, final Writer dest) throws IOException {
     this.toWriter((BinaryTag) input, dest);
   }
 
@@ -232,7 +231,7 @@ public final class TagStringIO {
    * @throws IOException if any IO or syntax errors occur while parsing
    * @since 4.22.0
    */
-  public void toWriter(final @NotNull BinaryTag input, final @NotNull Writer dest) throws IOException {
+  public void toWriter(final BinaryTag input, final Writer dest) throws IOException {
     Objects.requireNonNull(input, "input");
     Objects.requireNonNull(dest, "dest");
     try (final TagStringWriter emit = new TagStringWriter(dest, this.indent)) {
@@ -266,7 +265,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.0.0
      */
-    public @NotNull Builder indent(final int spaces) {
+    public Builder indent(final int spaces) {
       if (spaces == 0) {
         this.indent = "";
       } else if ((!this.indent.isEmpty() && this.indent.charAt(0) != ' ') || spaces != this.indent.length()) {
@@ -286,7 +285,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.0.0
      */
-    public @NotNull Builder indentTab(final int tabs) {
+    public Builder indentTab(final int tabs) {
       if (tabs == 0) {
         this.indent = "";
       } else if ((!this.indent.isEmpty() && this.indent.charAt(0) != '\t') || tabs != this.indent.length()) {
@@ -309,7 +308,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.0.0
      */
-    public @NotNull Builder acceptLegacy(final boolean legacy) {
+    public Builder acceptLegacy(final boolean legacy) {
       this.acceptLegacy = legacy;
       return this;
     }
@@ -321,7 +320,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.0.0
      */
-    public @NotNull Builder emitLegacy(final boolean legacy) {
+    public Builder emitLegacy(final boolean legacy) {
       this.emitLegacy = legacy;
       return this;
     }
@@ -336,7 +335,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.22.0
      */
-    public @NotNull Builder acceptHeterogeneousLists(final boolean heterogeneous) {
+    public Builder acceptHeterogeneousLists(final boolean heterogeneous) {
       this.acceptHeterogeneousLists = heterogeneous;
       return this;
     }
@@ -351,7 +350,7 @@ public final class TagStringIO {
      * @return this builder
      * @since 4.22.0
      */
-    public @NotNull Builder emitHeterogeneousLists(final boolean heterogeneous) {
+    public Builder emitHeterogeneousLists(final boolean heterogeneous) {
       this.emitHeterogeneousLists = heterogeneous;
       return this;
     }
@@ -362,7 +361,7 @@ public final class TagStringIO {
      * @return new IO configuration
      * @since 4.0.0
      */
-    public @NotNull TagStringIO build() {
+    public TagStringIO build() {
       return new TagStringIO(this);
     }
   }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TagStringReader.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class TagStringReader {
   private static final int MAX_DEPTH = 512;

--- a/nbt/src/main/java/net/kyori/adventure/nbt/TrackingDataInput.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/TrackingDataInput.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.nbt;
 
 import java.io.DataInput;
 import java.io.IOException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class TrackingDataInput implements DataInput, BinaryTagScope {
   private static final int MAX_DEPTH = 512;
@@ -86,13 +85,13 @@ final class TrackingDataInput implements DataInput, BinaryTagScope {
   }
 
   @Override
-  public void readFully(final byte@NotNull[] array) throws IOException {
+  public void readFully(final byte[] array) throws IOException {
     this.counter += array.length;
     this.input.readFully(array);
   }
 
   @Override
-  public void readFully(final byte@NotNull[] array, final int off, final int len) throws IOException {
+  public void readFully(final byte[] array, final int off, final int len) throws IOException {
     this.counter += len;
     this.input.readFully(array, off, len);
   }
@@ -172,7 +171,7 @@ final class TrackingDataInput implements DataInput, BinaryTagScope {
   }
 
   @Override
-  public @NotNull String readUTF() throws IOException {
+  public String readUTF() throws IOException {
     final String result = this.input.readUTF();
     this.counter += (result.length() * 2L) + 2; // not entirely accurate, but the closest we can get without doing implementation details
     return result;

--- a/serializer-configurate4/src/main/java/module-info.java
+++ b/serializer-configurate4/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serializers for Configurate 4.
+ */
+@NullMarked
+module net.kyori.adventure.serializer.configurate4 {
+  requires transitive net.kyori.adventure.api;
+  requires net.kyori.adventure.text.serializer.commons;
+  requires io.leangen.geantyref;
+  requires org.spongepowered.configurate;
+  requires static org.checkerframework.checker.qual;
+
+  exports net.kyori.adventure.serializer.configurate4;
+}

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/BlockNBTPosSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/BlockNBTPosSerializer.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.serializer.configurate4;
 import java.lang.reflect.Type;
 import java.util.function.Predicate;
 import net.kyori.adventure.text.BlockNBTComponent;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -38,7 +37,7 @@ final class BlockNBTPosSerializer extends ScalarSerializer<BlockNBTComponent.Pos
   }
 
   @Override
-  public BlockNBTComponent.Pos deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
+  public BlockNBTComponent.Pos deserialize(final Type type, final Object obj) throws SerializationException {
     try {
       return BlockNBTComponent.Pos.fromString(obj.toString());
     } catch (final IllegalArgumentException ex) {
@@ -47,7 +46,7 @@ final class BlockNBTPosSerializer extends ScalarSerializer<BlockNBTComponent.Pos
   }
 
   @Override
-  public Object serialize(final BlockNBTComponent.@NotNull Pos item, final @NotNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final BlockNBTComponent.Pos item, final Predicate<Class<?>> typeSupported) {
     return item.asString();
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/BookTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/BookTypeSerializer.java
@@ -27,8 +27,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -43,7 +42,7 @@ final class BookTypeSerializer implements TypeSerializer<Book> {
   }
 
   @Override
-  public Book deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
+  public Book deserialize(final Type type, final ConfigurationNode value) throws SerializationException {
     final Component title = value.node(TITLE).get(Component.class);
     final Component author = value.node(AUTHOR).get(Component.class);
     final List<Component> pages = value.node(PAGES).get(ComponentTypeSerializer.LIST_TYPE);
@@ -54,7 +53,7 @@ final class BookTypeSerializer implements TypeSerializer<Book> {
   }
 
   @Override
-  public void serialize(final @NotNull Type type, final @Nullable Book obj, final @NotNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final Type type, final @Nullable Book obj, final ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ComponentTypeSerializer.java
@@ -49,8 +49,7 @@ import net.kyori.adventure.text.object.ObjectContents;
 import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import net.kyori.adventure.text.object.SpriteObjectContents;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -94,11 +93,11 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
+  public Component deserialize(final Type type, final ConfigurationNode value) throws SerializationException {
     return this.deserialize0(value);
   }
 
-  private @NotNull BuildableComponent<?, ?> deserialize0(final @NotNull ConfigurationNode value) throws SerializationException {
+  private BuildableComponent<?, ?> deserialize0(final ConfigurationNode value) throws SerializationException {
     // Try to read as a string
     if (!value.isList() && !value.isMap()) {
       final String str = value.getString();
@@ -250,7 +249,7 @@ final class ComponentTypeSerializer implements TypeSerializer<Component> {
   }
 
   @Override
-  public void serialize(final @NotNull Type type, final @Nullable Component src, final @NotNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final Type type, final @Nullable Component src, final ConfigurationNode value) throws SerializationException {
     value.set(null);
     if (src == null) {
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializer.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.serializer.configurate4;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.TypeSerializer;
 import org.spongepowered.configurate.serialize.TypeSerializerCollection;
@@ -49,7 +48,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return the shared default instance
    * @since 4.2.0
    */
-  static @NotNull ConfigurateComponentSerializer configurate() {
+  static ConfigurateComponentSerializer configurate() {
     return ConfigurateComponentSerializerImpl.INSTANCE;
   }
 
@@ -59,7 +58,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return a new builder
    * @since 4.2.0
    */
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new ConfigurateComponentSerializerImpl.Builder();
   }
 
@@ -69,7 +68,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
    * @return a collection containing Adventure serializers
    * @since 4.2.0
    */
-  @NotNull TypeSerializerCollection serializers();
+  TypeSerializerCollection serializers();
 
   /**
    * A builder for a configurate serializer instance.
@@ -88,7 +87,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return this builder
      * @since 4.2.0
      */
-    @NotNull Builder scalarSerializer(final @NotNull ComponentSerializer<Component, ?, String> stringSerializer);
+    Builder scalarSerializer(final ComponentSerializer<Component, ?, String> stringSerializer);
 
     /**
      * If the {@link #scalarSerializer(ComponentSerializer)} is set, output components as serialized strings
@@ -101,7 +100,7 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return this builder
      * @since 4.2.0
      */
-    @NotNull Builder outputStringComponents(final boolean stringComponents);
+    Builder outputStringComponents(final boolean stringComponents);
 
     /**
      * Create a new component serializer instance.
@@ -109,6 +108,6 @@ public interface ConfigurateComponentSerializer extends ComponentSerializer<Comp
      * @return new serializer
      * @since 4.2.0
      */
-    @NotNull ConfigurateComponentSerializer build();
+    ConfigurateComponentSerializer build();
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializerImpl.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateComponentSerializerImpl.java
@@ -37,8 +37,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.title.Title;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.BasicConfigurationNode;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
@@ -55,7 +54,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   private final @Nullable ComponentSerializer<Component, ?, String> stringSerializer;
   private final boolean serializeStringComponents;
 
-  private ConfigurateComponentSerializerImpl(final @NotNull Builder builder) {
+  private ConfigurateComponentSerializerImpl(final Builder builder) {
     this.stringSerializer = builder.stringSerializer;
     this.serializeStringComponents = builder.outputStringComponents;
     this.serializers = this.makeSerializers(TypeSerializerCollection.defaults().childBuilder());
@@ -65,7 +64,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull ConfigurationNode input) {
+  public Component deserialize(final ConfigurationNode input) {
     try {
       final @Nullable Component deserialized = input.get(Component.class);
       if (deserialized != null) {
@@ -78,7 +77,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   }
 
   @Override
-  public @NotNull ConfigurationNode serialize(final @NotNull Component component) {
+  public ConfigurationNode serialize(final Component component) {
     final ConfigurationNode base = BasicConfigurationNode.root(this.ownNodeOptions);
     try {
       base.set(Component.class, component);
@@ -88,7 +87,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
     return base;
   }
 
-  private @NotNull TypeSerializerCollection makeSerializers(final TypeSerializerCollection.@NotNull Builder serializers) {
+  private TypeSerializerCollection makeSerializers(final TypeSerializerCollection.Builder serializers) {
     return serializers
       .register(Book.class, BookTypeSerializer.INSTANCE)
       .register(Title.class, TitleSerializer.INSTANCE)
@@ -116,7 +115,7 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
   }
 
   @Override
-  public @NotNull TypeSerializerCollection serializers() {
+  public TypeSerializerCollection serializers() {
     return this.serializers;
   }
 
@@ -128,19 +127,19 @@ final class ConfigurateComponentSerializerImpl implements ConfigurateComponentSe
     }
 
     @Override
-    public ConfigurateComponentSerializer.@NotNull Builder scalarSerializer(final @NotNull ComponentSerializer<Component, ?, String> stringSerializer) {
+    public ConfigurateComponentSerializer.Builder scalarSerializer(final ComponentSerializer<Component, ?, String> stringSerializer) {
       this.stringSerializer = requireNonNull(stringSerializer, "stringSerializer");
       return this;
     }
 
     @Override
-    public ConfigurateComponentSerializer.@NotNull Builder outputStringComponents(final boolean stringComponents) {
+    public ConfigurateComponentSerializer.Builder outputStringComponents(final boolean stringComponents) {
       this.outputStringComponents = stringComponents;
       return this;
     }
 
     @Override
-    public @NotNull ConfigurateComponentSerializer build() {
+    public ConfigurateComponentSerializer build() {
       return new ConfigurateComponentSerializerImpl(this);
     }
   }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateDataComponentValue.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateDataComponentValue.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.serializer.configurate4;
 
 import net.kyori.adventure.text.event.DataComponentValue;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurationNode;
 
 /**
@@ -40,7 +39,7 @@ public interface ConfigurateDataComponentValue extends DataComponentValue {
    * @return the captured value
    * @since 4.17.0
    */
-  static @NotNull ConfigurateDataComponentValue capturingDataComponentValue(final @NotNull ConfigurationNode existing) {
+  static ConfigurateDataComponentValue capturingDataComponentValue(final ConfigurationNode existing) {
     return SnapshottingConfigurateDataComponentValue.create(existing);
   }
 
@@ -50,5 +49,5 @@ public interface ConfigurateDataComponentValue extends DataComponentValue {
    * @param node the node to apply this value to
    * @since 4.17.0
    */
-  void applyTo(final @NotNull ConfigurationNode node);
+  void applyTo(final ConfigurationNode node);
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/DurationSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/DurationSerializer.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Type;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.function.Predicate;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -44,7 +43,7 @@ final class DurationSerializer extends ScalarSerializer<Duration> {
   }
 
   @Override
-  public Duration deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
+  public Duration deserialize(final Type type, final Object obj) throws SerializationException {
     if (obj instanceof CharSequence) {
       String value = obj.toString();
       if (!value.startsWith("P") && !value.startsWith("p")) {
@@ -61,7 +60,7 @@ final class DurationSerializer extends ScalarSerializer<Duration> {
   }
 
   @Override
-  public Object serialize(final @NotNull Duration item, final @NotNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final Duration item, final Predicate<Class<?>> typeSupported) {
     return item.toString();
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowEntitySerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowEntitySerializer.java
@@ -29,8 +29,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEventImpl;
 import net.kyori.adventure.text.serializer.commons.ComponentTreeConstants;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -42,7 +41,7 @@ final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEventI
   }
 
   @Override
-  public HoverEventImpl.ShowEntity deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
+  public HoverEventImpl.ShowEntity deserialize(final Type type, final ConfigurationNode value) throws SerializationException {
     final Key typeId = value.node(ComponentTreeConstants.SHOW_ENTITY_TYPE).get(Key.class);
     final UUID id = value.node(ComponentTreeConstants.SHOW_ENTITY_ID).get(UUID.class);
     if (typeId == null || id == null) {
@@ -54,7 +53,7 @@ final class HoverEventShowEntitySerializer implements TypeSerializer<HoverEventI
   }
 
   @Override
-  public void serialize(final @NotNull Type type, final HoverEventImpl.@Nullable ShowEntity obj, final @NotNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final Type type, final HoverEventImpl.@Nullable ShowEntity obj, final ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowItemSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/HoverEventShowItemSerializer.java
@@ -31,8 +31,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.event.HoverEventImpl;
 import net.kyori.adventure.text.serializer.commons.ComponentTreeConstants;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -47,7 +46,7 @@ final class HoverEventShowItemSerializer implements TypeSerializer<HoverEventImp
   }
 
   @Override
-  public HoverEventImpl.ShowItem deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
+  public HoverEventImpl.ShowItem deserialize(final Type type, final ConfigurationNode value) throws SerializationException {
     final Key id = value.node(ComponentTreeConstants.SHOW_ITEM_ID).get(Key.class);
     if (id == null) {
       throw new SerializationException("An id is required to deserialize the show_item hover event");
@@ -67,7 +66,7 @@ final class HoverEventShowItemSerializer implements TypeSerializer<HoverEventImp
   }
 
   @Override
-  public void serialize(final @NotNull Type type, final HoverEventImpl.@Nullable ShowItem obj, final @NotNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final Type type, final HoverEventImpl.@Nullable ShowItem obj, final ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/IndexSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/IndexSerializer.java
@@ -27,20 +27,19 @@ import io.leangen.geantyref.TypeToken;
 import java.lang.reflect.Type;
 import java.util.function.Predicate;
 import net.kyori.adventure.util.Index;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
 final class IndexSerializer<T> extends ScalarSerializer<T> {
   private final Index<String, T> idx;
 
-  IndexSerializer(final @NotNull TypeToken<T> type, final @NotNull Index<String, T> idx) {
+  IndexSerializer(final TypeToken<T> type, final Index<String, T> idx) {
     super(type);
     this.idx = idx;
   }
 
   @Override
-  public @NotNull T deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
+  public T deserialize(final Type type, final Object obj) throws SerializationException {
     final T value = this.idx.value(obj.toString());
     if (value == null) {
       throw new SerializationException("No value for key '" + obj + "' in index for type " + this.type());
@@ -49,7 +48,7 @@ final class IndexSerializer<T> extends ScalarSerializer<T> {
   }
 
   @Override
-  public Object serialize(final @NotNull T item, final @NotNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final T item, final Predicate<Class<?>> typeSupported) {
     return this.idx.key(item);
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/KeySerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/KeySerializer.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Type;
 import java.util.function.Predicate;
 import net.kyori.adventure.key.InvalidKeyException;
 import net.kyori.adventure.key.Key;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.CoercionFailedException;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -40,7 +39,7 @@ final class KeySerializer extends ScalarSerializer<Key> {
   }
 
   @Override
-  public @NotNull Key deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
+  public Key deserialize(final Type type, final Object obj) throws SerializationException {
     if (!(obj instanceof CharSequence seq)) {
       throw new CoercionFailedException(obj, "string");
     }
@@ -52,7 +51,7 @@ final class KeySerializer extends ScalarSerializer<Key> {
   }
 
   @Override
-  public @NotNull Object serialize(final @NotNull Key item, final @NotNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final Key item, final Predicate<Class<?>> typeSupported) {
     return item.asString();
   }
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SnapshottingConfigurateDataComponentValue.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SnapshottingConfigurateDataComponentValue.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.serializer.configurate4;
 
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.AttributedConfigurationNode;
 import org.spongepowered.configurate.BasicConfigurationNode;
 import org.spongepowered.configurate.CommentedConfigurationNode;
@@ -35,7 +34,7 @@ final class SnapshottingConfigurateDataComponentValue implements ConfigurateData
   private final ConfigurationNode ownedNode;
 
   // capture the value of an existing node without exposing any mutable state
-  static @NotNull SnapshottingConfigurateDataComponentValue create(final ConfigurationNode existing) {
+  static SnapshottingConfigurateDataComponentValue create(final ConfigurationNode existing) {
     final ConfigurationNode owned;
     if (existing instanceof AttributedConfigurationNode) {
       owned = AttributedConfigurationNode.root(((AttributedConfigurationNode) existing).tagName(), existing.options());
@@ -55,12 +54,12 @@ final class SnapshottingConfigurateDataComponentValue implements ConfigurateData
   }
 
   @Override
-  public void applyTo(final @NotNull ConfigurationNode node) {
+  public void applyTo(final ConfigurationNode node) {
     node.from(this.ownedNode);
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("ownedNode", this.ownedNode)
     );

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SoundSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SoundSerializer.java
@@ -27,8 +27,7 @@ import java.lang.reflect.Type;
 import java.util.OptionalLong;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -46,7 +45,7 @@ final class SoundSerializer implements TypeSerializer<Sound> {
   }
 
   @Override
-  public @Nullable Sound deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
+  public @Nullable Sound deserialize(final Type type, final ConfigurationNode value) throws SerializationException {
     if (value.empty()) {
       return null;
     }
@@ -71,7 +70,7 @@ final class SoundSerializer implements TypeSerializer<Sound> {
   }
 
   @Override
-  public void serialize(final @NotNull Type type, final @Nullable Sound obj, final @NotNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final Type type, final @Nullable Sound obj, final ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SoundStopSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/SoundStopSerializer.java
@@ -28,8 +28,7 @@ import java.util.Collections;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.sound.SoundStop;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -44,7 +43,7 @@ final class SoundStopSerializer implements TypeSerializer<SoundStop> {
   }
 
   @Override
-  public SoundStop deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
+  public SoundStop deserialize(final Type type, final ConfigurationNode value) throws SerializationException {
     if (value.empty()) {
       return SoundStop.all();
     } else {
@@ -59,7 +58,7 @@ final class SoundStopSerializer implements TypeSerializer<SoundStop> {
   }
 
   @Override
-  public void serialize(final @NotNull Type type, final @Nullable SoundStop obj, final @NotNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final Type type, final @Nullable SoundStop obj, final ConfigurationNode value) throws SerializationException {
     value.node(SOUND).set(Key.class, obj == null ? null : obj.sound());
     value.node(SOURCE).set(Sound.Source.class, obj == null ? null : obj.source());
     if (value.empty()) {

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/StyleSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/StyleSerializer.java
@@ -35,8 +35,7 @@ import net.kyori.adventure.text.format.ShadowColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -65,7 +64,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
   }
 
   @Override
-  public @NotNull Style deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
+  public Style deserialize(final Type type, final ConfigurationNode value) throws SerializationException {
     if (value.virtual()) {
       return Style.empty();
     }
@@ -135,7 +134,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
   }
 
   @Override
-  public void serialize(final @NotNull Type type, @Nullable Style obj, final @NotNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final Type type, @Nullable Style obj, final ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       obj = Style.empty();
     }
@@ -179,7 +178,7 @@ final class StyleSerializer implements TypeSerializer<Style> {
     }
   }
 
-  private static <T> @NotNull T nonNull(final @Nullable T value, final @NotNull String type) throws SerializationException {
+  private static <T> T nonNull(final @Nullable T value, final String type) throws SerializationException {
     if (value == null) {
       throw new SerializationException(type + " was null in an unexpected location");
     }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TextColorSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TextColorSerializer.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Type;
 import java.util.function.Predicate;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -39,7 +38,7 @@ final class TextColorSerializer extends ScalarSerializer<TextColor> {
   }
 
   @Override
-  public TextColor deserialize(final @NotNull Type type, final @NotNull Object obj) throws SerializationException {
+  public TextColor deserialize(final Type type, final Object obj) throws SerializationException {
     if (obj instanceof Number num) { // numerical values
       return TextColor.color(num.intValue());
     } else if (!(obj instanceof CharSequence)) {
@@ -59,7 +58,7 @@ final class TextColorSerializer extends ScalarSerializer<TextColor> {
   }
 
   @Override
-  public Object serialize(final @NotNull TextColor item, final @NotNull Predicate<Class<?>> typeSupported) {
+  public Object serialize(final TextColor item, final Predicate<Class<?>> typeSupported) {
     if (item instanceof NamedTextColor namedTextColor) { // TODO: Downsampling
       return NamedTextColor.NAMES.key(namedTextColor);
     } else {

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TitleSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TitleSerializer.java
@@ -28,8 +28,7 @@ import java.time.Duration;
 import java.util.Objects;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
@@ -49,7 +48,7 @@ final class TitleSerializer implements TypeSerializer<Title> {
   static final String FADE_OUT = "fade-out";
 
   @Override
-  public @Nullable Title deserialize(final @NotNull Type type, final @NotNull ConfigurationNode value) throws SerializationException {
+  public @Nullable Title deserialize(final Type type, final ConfigurationNode value) throws SerializationException {
     if (value.empty()) {
       return null;
     }
@@ -68,7 +67,7 @@ final class TitleSerializer implements TypeSerializer<Title> {
   }
 
   @Override
-  public void serialize(final @NotNull Type type, final @Nullable Title obj, final @NotNull ConfigurationNode value) throws SerializationException {
+  public void serialize(final Type type, final @Nullable Title obj, final ConfigurationNode value) throws SerializationException {
     if (obj == null) {
       value.set(null);
       return;

--- a/text-logger-slf4j/src/main/java/module-info.java
+++ b/text-logger-slf4j/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A wrapper around <a href="https://slf4j.org">SLF4J</a> providing methods for formatted logging of Components.
+ *
+ * <p>This wrapper supports the API provided in 1.7/1.8, but does not yet implement the fluent API present in the 2.0 betas.</p>
+ */
+@NullMarked
+module net.kyori.adventure.text.logger.slf4j {
+  requires transitive net.kyori.adventure.api;
+  requires transitive org.slf4j;
+
+  exports net.kyori.adventure.text.logger.slf4j;
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogger.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogger.java
@@ -24,8 +24,7 @@
 package net.kyori.adventure.text.logger.slf4j;
 
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
@@ -51,7 +50,7 @@ public interface ComponentLogger extends Logger {
    * @return a logger with the name of the calling class
    * @since 4.11.0
    */
-  static @NotNull ComponentLogger logger() {
+  static ComponentLogger logger() {
     return logger(CallerClassFinder.callingClassName());
   }
 
@@ -64,7 +63,7 @@ public interface ComponentLogger extends Logger {
    * @return a logger with the provided name
    * @since 4.11.0
    */
-  static @NotNull ComponentLogger logger(final @NotNull String name) {
+  static ComponentLogger logger(final String name) {
     return Handler.logger(requireNonNull(name, "name"));
   }
 
@@ -77,7 +76,7 @@ public interface ComponentLogger extends Logger {
    * @return a logger with the name of the calling class
    * @since 4.11.0
    */
-  static @NotNull ComponentLogger logger(final @NotNull Class<?> clazz) {
+  static ComponentLogger logger(final Class<?> clazz) {
     return logger(clazz.getName());
   }
 
@@ -87,7 +86,7 @@ public interface ComponentLogger extends Logger {
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void trace(final @NotNull Component msg);
+  void trace(final Component msg);
 
   /**
    * Log a message at the TRACE level according to the specified format
@@ -100,7 +99,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void trace(final @NotNull Component format, final @Nullable Object arg);
+  void trace(final Component format, final @Nullable Object arg);
 
   /**
    * Log a message at the TRACE level according to the specified format
@@ -114,7 +113,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void trace(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void trace(final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * Log a message at the TRACE level according to the specified format
@@ -130,7 +129,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void trace(final @NotNull Component format, final @Nullable Object @NotNull... arguments);
+  void trace(final Component format, final @Nullable Object ... arguments);
 
   /**
    * Log an exception (throwable) at the TRACE level with an
@@ -140,7 +139,7 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void trace(final @NotNull Component msg, final @Nullable Throwable t);
+  void trace(final Component msg, final @Nullable Throwable t);
 
   /**
    * Log a message with the specific Marker at the TRACE level.
@@ -149,7 +148,7 @@ public interface ComponentLogger extends Logger {
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void trace(final @NotNull Marker marker, final @NotNull Component msg);
+  void trace(final Marker marker, final Component msg);
 
   /**
    * This method is similar to {@link #trace(Component, Object)} method except that the
@@ -160,7 +159,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+  void trace(final Marker marker, final Component format, final @Nullable Object arg);
 
   /**
    * This method is similar to {@link #trace(Component, Object, Object)}
@@ -173,7 +172,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void trace(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * This method is similar to {@link #trace(Component, Object...)}
@@ -185,7 +184,7 @@ public interface ComponentLogger extends Logger {
    * @param argArray an array of arguments
    * @since 4.11.0
    */
-  void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray);
+  void trace(final Marker marker, final Component format, final @Nullable Object ... argArray);
 
   /**
    * This method is similar to {@link #trace(Component, Throwable)} method except that the
@@ -196,7 +195,7 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void trace(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t);
+  void trace(final Marker marker, final Component msg, final @Nullable Throwable t);
 
   /**
    * Log a message at the DEBUG level.
@@ -204,7 +203,7 @@ public interface ComponentLogger extends Logger {
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void debug(final @NotNull Component msg);
+  void debug(final Component msg);
 
   /**
    * Log a message at the DEBUG level according to the specified format
@@ -217,7 +216,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void debug(final @NotNull Component format, final @Nullable Object arg);
+  void debug(final Component format, final @Nullable Object arg);
 
   /**
    * Log a message at the DEBUG level according to the specified format
@@ -231,7 +230,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void debug(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void debug(final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * Log a message at the DEBUG level according to the specified format
@@ -248,7 +247,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void debug(final @NotNull Component format, final @Nullable Object @NotNull... arguments);
+  void debug(final Component format, final @Nullable Object ... arguments);
 
   /**
    * Log an exception (throwable) at the DEBUG level with an
@@ -258,7 +257,7 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void debug(final @NotNull Component msg, final @Nullable Throwable t);
+  void debug(final Component msg, final @Nullable Throwable t);
 
   /**
    * Log a message with the specific Marker at the DEBUG level.
@@ -267,7 +266,7 @@ public interface ComponentLogger extends Logger {
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void debug(final @NotNull Marker marker, final @NotNull Component msg);
+  void debug(final Marker marker, final Component msg);
 
   /**
    * This method is similar to {@link #debug(Component, Object)} method except that the
@@ -278,7 +277,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+  void debug(final Marker marker, final Component format, final @Nullable Object arg);
 
   /**
    * This method is similar to {@link #debug(Component, Object, Object)}
@@ -291,7 +290,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void debug(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * This method is similar to {@link #debug(Component, Object...)}
@@ -303,7 +302,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... arguments);
+  void debug(final Marker marker, final Component format, final @Nullable Object ... arguments);
 
   /**
    * This method is similar to {@link #debug(Component, Throwable)} method except that the
@@ -314,7 +313,7 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void debug(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t);
+  void debug(final Marker marker, final Component msg, final @Nullable Throwable t);
 
   /**
    * Log a message at the INFO level.
@@ -322,7 +321,7 @@ public interface ComponentLogger extends Logger {
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void info(final @NotNull Component msg);
+  void info(final Component msg);
 
   /**
    * Log a message at the INFO level according to the specified format
@@ -335,7 +334,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void info(final @NotNull Component format, final @Nullable Object arg);
+  void info(final Component format, final @Nullable Object arg);
 
   /**
    * Log a message at the INFO level according to the specified format
@@ -349,7 +348,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void info(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void info(final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * Log a message at the INFO level according to the specified format
@@ -366,7 +365,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void info(final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+  void info(final Component format, final @Nullable Object... arguments);
 
   /**
    * Log an exception (throwable) at the INFO level with an
@@ -376,7 +375,7 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void info(final @NotNull Component msg, final @Nullable Throwable t);
+  void info(final Component msg, final @Nullable Throwable t);
 
   /**
    * Log a message with the specific Marker at the INFO level.
@@ -385,7 +384,7 @@ public interface ComponentLogger extends Logger {
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void info(final @NotNull Marker marker, final @NotNull Component msg);
+  void info(final Marker marker, final Component msg);
 
   /**
    * This method is similar to {@link #info(Component, Object)} method except that the
@@ -396,7 +395,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+  void info(final Marker marker, final Component format, final @Nullable Object arg);
 
   /**
    * This method is similar to {@link #info(Component, Object, Object)}
@@ -409,7 +408,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void info(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * This method is similar to {@link #info(Component, Object...)}
@@ -421,7 +420,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+  void info(final Marker marker, final Component format, final @Nullable Object... arguments);
 
   /**
    * This method is similar to {@link #info(Component, Throwable)} method
@@ -432,7 +431,7 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void info(final @NotNull Marker marker, final @NotNull Component msg, final @NotNull Throwable t);
+  void info(final Marker marker, final Component msg, final Throwable t);
 
   /**
    * Log a message at the WARN level.
@@ -440,7 +439,7 @@ public interface ComponentLogger extends Logger {
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void warn(final @NotNull Component msg);
+  void warn(final Component msg);
 
   /**
    * Log a message at the WARN level according to the specified format
@@ -453,7 +452,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void warn(final @NotNull Component format, final @Nullable Object arg);
+  void warn(final Component format, final @Nullable Object arg);
 
   /**
    * Log a message at the WARN level according to the specified format
@@ -470,7 +469,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void warn(final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+  void warn(final Component format, final @Nullable Object... arguments);
 
   /**
    * Log a message at the WARN level according to the specified format
@@ -484,7 +483,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void warn(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void warn(final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * Log an exception (throwable) at the WARN level with an
@@ -494,16 +493,16 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void warn(final @NotNull Component msg, final @NotNull Throwable t);
+  void warn(final Component msg, final Throwable t);
 
   /**
-   * Log a message with the specific final @NotNull Marker at the WARN level.
+   * Log a message with the specific final Marker at the WARN level.
    *
    * @param marker The marker specific to this log statement
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void warn(final @NotNull Marker marker, final @NotNull Component msg);
+  void warn(final Marker marker, final Component msg);
 
   /**
    * This method is similar to {@link #warn(Component, Object)} method except that the
@@ -514,7 +513,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+  void warn(final Marker marker, final Component format, final @Nullable Object arg);
 
   /**
    * This method is similar to {@link #warn(Component, Object, Object)}
@@ -527,7 +526,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void warn(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * This method is similar to {@link #warn(Component, Object...)}
@@ -539,7 +538,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+  void warn(final Marker marker, final Component format, final @Nullable Object... arguments);
 
   /**
    * This method is similar to {@link #warn(Component, Throwable)} method
@@ -550,7 +549,7 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void warn(final @NotNull Marker marker, final @NotNull Component msg, final @NotNull Throwable t);
+  void warn(final Marker marker, final Component msg, final Throwable t);
 
   /**
    * Log a message at the ERROR level.
@@ -558,7 +557,7 @@ public interface ComponentLogger extends Logger {
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void error(final @NotNull Component msg);
+  void error(final Component msg);
 
   /**
    * Log a message at the ERROR level according to the specified format
@@ -571,7 +570,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void error(final @NotNull Component format, final @Nullable Object arg);
+  void error(final Component format, final @Nullable Object arg);
 
   /**
    * Log a message at the ERROR level according to the specified format
@@ -585,7 +584,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void error(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void error(final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * Log a message at the ERROR level according to the specified format
@@ -602,7 +601,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void error(final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+  void error(final Component format, final @Nullable Object... arguments);
 
   /**
    * Log an exception (throwable) at the ERROR level with an
@@ -612,16 +611,16 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void error(final @NotNull Component msg, final @NotNull Throwable t);
+  void error(final Component msg, final Throwable t);
 
   /**
-   * Log a message with the specific final @NotNull Marker at the ERROR level.
+   * Log a message with the specific final Marker at the ERROR level.
    *
    * @param marker The marker specific to this log statement
    * @param msg the message string to be logged
    * @since 4.11.0
    */
-  void error(final @NotNull Marker marker, final @NotNull Component msg);
+  void error(final Marker marker, final Component msg);
 
   /**
    * This method is similar to {@link #error(Component, Object)} method except that the
@@ -632,7 +631,7 @@ public interface ComponentLogger extends Logger {
    * @param arg the argument
    * @since 4.11.0
    */
-  void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg);
+  void error(final Marker marker, final Component format, final @Nullable Object arg);
 
   /**
    * This method is similar to {@link #error(Component, Object, Object)}
@@ -645,7 +644,7 @@ public interface ComponentLogger extends Logger {
    * @param arg2 the second argument
    * @since 4.11.0
    */
-  void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2);
+  void error(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2);
 
   /**
    * This method is similar to {@link #error(Component, Object...)}
@@ -657,7 +656,7 @@ public interface ComponentLogger extends Logger {
    * @param arguments a list of 3 or more arguments
    * @since 4.11.0
    */
-  void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object@NotNull... arguments);
+  void error(final Marker marker, final Component format, final @Nullable Object... arguments);
 
   /**
    * This method is similar to {@link #error(Component, Throwable)}
@@ -669,5 +668,5 @@ public interface ComponentLogger extends Logger {
    * @param t the exception (throwable) to log
    * @since 4.11.0
    */
-  void error(final @NotNull Marker marker, final @NotNull Component msg, final @NotNull Throwable t);
+  void error(final Marker marker, final Component msg, final Throwable t);
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
@@ -27,7 +27,6 @@ import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.PlatformAPI;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 /**
@@ -46,7 +45,7 @@ public interface ComponentLoggerProvider {
    * @return a component logger with the provided name
    * @since 4.11.0
    */
-  @NotNull ComponentLogger logger(final @NotNull LoggerHelper helper, final @NotNull String name);
+  ComponentLogger logger(final LoggerHelper helper, final String name);
 
   /**
    * A factory for default implementations of component loggers.
@@ -63,7 +62,7 @@ public interface ComponentLoggerProvider {
      * @return a plain serializer
      * @since 4.11.0
      */
-    @NotNull Function<Component, String> plainSerializer();
+    Function<Component, String> plainSerializer();
 
     /**
      * Create a component logger based on one which delegates to an underlying plain {@link Logger} implementation.
@@ -75,6 +74,6 @@ public interface ComponentLoggerProvider {
      * @return a new logger
      * @since 4.11.0
      */
-    @NotNull ComponentLogger delegating(final @NotNull Logger base, final @NotNull Function<Component, String> serializer);
+    ComponentLogger delegating(final Logger base, final Function<Component, String> serializer);
   }
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
@@ -31,7 +31,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.util.Services;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +52,7 @@ final class Handler {
     private final Map<String, ComponentLogger> loggers = new ConcurrentHashMap<>();
 
     @Override
-    public @NotNull ComponentLogger logger(final @NotNull LoggerHelper helper, final @NotNull String name) {
+    public ComponentLogger logger(final LoggerHelper helper, final String name) {
       final ComponentLogger initial = this.loggers.get(name);
       if (initial != null) return initial;
 
@@ -71,7 +70,7 @@ final class Handler {
     }
 
     @Override
-    public @NotNull Function<Component, String> plainSerializer() {
+    public Function<Component, String> plainSerializer() {
       return comp -> {
         final Component translated = GlobalTranslator.render(comp, Locale.getDefault());
         final StringBuilder contents = new StringBuilder();
@@ -81,7 +80,7 @@ final class Handler {
     }
 
     @Override
-    public @NotNull ComponentLogger delegating(final @NotNull Logger base, final @NotNull Function<Component, String> serializer) {
+    public ComponentLogger delegating(final Logger base, final Function<Component, String> serializer) {
       return new WrappingComponentLoggerImpl(base, serializer);
     }
   }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/UnpackedComponentThrowable.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/UnpackedComponentThrowable.java
@@ -27,7 +27,7 @@ import java.io.Serial;
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.ComponentMessageThrowable;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A wrapper for exceptions that implement ComponentMessageThrowable.

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -27,8 +27,7 @@ import java.util.Arrays;
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
@@ -63,7 +62,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
     }
   }
 
-  private Object[] maybeSerialize(final @Nullable Object@NotNull... args) {
+  private Object[] maybeSerialize(final @Nullable Object... args) {
     Object[] writable = args;
     for (int i = 0; i < writable.length; i++) {
       if (writable[i] instanceof ComponentLike) {
@@ -147,12 +146,12 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public @NotNull LoggingEventBuilder makeLoggingEventBuilder(final @NotNull Level level) {
+  public LoggingEventBuilder makeLoggingEventBuilder(final Level level) {
     return this.logger.makeLoggingEventBuilder(level);
   }
 
   @Override
-  public @NotNull LoggingEventBuilder atLevel(final @NotNull Level level) {
+  public LoggingEventBuilder atLevel(final Level level) {
     if (this.logger.isEnabledForLevel(level)) {
       return this.logger.makeLoggingEventBuilder(level);
     } else {
@@ -163,7 +162,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   // Standard string methods, to process potential Component arguments
 
   @Override
-  public void trace(final @NotNull String format) {
+  public void trace(final String format) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -181,7 +180,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull String format, final @Nullable Object arg) {
+  public void trace(final String format, final @Nullable Object arg) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -199,7 +198,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void trace(final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -217,7 +216,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+  public void trace(final String format, final @Nullable Object ... arguments) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -235,7 +234,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull String msg, final @Nullable Throwable t) {
+  public void trace(final String msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -253,7 +252,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull String msg) {
+  public void trace(final Marker marker, final String msg) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -271,7 +270,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+  public void trace(final Marker marker, final String format, final @Nullable Object arg) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -289,7 +288,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void trace(final Marker marker, final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -307,7 +306,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+  public void trace(final Marker marker, final String format, final @Nullable Object ... argArray) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -325,7 +324,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+  public void trace(final Marker marker, final String msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -343,7 +342,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull String format) {
+  public void debug(final String format) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -361,7 +360,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull String format, final @Nullable Object arg) {
+  public void debug(final String format, final @Nullable Object arg) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -379,7 +378,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void debug(final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -397,7 +396,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+  public void debug(final String format, final @Nullable Object ... arguments) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -415,7 +414,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull String msg, final @Nullable Throwable t) {
+  public void debug(final String msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -433,7 +432,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull String msg) {
+  public void debug(final Marker marker, final String msg) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -451,7 +450,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+  public void debug(final Marker marker, final String format, final @Nullable Object arg) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -469,7 +468,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void debug(final Marker marker, final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -487,7 +486,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+  public void debug(final Marker marker, final String format, final @Nullable Object ... argArray) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -505,7 +504,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+  public void debug(final Marker marker, final String msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -523,7 +522,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull String format) {
+  public void info(final String format) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -541,7 +540,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull String format, final @Nullable Object arg) {
+  public void info(final String format, final @Nullable Object arg) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -559,7 +558,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void info(final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -577,7 +576,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+  public void info(final String format, final @Nullable Object ... arguments) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -595,7 +594,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull String msg, final @Nullable Throwable t) {
+  public void info(final String msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -613,7 +612,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull String msg) {
+  public void info(final Marker marker, final String msg) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -631,7 +630,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+  public void info(final Marker marker, final String format, final @Nullable Object arg) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -649,7 +648,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void info(final Marker marker, final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -667,7 +666,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+  public void info(final Marker marker, final String format, final @Nullable Object ... argArray) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -685,7 +684,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+  public void info(final Marker marker, final String msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -703,7 +702,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull String format) {
+  public void warn(final String format) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -721,7 +720,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull String format, final @Nullable Object arg) {
+  public void warn(final String format, final @Nullable Object arg) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -739,7 +738,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void warn(final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -757,7 +756,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+  public void warn(final String format, final @Nullable Object ... arguments) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -775,7 +774,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull String msg, final @Nullable Throwable t) {
+  public void warn(final String msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -793,7 +792,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull String msg) {
+  public void warn(final Marker marker, final String msg) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -811,7 +810,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+  public void warn(final Marker marker, final String format, final @Nullable Object arg) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -829,7 +828,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void warn(final Marker marker, final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -847,7 +846,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+  public void warn(final Marker marker, final String format, final @Nullable Object ... argArray) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -865,7 +864,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+  public void warn(final Marker marker, final String msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -883,7 +882,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull String format) {
+  public void error(final String format) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -901,7 +900,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull String format, final @Nullable Object arg) {
+  public void error(final String format, final @Nullable Object arg) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -919,7 +918,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void error(final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -937,7 +936,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
+  public void error(final String format, final @Nullable Object ... arguments) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -955,7 +954,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull String msg, final @Nullable Throwable t) {
+  public void error(final String msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -973,7 +972,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull String msg) {
+  public void error(final Marker marker, final String msg) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -991,7 +990,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
+  public void error(final Marker marker, final String format, final @Nullable Object arg) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1009,7 +1008,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void error(final Marker marker, final String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1027,7 +1026,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
+  public void error(final Marker marker, final String format, final @Nullable Object ... argArray) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1045,7 +1044,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
+  public void error(final Marker marker, final String msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1065,7 +1064,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   // Component-primary methods
 
   @Override
-  public void trace(final @NotNull Component format) {
+  public void trace(final Component format) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1083,7 +1082,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Component format, final @Nullable Object arg) {
+  public void trace(final Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1101,7 +1100,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void trace(final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1119,7 +1118,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+  public void trace(final Component format, final @Nullable Object ... arguments) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1137,7 +1136,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Component msg, final @Nullable Throwable t) {
+  public void trace(final Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1155,7 +1154,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull Component msg) {
+  public void trace(final Marker marker, final Component msg) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1173,7 +1172,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void trace(final Marker marker, final Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1191,7 +1190,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void trace(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1209,7 +1208,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void trace(final Marker marker, final Component format, final @Nullable Object ... argArray) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1227,7 +1226,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void trace(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void trace(final Marker marker, final Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1245,7 +1244,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Component format) {
+  public void debug(final Component format) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1263,7 +1262,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Component format, final @Nullable Object arg) {
+  public void debug(final Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1281,7 +1280,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void debug(final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1299,7 +1298,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+  public void debug(final Component format, final @Nullable Object ... arguments) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1317,7 +1316,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Component msg, final @Nullable Throwable t) {
+  public void debug(final Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1335,7 +1334,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull Component msg) {
+  public void debug(final Marker marker, final Component msg) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1353,7 +1352,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void debug(final Marker marker, final Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1371,7 +1370,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void debug(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1389,7 +1388,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void debug(final Marker marker, final Component format, final @Nullable Object ... argArray) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1407,7 +1406,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void debug(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void debug(final Marker marker, final Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1425,7 +1424,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Component format) {
+  public void info(final Component format) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1443,7 +1442,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Component format, final @Nullable Object arg) {
+  public void info(final Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1461,7 +1460,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void info(final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1479,7 +1478,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+  public void info(final Component format, final @Nullable Object ... arguments) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1497,7 +1496,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Component msg, final @Nullable Throwable t) {
+  public void info(final Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1515,7 +1514,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull Component msg) {
+  public void info(final Marker marker, final Component msg) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1533,7 +1532,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void info(final Marker marker, final Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1551,7 +1550,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void info(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1569,7 +1568,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void info(final Marker marker, final Component format, final @Nullable Object ... argArray) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1587,7 +1586,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void info(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void info(final Marker marker, final Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1605,7 +1604,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Component format) {
+  public void warn(final Component format) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1623,7 +1622,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Component format, final @Nullable Object arg) {
+  public void warn(final Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1641,7 +1640,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void warn(final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1659,7 +1658,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+  public void warn(final Component format, final @Nullable Object ... arguments) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1677,7 +1676,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Component msg, final @Nullable Throwable t) {
+  public void warn(final Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1695,7 +1694,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull Component msg) {
+  public void warn(final Marker marker, final Component msg) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1713,7 +1712,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void warn(final Marker marker, final Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1731,7 +1730,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void warn(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1749,7 +1748,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void warn(final Marker marker, final Component format, final @Nullable Object ... argArray) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1767,7 +1766,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void warn(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void warn(final Marker marker, final Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1785,7 +1784,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Component format) {
+  public void error(final Component format) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1803,7 +1802,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Component format, final @Nullable Object arg) {
+  public void error(final Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1821,7 +1820,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void error(final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1839,7 +1838,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
+  public void error(final Component format, final @Nullable Object ... arguments) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1857,7 +1856,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Component msg, final @Nullable Throwable t) {
+  public void error(final Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
     if (this.isLocationAware) {
@@ -1875,7 +1874,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull Component msg) {
+  public void error(final Marker marker, final Component msg) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1893,7 +1892,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
+  public void error(final Marker marker, final Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1911,7 +1910,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
+  public void error(final Marker marker, final Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1929,7 +1928,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
+  public void error(final Marker marker, final Component format, final @Nullable Object ... argArray) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {
@@ -1947,7 +1946,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   }
 
   @Override
-  public void error(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
+  public void error(final Marker marker, final Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
     if (this.isLocationAware) {

--- a/text-minimessage/src/main/java/module-info.java
+++ b/text-minimessage/src/main/java/module-info.java
@@ -1,0 +1,16 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * MiniMessage, a friendly text format for representing chat components.
+ *
+ * @see <a href="https://docs.papermc.io/adventure/minimessage/format">Format Documentation</a>
+ */
+@NullMarked
+module net.kyori.adventure.text.minimessage {
+  requires transitive net.kyori.adventure.api;
+
+  exports net.kyori.adventure.text.minimessage;
+  exports net.kyori.adventure.text.minimessage.tag;
+  exports net.kyori.adventure.text.minimessage.translation;
+  exports net.kyori.adventure.text.minimessage.tree;
+}

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ArgumentQueueImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ArgumentQueueImpl.java
@@ -28,8 +28,7 @@ import java.util.function.Supplier;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -45,7 +44,7 @@ public final class ArgumentQueueImpl<T extends Tag.Argument> implements Argument
   }
 
   @Override
-  public @NotNull T pop() {
+  public T pop() {
     if (!this.hasNext()) {
       throw this.context.newException("Missing argument for this tag!", this);
     }
@@ -53,7 +52,7 @@ public final class ArgumentQueueImpl<T extends Tag.Argument> implements Argument
   }
 
   @Override
-  public @NotNull T popOr(final @NotNull String errorMessage) {
+  public T popOr(final String errorMessage) {
     requireNonNull(errorMessage, "errorMessage");
     if (!this.hasNext()) {
       throw this.context.newException(errorMessage, this);
@@ -62,7 +61,7 @@ public final class ArgumentQueueImpl<T extends Tag.Argument> implements Argument
   }
 
   @Override
-  public @NotNull T popOr(final @NotNull Supplier<String> errorMessage) {
+  public T popOr(final Supplier<String> errorMessage) {
     requireNonNull(errorMessage, "errorMessage");
     if (!this.hasNext()) {
       throw this.context.newException(requireNonNull(errorMessage.get(), "errorMessage.get()"), this);

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -27,9 +27,7 @@ import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Parser context for use within transformations.
@@ -58,7 +56,7 @@ public sealed interface Context permits ContextImpl {
    * @return the target, if provided
    * @since 4.17.0
    */
-  @NotNull Pointered targetOrThrow();
+  Pointered targetOrThrow();
 
   /**
    * The target of the parse context, casted to a provided type.
@@ -72,7 +70,7 @@ public sealed interface Context permits ContextImpl {
    * @return the target
    * @since 4.17.0
    */
-  <T extends Pointered> @NotNull T targetAsType(final @NotNull Class<T> targetClass);
+  <T extends Pointered> T targetAsType(final Class<T> targetClass);
 
   /**
    * Deserializes a MiniMessage string using all the settings of this context.
@@ -81,7 +79,7 @@ public sealed interface Context permits ContextImpl {
    * @return the parsed message
    * @since 4.10.0
    */
-  @NotNull Component deserialize(final @NotNull String message);
+  Component deserialize(final String message);
 
   /**
    * Deserializes a MiniMessage string using all the settings of this context.
@@ -91,7 +89,7 @@ public sealed interface Context permits ContextImpl {
    * @return the parsed message
    * @since 4.10.0
    */
-  @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver resolver);
+  Component deserialize(final String message, final TagResolver resolver);
 
   /**
    * Deserializes a MiniMessage string using all the settings of this context.
@@ -101,7 +99,7 @@ public sealed interface Context permits ContextImpl {
    * @return the parsed message
    * @since 4.10.0
    */
-  @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers);
+  Component deserialize(final String message, final TagResolver... resolvers);
 
   /**
    * Create a new parsing exception.
@@ -111,9 +109,9 @@ public sealed interface Context permits ContextImpl {
    * @return the new parsing exception
    * @since 4.10.0
    */
-  @NotNull ParsingException newException(
-    final @NotNull String message,
-    final @NotNull ArgumentQueue tags
+  ParsingException newException(
+    final String message,
+    final ArgumentQueue tags
   );
 
   /**
@@ -123,7 +121,7 @@ public sealed interface Context permits ContextImpl {
    * @return the new parsing exception
    * @since 4.10.0
    */
-  @NotNull ParsingException newException(final @NotNull String message);
+  ParsingException newException(final String message);
 
   /**
    * Create a new parsing exception.
@@ -134,10 +132,10 @@ public sealed interface Context permits ContextImpl {
    * @return the new parsing exception
    * @since 4.10.0
    */
-  @NotNull ParsingException newException(
-    final @NotNull String message,
+  ParsingException newException(
+    final String message,
     final @Nullable Throwable cause,
-    final @NotNull ArgumentQueue args
+    final ArgumentQueue args
   );
 
   /**

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ContextImpl.java
@@ -34,8 +34,7 @@ import net.kyori.adventure.text.minimessage.internal.parser.node.TagPart;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -93,15 +92,15 @@ final class ContextImpl implements Context {
     return this.debugOutput;
   }
 
-  public @NotNull String message() {
+  public String message() {
     return this.message;
   }
 
-  void message(final @NotNull String message) {
+  void message(final String message) {
     this.message = message;
   }
 
-  public @NotNull TagResolver extraTags() {
+  public TagResolver extraTags() {
     return this.tagResolver;
   }
 
@@ -119,7 +118,7 @@ final class ContextImpl implements Context {
   }
 
   @Override
-  public @NotNull Pointered targetOrThrow() {
+  public Pointered targetOrThrow() {
     if (this.target == null) {
       throw this.newException("A target is required for this deserialization attempt");
     } else {
@@ -128,7 +127,7 @@ final class ContextImpl implements Context {
   }
 
   @Override
-  public <T extends Pointered> @NotNull T targetAsType(final @NotNull Class<T> targetClass) {
+  public <T extends Pointered> T targetAsType(final Class<T> targetClass) {
     if (requireNonNull(targetClass, "targetClass").isInstance(this.target)) {
       return targetClass.cast(this.target);
     } else {
@@ -137,40 +136,40 @@ final class ContextImpl implements Context {
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String message) {
+  public Component deserialize(final String message) {
     return this.deserializeWithOptionalTarget(requireNonNull(message, "message"), this.tagResolver);
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver resolver) {
+  public Component deserialize(final String message, final TagResolver resolver) {
     requireNonNull(message, "message");
     final TagResolver combinedResolver = TagResolver.builder().resolver(this.tagResolver).resolver(resolver).build();
     return this.deserializeWithOptionalTarget(message, combinedResolver);
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String message, final @NotNull TagResolver@NotNull... resolvers) {
+  public Component deserialize(final String message, final TagResolver... resolvers) {
     requireNonNull(message, "message");
     final TagResolver combinedResolver = TagResolver.builder().resolver(this.tagResolver).resolvers(resolvers).build();
     return this.deserializeWithOptionalTarget(message, combinedResolver);
   }
 
   @Override
-  public @NotNull ParsingException newException(final @NotNull String message) {
+  public ParsingException newException(final String message) {
     return new ParsingExceptionImpl(message, this.message, null, false, EMPTY_TOKEN_ARRAY);
   }
 
   @Override
-  public @NotNull ParsingException newException(final @NotNull String message, final @NotNull ArgumentQueue tags) {
+  public ParsingException newException(final String message, final ArgumentQueue tags) {
     return new ParsingExceptionImpl(message, this.message, null, false, tagsToTokens(((ArgumentQueueImpl<?>) tags).args));
   }
 
   @Override
-  public @NotNull ParsingException newException(final @NotNull String message, final @Nullable Throwable cause, final @NotNull ArgumentQueue tags) {
+  public ParsingException newException(final String message, final @Nullable Throwable cause, final ArgumentQueue tags) {
     return new ParsingExceptionImpl(message, this.message, cause, false, tagsToTokens(((ArgumentQueueImpl<?>) tags).args));
   }
 
-  private @NotNull Component deserializeWithOptionalTarget(final @NotNull String message, final @NotNull TagResolver tagResolver) {
+  private Component deserializeWithOptionalTarget(final String message, final TagResolver tagResolver) {
     if (this.target != null) {
       return this.miniMessage.deserialize(message, this.target, tagResolver);
     } else {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -33,8 +33,7 @@ import net.kyori.adventure.text.minimessage.tree.Node;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.PlatformAPI;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * MiniMessage is a textual representation of components.
@@ -51,7 +50,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return a simple instance
    * @since 4.10.0
    */
-  static @NotNull MiniMessage miniMessage() {
+  static MiniMessage miniMessage() {
     return MiniMessageImpl.Instances.INSTANCE;
   }
 
@@ -66,7 +65,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output, with escaped tags
    * @since 4.10.0
    */
-  @NotNull String escapeTags(final @NotNull String input);
+  String escapeTags(final String input);
 
   /**
    * Escapes all known tags in the input message, so that they are ignored in deserialization.
@@ -78,7 +77,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output, with escaped tags
    * @since 4.10.0
    */
-  @NotNull String escapeTags(final @NotNull String input, final @NotNull TagResolver tagResolver);
+  String escapeTags(final String input, final TagResolver tagResolver);
 
   /**
    * Escapes all known tags in the input message, so that they are ignored in deserialization.
@@ -90,7 +89,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output, with escaped tags
    * @since 4.10.0
    */
-  default @NotNull String escapeTags(final @NotNull String input, final @NotNull TagResolver... tagResolvers) {
+  default String escapeTags(final String input, final TagResolver... tagResolvers) {
     return this.escapeTags(input, TagResolver.resolver(tagResolvers));
   }
 
@@ -105,7 +104,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output, without tags
    * @since 4.10.0
    */
-  @NotNull String stripTags(final @NotNull String input);
+  String stripTags(final String input);
 
   /**
    * Removes all known tags in the input message, so that they are ignored in deserialization.
@@ -117,7 +116,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output, without tags
    * @since 4.10.0
    */
-  @NotNull String stripTags(final @NotNull String input, final @NotNull TagResolver tagResolver);
+  String stripTags(final String input, final TagResolver tagResolver);
 
   /**
    * Removes all known tags in the input message, so that they are ignored in deserialization.
@@ -129,7 +128,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output, without tags
    * @since 4.10.0
    */
-  default @NotNull String stripTags(final @NotNull String input, final @NotNull TagResolver... tagResolvers) {
+  default String stripTags(final String input, final TagResolver... tagResolvers) {
     return this.stripTags(input, TagResolver.resolver(tagResolvers));
   }
 
@@ -141,7 +140,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output component
    * @since 4.17.0
    */
-  @NotNull Component deserialize(final @NotNull String input, final @NotNull Pointered target);
+  Component deserialize(final String input, final Pointered target);
 
   /**
    * Deserializes a string into a component, with a tag resolver to parse tags of the form {@code <key>}.
@@ -153,7 +152,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output component
    * @since 4.10.0
    */
-  @NotNull Component deserialize(final @NotNull String input, final @NotNull TagResolver tagResolver);
+  Component deserialize(final String input, final TagResolver tagResolver);
 
   /**
    * Deserializes a string into a component, with a tag resolver to parse tags of the form {@code <key>} and a target.
@@ -166,7 +165,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output component
    * @since 4.17.0
    */
-  @NotNull Component deserialize(final @NotNull String input, final @NotNull Pointered target, final @NotNull TagResolver tagResolver);
+  Component deserialize(final String input, final Pointered target, final TagResolver tagResolver);
 
   /**
    * Deserializes a string into a component, with tag resolvers to parse tags of the form {@code <key>}.
@@ -178,7 +177,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output component
    * @since 4.10.0
    */
-  default @NotNull Component deserialize(final @NotNull String input, final @NotNull TagResolver... tagResolvers) {
+  default Component deserialize(final String input, final TagResolver... tagResolvers) {
     return this.deserialize(input, TagResolver.resolver(tagResolvers));
   }
 
@@ -193,7 +192,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the output component
    * @since 4.17.0
    */
-  default @NotNull Component deserialize(final @NotNull String input, final @NotNull Pointered target, final @NotNull TagResolver... tagResolvers) {
+  default Component deserialize(final String input, final Pointered target, final TagResolver... tagResolvers) {
     return this.deserialize(input, target, TagResolver.resolver(tagResolvers));
   }
 
@@ -205,7 +204,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.10.0
    */
-  Node.@NotNull Root deserializeToTree(final @NotNull String input);
+  Node.Root deserializeToTree(final String input);
 
   /**
    * Deserializes a string into a tree of parsed elements, with a target.
@@ -216,7 +215,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.17.0
    */
-  Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull Pointered target);
+  Node.Root deserializeToTree(final String input, final Pointered target);
 
   /**
    * Deserializes a string into a tree of parsed elements, with a tag resolver to parse tags of the form {@code <key>}.
@@ -229,7 +228,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.10.0
    */
-  Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver);
+  Node.Root deserializeToTree(final String input, final TagResolver tagResolver);
 
   /**
    * Deserializes a string into a tree of parsed elements, with a tag resolver to parse tags of the form {@code <key>} and a target.
@@ -243,7 +242,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.17.0
    */
-  Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull Pointered target, final @NotNull TagResolver tagResolver);
+  Node.Root deserializeToTree(final String input, final Pointered target, final TagResolver tagResolver);
 
   /**
    * Deserializes a string into a tree of parsed elements, with a tag resolver to parse tags of the form {@code <key>}.
@@ -256,7 +255,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.10.0
    */
-  default Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull TagResolver... tagResolvers) {
+  default Node.Root deserializeToTree(final String input, final TagResolver... tagResolvers) {
     return this.deserializeToTree(input, TagResolver.resolver(tagResolvers));
   }
 
@@ -272,7 +271,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the root of the resulting tree
    * @since 4.17.0
    */
-  default Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull Pointered target, final @NotNull TagResolver... tagResolvers) {
+  default Node.Root deserializeToTree(final String input, final Pointered target, final TagResolver... tagResolvers) {
     return this.deserializeToTree(input, target, TagResolver.resolver(tagResolvers));
   }
 
@@ -291,7 +290,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @return the base tag resolver
    * @since 4.15.0
    */
-  @NotNull TagResolver tags();
+  TagResolver tags();
 
   /**
    * Creates a new {@link MiniMessage.Builder}.
@@ -320,7 +319,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder tags(final @NotNull TagResolver tags);
+    Builder tags(final TagResolver tags);
 
     /**
      * Add to the set of known tags this MiniMessage instance can use.
@@ -329,7 +328,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder editTags(final @NotNull Consumer<TagResolver.Builder> adder);
+    Builder editTags(final Consumer<TagResolver.Builder> adder);
 
     /**
      * Enables strict mode (disabled by default).
@@ -344,7 +343,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder strict(final boolean strict);
+    Builder strict(final boolean strict);
 
     /**
      * Configures if MiniMessage should emit virtual components (enabled by default).
@@ -361,7 +360,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @return this builder.
      * @since 4.19.0
      */
-    @NotNull Builder emitVirtuals(final boolean emitVirtuals);
+    Builder emitVirtuals(final boolean emitVirtuals);
 
     /**
      * Print debug information to the given output (disabled by default).
@@ -375,7 +374,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder debug(final @Nullable Consumer<String> debugOutput);
+    Builder debug(final @Nullable Consumer<String> debugOutput);
 
     /**
      * Specify a function that takes the component at the end of the parser process.
@@ -386,7 +385,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder postProcessor(final @NotNull UnaryOperator<Component> postProcessor);
+    Builder postProcessor(final UnaryOperator<Component> postProcessor);
 
     /**
      * Specify a function that takes the string at the start of the parser process.
@@ -397,7 +396,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @return this builder
      * @since 4.11.0
      */
-    @NotNull Builder preProcessor(final @NotNull UnaryOperator<String> preProcessor);
+    Builder preProcessor(final UnaryOperator<String> preProcessor);
 
     /**
      * Builds the serializer.
@@ -406,7 +405,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @since 4.10.0
      */
     @Override
-    @NotNull MiniMessage build();
+    MiniMessage build();
   }
 
   /**
@@ -426,7 +425,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull MiniMessage miniMessage();
+    MiniMessage miniMessage();
 
     /**
      * Initialize a {@link Builder} before it is returned to the API caller.
@@ -436,6 +435,6 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull Consumer<Builder> builder();
+    Consumer<Builder> builder();
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -33,8 +33,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tree.Node;
 import net.kyori.adventure.util.Services;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -68,7 +67,7 @@ final class MiniMessageImpl implements MiniMessage {
   private final UnaryOperator<String> preProcessor;
   final MiniMessageParser parser;
 
-  MiniMessageImpl(final @NotNull TagResolver resolver, final boolean strict, final boolean emitVirtuals, final @Nullable Consumer<String> debugOutput, final @NotNull UnaryOperator<String> preProcessor, final @NotNull UnaryOperator<Component> postProcessor) {
+  MiniMessageImpl(final TagResolver resolver, final boolean strict, final boolean emitVirtuals, final @Nullable Consumer<String> debugOutput, final UnaryOperator<String> preProcessor, final UnaryOperator<Component> postProcessor) {
     this.parser = new MiniMessageParser(resolver);
     this.strict = strict;
     this.emitVirtuals = emitVirtuals;
@@ -78,47 +77,47 @@ final class MiniMessageImpl implements MiniMessage {
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String input) {
+  public Component deserialize(final String input) {
     return this.parser.parseFormat(this.newContext(input, null, null));
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String input, final @NotNull Pointered target) {
+  public Component deserialize(final String input, final Pointered target) {
     return this.parser.parseFormat(this.newContext(input, requireNonNull(target, "target"), null));
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String input, final @NotNull TagResolver tagResolver) {
+  public Component deserialize(final String input, final TagResolver tagResolver) {
     return this.parser.parseFormat(this.newContext(input, null, requireNonNull(tagResolver, "tagResolver")));
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String input, final @NotNull Pointered target, final @NotNull TagResolver tagResolver) {
+  public Component deserialize(final String input, final Pointered target, final TagResolver tagResolver) {
     return this.parser.parseFormat(this.newContext(input, requireNonNull(target, "target"), requireNonNull(tagResolver, "tagResolver")));
   }
 
   @Override
-  public Node.@NotNull Root deserializeToTree(final @NotNull String input) {
+  public Node.Root deserializeToTree(final String input) {
     return this.parser.parseToTree(this.newContext(input, null, null));
   }
 
   @Override
-  public Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull Pointered target) {
+  public Node.Root deserializeToTree(final String input, final Pointered target) {
     return this.parser.parseToTree(this.newContext(input, requireNonNull(target, "target"), null));
   }
 
   @Override
-  public Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull TagResolver tagResolver) {
+  public Node.Root deserializeToTree(final String input, final TagResolver tagResolver) {
     return this.parser.parseToTree(this.newContext(input, null, requireNonNull(tagResolver, "tagResolver")));
   }
 
   @Override
-  public Node.@NotNull Root deserializeToTree(final @NotNull String input, final @NotNull Pointered target, final @NotNull TagResolver tagResolver) {
+  public Node.Root deserializeToTree(final String input, final Pointered target, final TagResolver tagResolver) {
     return this.parser.parseToTree(this.newContext(input, requireNonNull(target, "target"), requireNonNull(tagResolver, "tagResolver")));
   }
 
   @Override
-  public @NotNull String serialize(final @NotNull Component component) {
+  public String serialize(final Component component) {
     return MiniMessageSerializer.serialize(component, this.serialResolver(null), this.strict);
   }
 
@@ -138,22 +137,22 @@ final class MiniMessageImpl implements MiniMessage {
   }
 
   @Override
-  public @NotNull String escapeTags(final @NotNull String input) {
+  public String escapeTags(final String input) {
     return this.parser.escapeTokens(this.newContext(input, null, null));
   }
 
   @Override
-  public @NotNull String escapeTags(final @NotNull String input, final @NotNull TagResolver tagResolver) {
+  public String escapeTags(final String input, final TagResolver tagResolver) {
     return this.parser.escapeTokens(this.newContext(input, null, tagResolver));
   }
 
   @Override
-  public @NotNull String stripTags(final @NotNull String input) {
+  public String stripTags(final String input) {
     return this.parser.stripTokens(this.newContext(input, null, null));
   }
 
   @Override
-  public @NotNull String stripTags(final @NotNull String input, final @NotNull TagResolver tagResolver) {
+  public String stripTags(final String input, final TagResolver tagResolver) {
     return this.parser.stripTokens(this.newContext(input, null, tagResolver));
   }
 
@@ -163,11 +162,11 @@ final class MiniMessageImpl implements MiniMessage {
   }
 
   @Override
-  public @NotNull TagResolver tags() {
+  public TagResolver tags() {
     return this.parser.tagResolver;
   }
 
-  private @NotNull ContextImpl newContext(final @NotNull String input, final @Nullable Pointered target, final @Nullable TagResolver resolver) {
+  private ContextImpl newContext(final String input, final @Nullable Pointered target, final @Nullable TagResolver resolver) {
     requireNonNull(input, "input");
     return new ContextImpl(this.strict, this.emitVirtuals, this.debugOutput, input, this, target, resolver, this.preProcessor, this.postProcessor);
   }
@@ -194,13 +193,13 @@ final class MiniMessageImpl implements MiniMessage {
     }
 
     @Override
-    public @NotNull Builder tags(final @NotNull TagResolver tags) {
+    public Builder tags(final TagResolver tags) {
       this.tagResolver = requireNonNull(tags, "tags");
       return this;
     }
 
     @Override
-    public @NotNull Builder editTags(final @NotNull Consumer<TagResolver.Builder> adder) {
+    public Builder editTags(final Consumer<TagResolver.Builder> adder) {
       requireNonNull(adder, "adder");
       final TagResolver.Builder builder = TagResolver.builder().resolver(this.tagResolver);
       adder.accept(builder);
@@ -209,37 +208,37 @@ final class MiniMessageImpl implements MiniMessage {
     }
 
     @Override
-    public @NotNull Builder strict(final boolean strict) {
+    public Builder strict(final boolean strict) {
       this.strict = strict;
       return this;
     }
 
     @Override
-    public @NotNull Builder emitVirtuals(final boolean emitVirtuals) {
+    public Builder emitVirtuals(final boolean emitVirtuals) {
       this.emitVirtuals = emitVirtuals;
       return this;
     }
 
     @Override
-    public @NotNull Builder debug(final @Nullable Consumer<String> debugOutput) {
+    public Builder debug(final @Nullable Consumer<String> debugOutput) {
       this.debug = debugOutput;
       return this;
     }
 
     @Override
-    public @NotNull Builder postProcessor(final @NotNull UnaryOperator<Component> postProcessor) {
+    public Builder postProcessor(final UnaryOperator<Component> postProcessor) {
       this.postProcessor = Objects.requireNonNull(postProcessor, "postProcessor");
       return this;
     }
 
     @Override
-    public @NotNull Builder preProcessor(final @NotNull UnaryOperator<String> preProcessor) {
+    public Builder preProcessor(final UnaryOperator<String> preProcessor) {
       this.preProcessor = Objects.requireNonNull(preProcessor, "preProcessor");
       return this;
     }
 
     @Override
-    public @NotNull MiniMessage build() {
+    public MiniMessage build() {
       return new MiniMessageImpl(this.tagResolver, this.strict, this.emitVirtuals, this.debug, this.preProcessor, this.postProcessor);
     }
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -45,8 +45,7 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.string.MultiLineStringExaminer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class MiniMessageParser {
   final TagResolver tagResolver;
@@ -59,13 +58,13 @@ final class MiniMessageParser {
     this.tagResolver = tagResolver;
   }
 
-  @NotNull String escapeTokens(final @NotNull ContextImpl context) {
+  String escapeTokens(final ContextImpl context) {
     final StringBuilder sb = new StringBuilder(context.message().length());
     this.escapeTokens(sb, context);
     return sb.toString();
   }
 
-  void escapeTokens(final StringBuilder sb, final @NotNull ContextImpl context) {
+  void escapeTokens(final StringBuilder sb, final ContextImpl context) {
     this.escapeTokens(sb, context.message(), context);
   }
 
@@ -86,17 +85,17 @@ final class MiniMessageParser {
     });
   }
 
-  @NotNull String stripTokens(final @NotNull ContextImpl context) {
+  String stripTokens(final ContextImpl context) {
     final StringBuilder sb = new StringBuilder(context.message().length());
     this.processTokens(sb, context, (token, builder) -> {});
     return sb.toString();
   }
 
-  private void processTokens(final @NotNull StringBuilder sb, final @NotNull ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {
+  private void processTokens(final StringBuilder sb, final ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {
     this.processTokens(sb, context.message(), context, tagHandler);
   }
 
-  private void processTokens(final @NotNull StringBuilder sb, final @NotNull String richMessage, final @NotNull ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {
+  private void processTokens(final StringBuilder sb, final String richMessage, final ContextImpl context, final BiConsumer<Token, StringBuilder> tagHandler) {
     final TagResolver combinedResolver = TagResolver.resolver(this.tagResolver, context.extraTags());
     final List<Token> root = TokenParser.tokenize(richMessage, true);
     for (final Token token : root) {
@@ -125,7 +124,7 @@ final class MiniMessageParser {
     }
   }
 
-  @NotNull RootNode parseToTree(final @NotNull ContextImpl context) {
+  RootNode parseToTree(final ContextImpl context) {
     final TagResolver combinedResolver = TagResolver.resolver(this.tagResolver, context.extraTags());
     final String processedMessage = context.preProcessor().apply(context.message());
     final Consumer<String> debug = context.debugOutput();
@@ -204,12 +203,12 @@ final class MiniMessageParser {
     return root;
   }
 
-  @NotNull Component parseFormat(final @NotNull ContextImpl context) {
+  Component parseFormat(final ContextImpl context) {
     final ElementNode root = this.parseToTree(context);
     return Objects.requireNonNull(context.postProcessor().apply(this.treeToComponent(root, context)), "Post-processor must not return null");
   }
 
-  @NotNull Component treeToComponent(final @NotNull ElementNode node, final @NotNull ContextImpl context) {
+  Component treeToComponent(final ElementNode node, final ContextImpl context) {
     Component comp = Component.empty();
     Tag tag = null;
     if (node instanceof ValueNode) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageSerializer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageSerializer.java
@@ -35,8 +35,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.Emitable;
 import net.kyori.adventure.text.minimessage.internal.serializer.QuotingOverride;
 import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
 import net.kyori.adventure.text.minimessage.internal.serializer.TokenEmitter;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -49,7 +48,7 @@ final class MiniMessageSerializer {
   // - abbreviated vs long tag names (tag-specific option)
   //
 
-  static @NotNull String serialize(final @NotNull Component component, final @NotNull SerializableResolver resolver, final boolean strict) {
+  static String serialize(final Component component, final SerializableResolver resolver, final boolean strict) {
     final StringBuilder sb = new StringBuilder();
     final Collector emitter = new Collector(resolver, strict, sb);
 
@@ -65,7 +64,7 @@ final class MiniMessageSerializer {
     return sb.toString();
   }
 
-  private static void visit(final @NotNull Component component, final Collector emitter, final SerializableResolver resolver, final boolean lastChild) {
+  private static void visit(final Component component, final Collector emitter, final SerializableResolver resolver, final boolean lastChild) {
     // visit self
     resolver.handle(component, emitter);
     Component childSource = emitter.flushClaims(component);
@@ -171,7 +170,7 @@ final class MiniMessageSerializer {
     // TokenEmitter
 
     @Override
-    public @NotNull Collector tag(final @NotNull String token) {
+    public Collector tag(final String token) {
       this.completeTag();
       this.consumer.append(TokenParser.TAG_START);
       this.escapeTagContent(token, QuotingOverride.UNQUOTED);
@@ -181,7 +180,7 @@ final class MiniMessageSerializer {
     }
 
     @Override
-    public @NotNull TokenEmitter selfClosingTag(final @NotNull String token) {
+    public TokenEmitter selfClosingTag(final String token) {
       this.completeTag();
       this.consumer.append(TokenParser.TAG_START);
       this.escapeTagContent(token, QuotingOverride.UNQUOTED);
@@ -190,7 +189,7 @@ final class MiniMessageSerializer {
     }
 
     @Override
-    public @NotNull TokenEmitter argument(final @NotNull String arg) {
+    public TokenEmitter argument(final String arg) {
       if (!this.tagState.isTag) {
         throw new IllegalStateException("Not within a tag!");
       }
@@ -200,7 +199,7 @@ final class MiniMessageSerializer {
     }
 
     @Override
-    public @NotNull TokenEmitter argument(final @NotNull String arg, final @NotNull QuotingOverride quotingPreference) {
+    public TokenEmitter argument(final String arg, final QuotingOverride quotingPreference) {
       if (!this.tagState.isTag) {
         throw new IllegalStateException("Not within a tag!");
       }
@@ -210,13 +209,13 @@ final class MiniMessageSerializer {
     }
 
     @Override
-    public @NotNull TokenEmitter argument(final @NotNull Component arg) {
+    public TokenEmitter argument(final Component arg) {
       final String serialized = MiniMessageSerializer.serialize(arg, this.resolver, this.strict);
       return this.argument(serialized, QuotingOverride.QUOTED); // always quote tokens
     }
 
     @Override
-    public @NotNull Collector text(final @NotNull String text) {
+    public Collector text(final String text) {
       this.completeTag();
       // escape '\' and '<'
       appendEscaping(this.consumer, text, TEXT_ESCAPES, true);
@@ -288,12 +287,12 @@ final class MiniMessageSerializer {
     }
 
     @Override
-    public @NotNull Collector pop() {
+    public Collector pop() {
       this.emitClose(this.popTag(false));
       return this;
     }
 
-    private void emitClose(final @NotNull String tag) {
+    private void emitClose(final String tag) {
       // currently: we don't keep any arguments, does it ever make sense to?
       if (this.tagState.isTag) {
         if (this.tagState == TagState.MID) { // not _SELF_CLOSING
@@ -315,14 +314,14 @@ final class MiniMessageSerializer {
     final Set<String> claimedStyleElements = new HashSet<>();
 
     @Override
-    public void style(final @NotNull String claimKey, final @NotNull Emitable styleClaim) {
+    public void style(final String claimKey, final Emitable styleClaim) {
       if (this.claimedStyleElements.add(requireNonNull(claimKey, "claimKey"))) {
         styleClaim.emit(this);
       }
     }
 
     @Override
-    public boolean component(final @NotNull Emitable componentClaim) {
+    public boolean component(final Emitable componentClaim) {
       if (this.componentClaim != null) return false;
 
       this.componentClaim = requireNonNull(componentClaim, "componentClaim");
@@ -335,7 +334,7 @@ final class MiniMessageSerializer {
     }
 
     @Override
-    public boolean styleClaimed(final @NotNull String claimId) {
+    public boolean styleClaimed(final String claimId) {
       return this.claimedStyleElements.contains(claimId);
     }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ParsingException.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ParsingException.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.text.minimessage;
 
 import java.io.Serial;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An exception thrown when an error occurs while parsing a MiniMessage string.
@@ -79,7 +78,7 @@ public abstract class ParsingException extends RuntimeException {
    * @return the original input message
    * @since 4.10.0
    */
-  public abstract @NotNull String originalText();
+  public abstract String originalText();
 
   /**
    * Get the detail message optionally passed with this exception.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ParsingException.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/ParsingException.java
@@ -23,11 +23,10 @@
  */
 package net.kyori.adventure.text.minimessage;
 
+import java.io.Serial;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.io.Serial;
 
 /**
  * An exception thrown when an error occurs while parsing a MiniMessage string.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/TagInternals.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/TagInternals.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 import net.kyori.adventure.text.minimessage.tag.TagPattern;
 import org.intellij.lang.annotations.RegExp;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Utility class for tag naming.
@@ -51,7 +50,7 @@ public final class TagInternals {
    * @param tagName the name of the tag
    * @since 4.10.0
    */
-  public static void assertValidTagName(@TagPattern final @NotNull String tagName) {
+  public static void assertValidTagName(@TagPattern final String tagName) {
     if (!TAG_NAME_PATTERN.matcher(Objects.requireNonNull(tagName)).matches()) {
       throw new IllegalArgumentException("Tag name must match pattern " + TAG_NAME_PATTERN.pattern() + ", was " + tagName);
     }
@@ -65,7 +64,7 @@ public final class TagInternals {
    * @return validity of this tag when sanitized
    * @since 4.10.1
    */
-  public static boolean sanitizeAndCheckValidTagName(@TagPattern final @NotNull String tagName) {
+  public static boolean sanitizeAndCheckValidTagName(@TagPattern final String tagName) {
     return TAG_NAME_PATTERN.matcher(Objects.requireNonNull(tagName).toLowerCase(Locale.ROOT)).matches();
   }
 
@@ -77,7 +76,7 @@ public final class TagInternals {
    * @param tagName the name of the tag
    * @since 4.10.0
    */
-  public static void sanitizeAndAssertValidTagName(@TagPattern final @NotNull String tagName) {
+  public static void sanitizeAndAssertValidTagName(@TagPattern final String tagName) {
     assertValidTagName(Objects.requireNonNull(tagName).toLowerCase(Locale.ROOT));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/ParsingExceptionImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/ParsingExceptionImpl.java
@@ -27,8 +27,7 @@ import java.io.Serial;
 import java.util.Arrays;
 import net.kyori.adventure.text.minimessage.ParsingException;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An exception that happens while parsing.
@@ -40,7 +39,7 @@ public class ParsingExceptionImpl extends ParsingException {
   private static final @Serial long serialVersionUID = 2507190809441787202L;
 
   private final String originalText;
-  private Token @NotNull [] tokens;
+  private Token [] tokens;
 
   /**
    * Create a new parsing exception.
@@ -53,7 +52,7 @@ public class ParsingExceptionImpl extends ParsingException {
   public ParsingExceptionImpl(
     final String message,
     final @Nullable String originalText,
-    final @NotNull Token @NotNull ... tokens
+    final Token ... tokens
   ) {
     super(message, null, true, false);
     this.tokens = tokens;
@@ -75,7 +74,7 @@ public class ParsingExceptionImpl extends ParsingException {
     final @Nullable String originalText,
     final @Nullable Throwable cause,
     final boolean withStackTrace,
-    final @NotNull Token @NotNull ... tokens
+    final Token ... tokens
   ) {
     super(message, cause, true, withStackTrace);
     this.tokens = tokens;
@@ -115,7 +114,7 @@ public class ParsingExceptionImpl extends ParsingException {
    * @return the tokens for this error
    * @since 4.10.0
    */
-  public @NotNull Token @NotNull [] tokens() {
+  public Token [] tokens() {
     return this.tokens;
   }
 
@@ -125,12 +124,12 @@ public class ParsingExceptionImpl extends ParsingException {
    * @param tokens the tokens for this error
    * @since 4.10.0
    */
-  public void tokens(final @NotNull Token @NotNull [] tokens) {
+  public void tokens(final Token [] tokens) {
     this.tokens = tokens;
   }
 
   private String arrow() {
-    final @NotNull Token[] ts = this.tokens();
+    final Token[] ts = this.tokens();
     final char[] chars = new char[ts[ts.length - 1].endIndex()];
 
     int i = 0;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/Token.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/Token.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a token for the lexer.
@@ -119,7 +118,7 @@ public final class Token implements Examinable {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("startIndex", this.startIndex),
       ExaminableProperty.of("endIndex", this.endIndex),

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
@@ -44,8 +44,7 @@ import net.kyori.adventure.text.minimessage.tag.Inserting;
 import net.kyori.adventure.text.minimessage.tag.ParserDirective;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Handles parsing a string into a list of tokens and then into a tree of nodes.
@@ -79,10 +78,10 @@ public final class TokenParser {
    * @since 4.10.0
    */
   public static RootNode parse(
-    final @NotNull TagProvider tagProvider,
-    final @NotNull Predicate<String> tagNameChecker,
-    final @NotNull String message,
-    final @NotNull String originalMessage,
+    final TagProvider tagProvider,
+    final Predicate<String> tagNameChecker,
+    final String message,
+    final String originalMessage,
     final boolean strict
   ) throws ParsingException {
     // collect tokens...
@@ -382,11 +381,11 @@ public final class TokenParser {
    * Build a tree from the OPEN_TAG and CLOSE_TAG tokens
    */
   private static RootNode buildTree(
-    final @NotNull TagProvider tagProvider,
-    final @NotNull Predicate<String> tagNameChecker,
-    final @NotNull List<Token> tokens,
-    final @NotNull String message,
-    final @NotNull String originalMessage,
+    final TagProvider tagProvider,
+    final Predicate<String> tagNameChecker,
+    final List<Token> tokens,
+    final String message,
+    final String originalMessage,
     final boolean strict
   ) throws ParsingException {
     final RootNode root = new RootNode(message, originalMessage);
@@ -674,7 +673,7 @@ public final class TokenParser {
      * @return a tag
      * @since 4.10.0
      */
-    @Nullable Tag resolve(final @NotNull String name, final @NotNull List<? extends Tag.Argument> trimmedArgs, final @Nullable Token token);
+    @Nullable Tag resolve(final String name, final List<? extends Tag.Argument> trimmedArgs, final @Nullable Token token);
 
     /**
      * Resolve by sanitized name.
@@ -683,7 +682,7 @@ public final class TokenParser {
      * @return a tag, if any is available
      * @since 4.10.0
      */
-    default @Nullable Tag resolve(final @NotNull String name) {
+    default @Nullable Tag resolve(final String name) {
       return this.resolve(name, Collections.emptyList(), null);
     }
 
@@ -694,7 +693,7 @@ public final class TokenParser {
      * @return a tag, if any is available
      * @since 4.10.0
      */
-    default @Nullable Tag resolve(final @NotNull TagNode node) {
+    default @Nullable Tag resolve(final TagNode node) {
       return this.resolve(
         sanitizePlaceholderName(node.name()),
         node.parts().subList(1, node.parts().size()),
@@ -711,7 +710,7 @@ public final class TokenParser {
      * @return a sanitized name
      * @since 4.10.0
      */
-    static @NotNull String sanitizePlaceholderName(final @NotNull String name) {
+    static String sanitizePlaceholderName(final String name) {
       return name.toLowerCase(Locale.ROOT);
     }
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/MatchedTokenConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/MatchedTokenConsumer.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.minimessage.internal.parser.match;
 
 import net.kyori.adventure.text.minimessage.internal.parser.TokenType;
 import org.jetbrains.annotations.MustBeInvokedByOverriders;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnknownNullability;
 
 /**
@@ -45,7 +44,7 @@ public abstract class MatchedTokenConsumer<T> {
    * @param input the input
    * @since 4.10.0
    */
-  public MatchedTokenConsumer(final @NotNull String input) {
+  public MatchedTokenConsumer(final String input) {
     this.input = input;
   }
 
@@ -58,7 +57,7 @@ public abstract class MatchedTokenConsumer<T> {
    * @since 4.10.0
    */
   @MustBeInvokedByOverriders
-  public void accept(final int start, final int end, final @NotNull TokenType tokenType) {
+  public void accept(final int start, final int end, final TokenType tokenType) {
     this.lastIndex = end;
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/StringResolvingMatchedTokenConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/StringResolvingMatchedTokenConsumer.java
@@ -34,8 +34,7 @@ import net.kyori.adventure.text.minimessage.internal.parser.TokenType;
 import net.kyori.adventure.text.minimessage.internal.parser.node.TagPart;
 import net.kyori.adventure.text.minimessage.tag.PreProcess;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static net.kyori.adventure.text.minimessage.internal.parser.TokenParser.SEPARATOR;
 import static net.kyori.adventure.text.minimessage.internal.parser.TokenParser.tokenize;
@@ -57,8 +56,8 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
    * @since 4.10.0
    */
   public StringResolvingMatchedTokenConsumer(
-    final @NotNull String input,
-    final @NotNull TagProvider tagProvider
+    final String input,
+    final TagProvider tagProvider
   ) {
     super(input);
     this.builder = new StringBuilder(input.length());
@@ -66,7 +65,7 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
   }
 
   @Override
-  public void accept(final int start, final int end, final @NotNull TokenType tokenType) {
+  public void accept(final int start, final int end, final TokenType tokenType) {
     super.accept(start, end, tokenType);
 
     if (tokenType != TokenType.OPEN_TAG) {
@@ -105,7 +104,7 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
   }
 
   @Override
-  public @NotNull String result() {
+  public String result() {
     return this.builder.toString();
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/TokenListProducingMatchedTokenConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/TokenListProducingMatchedTokenConsumer.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenType;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A matched token consumer that produces a list of matched tokens.
@@ -44,12 +43,12 @@ public final class TokenListProducingMatchedTokenConsumer extends MatchedTokenCo
    * @param input the input
    * @since 4.10.0
    */
-  public TokenListProducingMatchedTokenConsumer(final @NotNull String input) {
+  public TokenListProducingMatchedTokenConsumer(final String input) {
     super(input);
   }
 
   @Override
-  public void accept(final int start, final int end, final @NotNull TokenType tokenType) {
+  public void accept(final int start, final int end, final TokenType tokenType) {
     super.accept(start, end, tokenType);
 
     if (this.result == null) {
@@ -60,7 +59,7 @@ public final class TokenListProducingMatchedTokenConsumer extends MatchedTokenCo
   }
 
   @Override
-  public @NotNull List<Token> result() {
+  public List<Token> result() {
     return this.result == null ? Collections.emptyList() : this.result;
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/ElementNode.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/ElementNode.java
@@ -30,8 +30,7 @@ import java.util.List;
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenType;
 import net.kyori.adventure.text.minimessage.tree.Node;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a node in the tree.
@@ -52,7 +51,7 @@ public sealed class ElementNode implements Node permits RootNode, TagNode, Value
    * @param sourceMessage the source message
    * @since 4.10.0
    */
-  ElementNode(final @Nullable ElementNode parent, final @Nullable Token token, final @NotNull String sourceMessage) {
+  ElementNode(final @Nullable ElementNode parent, final @Nullable Token token, final String sourceMessage) {
     this.parent = parent;
     this.token = token;
     this.sourceMessage = sourceMessage;
@@ -85,7 +84,7 @@ public sealed class ElementNode implements Node permits RootNode, TagNode, Value
    * @return the source message
    * @since 4.10.0
    */
-  public @NotNull String sourceMessage() {
+  public String sourceMessage() {
     return this.sourceMessage;
   }
 
@@ -96,7 +95,7 @@ public sealed class ElementNode implements Node permits RootNode, TagNode, Value
    * @since 4.10.0
    */
   @Override
-  public @NotNull List<ElementNode> children() {
+  public List<ElementNode> children() {
     return Collections.unmodifiableList(this.children);
   }
 
@@ -106,7 +105,7 @@ public sealed class ElementNode implements Node permits RootNode, TagNode, Value
    * @return the children of this node
    * @since 4.10.0
    */
-  public @NotNull List<ElementNode> unsafeChildren() {
+  public List<ElementNode> unsafeChildren() {
     return this.children;
   }
 
@@ -118,7 +117,7 @@ public sealed class ElementNode implements Node permits RootNode, TagNode, Value
    * @param childNode the child node to add.
    * @since 4.10.0
    */
-  public void addChild(final @NotNull ElementNode childNode) {
+  public void addChild(final ElementNode childNode) {
     final int last = this.children.size() - 1;
     if (!(childNode instanceof TextNode) || this.children.isEmpty() || !(this.children.get(last) instanceof TextNode)) {
       this.children.add(childNode);
@@ -143,7 +142,7 @@ public sealed class ElementNode implements Node permits RootNode, TagNode, Value
    * @return the passed string builder, for chaining
    * @since 4.10.0
    */
-  public @NotNull StringBuilder buildToString(final @NotNull StringBuilder sb, final int indent) {
+  public StringBuilder buildToString(final StringBuilder sb, final int indent) {
     final char[] in = this.ident(indent);
     sb.append(in).append("Node {\n");
     for (final ElementNode child : this.children) {
@@ -153,14 +152,14 @@ public sealed class ElementNode implements Node permits RootNode, TagNode, Value
     return sb;
   }
 
-  char @NotNull [] ident(final int indent) {
+  char [] ident(final int indent) {
     final char[] c = new char[indent * 2];
     Arrays.fill(c, ' ');
     return c;
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return this.buildToString(new StringBuilder(), 0).toString();
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/RootNode.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/RootNode.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.minimessage.internal.parser.node;
 
 import net.kyori.adventure.text.minimessage.tree.Node;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents the root node of a tree.
@@ -41,13 +40,13 @@ public final class RootNode extends ElementNode implements Node.Root {
    * @param beforePreprocessing the source message before handling preProcess tags
    * @since 4.10.0
    */
-  public RootNode(final @NotNull String sourceMessage, final @NotNull String beforePreprocessing) {
+  public RootNode(final String sourceMessage, final String beforePreprocessing) {
     super(null, null, sourceMessage);
     this.beforePreprocessing = beforePreprocessing;
   }
 
   @Override
-  public @NotNull String input() {
+  public String input() {
     return this.beforePreprocessing;
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TagNode.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TagNode.java
@@ -30,8 +30,7 @@ import net.kyori.adventure.text.minimessage.internal.parser.ParsingExceptionImpl
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenParser;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Node that represents a tag.
@@ -52,10 +51,10 @@ public final class TagNode extends ElementNode {
    * @since 4.10.0
    */
   public TagNode(
-      final @NotNull ElementNode parent,
-      final @NotNull Token token,
-      final @NotNull String sourceMessage,
-      final TokenParser.@NotNull TagProvider tagProvider
+      final ElementNode parent,
+      final Token token,
+      final String sourceMessage,
+      final TokenParser.TagProvider tagProvider
   ) {
     super(parent, token, sourceMessage);
     this.parts = genParts(token, sourceMessage, tagProvider);
@@ -66,10 +65,10 @@ public final class TagNode extends ElementNode {
     }
   }
 
-  private static @NotNull List<TagPart> genParts(
-    final @NotNull Token token,
-    final @NotNull String sourceMessage,
-    final TokenParser.@NotNull TagProvider tagProvider
+  private static List<TagPart> genParts(
+    final Token token,
+    final String sourceMessage,
+    final TokenParser.TagProvider tagProvider
   ) {
     final ArrayList<TagPart> parts = new ArrayList<>();
 
@@ -88,7 +87,7 @@ public final class TagNode extends ElementNode {
    * @return the parts
    * @since 4.10.0
    */
-  public @NotNull List<TagPart> parts() {
+  public List<TagPart> parts() {
     return this.parts;
   }
 
@@ -98,12 +97,12 @@ public final class TagNode extends ElementNode {
    * @return the name
    * @since 4.10.0
    */
-  public @NotNull String name() {
+  public String name() {
     return this.parts.get(0).value();
   }
 
   @Override
-  public @NotNull Token token() {
+  public Token token() {
     return Objects.requireNonNull(super.token(), "token is not set");
   }
 
@@ -113,7 +112,7 @@ public final class TagNode extends ElementNode {
    * @return the tag for this tag node
    * @since 4.10.0
    */
-  public @NotNull Tag tag() {
+  public Tag tag() {
     return Objects.requireNonNull(this.tag, "no tag set");
   }
 
@@ -123,12 +122,12 @@ public final class TagNode extends ElementNode {
    * @param tag the tag logic
    * @since 4.10.0
    */
-  public void tag(final @NotNull Tag tag) {
+  public void tag(final Tag tag) {
     this.tag = tag;
   }
 
   @Override
-  public @NotNull StringBuilder buildToString(final @NotNull StringBuilder sb, final int indent) {
+  public StringBuilder buildToString(final StringBuilder sb, final int indent) {
     final char[] in = this.ident(indent);
     sb.append(in).append("TagNode(");
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TagPart.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TagPart.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.minimessage.internal.parser.node;
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenParser;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an inner part of a tag.
@@ -46,9 +45,9 @@ public final class TagPart implements Tag.Argument {
    * @since 4.10.0
    */
   public TagPart(
-    final @NotNull String sourceMessage,
-    final @NotNull Token token,
-    final TokenParser.@NotNull TagProvider tagResolver
+    final String sourceMessage,
+    final Token token,
+    final TokenParser.TagProvider tagResolver
   ) {
     String v = unquoteAndEscape(sourceMessage, token.startIndex(), token.endIndex());
     v = TokenParser.resolvePreProcessTags(v, tagResolver);
@@ -64,7 +63,7 @@ public final class TagPart implements Tag.Argument {
    * @since 4.10.0
    */
   @Override
-  public @NotNull String value() {
+  public String value() {
     return this.value;
   }
 
@@ -74,7 +73,7 @@ public final class TagPart implements Tag.Argument {
    * @return the token
    * @since 4.10.0
    */
-  public @NotNull Token token() {
+  public Token token() {
     return this.token;
   }
 
@@ -87,7 +86,7 @@ public final class TagPart implements Tag.Argument {
    * @return the output substring
    * @since 4.10.0
    */
-  public static @NotNull String unquoteAndEscape(final @NotNull String text, final int start, final int end) {
+  public static String unquoteAndEscape(final String text, final int start, final int end) {
     if (start == end) {
       return "";
     }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TextNode.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/TextNode.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.text.minimessage.internal.parser.node;
 
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenParser;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a string of chars.
@@ -48,8 +47,8 @@ public final class TextNode extends ValueNode {
    */
   public TextNode(
     final @Nullable ElementNode parent,
-    final @NotNull Token token,
-    final @NotNull String sourceMessage
+    final Token token,
+    final String sourceMessage
   ) {
     super(parent, token, sourceMessage, TokenParser.unescape(sourceMessage, token.startIndex(), token.endIndex(), TextNode::isEscape));
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/ValueNode.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/node/ValueNode.java
@@ -25,8 +25,7 @@ package net.kyori.adventure.text.minimessage.internal.parser.node;
 
 import java.util.Objects;
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a node in the tree which has a text value.
@@ -46,7 +45,7 @@ public sealed abstract class ValueNode extends ElementNode permits TextNode {
    * @param value the value of this text node
    * @since 4.10.0
    */
-  ValueNode(final @Nullable ElementNode parent, final @Nullable Token token, final @NotNull String sourceMessage, final @NotNull String value) {
+  ValueNode(final @Nullable ElementNode parent, final @Nullable Token token, final String sourceMessage, final String value) {
     super(parent, token, sourceMessage);
     this.value = value;
   }
@@ -59,17 +58,17 @@ public sealed abstract class ValueNode extends ElementNode permits TextNode {
    * @return the value
    * @since 4.10.0
    */
-  public @NotNull String value() {
+  public String value() {
     return this.value;
   }
 
   @Override
-  public @NotNull Token token() {
+  public Token token() {
     return Objects.requireNonNull(super.token(), "token is not set");
   }
 
   @Override
-  public @NotNull StringBuilder buildToString(final @NotNull StringBuilder sb, final int indent) {
+  public StringBuilder buildToString(final StringBuilder sb, final int indent) {
     final char[] in = this.ident(indent);
     sb.append(in).append(this.valueName()).append("('").append(this.value).append("')\n");
     return sb;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/ClaimConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/ClaimConsumer.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.text.minimessage.internal.serializer;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A consumer of serialization claims.
  *
@@ -40,7 +38,7 @@ public interface ClaimConsumer {
    * @param styleClaim the claim of a style
    * @since 4.10.0
    */
-  void style(final @NotNull String claimKey, final @NotNull Emitable styleClaim);
+  void style(final String claimKey, final Emitable styleClaim);
 
   /**
    * Submit a component claim for the active component.
@@ -51,7 +49,7 @@ public interface ClaimConsumer {
    * @return whether the claim was successful
    * @since 4.10.0
    */
-  boolean component(final @NotNull Emitable componentClaim);
+  boolean component(final Emitable componentClaim);
 
   /**
    * Get whether a style element has been claimed yet.
@@ -60,7 +58,7 @@ public interface ClaimConsumer {
    * @return whether style is claimed
    * @since 4.10.0
    */
-  boolean styleClaimed(final @NotNull String claimId);
+  boolean styleClaimed(final String claimId);
 
   /**
    * Get whether a component has been claimed yet.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/ComponentClaimingResolverImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/ComponentClaimingResolverImpl.java
@@ -32,13 +32,12 @@ import net.kyori.adventure.text.minimessage.ParsingException;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 class ComponentClaimingResolverImpl implements TagResolver, SerializableResolver.Single {
-  private final @NotNull Set<String> names;
-  private final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler;
-  private final @NotNull Function<Component, @Nullable Emitable> componentClaim;
+  private final Set<String> names;
+  private final BiFunction<ArgumentQueue, Context, Tag> handler;
+  private final Function<Component, @Nullable Emitable> componentClaim;
 
   ComponentClaimingResolverImpl(final Set<String> names, final BiFunction<ArgumentQueue, Context, Tag> handler, final Function<Component, @Nullable Emitable> componentClaim) {
     this.names = names;
@@ -47,19 +46,19 @@ class ComponentClaimingResolverImpl implements TagResolver, SerializableResolver
   }
 
   @Override
-  public @Nullable Tag resolve(final @NotNull String name, final @NotNull ArgumentQueue arguments, final @NotNull Context ctx) throws ParsingException {
+  public @Nullable Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) throws ParsingException {
     if (!this.names.contains(name)) return null;
 
     return this.handler.apply(arguments, ctx);
   }
 
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     return this.names.contains(name);
   }
 
   @Override
-  public @Nullable Emitable claimComponent(final @NotNull Component component) {
+  public @Nullable Emitable claimComponent(final Component component) {
     return this.componentClaim.apply(component);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/Emitable.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/Emitable.java
@@ -24,8 +24,7 @@
 package net.kyori.adventure.text.minimessage.internal.serializer;
 
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Something that holds data representable as MiniMessage tags.
@@ -40,7 +39,7 @@ public interface Emitable {
    * @param emitter the target to emit to
    * @since 4.10.0
    */
-  void emit(final @NotNull TokenEmitter emitter);
+  void emit(final TokenEmitter emitter);
 
   /**
    * Provide a substitute for this component's actual children.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/SerializableResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/SerializableResolver.java
@@ -35,8 +35,7 @@ import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -55,7 +54,7 @@ public interface SerializableResolver {
    * @return a resolver that creates tags using the provided handler
    * @since 4.10.0
    */
-  static @NotNull TagResolver claimingComponent(final @NotNull String name, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler, final @NotNull Function<Component, @Nullable Emitable> componentClaim) {
+  static TagResolver claimingComponent(final String name, final BiFunction<ArgumentQueue, Context, Tag> handler, final Function<Component, @Nullable Emitable> componentClaim) {
     return claimingComponent(Collections.singleton(name), handler, componentClaim);
   }
 
@@ -68,7 +67,7 @@ public interface SerializableResolver {
    * @return a resolver that creates tags using the provided handler
    * @since 4.10.0
    */
-  static @NotNull TagResolver claimingComponent(final @NotNull Set<String> names, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler, final @NotNull Function<Component, @Nullable Emitable> componentClaim) {
+  static TagResolver claimingComponent(final Set<String> names, final BiFunction<ArgumentQueue, Context, Tag> handler, final Function<Component, @Nullable Emitable> componentClaim) {
     final Set<String> ownNames = new HashSet<>(names);
     for (final String name : ownNames) {
       TagInternals.assertValidTagName(name);
@@ -86,7 +85,7 @@ public interface SerializableResolver {
    * @return a resolver that creates tags using the provided handler
    * @since 4.10.0
    */
-  static @NotNull TagResolver claimingStyle(final @NotNull String name, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler, final @NotNull StyleClaim<?> styleClaim) {
+  static TagResolver claimingStyle(final String name, final BiFunction<ArgumentQueue, Context, Tag> handler, final StyleClaim<?> styleClaim) {
     return claimingStyle(Collections.singleton(name), handler, styleClaim);
   }
 
@@ -99,7 +98,7 @@ public interface SerializableResolver {
    * @return a resolver that creates tags using the provided handler
    * @since 4.10.0
    */
-  static @NotNull TagResolver claimingStyle(final @NotNull Set<String> names, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler, final @NotNull StyleClaim<?> styleClaim) {
+  static TagResolver claimingStyle(final Set<String> names, final BiFunction<ArgumentQueue, Context, Tag> handler, final StyleClaim<?> styleClaim) {
     final Set<String> ownNames = new HashSet<>(names);
     for (final String name : ownNames) {
       TagInternals.assertValidTagName(name);
@@ -115,7 +114,7 @@ public interface SerializableResolver {
    * @param consumer a consumer for component claims, must not be stored
    * @since 4.10.0
    */
-  void handle(final @NotNull Component serializable, final @NotNull ClaimConsumer consumer);
+  void handle(final Component serializable, final ClaimConsumer consumer);
 
   /**
    * A subinterface for resolvers that only handle one single tag.
@@ -124,7 +123,7 @@ public interface SerializableResolver {
    */
   interface Single extends SerializableResolver {
     @Override
-    default void handle(final @NotNull Component serializable, final @NotNull ClaimConsumer consumer) {
+    default void handle(final Component serializable, final ClaimConsumer consumer) {
       final @Nullable StyleClaim<?> style = this.claimStyle();
       if (style != null && !consumer.styleClaimed(style.claimKey())) {
         final @Nullable Emitable applied = style.apply(serializable.style());
@@ -164,7 +163,7 @@ public interface SerializableResolver {
      * @return an emitable if this claimer handles the provided component type
      * @since 4.10.0
      */
-    default @Nullable Emitable claimComponent(final @NotNull Component component) {
+    default @Nullable Emitable claimComponent(final Component component) {
       return null;
     }
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/StyleClaim.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/StyleClaim.java
@@ -27,8 +27,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -49,7 +48,7 @@ public interface StyleClaim<V> {
    * @return a new claim
    * @since 4.10.0
    */
-  static <T> @NotNull StyleClaim<T> claim(final @NotNull String claimKey, final @NotNull Function<Style, @Nullable T> lens, final @NotNull BiConsumer<T, TokenEmitter> emitable) {
+  static <T> StyleClaim<T> claim(final String claimKey, final Function<Style, @Nullable T> lens, final BiConsumer<T, TokenEmitter> emitable) {
     return claim(claimKey, lens, $ -> true, emitable);
   }
 
@@ -64,7 +63,7 @@ public interface StyleClaim<V> {
    * @return a new claim
    * @since 4.10.0
    */
-  static <T> @NotNull StyleClaim<T> claim(final @NotNull String claimKey, final @NotNull Function<Style, @Nullable T> lens, final @NotNull Predicate<T> filter, final @NotNull BiConsumer<T, TokenEmitter> emitable) {
+  static <T> StyleClaim<T> claim(final String claimKey, final Function<Style, @Nullable T> lens, final Predicate<T> filter, final BiConsumer<T, TokenEmitter> emitable) {
     return new StyleClaimImpl<>(
       requireNonNull(claimKey, "claimKey"),
       requireNonNull(lens, "lens"),
@@ -79,7 +78,7 @@ public interface StyleClaim<V> {
    * @return the key to claim
    * @since 4.10.0
    */
-  @NotNull String claimKey(); // TODO: multiple claim keys? for custom styling tags?
+  String claimKey(); // TODO: multiple claim keys? for custom styling tags?
 
   /**
    * Prepare an emitable to apply this claim based on the style.
@@ -88,5 +87,5 @@ public interface StyleClaim<V> {
    * @return an emitable for this style claim, if it is applicable to the provided style
    * @since 4.10.0
    */
-  @Nullable Emitable apply(final @NotNull Style style);
+  @Nullable Emitable apply(final Style style);
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/StyleClaimImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/StyleClaimImpl.java
@@ -28,8 +28,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import net.kyori.adventure.text.format.Style;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 class StyleClaimImpl<V> implements StyleClaim<V> {
   private final String claimKey;
@@ -45,12 +44,12 @@ class StyleClaimImpl<V> implements StyleClaim<V> {
   }
 
   @Override
-  public @NotNull String claimKey() {
+  public String claimKey() {
     return this.claimKey;
   }
 
   @Override
-  public @Nullable Emitable apply(final @NotNull Style style) {
+  public @Nullable Emitable apply(final Style style) {
     final V element = this.lens.apply(style);
     if (element == null || !this.filter.test(element)) return null;
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/StyleClaimingResolverImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/StyleClaimingResolverImpl.java
@@ -30,29 +30,28 @@ import net.kyori.adventure.text.minimessage.ParsingException;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class StyleClaimingResolverImpl implements TagResolver, SerializableResolver.Single {
-  private final @NotNull Set<String> names;
-  private final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler;
-  private final @NotNull StyleClaim<?> styleClaim;
+  private final Set<String> names;
+  private final BiFunction<ArgumentQueue, Context, Tag> handler;
+  private final StyleClaim<?> styleClaim;
 
-  StyleClaimingResolverImpl(final @NotNull Set<String> names, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler, final @NotNull StyleClaim<?> styleClaim) {
+  StyleClaimingResolverImpl(final Set<String> names, final BiFunction<ArgumentQueue, Context, Tag> handler, final StyleClaim<?> styleClaim) {
     this.names = names;
     this.handler = handler;
     this.styleClaim = styleClaim;
   }
 
   @Override
-  public @Nullable Tag resolve(final @NotNull String name, final @NotNull ArgumentQueue arguments, final @NotNull Context ctx) throws ParsingException {
+  public @Nullable Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) throws ParsingException {
     if (!this.names.contains(name)) return null;
 
     return this.handler.apply(arguments, ctx);
   }
 
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     return this.names.contains(name);
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/TokenEmitter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/TokenEmitter.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.minimessage.internal.serializer;
 
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A consumer of tokens used to generate MiniMessage output.
@@ -39,7 +38,7 @@ public interface TokenEmitter {
    * @return this emitter
    * @since 4.10.0
    */
-  @NotNull TokenEmitter tag(final @NotNull String token); // TODO: some sort of TagFlags, with things like SELF_CLOSING, CLOSE_WITH_ARGUMENTS, etc?
+  TokenEmitter tag(final String token); // TODO: some sort of TagFlags, with things like SELF_CLOSING, CLOSE_WITH_ARGUMENTS, etc?
 
   /**
    * Open a tag with or without arguments that cannot have children.
@@ -50,7 +49,7 @@ public interface TokenEmitter {
    * @return this emitter
    * @since 4.10.0
    */
-  @NotNull TokenEmitter selfClosingTag(final @NotNull String token); // TODO: some sort of TagFlags, with things like SELF_CLOSING, CLOSE_WITH_ARGUMENTS, etc?
+  TokenEmitter selfClosingTag(final String token); // TODO: some sort of TagFlags, with things like SELF_CLOSING, CLOSE_WITH_ARGUMENTS, etc?
 
   /**
    * Add arguments to the current tag.
@@ -61,7 +60,7 @@ public interface TokenEmitter {
    * @return this emitter
    * @since 4.10.0
    */
-  default @NotNull TokenEmitter arguments(final @NotNull String... args) {
+  default TokenEmitter arguments(final String... args) {
     for (final String arg : args) {
       this.argument(arg);
     }
@@ -77,7 +76,7 @@ public interface TokenEmitter {
    * @return this emitter
    * @since 4.10.0
    */
-  @NotNull TokenEmitter argument(final @NotNull String arg);
+  TokenEmitter argument(final String arg);
 
   /**
    * Add a single argument to the current tag.
@@ -89,7 +88,7 @@ public interface TokenEmitter {
    * @return this emitter
    * @since 4.10.0
    */
-  @NotNull TokenEmitter argument(final @NotNull String arg, final @NotNull QuotingOverride quotingPreference);
+  TokenEmitter argument(final String arg, final QuotingOverride quotingPreference);
 
   /**
    * Add a single argument to the current tag.
@@ -100,7 +99,7 @@ public interface TokenEmitter {
    * @return this emitter
    * @since 4.10.0
    */
-  @NotNull TokenEmitter argument(final @NotNull Component arg);
+  TokenEmitter argument(final Component arg);
 
   /**
    * Emit literal text.
@@ -111,7 +110,7 @@ public interface TokenEmitter {
    * @return this emitter
    * @since 4.10.0
    */
-  @NotNull TokenEmitter text(final @NotNull String text);
+  TokenEmitter text(final String text);
 
   /**
    * Explicitly end a token, only needed if there are multiple tokens within an {@link Emitable} for some reason.
@@ -121,5 +120,5 @@ public interface TokenEmitter {
    * @return this emitter
    * @since 4.10.0
    */
-  @NotNull TokenEmitter pop();
+  TokenEmitter pop();
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/CallbackStylingTagImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/CallbackStylingTagImpl.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 final class CallbackStylingTagImpl extends AbstractTag implements Inserting {
   private final Consumer<Style.Builder> styles;
@@ -39,7 +38,7 @@ final class CallbackStylingTagImpl extends AbstractTag implements Inserting {
   }
 
   @Override
-  public @NotNull Component value() {
+  public Component value() {
     return Component.text("", Style.style(this.styles));
   }
 
@@ -57,7 +56,7 @@ final class CallbackStylingTagImpl extends AbstractTag implements Inserting {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("styles", this.styles));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Inserting.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Inserting.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.minimessage.tag;
 
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A tag that inserts a {@link Component} into the output.
@@ -38,7 +37,7 @@ public non-sealed interface Inserting extends Tag {
    * @return the component this tag produces
    * @since 4.10.0
    */
-  @NotNull Component value();
+  Component value();
 
   /**
    * Get whether this tag allows children.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/InsertingImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/InsertingImpl.java
@@ -27,8 +27,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class InsertingImpl extends AbstractTag implements Inserting {
   private final boolean allowsChildren;
@@ -45,7 +44,7 @@ final class InsertingImpl extends AbstractTag implements Inserting {
   }
 
   @Override
-  public @NotNull Component value() {
+  public Component value() {
     return this.value;
   }
 
@@ -62,7 +61,7 @@ final class InsertingImpl extends AbstractTag implements Inserting {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("allowsChildren", this.allowsChildren),
       ExaminableProperty.of("value", this.value)

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Modifying.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Modifying.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.minimessage.tag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tree.Node;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A tag that can transform a whole subtree of nodes.
@@ -42,7 +41,7 @@ public non-sealed interface Modifying extends Tag {
    * @param depth depth in the tree this node is at
    * @since 4.10.0
    */
-  default void visit(final @NotNull Node current, final int depth) {
+  default void visit(final Node current, final int depth) {
   }
 
   /**
@@ -65,5 +64,5 @@ public non-sealed interface Modifying extends Tag {
    * @return the new parent
    * @since 4.10.0
    */
-  Component apply(final @NotNull Component current, final int depth);
+  Component apply(final Component current, final int depth);
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/ParserDirective.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/ParserDirective.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.text.minimessage.tag;
 
-import org.jetbrains.annotations.ApiStatus;
-
 /**
  * Tags implementing this interface are used to provide directives, or instructions, to the parser directly.
  *

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/PreProcess.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/PreProcess.java
@@ -23,8 +23,6 @@
  */
 package net.kyori.adventure.text.minimessage.tag;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A tag that is applied at the tokenization stage, before the tree is constructed.
  *
@@ -39,5 +37,5 @@ public non-sealed interface PreProcess extends Tag {
    * @return the value to insert
    * @since 4.10.0
    */
-  @NotNull String value();
+  String value();
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagImpl.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.text.minimessage.tag;
 import java.util.Objects;
 import java.util.stream.Stream;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class PreProcessTagImpl extends AbstractTag implements PreProcess {
   private final String value;
@@ -37,7 +36,7 @@ final class PreProcessTagImpl extends AbstractTag implements PreProcess {
   }
 
   @Override
-  public @NotNull String value() {
+  public String value() {
     return this.value;
   }
 
@@ -55,7 +54,7 @@ final class PreProcessTagImpl extends AbstractTag implements PreProcess {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("value", this.value));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/ResetParserDirective.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/ResetParserDirective.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package net.kyori.adventure.text.minimessage.tag;
 
 final class ResetParserDirective implements ParserDirective {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/StylingTagImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/StylingTagImpl.java
@@ -29,8 +29,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class StylingTagImpl extends AbstractTag implements Inserting {
   private final StyleBuilderApplicable[] styles;
@@ -40,7 +39,7 @@ final class StylingTagImpl extends AbstractTag implements Inserting {
   }
 
   @Override
-  public @NotNull Component value() {
+  public Component value() {
     return Component.text("", Style.style(this.styles));
   }
 
@@ -57,7 +56,7 @@ final class StylingTagImpl extends AbstractTag implements Inserting {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("styles", this.styles));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Tag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/Tag.java
@@ -33,8 +33,6 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
 import net.kyori.adventure.text.minimessage.internal.parser.node.TagPart;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -55,7 +53,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
    * @return a new tag
    * @since 4.10.0
    */
-  static @NotNull PreProcess preProcessParsed(final @NotNull String content) {
+  static PreProcess preProcessParsed(final String content) {
     return new PreProcessTagImpl(requireNonNull(content, "content"));
   }
 
@@ -68,7 +66,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
    * @return a tag that will insert this component
    * @since 4.10.0
    */
-  static @NotNull Tag inserting(final @NotNull Component content) {
+  static Tag inserting(final Component content) {
     return new InsertingImpl(true, requireNonNull(content, "content must not be null"));
   }
 
@@ -81,7 +79,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
    * @return a tag that will insert this component
    * @since 4.10.0
    */
-  static @NotNull Tag inserting(final @NotNull ComponentLike value) {
+  static Tag inserting(final ComponentLike value) {
     return inserting(requireNonNull(value, "value").asComponent());
   }
 
@@ -94,7 +92,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
    * @return a tag that will insert this component
    * @since 4.10.0
    */
-  static @NotNull Tag selfClosingInserting(final @NotNull Component content) {
+  static Tag selfClosingInserting(final Component content) {
     return new InsertingImpl(false, requireNonNull(content, "content must not be null"));
   }
 
@@ -107,7 +105,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
    * @return a tag that will insert this component
    * @since 4.10.0
    */
-  static @NotNull Tag selfClosingInserting(final @NotNull ComponentLike value) {
+  static Tag selfClosingInserting(final ComponentLike value) {
     return selfClosingInserting(requireNonNull(value, "value").asComponent());
   }
 
@@ -118,7 +116,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
    * @return a tag for this action
    * @since 4.10.0
    */
-  static @NotNull Tag styling(final Consumer<Style.Builder> styles) {
+  static Tag styling(final Consumer<Style.Builder> styles) {
     return new CallbackStylingTagImpl(styles);
   }
 
@@ -129,7 +127,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
    * @return a tag for these actions
    * @since 4.10.0
    */
-  static @NotNull Tag styling(final @NotNull StyleBuilderApplicable@NotNull... actions) {
+  static Tag styling(final StyleBuilderApplicable... actions) {
     requireNonNull(actions, "actions");
     for (int i = 0, length = actions.length; i < length; i++) {
       if (actions[i] == null) {
@@ -151,7 +149,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
      * @return the value
      * @since 4.10.0
      */
-    @NotNull String value();
+    String value();
 
     /**
      * Returns the value of this argument, lower-cased in the root locale.
@@ -161,7 +159,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
      * @return the lower-cased value of this argument
      * @since 4.10.0
      */
-    default @NotNull String lowerValue() {
+    default String lowerValue() {
       return this.value().toLowerCase(Locale.ROOT);
     }
 
@@ -193,7 +191,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
      * @return an optional providing the value of this argument as an integer
      * @since 4.10.0
      */
-    default @NotNull OptionalInt asInt() {
+    default OptionalInt asInt() {
       try {
         return OptionalInt.of(Integer.parseInt(this.value()));
       } catch (final NumberFormatException ex) {
@@ -209,7 +207,7 @@ public sealed interface Tag permits Inserting, Modifying, ParserDirective, PrePr
      * @return an optional providing the value of this argument as an integer
      * @since 4.10.0
      */
-    default @NotNull OptionalDouble asDouble() {
+    default OptionalDouble asDouble() {
       try {
         return OptionalDouble.of(Double.parseDouble(this.value()));
       } catch (final NumberFormatException ex) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/ArgumentQueue.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/ArgumentQueue.java
@@ -26,9 +26,7 @@ package net.kyori.adventure.text.minimessage.tag.resolver;
 import java.util.function.Supplier;
 import net.kyori.adventure.text.minimessage.ArgumentQueueImpl;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A queue of {@link Tag} arguments.
@@ -44,7 +42,7 @@ public sealed interface ArgumentQueue permits ArgumentQueueImpl {
    * @return the popped argument
    * @since 4.10.0
    */
-  Tag.@NotNull Argument pop();
+  Tag.Argument pop();
 
   /**
    * Pop an argument, throwing an exception if no argument was present.
@@ -55,7 +53,7 @@ public sealed interface ArgumentQueue permits ArgumentQueueImpl {
    * @return the popped argument
    * @since 4.10.0
    */
-  Tag.@NotNull Argument popOr(final @NotNull String errorMessage);
+  Tag.Argument popOr(final String errorMessage);
 
   /**
    * Pop an argument, throwing an exception if no argument was present.
@@ -66,7 +64,7 @@ public sealed interface ArgumentQueue permits ArgumentQueueImpl {
    * @return the popped argument
    * @since 4.10.0
    */
-  Tag.@NotNull Argument popOr(final @NotNull Supplier<String> errorMessage);
+  Tag.Argument popOr(final Supplier<String> errorMessage);
 
   /**
    * Peek at the next argument without advancing the iteration pointer.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/ArgumentQueue.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/ArgumentQueue.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.minimessage.tag.resolver;
 
 import java.util.function.Supplier;
-
 import net.kyori.adventure.text.minimessage.ArgumentQueueImpl;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import org.jetbrains.annotations.ApiStatus;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/CachingTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/CachingTagResolver.java
@@ -31,8 +31,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.ClaimConsumer;
 import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
 import net.kyori.adventure.text.minimessage.tag.Inserting;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class CachingTagResolver implements TagResolver.WithoutArguments, MappableResolver, SerializableResolver {
   private static final Tag NULL_REPLACEMENT = (Inserting) () -> {
@@ -46,7 +45,7 @@ final class CachingTagResolver implements TagResolver.WithoutArguments, Mappable
     this.resolver = resolver;
   }
 
-  private Tag query(final @NotNull String key) {
+  private Tag query(final String key) {
     return this.cache.computeIfAbsent(key, k -> {
       final @Nullable Tag result = this.resolver.resolve(k);
       return result == null ? NULL_REPLACEMENT : result;
@@ -54,18 +53,18 @@ final class CachingTagResolver implements TagResolver.WithoutArguments, Mappable
   }
 
   @Override
-  public @Nullable Tag resolve(final @NotNull String name) {
+  public @Nullable Tag resolve(final String name) {
     final Tag potentialValue = this.query(name);
     return potentialValue == NULL_REPLACEMENT ? null : potentialValue;
   }
 
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     return this.query(name) != NULL_REPLACEMENT;
   }
 
   @Override
-  public boolean contributeToMap(final @NotNull Map<String, Tag> map) {
+  public boolean contributeToMap(final Map<String, Tag> map) {
     if (this.resolver instanceof MappableResolver) {
       return ((MappableResolver) this.resolver).contributeToMap(map);
     } else {
@@ -74,7 +73,7 @@ final class CachingTagResolver implements TagResolver.WithoutArguments, Mappable
   }
 
   @Override
-  public void handle(final @NotNull Component serializable, final @NotNull ClaimConsumer consumer) {
+  public void handle(final Component serializable, final ClaimConsumer consumer) {
     if (this.resolver instanceof SerializableResolver) {
       ((SerializableResolver) this.resolver).handle(serializable, consumer);
     }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/EmptyTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/EmptyTagResolver.java
@@ -29,8 +29,7 @@ import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.internal.serializer.ClaimConsumer;
 import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class EmptyTagResolver implements TagResolver, MappableResolver, SerializableResolver {
   static final EmptyTagResolver INSTANCE = new EmptyTagResolver();
@@ -39,21 +38,21 @@ final class EmptyTagResolver implements TagResolver, MappableResolver, Serializa
   }
 
   @Override
-  public @Nullable Tag resolve(final @NotNull String name, final @NotNull ArgumentQueue arguments, final @NotNull Context ctx) {
+  public @Nullable Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) {
     return null;
   }
 
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     return false;
   }
 
   @Override
-  public boolean contributeToMap(final @NotNull Map<String, Tag> map) {
+  public boolean contributeToMap(final Map<String, Tag> map) {
     return true;
   }
 
   @Override
-  public void handle(final @NotNull Component serializable, final @NotNull ClaimConsumer consumer) {
+  public void handle(final Component serializable, final ClaimConsumer consumer) {
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Formatter.java
@@ -36,7 +36,6 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.TagPattern;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Tag resolvers producing tags that insert formatted values.
@@ -63,7 +62,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.11.0
    */
-  public static @NotNull TagResolver number(@TagPattern final @NotNull String key, final @NotNull Number number) {
+  public static TagResolver number(@TagPattern final String key, final Number number) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final NumberFormat decimalFormat;
       if (argumentQueue.hasNext()) {
@@ -97,7 +96,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.11.0
    */
-  public static @NotNull TagResolver date(@TagPattern final @NotNull String key, final @NotNull TemporalAccessor time) {
+  public static TagResolver date(@TagPattern final String key, final TemporalAccessor time) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
       return Tag.inserting(context.deserialize(DateTimeFormatter.ofPattern(format).format(time)));
@@ -116,7 +115,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.11.0
    */
-  public static @NotNull TagResolver choice(@TagPattern final @NotNull String key, final Number number) {
+  public static TagResolver choice(@TagPattern final String key, final Number number) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final String format = argumentQueue.popOr("Format expected.").value();
       final ChoiceFormat choiceFormat = new ChoiceFormat(format);
@@ -136,7 +135,7 @@ public final class Formatter {
    * @return the placeholder
    * @since 4.13.0
    */
-  public static TagResolver booleanChoice(@TagPattern final @NotNull String key, final boolean value) {
+  public static TagResolver booleanChoice(@TagPattern final String key, final boolean value) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       final String trueCase = argumentQueue.popOr("True format expected.").value();
       final String falseCase = argumentQueue.popOr("False format expected.").value();
@@ -159,7 +158,7 @@ public final class Formatter {
    * @see JoinConfiguration
    * @since 4.18.0
    */
-  public static TagResolver joining(@TagPattern final @NotNull String key, final @NotNull Iterable<? extends ComponentLike> components) {
+  public static TagResolver joining(@TagPattern final String key, final Iterable<? extends ComponentLike> components) {
     return TagResolver.resolver(key, (argumentQueue, context) -> {
       if (!argumentQueue.hasNext()) {
         return Tag.inserting(Component.join(JoinConfiguration.noSeparators(), components));
@@ -198,7 +197,7 @@ public final class Formatter {
    * @see JoinConfiguration
    * @since 4.18.0
    */
-  public static TagResolver joining(@TagPattern final @NotNull String key, final @NotNull ComponentLike@NotNull... components) {
+  public static TagResolver joining(@TagPattern final String key, final ComponentLike... components) {
     return joining(key, Arrays.asList(components));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/MapTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/MapTagResolver.java
@@ -26,28 +26,27 @@ package net.kyori.adventure.text.minimessage.tag.resolver;
 import java.util.Map;
 import java.util.Objects;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class MapTagResolver implements TagResolver.WithoutArguments, MappableResolver {
   private final Map<String, ? extends Tag> tagMap;
 
-  MapTagResolver(final @NotNull Map<String, ? extends Tag> placeholderMap) {
+  MapTagResolver(final Map<String, ? extends Tag> placeholderMap) {
     this.tagMap = placeholderMap;
   }
 
   @Override
-  public @Nullable Tag resolve(final @NotNull String name) {
+  public @Nullable Tag resolve(final String name) {
     return this.tagMap.get(name);
   }
 
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     return this.tagMap.containsKey(name);
   }
 
   @Override
-  public boolean contributeToMap(final @NotNull Map<String, Tag> map) {
+  public boolean contributeToMap(final Map<String, Tag> map) {
     map.putAll(this.tagMap);
     return true;
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/MappableResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/MappableResolver.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.minimessage.tag.resolver;
 
 import java.util.Map;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Marker interface for resolvers that may handle a fixed domain of tags.
@@ -42,5 +41,5 @@ interface MappableResolver {
    * @param map the map to add to
    * @return whether the set of values was actually known
    */
-  boolean contributeToMap(final @NotNull Map<String, Tag> map);
+  boolean contributeToMap(final Map<String, Tag> map);
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.java
@@ -28,7 +28,6 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.format.StyleBuilderApplicable;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.TagPattern;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -53,7 +52,7 @@ public final class Placeholder {
    * @return the placeholder
    * @since 4.10.0
    */
-  public static TagResolver.@NotNull Single parsed(@TagPattern final @NotNull String key, final @NotNull String value) {
+  public static TagResolver.Single parsed(@TagPattern final String key, final String value) {
     return TagResolver.resolver(key, Tag.preProcessParsed(value));
   }
 
@@ -65,7 +64,7 @@ public final class Placeholder {
    * @return the placeholder
    * @since 4.10.0
    */
-  public static TagResolver.@NotNull Single unparsed(@TagPattern final @NotNull String key, final @NotNull String value) {
+  public static TagResolver.Single unparsed(@TagPattern final String key, final String value) {
     requireNonNull(value, "value");
     return Placeholder.component(key, Component.text(value));
   }
@@ -80,7 +79,7 @@ public final class Placeholder {
    * @return the placeholder
    * @since 4.10.0
    */
-  public static TagResolver.@NotNull Single component(@TagPattern final @NotNull String key, final @NotNull ComponentLike value) {
+  public static TagResolver.Single component(@TagPattern final String key, final ComponentLike value) {
     return TagResolver.resolver(key, Tag.selfClosingInserting(value));
   }
 
@@ -94,7 +93,7 @@ public final class Placeholder {
    * @return the placeholder
    * @since 4.13.0
    */
-  public static TagResolver.@NotNull Single styling(@TagPattern final @NotNull String key, final @NotNull StyleBuilderApplicable@NotNull... style) {
+  public static TagResolver.Single styling(@TagPattern final String key, final StyleBuilderApplicable... style) {
     return TagResolver.resolver(key, Tag.styling(style));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SequentialTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SequentialTagResolver.java
@@ -30,16 +30,15 @@ import net.kyori.adventure.text.minimessage.ParsingException;
 import net.kyori.adventure.text.minimessage.internal.serializer.ClaimConsumer;
 import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 record SequentialTagResolver(TagResolver[] resolvers) implements TagResolver, SerializableResolver {
-  SequentialTagResolver(final @NotNull TagResolver @NotNull [] resolvers) {
+  SequentialTagResolver(final TagResolver [] resolvers) {
     this.resolvers = resolvers;
   }
 
   @Override
-  public @Nullable Tag resolve(final @NotNull String name, final @NotNull ArgumentQueue arguments, final @NotNull Context ctx) throws ParsingException {
+  public @Nullable Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) throws ParsingException {
     @Nullable ParsingException thrown = null;
     for (final TagResolver resolver : this.resolvers) {
       try {
@@ -74,7 +73,7 @@ record SequentialTagResolver(TagResolver[] resolvers) implements TagResolver, Se
   }
 
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     for (final TagResolver resolver : this.resolvers) {
       if (resolver.has(name)) {
         return true;
@@ -84,7 +83,7 @@ record SequentialTagResolver(TagResolver[] resolvers) implements TagResolver, Se
   }
 
   @Override
-  public void handle(final @NotNull Component serializable, final @NotNull ClaimConsumer consumer) {
+  public void handle(final Component serializable, final ClaimConsumer consumer) {
     for (final TagResolver resolver : this.resolvers) {
       if (resolver instanceof SerializableResolver) {
         ((SerializableResolver) resolver).handle(serializable, consumer);

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SingleResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SingleResolver.java
@@ -24,18 +24,16 @@
 package net.kyori.adventure.text.minimessage.tag.resolver;
 
 import java.util.Map;
-import java.util.Objects;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
 
 record SingleResolver(String key, Tag tag) implements TagResolver.Single, MappableResolver {
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     return this.key.equals(name);
   }
 
   @Override
-  public boolean contributeToMap(final @NotNull Map<String, Tag> map) {
+  public boolean contributeToMap(final Map<String, Tag> map) {
     map.put(this.key, this.tag);
     return true;
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/TagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/TagResolver.java
@@ -36,9 +36,7 @@ import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.TagPattern;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -58,7 +56,7 @@ public interface TagResolver {
    * @return the tag resolver builder
    * @since 4.10.0
    */
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new TagResolverBuilderImpl();
   }
 
@@ -70,7 +68,7 @@ public interface TagResolver {
    * @return the default resolver
    * @since 4.10.0
    */
-  static @NotNull TagResolver standard() {
+  static TagResolver standard() {
     return StandardTags.defaults();
   }
 
@@ -80,7 +78,7 @@ public interface TagResolver {
    * @return the tag resolver
    * @since 4.10.0
    */
-  static @NotNull TagResolver empty() {
+  static TagResolver empty() {
     return EmptyTagResolver.INSTANCE;
   }
 
@@ -92,7 +90,7 @@ public interface TagResolver {
    * @return a new tag resolver
    * @since 4.10.0
    */
-  static TagResolver.@NotNull Single resolver(@TagPattern final @NotNull String name, final @NotNull Tag tag) {
+  static TagResolver.Single resolver(@TagPattern final String name, final Tag tag) {
     TagInternals.assertValidTagName(name);
     return new SingleResolver(
       name,
@@ -108,7 +106,7 @@ public interface TagResolver {
    * @return a resolver that creates tags using the provided handler
    * @since 4.10.0
    */
-  static @NotNull TagResolver resolver(@TagPattern final @NotNull String name, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler) {
+  static TagResolver resolver(@TagPattern final String name, final BiFunction<ArgumentQueue, Context, Tag> handler) {
     return resolver(Collections.singleton(name), handler);
   }
 
@@ -120,7 +118,7 @@ public interface TagResolver {
    * @return a resolver that creates tags using the provided handler
    * @since 4.10.0
    */
-  static @NotNull TagResolver resolver(final @NotNull Set<String> names, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler) {
+  static TagResolver resolver(final Set<String> names, final BiFunction<ArgumentQueue, Context, Tag> handler) {
     final Set<String> ownNames = new HashSet<>(names);
     for (final String name : ownNames) {
       TagInternals.assertValidTagName(name);
@@ -129,14 +127,14 @@ public interface TagResolver {
 
     return new TagResolver() {
       @Override
-      public @Nullable Tag resolve(final @NotNull String name, final @NotNull ArgumentQueue arguments, final @NotNull Context ctx) throws ParsingException {
+      public @Nullable Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) throws ParsingException {
         if (!names.contains(name)) return null;
 
         return handler.apply(arguments, ctx);
       }
 
       @Override
-      public boolean has(final @NotNull String name) {
+      public boolean has(final String name) {
         return names.contains(name);
       }
     };
@@ -151,7 +149,7 @@ public interface TagResolver {
    * @return the tag resolver
    * @since 4.10.0
    */
-  static @NotNull TagResolver resolver(final @NotNull TagResolver@NotNull... resolvers) {
+  static TagResolver resolver(final TagResolver... resolvers) {
     if (Objects.requireNonNull(resolvers, "resolvers").length == 1) {
       return Objects.requireNonNull(resolvers[0], "resolvers must not contain null elements");
     }
@@ -169,7 +167,7 @@ public interface TagResolver {
    * @return the tag resolver
    * @since 4.10.0
    */
-  static @NotNull TagResolver resolver(final @NotNull Iterable<? extends TagResolver> resolvers) {
+  static TagResolver resolver(final Iterable<? extends TagResolver> resolvers) {
     // We can break out early and return exact resolvers in the case of a zero/one length array.
     if (resolvers instanceof Collection<?>) {
       final int size = ((Collection<?>) resolvers).size();
@@ -193,7 +191,7 @@ public interface TagResolver {
    * @return the caching tag resolver
    * @since 4.10.0
    */
-  static @NotNull TagResolver caching(final TagResolver.@NotNull WithoutArguments resolver) {
+  static TagResolver caching(final TagResolver.WithoutArguments resolver) {
     if (resolver instanceof CachingTagResolver) {
       return resolver;
     } else {
@@ -207,7 +205,7 @@ public interface TagResolver {
    * @return a collector for tag resolvers
    * @since 4.10.0
    */
-  static @NotNull Collector<TagResolver, ?, TagResolver> toTagResolver() {
+  static Collector<TagResolver, ?, TagResolver> toTagResolver() {
     return TagResolverBuilderImpl.COLLECTOR;
   }
 
@@ -221,7 +219,7 @@ public interface TagResolver {
    * @throws ParsingException if the provided arguments are invalid
    * @since 4.10.0
    */
-  @Nullable Tag resolve(@TagPattern final @NotNull String name, final @NotNull ArgumentQueue arguments, final @NotNull Context ctx) throws ParsingException;
+  @Nullable Tag resolve(@TagPattern final String name, final ArgumentQueue arguments, final Context ctx) throws ParsingException;
 
   /**
    * Get whether this resolver handles tags with a certain name.
@@ -232,7 +230,7 @@ public interface TagResolver {
    * @return whether this resolver has a tag with this name
    * @since 4.10.0
    */
-  boolean has(final @NotNull String name);
+  boolean has(final String name);
 
   /**
    * A resolver that only handles a single tag key.
@@ -249,7 +247,7 @@ public interface TagResolver {
      * @return the key
      * @since 4.10.0
      */
-    @NotNull String key();
+    String key();
 
     /**
      * The tag returned by this resolver when the key is matching.
@@ -257,10 +255,10 @@ public interface TagResolver {
      * @return the tag
      * @since 4.10.0
      */
-    @NotNull Tag tag();
+    Tag tag();
 
     @Override
-    default @Nullable Tag resolve(@TagPattern final @NotNull String name) {
+    default @Nullable Tag resolve(@TagPattern final String name) {
       if (this.has(name)) {
         return this.tag();
       }
@@ -268,7 +266,7 @@ public interface TagResolver {
     }
 
     @Override
-    default boolean has(final @NotNull String name) {
+    default boolean has(final String name) {
       return name.equalsIgnoreCase(this.key());
     }
   }
@@ -287,7 +285,7 @@ public interface TagResolver {
      * @return a tag, if any is known.
      * @since 4.10.0
      */
-    @Nullable Tag resolve(@TagPattern final @NotNull String name);
+    @Nullable Tag resolve(@TagPattern final String name);
 
     /**
      * Check if this resolver knows of a tag.
@@ -297,12 +295,12 @@ public interface TagResolver {
      * @since 4.10.0
      */
     @Override
-    default boolean has(final @NotNull String name) {
+    default boolean has(final String name) {
       return this.resolve(name) != null;
     }
 
     @Override
-    default @Nullable Tag resolve(@TagPattern final @NotNull String name, final @NotNull ArgumentQueue arguments, final @NotNull Context ctx) throws ParsingException {
+    default @Nullable Tag resolve(@TagPattern final String name, final ArgumentQueue arguments, final Context ctx) throws ParsingException {
       final Tag resolved = this.resolve(name);
       if (resolved != null && arguments.hasNext()) {
         throw ctx.newException("Tag '<" + name + ">' does not accept any arguments");
@@ -327,7 +325,7 @@ public interface TagResolver {
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder tag(@TagPattern final @NotNull String name, final @NotNull Tag tag);
+    Builder tag(@TagPattern final String name, final Tag tag);
 
     /**
      * Add a single dynamically created tag to this resolver.
@@ -337,7 +335,7 @@ public interface TagResolver {
      * @return this builder
      * @since 4.10.0
      */
-    default @NotNull Builder tag(@TagPattern final @NotNull String name, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler) {
+    default Builder tag(@TagPattern final String name, final BiFunction<ArgumentQueue, Context, Tag> handler) {
       return this.tag(Collections.singleton(name), handler);
     }
 
@@ -349,7 +347,7 @@ public interface TagResolver {
      * @return this builder
      * @since 4.10.0
      */
-    default @NotNull Builder tag(final @NotNull Set<String> names, final @NotNull BiFunction<ArgumentQueue, Context, Tag> handler) {
+    default Builder tag(final Set<String> names, final BiFunction<ArgumentQueue, Context, Tag> handler) {
       return this.resolver(TagResolver.resolver(names, handler));
     }
 
@@ -360,7 +358,7 @@ public interface TagResolver {
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder resolver(final @NotNull TagResolver resolver);
+    Builder resolver(final TagResolver resolver);
 
     /**
      * Add placeholder resolvers to those queried by the result of this builder.
@@ -369,7 +367,7 @@ public interface TagResolver {
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder resolvers(final @NotNull TagResolver@NotNull... resolvers);
+    Builder resolvers(final TagResolver... resolvers);
 
     /**
      * Add placeholder resolvers to those queried by the result of this builder.
@@ -378,7 +376,7 @@ public interface TagResolver {
      * @return this builder
      * @since 4.10.0
      */
-    @NotNull Builder resolvers(final @NotNull Iterable<? extends TagResolver> resolvers);
+    Builder resolvers(final Iterable<? extends TagResolver> resolvers);
 
     /**
      * Add a resolver that dynamically queries and caches based on the provided function.
@@ -387,7 +385,7 @@ public interface TagResolver {
      * @return this builder
      * @since 4.10.0
      */
-    default @NotNull Builder caching(final TagResolver.@NotNull WithoutArguments dynamic) {
+    default Builder caching(final TagResolver.WithoutArguments dynamic) {
       return this.resolver(TagResolver.caching(dynamic));
     }
 
@@ -399,6 +397,6 @@ public interface TagResolver {
      * @return the resolver
      * @since 4.10.0
      */
-    @NotNull TagResolver build();
+    TagResolver build();
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/TagResolverBuilderImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/TagResolverBuilderImpl.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.stream.Collector;
 import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.tag.Tag;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,7 +47,7 @@ final class TagResolverBuilderImpl implements TagResolver.Builder {
   private final List<TagResolver> resolvers = new ArrayList<>();
 
   @Override
-  public TagResolver.@NotNull Builder tag(final @NotNull String name, final @NotNull Tag tag) {
+  public TagResolver.Builder tag(final String name, final Tag tag) {
     TagInternals.assertValidTagName(requireNonNull(name, "name"));
     this.replacements.put(
       name,
@@ -58,7 +57,7 @@ final class TagResolverBuilderImpl implements TagResolver.Builder {
   }
 
   @Override
-  public TagResolver.@NotNull Builder resolver(final @NotNull TagResolver resolver) {
+  public TagResolver.Builder resolver(final TagResolver resolver) {
     if (resolver instanceof SequentialTagResolver(TagResolver[] sequentialResolvers)) {
       this.resolvers(sequentialResolvers, false);
     } else if (!this.consumePotentialMappable(resolver)) {
@@ -69,11 +68,11 @@ final class TagResolverBuilderImpl implements TagResolver.Builder {
   }
 
   @Override
-  public TagResolver.@NotNull Builder resolvers(final @NotNull TagResolver @NotNull... resolvers) {
+  public TagResolver.Builder resolvers(final TagResolver ... resolvers) {
     return this.resolvers(resolvers, true);
   }
 
-  private TagResolver.@NotNull Builder resolvers(final @NotNull TagResolver @NotNull[] resolvers, final boolean forwards) {
+  private TagResolver.Builder resolvers(final TagResolver [] resolvers, final boolean forwards) {
     boolean popped = false;
     requireNonNull(resolvers, "resolvers");
     if (forwards) {
@@ -89,7 +88,7 @@ final class TagResolverBuilderImpl implements TagResolver.Builder {
   }
 
   @Override
-  public TagResolver.@NotNull Builder resolvers(final @NotNull Iterable<? extends TagResolver> resolvers) {
+  public TagResolver.Builder resolvers(final Iterable<? extends TagResolver> resolvers) {
     boolean popped = false;
     for (final TagResolver resolver : requireNonNull(resolvers, "resolvers")) {
       popped = this.single(resolver, popped);
@@ -126,7 +125,7 @@ final class TagResolverBuilderImpl implements TagResolver.Builder {
   }
 
   @Override
-  public @NotNull TagResolver build() {
+  public TagResolver build() {
     this.popMap();
     if (this.resolvers.isEmpty()) {
       return EmptyTagResolver.INSTANCE;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/AbstractColorChangingTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/AbstractColorChangingTag.java
@@ -45,9 +45,8 @@ import net.kyori.adventure.text.minimessage.tag.Modifying;
 import net.kyori.adventure.text.minimessage.tree.Node;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A transformation that applies a colour change.
@@ -81,7 +80,7 @@ abstract class AbstractColorChangingTag implements Modifying, Examinable {
   }
 
   @Override
-  public final void visit(final @NotNull Node current, final int depth) {
+  public final void visit(final Node current, final int depth) {
     if (this.visited) {
       throw new IllegalStateException("Color changing tag instances cannot be re-used, return a new one for each resolve");
     }
@@ -105,7 +104,7 @@ abstract class AbstractColorChangingTag implements Modifying, Examinable {
   }
 
   @Override
-  public final Component apply(final @NotNull Component current, final int depth) {
+  public final Component apply(final Component current, final int depth) {
     if (this.emitVirtuals && depth == 0) {
       // capture state into a virtual component, no other logic is needed in normal MM handling
       return Component.virtual(Void.class, new TagInfoHolder(this.preserveData(), current), current.style());
@@ -185,15 +184,15 @@ abstract class AbstractColorChangingTag implements Modifying, Examinable {
    * @return the emitable for this tag
    * @since 4.18.0
    */
-  protected abstract @NotNull Consumer<TokenEmitter> preserveData();
+  protected abstract Consumer<TokenEmitter> preserveData();
 
   // misc
 
   @Override
-  public abstract @NotNull Stream<? extends ExaminableProperty> examinableProperties();
+  public abstract Stream<? extends ExaminableProperty> examinableProperties();
 
   @Override
-  public final @NotNull String toString() {
+  public final String toString() {
     return Internals.toString(this);
   }
 
@@ -205,17 +204,17 @@ abstract class AbstractColorChangingTag implements Modifying, Examinable {
 
   private record TagInfoHolder(Consumer<TokenEmitter> output, Component originalComp) implements VirtualComponentRenderer<Void>, Emitable {
     @Override
-    public @UnknownNullability ComponentLike apply(final @NotNull Void context) {
+    public @UnknownNullability ComponentLike apply(final Void context) {
       return this.originalComp;
     }
 
     @Override
-    public @NotNull String fallbackString() {
+    public String fallbackString() {
       return ""; // only holds data for reserialization, not for display
     }
 
     @Override
-    public void emit(final @NotNull TokenEmitter emitter) {
+    public void emit(final TokenEmitter emitter) {
       this.output.accept(emitter);
     }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ClickTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ClickTag.java
@@ -33,7 +33,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.StyleClaim;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Click events.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ColorTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ColorTagResolver.java
@@ -35,8 +35,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.StyleClaim;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A transformation applying a single text color.
@@ -74,7 +73,7 @@ final class ColorTagResolver implements TagResolver, SerializableResolver.Single
   }
 
   @Override
-  public @Nullable Tag resolve(final @NotNull String name, final @NotNull ArgumentQueue args, final @NotNull Context ctx) throws ParsingException {
+  public @Nullable Tag resolve(final String name, final ArgumentQueue args, final Context ctx) throws ParsingException {
     if (!this.has(name)) {
       return null;
     }
@@ -103,7 +102,7 @@ final class ColorTagResolver implements TagResolver, SerializableResolver.Single
     return color;
   }
 
-  static @NotNull TextColor resolveColor(final @NotNull String colorName, final @NotNull Context ctx) throws ParsingException {
+  static TextColor resolveColor(final String colorName, final Context ctx) throws ParsingException {
     final TextColor color = resolveColorOrNull(colorName);
     if (color == null) {
       throw ctx.newException(String.format("Unable to parse a color from '%s'. Please use named colours or hex (#RRGGBB) colors.", colorName));
@@ -112,7 +111,7 @@ final class ColorTagResolver implements TagResolver, SerializableResolver.Single
   }
 
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     return isColorOrAbbreviation(name)
       || NamedTextColor.NAMES.value(name) != null
       || COLOR_ALIASES.containsKey(name)

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/DecorationTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/DecorationTag.java
@@ -41,8 +41,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.TokenEmitter;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -63,7 +62,7 @@ final class DecorationTag {
   public static final String REVERT = "!";
 
   // create resolvers for canonical + configured alternates
-  static Map.Entry<TextDecoration, Stream<TagResolver>> resolvers(final TextDecoration decoration, final @Nullable String shortName, final @NotNull String@NotNull... secondaryAliases) {
+  static Map.Entry<TextDecoration, Stream<TagResolver>> resolvers(final TextDecoration decoration, final @Nullable String shortName, final String... secondaryAliases) {
     final String canonicalName = TextDecoration.NAMES.key(decoration);
     final Set<String> names = new HashSet<>();
     names.add(canonicalName);
@@ -109,7 +108,7 @@ final class DecorationTag {
     return Tag.styling(toApply.withState(false));
   }
 
-  static @NotNull StyleClaim<TextDecoration.State> claim(final @NotNull TextDecoration decoration, final @NotNull BiConsumer<TextDecoration.State, TokenEmitter> emitable) {
+  static StyleClaim<TextDecoration.State> claim(final TextDecoration decoration, final BiConsumer<TextDecoration.State, TokenEmitter> emitable) {
     requireNonNull(decoration, "decoration");
     return StyleClaim.claim(
       "decoration_" + TextDecoration.NAMES.key(decoration),
@@ -119,7 +118,7 @@ final class DecorationTag {
     );
   }
 
-  static void emit(final @NotNull String longName, final @NotNull String shortName, final TextDecoration.@NotNull State state, final @NotNull TokenEmitter emitter) {
+  static void emit(final String longName, final String shortName, final TextDecoration.State state, final TokenEmitter emitter) {
     if (state == State.FALSE) {
       emitter.tag(REVERT + longName);
     } else {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/GradientTag.java
@@ -41,9 +41,8 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A transformation that applies a colour gradient.
@@ -154,7 +153,7 @@ class GradientTag extends AbstractColorChangingTag {
   }
 
   @Override
-  protected @NotNull Consumer<TokenEmitter> preserveData() {
+  protected Consumer<TokenEmitter> preserveData() {
     final TextColor[] colors;
     final double phase;
 
@@ -186,7 +185,7 @@ class GradientTag extends AbstractColorChangingTag {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("phase", this.phase),
       ExaminableProperty.of("colors", this.colors)

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
@@ -41,8 +41,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.TokenEmitter;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Hover tag.
@@ -95,7 +94,7 @@ final class HoverTag {
   }
 
   interface ActionHandler<V> {
-    @NotNull V parse(final @NotNull ArgumentQueue args, final @NotNull Context ctx) throws ParsingException;
+    V parse(final ArgumentQueue args, final Context ctx) throws ParsingException;
 
     void emit(final V event, final TokenEmitter emit);
   }
@@ -107,7 +106,7 @@ final class HoverTag {
     }
 
     @Override
-    public @NotNull Component parse(final @NotNull ArgumentQueue args, final @NotNull Context ctx) throws ParsingException {
+    public Component parse(final ArgumentQueue args, final Context ctx) throws ParsingException {
       return ctx.deserialize(args.popOr("show_text action requires a message").value());
     }
 
@@ -124,7 +123,7 @@ final class HoverTag {
     }
 
     @Override
-    public HoverEvent.@NotNull ShowItem parse(final @NotNull ArgumentQueue args, final @NotNull Context ctx) throws ParsingException {
+    public HoverEvent.ShowItem parse(final ArgumentQueue args, final Context ctx) throws ParsingException {
       try {
         @SuppressWarnings("PatternValidation")
         final Key key = Key.key(args.popOr("Show item hover needs at least an item ID").value());
@@ -191,7 +190,7 @@ final class HoverTag {
     }
 
     @Override
-    public HoverEvent.@NotNull ShowEntity parse(final @NotNull ArgumentQueue args, final @NotNull Context ctx) throws ParsingException {
+    public HoverEvent.ShowEntity parse(final ArgumentQueue args, final Context ctx) throws ParsingException {
       try {
         final Key key = Key.key(args.popOr("Show entity needs a type argument").value());
         final UUID id = UUID.fromString(args.popOr("Show entity needs an entity UUID").value());
@@ -216,7 +215,7 @@ final class HoverTag {
     }
   }
 
-  static @NotNull String compactAsString(final @NotNull Key key) {
+  static String compactAsString(final Key key) {
     if (key.namespace().equals(Key.MINECRAFT_NAMESPACE)) {
       return key.value();
     } else {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/KeybindTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/KeybindTag.java
@@ -32,7 +32,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A transformation that inserts a key binding component.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NbtTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NbtTag.java
@@ -37,7 +37,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * One tag for all NBT components.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NewlineTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/NewlineTag.java
@@ -31,7 +31,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Newline tag.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/PrideTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/PrideTag.java
@@ -24,8 +24,6 @@
 package net.kyori.adventure.text.minimessage.tag.standard;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -38,8 +36,7 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Applies pride flags to a component.
@@ -107,13 +104,13 @@ final class PrideTag extends GradientTag {
 
   private final String flag;
 
-  PrideTag(final double phase, final @NotNull List<@NotNull TextColor> colors, final @NotNull String flag, final Context ctx) {
+  PrideTag(final double phase, final List<TextColor> colors, final String flag, final Context ctx) {
     super(phase, colors, ctx);
     this.flag = flag;
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("flag", this.flag),
       ExaminableProperty.of("phase", this.phase)
@@ -134,7 +131,7 @@ final class PrideTag extends GradientTag {
       && this.flag.equals(that.flag);
   }
 
-  private static @NotNull List<TextColor> colors(final int @NotNull ... colors) {
+  private static List<TextColor> colors(final int ... colors) {
     return Arrays.stream(colors).mapToObj(TextColor::color).collect(Collectors.toList());
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/RainbowTag.java
@@ -35,8 +35,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.util.HSVLike;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Applies rainbow color to a component.
@@ -110,7 +109,7 @@ final class RainbowTag extends AbstractColorChangingTag {
   }
 
   @Override
-  protected @NotNull Consumer<TokenEmitter> preserveData() {
+  protected Consumer<TokenEmitter> preserveData() {
     final boolean reversed = this.reversed;
     final int phase = (int) Math.round(this.dividedPhase * 10);
     return emit -> {
@@ -126,7 +125,7 @@ final class RainbowTag extends AbstractColorChangingTag {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(ExaminableProperty.of("phase", this.dividedPhase));
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ScoreTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ScoreTag.java
@@ -32,7 +32,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class ScoreTag {
   public static final String SCORE = "score";

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SelectorTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SelectorTag.java
@@ -33,7 +33,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Insert a selector component into the result.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SequentialHeadTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SequentialHeadTag.java
@@ -41,7 +41,7 @@ import net.kyori.adventure.text.object.ObjectContents;
 import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import net.kyori.adventure.util.TriState;
 import org.intellij.lang.annotations.Subst;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A simplified head object tag for only setting either the name,

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ShadowColorTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/ShadowColorTag.java
@@ -35,8 +35,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.TokenEmitter;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class ShadowColorTag {
   private static final String SHADOW_COLOR = "shadow";
@@ -52,7 +51,7 @@ final class ShadowColorTag {
     TagResolver.resolver(SHADOW_NONE, Tag.styling(ShadowColor.none()))
   );
 
-  static Tag create(final @NotNull ArgumentQueue args, final @NotNull Context ctx) throws ParsingException {
+  static Tag create(final ArgumentQueue args, final Context ctx) throws ParsingException {
     final String colorString = args.popOr("Expected to find a color parameter: #RRGGBBAA").lowerValue();
     final ShadowColor color;
     if (colorString.startsWith(TextColor.HEX_PREFIX) && colorString.length() == 9) {
@@ -69,7 +68,7 @@ final class ShadowColorTag {
     return Tag.styling(color);
   }
 
-  static void emit(final @NotNull ShadowColor color, final @NotNull TokenEmitter emitter) {
+  static void emit(final ShadowColor color, final TokenEmitter emitter) {
     if (ShadowColor.none().equals(color)) {
       emitter.tag(SHADOW_NONE);
       return;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/SpriteTag.java
@@ -36,7 +36,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.object.ObjectContents;
 import net.kyori.adventure.text.object.SpriteObjectContents;
 import org.intellij.lang.annotations.Subst;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A sprite object tag.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import net.kyori.adventure.text.format.NamedTextColorImpl;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -80,7 +79,7 @@ public final class StandardTags {
    * @return a resolver for a certain decoration's tags
    * @since 4.10.0
    */
-  public static @NotNull TagResolver decorations(final @NotNull TextDecoration decoration) {
+  public static TagResolver decorations(final TextDecoration decoration) {
     return requireNonNull(DecorationTag.RESOLVERS.get(decoration), "No resolver found for decoration (this should not be possible?)");
   }
 
@@ -92,7 +91,7 @@ public final class StandardTags {
    * @return a resolver for all decoration tags
    * @since 4.10.0
    */
-  public static @NotNull TagResolver decorations() {
+  public static TagResolver decorations() {
     return DecorationTag.RESOLVER;
   }
 
@@ -104,7 +103,7 @@ public final class StandardTags {
    * @return a resolver for the {@value ColorTagResolver#COLOR} tags
    * @since 4.10.0
    */
-  public static @NotNull TagResolver color() {
+  public static TagResolver color() {
     return ColorTagResolver.INSTANCE;
   }
 
@@ -114,7 +113,7 @@ public final class StandardTags {
    * @return a resolver for the {@value HoverTag#HOVER} tag
    * @since 4.10.0
    */
-  public static @NotNull TagResolver hoverEvent() {
+  public static TagResolver hoverEvent() {
     return HoverTag.RESOLVER;
   }
 
@@ -124,7 +123,7 @@ public final class StandardTags {
    * @return a resolver for the {@value ClickTag#CLICK} tag
    * @since 4.10.0
    */
-  public static @NotNull TagResolver clickEvent() {
+  public static TagResolver clickEvent() {
     return ClickTag.RESOLVER;
   }
 
@@ -134,7 +133,7 @@ public final class StandardTags {
    * @return a resolver for the {@value KeybindTag#KEYBIND} tag
    * @since 4.10.0
    */
-  public static @NotNull TagResolver keybind() {
+  public static TagResolver keybind() {
     return KeybindTag.RESOLVER;
   }
 
@@ -148,7 +147,7 @@ public final class StandardTags {
    * @since 4.25.0
    * @sinceMinecraft 1.21.9
    */
-  public static @NotNull TagResolver sequentialHead() {
+  public static TagResolver sequentialHead() {
     return SequentialHeadTag.RESOLVER;
   }
 
@@ -160,7 +159,7 @@ public final class StandardTags {
    * @return a resolver for the {@value TranslatableTag#TRANSLATE} tag
    * @since 4.10.0
    */
-  public static @NotNull TagResolver translatable() {
+  public static TagResolver translatable() {
     return TranslatableTag.RESOLVER;
   }
 
@@ -172,7 +171,7 @@ public final class StandardTags {
    * @return a resolver for the {@value TranslatableFallbackTag#TRANSLATE_OR} tag
    * @since 4.13.0
    */
-  public static @NotNull TagResolver translatableFallback() {
+  public static TagResolver translatableFallback() {
     return TranslatableFallbackTag.RESOLVER;
   }
 
@@ -182,7 +181,7 @@ public final class StandardTags {
    * @return a resolver for the {@value InsertionTag#INSERTION} tag
    * @since 4.10.0
    */
-  public static @NotNull TagResolver insertion() {
+  public static TagResolver insertion() {
     return InsertionTag.RESOLVER;
   }
 
@@ -192,7 +191,7 @@ public final class StandardTags {
    * @return a resolver for the {@value FontTag#FONT} tag
    * @since 4.10.0
    */
-  public static @NotNull TagResolver font() {
+  public static TagResolver font() {
     return FontTag.RESOLVER;
   }
 
@@ -202,7 +201,7 @@ public final class StandardTags {
    * @return a resolver for the {@value GradientTag#GRADIENT} tag
    * @since 4.10.0
    */
-  public static @NotNull TagResolver gradient() {
+  public static TagResolver gradient() {
     return GradientTag.RESOLVER;
   }
 
@@ -212,7 +211,7 @@ public final class StandardTags {
    * @return a resolver for the {@value RainbowTag#RAINBOW} tag
    * @since 4.10.0
    */
-  public static @NotNull TagResolver rainbow() {
+  public static TagResolver rainbow() {
     return RainbowTag.RESOLVER;
   }
 
@@ -232,7 +231,7 @@ public final class StandardTags {
    * @return a resolver for the {@value ResetTag#RESET} tag.
    * @since 4.10.0
    */
-  public static @NotNull TagResolver reset() {
+  public static TagResolver reset() {
     return ResetTag.RESOLVER;
   }
 
@@ -244,7 +243,7 @@ public final class StandardTags {
    * @return a resolver for the {@value NewlineTag#NEWLINE} tag.
    * @since 4.10.0
    */
-  public static @NotNull TagResolver newline() {
+  public static TagResolver newline() {
     return NewlineTag.RESOLVER;
   }
 
@@ -256,7 +255,7 @@ public final class StandardTags {
    * @return a resolver for the {@value SelectorTag#SELECTOR} tag
    * @since 4.11.0
    */
-  public static @NotNull TagResolver selector() {
+  public static TagResolver selector() {
     return SelectorTag.RESOLVER;
   }
 
@@ -266,7 +265,7 @@ public final class StandardTags {
    * @return a resolver for the {@value ScoreTag#SCORE} tag
    * @since 4.13.0
    */
-  public static @NotNull TagResolver score() {
+  public static TagResolver score() {
     return ScoreTag.RESOLVER;
   }
 
@@ -278,7 +277,7 @@ public final class StandardTags {
    * @return a resolver for the {@value NbtTag#NBT} tag.
    * @since 4.13.0
    */
-  public static @NotNull TagResolver nbt() {
+  public static TagResolver nbt() {
     return NbtTag.RESOLVER;
   }
 
@@ -288,7 +287,7 @@ public final class StandardTags {
    * @return a resolver for the {@value PrideTag#PRIDE} tag
    * @since 4.18.0
    */
-  public static @NotNull TagResolver pride() {
+  public static TagResolver pride() {
     return PrideTag.RESOLVER;
   }
 
@@ -300,7 +299,7 @@ public final class StandardTags {
    * @return a resolver for the {@value ShadowColorTag#SHADOW_COLOR} tags
    * @since 4.18.0
    */
-  public static @NotNull TagResolver shadowColor() {
+  public static TagResolver shadowColor() {
     return ShadowColorTag.RESOLVER;
   }
 
@@ -311,7 +310,7 @@ public final class StandardTags {
    * @since 4.25.0
    * @sinceMinecraft 1.21.9
    */
-  public static @NotNull TagResolver sprite() {
+  public static TagResolver sprite() {
     return SpriteTag.RESOLVER;
   }
 
@@ -324,7 +323,7 @@ public final class StandardTags {
    * @return the resolver for built-in tags
    * @since 4.10.0
    */
-  public static @NotNull TagResolver defaults() {
+  public static TagResolver defaults() {
     return ALL;
   }
 

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TransitionTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TransitionTag.java
@@ -39,7 +39,6 @@ import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Changes the color based on a phase param.
@@ -115,7 +114,7 @@ public final class TransitionTag implements Inserting, Examinable {
   }
 
   @Override
-  public @NotNull Component value() {
+  public Component value() {
     return Component.text("", this.color());
   }
 
@@ -138,7 +137,7 @@ public final class TransitionTag implements Inserting, Examinable {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("phase", this.phase),
       ExaminableProperty.of("colors", this.colors)

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableFallbackTag.java
@@ -36,7 +36,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Insert a translation component into the result, with a fallback string.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/TranslatableTag.java
@@ -33,7 +33,7 @@ import net.kyori.adventure.text.minimessage.internal.serializer.SerializableReso
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Insert a translation component into the result.

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/package-info.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/package-info.java
@@ -24,7 +24,7 @@
 /**
  * Built-in tags shipped with MiniMessage.
  *
- * <p>The tags in {@link StandardTags} will be included in MiniMessage instances by default.</p>
+ * <p>The tags in {@link net.kyori.adventure.text.minimessage.tag.standard.StandardTags} will be included in MiniMessage instances by default.</p>
  *
  * @since 4.10.0
  */

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/Argument.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/Argument.java
@@ -33,7 +33,6 @@ import net.kyori.adventure.text.VirtualComponent;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.TagPattern;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -65,7 +64,7 @@ public final class Argument {
    * @return the named argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike bool(final @TagPattern @NotNull String name, final boolean value) {
+  public static ComponentLike bool(final @TagPattern String name, final boolean value) {
     return argument(name, TranslationArgument.bool(value));
   }
 
@@ -77,7 +76,7 @@ public final class Argument {
    * @return the named argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike numeric(final @TagPattern @NotNull String name, final @NotNull Number value) {
+  public static ComponentLike numeric(final @TagPattern String name, final Number value) {
     return argument(name, TranslationArgument.numeric(value));
   }
 
@@ -89,7 +88,7 @@ public final class Argument {
    * @return the named argument
    * @since 4.21.0
    */
-  public static @NotNull ComponentLike string(final @TagPattern @NotNull String name, final @NotNull String value) {
+  public static ComponentLike string(final @TagPattern String name, final String value) {
     return argument(name, TranslationArgument.component(Component.text(value)));
   }
 
@@ -101,7 +100,7 @@ public final class Argument {
    * @return the named argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike component(final @TagPattern @NotNull String name, final @NotNull ComponentLike value) {
+  public static ComponentLike component(final @TagPattern String name, final ComponentLike value) {
     return argument(name, TranslationArgument.component(value));
   }
 
@@ -113,7 +112,7 @@ public final class Argument {
    * @return the named argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike argument(final @TagPattern @NotNull String name, final @NotNull TranslationArgumentLike argument) {
+  public static ComponentLike argument(final @TagPattern String name, final TranslationArgumentLike argument) {
     return argument(name, requireNonNull(argument, "argument").asTranslationArgument());
   }
 
@@ -125,7 +124,7 @@ public final class Argument {
    * @return the named argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike argument(final @TagPattern @NotNull String name, final @NotNull TranslationArgument argument) {
+  public static ComponentLike argument(final @TagPattern String name, final TranslationArgument argument) {
     return Component.virtual(Void.class, new MiniMessageTranslatorArgument<>(name, requireNonNull(argument, "argument")));
   }
 
@@ -137,7 +136,7 @@ public final class Argument {
    * @return the named argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike tag(final @TagPattern @NotNull String name, final @NotNull Tag tag) {
+  public static ComponentLike tag(final @TagPattern String name, final Tag tag) {
     return Component.virtual(Void.class, new MiniMessageTranslatorArgument<>(name, requireNonNull(tag, "tag")));
   }
 
@@ -148,7 +147,7 @@ public final class Argument {
    * @return the argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike tagResolver(final @NotNull TagResolver @NotNull... resolvers) {
+  public static ComponentLike tagResolver(final TagResolver ... resolvers) {
     return tagResolver(TagResolver.resolver(resolvers));
   }
 
@@ -159,7 +158,7 @@ public final class Argument {
    * @return the argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike tagResolver(final @NotNull Iterable<TagResolver> resolvers) {
+  public static ComponentLike tagResolver(final Iterable<TagResolver> resolvers) {
     return tagResolver(TagResolver.resolver(resolvers));
   }
 
@@ -170,7 +169,7 @@ public final class Argument {
    * @return the argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike tagResolver(final @NotNull TagResolver tagResolver) {
+  public static ComponentLike tagResolver(final TagResolver tagResolver) {
     // The name field is unused here.
     return Component.virtual(Void.class, new MiniMessageTranslatorArgument<>("unused", requireNonNull(tagResolver, "tagResolver")));
   }
@@ -182,7 +181,7 @@ public final class Argument {
    * @return the argument
    * @since 4.20.0
    */
-  public static @NotNull ComponentLike target(final @NotNull Pointered target) {
+  public static ComponentLike target(final Pointered target) {
     return Component.virtual(Void.class, new MiniMessageTranslatorTarget(requireNonNull(target, "target")));
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/ArgumentTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/ArgumentTag.java
@@ -29,8 +29,7 @@ import net.kyori.adventure.text.minimessage.ParsingException;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class ArgumentTag implements TagResolver {
   private static final String NAME = "argument";
@@ -39,13 +38,13 @@ final class ArgumentTag implements TagResolver {
   private final List<Tag> arguments;
   private final TagResolver tagResolver;
 
-  ArgumentTag(final @NotNull List<Tag> arguments, final @NotNull TagResolver tagResolver) {
+  ArgumentTag(final List<Tag> arguments, final TagResolver tagResolver) {
     this.arguments = arguments;
     this.tagResolver = tagResolver;
   }
 
   @Override
-  public @Nullable Tag resolve(final @NotNull String name, final @NotNull ArgumentQueue arguments, final @NotNull Context ctx) throws ParsingException {
+  public @Nullable Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) throws ParsingException {
     if (name.equals(NAME) || name.equals(NAME_1)) {
       final int index = arguments.popOr("No argument number provided").asInt().orElseThrow(() -> ctx.newException("Invalid argument number", arguments));
 
@@ -60,7 +59,7 @@ final class ArgumentTag implements TagResolver {
   }
 
   @Override
-  public boolean has(final @NotNull String name) {
+  public boolean has(final String name) {
     return name.equals(NAME) || name.equals(NAME_1) || this.tagResolver.has(name);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/LocalePointered.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/LocalePointered.java
@@ -27,15 +27,14 @@ import java.util.Locale;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.pointer.Pointers;
-import org.jetbrains.annotations.NotNull;
 
 record LocalePointered(Pointers pointers) implements Pointered {
-  LocalePointered(final @NotNull Locale pointers) {
+  LocalePointered(final Locale pointers) {
     this(Pointers.builder().withStatic(Identity.LOCALE, pointers).build());
   }
 
   @Override
-  public @NotNull Pointers pointers() {
+  public Pointers pointers() {
     return this.pointers;
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslationStore.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslationStore.java
@@ -26,8 +26,6 @@ package net.kyori.adventure.text.minimessage.translation;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.translation.TranslationStore;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A MiniMessage translation store.
@@ -46,7 +44,7 @@ public sealed interface MiniMessageTranslationStore extends TranslationStore.Str
    * @return the translation store
    * @since 4.20.0
    */
-  static @NotNull MiniMessageTranslationStore create(final @NotNull Key name) {
+  static MiniMessageTranslationStore create(final Key name) {
     return create(name, MiniMessage.miniMessage());
   }
 
@@ -58,7 +56,7 @@ public sealed interface MiniMessageTranslationStore extends TranslationStore.Str
    * @return the translation store
    * @since 4.20.0
    */
-  static @NotNull MiniMessageTranslationStore create(final @NotNull Key name, final @NotNull MiniMessage miniMessage) {
+  static MiniMessageTranslationStore create(final Key name, final MiniMessage miniMessage) {
     return new MiniMessageTranslationStoreImpl(name, miniMessage);
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslationStoreImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslationStoreImpl.java
@@ -32,50 +32,49 @@ import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.translation.AbstractTranslationStore;
 import net.kyori.adventure.util.TriState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class MiniMessageTranslationStoreImpl extends AbstractTranslationStore.StringBased<String> implements MiniMessageTranslationStore {
   private final Translator translator;
 
-  MiniMessageTranslationStoreImpl(final @NotNull Key name, final @NotNull MiniMessage miniMessage) {
+  MiniMessageTranslationStoreImpl(final Key name, final MiniMessage miniMessage) {
     super(name);
     this.translator = new Translator(Objects.requireNonNull(miniMessage, "miniMessage"));
   }
 
   @Override
-  protected @NotNull String parse(final @NotNull String string, final @NotNull Locale locale) {
+  protected String parse(final String string, final Locale locale) {
     return string;
   }
 
   @Override
-  public @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
+  public @Nullable MessageFormat translate(final String key, final Locale locale) {
     return null;
   }
 
   @Override
-  public @Nullable Component translate(final @NotNull TranslatableComponent component, final @NotNull Locale locale) {
+  public @Nullable Component translate(final TranslatableComponent component, final Locale locale) {
     return this.translator.translate(component, locale);
   }
 
   private final class Translator extends MiniMessageTranslator {
 
-    private Translator(final @NotNull MiniMessage miniMessage) {
+    private Translator(final MiniMessage miniMessage) {
       super(miniMessage);
     }
 
     @Override
-    protected @Nullable String getMiniMessageString(final @NotNull String key, final @NotNull Locale locale) {
+    protected @Nullable String getMiniMessageString(final String key, final Locale locale) {
       return MiniMessageTranslationStoreImpl.this.translationValue(key, locale);
     }
 
     @Override
-    public @NotNull Key name() {
+    public Key name() {
       return MiniMessageTranslationStoreImpl.this.name();
     }
 
     @Override
-    public @NotNull TriState hasAnyTranslations() {
+    public TriState hasAnyTranslations() {
       return MiniMessageTranslationStoreImpl.this.hasAnyTranslations();
     }
   }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslator.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslator.java
@@ -42,8 +42,7 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.translation.Translator;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A {@link Translator} implementation that translates strings using MiniMessage.
@@ -118,7 +117,7 @@ public abstract class MiniMessageTranslator implements Translator {
    * @see MiniMessage#miniMessage()
    * @since 4.20.0
    */
-  public MiniMessageTranslator(final @NotNull MiniMessage miniMessage) {
+  public MiniMessageTranslator(final MiniMessage miniMessage) {
     this.miniMessage = Objects.requireNonNull(miniMessage, "miniMessage");
   }
 
@@ -135,15 +134,15 @@ public abstract class MiniMessageTranslator implements Translator {
    * @since 4.20.0
    */
   @SuppressWarnings("checkstyle:MethodName")
-  protected abstract @Nullable String getMiniMessageString(final @NotNull String key, final @NotNull Locale locale);
+  protected abstract @Nullable String getMiniMessageString(final String key, final Locale locale);
 
   @Override
-  public final @Nullable MessageFormat translate(final @NotNull String key, final @NotNull Locale locale) {
+  public final @Nullable MessageFormat translate(final String key, final Locale locale) {
     return null;
   }
 
   @Override
-  public final @Nullable Component translate(final @NotNull TranslatableComponent component, final @NotNull Locale locale) {
+  public final @Nullable Component translate(final TranslatableComponent component, final Locale locale) {
     final String miniMessageString = this.getMiniMessageString(component.key(), locale);
 
     if (miniMessageString == null) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslatorArgument.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslatorArgument.java
@@ -28,14 +28,13 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.VirtualComponentRenderer;
 import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.tag.TagPattern;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnknownNullability;
 
 final class MiniMessageTranslatorArgument<T> implements VirtualComponentRenderer<Void> {
-  private final @NotNull String name;
-  private final @NotNull T data;
+  private final String name;
+  private final T data;
 
-  MiniMessageTranslatorArgument(final @TagPattern @NotNull String name, final @NotNull T data) {
+  MiniMessageTranslatorArgument(final @TagPattern String name, final T data) {
     Objects.requireNonNull(name, "name");
     Objects.requireNonNull(data, "data");
     TagInternals.assertValidTagName(name);
@@ -44,16 +43,16 @@ final class MiniMessageTranslatorArgument<T> implements VirtualComponentRenderer
     this.data = data;
   }
 
-  public @NotNull String name() {
+  public String name() {
     return this.name;
   }
 
-  public @NotNull T data() {
+  public T data() {
     return this.data;
   }
 
   @Override
-  public @UnknownNullability ComponentLike apply(final @NotNull Void context) {
+  public @UnknownNullability ComponentLike apply(final Void context) {
     if (this.data instanceof ComponentLike componentLike) {
       return componentLike;
     } else {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslatorTarget.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslatorTarget.java
@@ -26,22 +26,21 @@ package net.kyori.adventure.text.minimessage.translation;
 import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.VirtualComponentRenderer;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnknownNullability;
 
 final class MiniMessageTranslatorTarget implements VirtualComponentRenderer<Void> {
   private final Pointered pointered;
 
-  MiniMessageTranslatorTarget(final @NotNull Pointered pointered) {
+  MiniMessageTranslatorTarget(final Pointered pointered) {
     this.pointered = pointered;
   }
 
-  @NotNull Pointered pointered() {
+  Pointered pointered() {
     return this.pointered;
   }
 
   @Override
-  public @UnknownNullability ComponentLike apply(final @NotNull Void context) {
+  public @UnknownNullability ComponentLike apply(final Void context) {
     return null;
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tree/Node.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tree/Node.java
@@ -26,9 +26,7 @@ package net.kyori.adventure.text.minimessage.tree;
 import java.util.List;
 import net.kyori.adventure.text.minimessage.internal.parser.node.ElementNode;
 import net.kyori.adventure.text.minimessage.internal.parser.node.RootNode;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A node in the MiniMessage parse tree.
@@ -45,7 +43,7 @@ public sealed interface Node permits ElementNode, Node.Root {
    * @since 4.10.0
    */
   @Override
-  @NotNull String toString();
+  String toString();
 
   /**
    * Get children of this node.
@@ -55,7 +53,7 @@ public sealed interface Node permits ElementNode, Node.Root {
    * @return a list of children
    * @since 4.10.0
    */
-  @NotNull List<? extends Node> children();
+  List<? extends Node> children();
 
   /**
    * Get the parent of this node.
@@ -79,6 +77,6 @@ public sealed interface Node permits ElementNode, Node.Root {
      * @return the input message
      * @since 4.10.0
      */
-    @NotNull String input();
+    String input();
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tree/Node.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tree/Node.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.minimessage.tree;
 
 import java.util.List;
-
 import net.kyori.adventure.text.minimessage.internal.parser.node.ElementNode;
 import net.kyori.adventure.text.minimessage.internal.parser.node.RootNode;
 import org.jetbrains.annotations.ApiStatus;

--- a/text-serializer-ansi/src/main/java/module-info.java
+++ b/text-serializer-ansi/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Serialization to ANSI escape sequences. Does not support deserialization.
+ */
+@NullMarked
+module net.kyori.adventure.text.serializer.ansi {
+  requires transitive net.kyori.adventure.api;
+  requires transitive net.kyori.ansi;
+
+  exports net.kyori.adventure.text.serializer.ansi;
+}

--- a/text-serializer-ansi/src/main/java/net/kyori/adventure/text/serializer/ansi/ANSIComponentSerializer.java
+++ b/text-serializer-ansi/src/main/java/net/kyori/adventure/text/serializer/ansi/ANSIComponentSerializer.java
@@ -31,7 +31,6 @@ import net.kyori.adventure.text.serializer.ComponentEncoder;
 import net.kyori.adventure.util.PlatformAPI;
 import net.kyori.ansi.ColorLevel;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A serializer which emits <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">ANSI escape sequences</a>.
@@ -49,7 +48,7 @@ public interface ANSIComponentSerializer extends ComponentEncoder<Component, Str
    * @return a component serializer for serialization with ANSI escape sequences.
    * @since 4.14.0
    */
-  static @NotNull ANSIComponentSerializer ansi() {
+  static ANSIComponentSerializer ansi() {
     return ANSIComponentSerializerImpl.Instances.INSTANCE;
   }
 
@@ -59,7 +58,7 @@ public interface ANSIComponentSerializer extends ComponentEncoder<Component, Str
    * @return a new ANSI serializer builder
    * @since 4.14.0
    */
-  static ANSIComponentSerializer.@NotNull Builder builder() {
+  static ANSIComponentSerializer.Builder builder() {
     return new ANSIComponentSerializerImpl.BuilderImpl();
   }
 
@@ -79,7 +78,7 @@ public interface ANSIComponentSerializer extends ComponentEncoder<Component, Str
      * @see ColorLevel
      * @since 4.14.0
      */
-    @NotNull Builder colorLevel(final @NotNull ColorLevel colorLevel);
+    Builder colorLevel(final ColorLevel colorLevel);
 
     /**
      * Sets the component flattener instance to use when traversing the component for serialization.
@@ -90,7 +89,7 @@ public interface ANSIComponentSerializer extends ComponentEncoder<Component, Str
      * @return this builder
      * @since 4.14.0
      */
-    @NotNull Builder flattener(final @NotNull ComponentFlattener componentFlattener);
+    Builder flattener(final ComponentFlattener componentFlattener);
 
     /**
      * Builds the serializer.
@@ -98,7 +97,7 @@ public interface ANSIComponentSerializer extends ComponentEncoder<Component, Str
      * @return the built serializer
      */
     @Override
-    @NotNull ANSIComponentSerializer build();
+    ANSIComponentSerializer build();
   }
 
   /**
@@ -117,7 +116,7 @@ public interface ANSIComponentSerializer extends ComponentEncoder<Component, Str
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull ANSIComponentSerializer ansi();
+    ANSIComponentSerializer ansi();
 
     /**
      * Completes the building process of {@link Builder}.
@@ -127,6 +126,6 @@ public interface ANSIComponentSerializer extends ComponentEncoder<Component, Str
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull Consumer<Builder> builder();
+    Consumer<Builder> builder();
   }
 }

--- a/text-serializer-ansi/src/main/java/net/kyori/adventure/text/serializer/ansi/ANSIComponentSerializerImpl.java
+++ b/text-serializer-ansi/src/main/java/net/kyori/adventure/text/serializer/ansi/ANSIComponentSerializerImpl.java
@@ -36,9 +36,8 @@ import net.kyori.adventure.util.Services;
 import net.kyori.ansi.ANSIComponentRenderer;
 import net.kyori.ansi.ColorLevel;
 import net.kyori.ansi.StyleOps;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
+import org.jspecify.annotations.Nullable;
 
 final class ANSIComponentSerializerImpl implements ANSIComponentSerializer {
   private static final Optional<Provider> SERVICE = Services.service(Provider.class);
@@ -64,7 +63,7 @@ final class ANSIComponentSerializerImpl implements ANSIComponentSerializer {
   }
 
   @Override
-  public @NotNull String serialize(final @NotNull Component component) {
+  public String serialize(final Component component) {
     final ANSIComponentRenderer.ToString<Style> renderer = ANSIComponentRenderer.toString(ComponentStyleOps.INSTANCE, this.colorLevel);
     this.flattener.flatten(component, new ANSIFlattenerListener(renderer));
     renderer.complete();
@@ -83,38 +82,38 @@ final class ANSIComponentSerializerImpl implements ANSIComponentSerializer {
     static final ComponentStyleOps INSTANCE = new ComponentStyleOps();
 
     @Override
-    public State bold(final @NotNull Style style) {
+    public State bold(final Style style) {
       return mapState(style.decoration(TextDecoration.BOLD));
     }
 
     @Override
-    public State italics(final @NotNull Style style) {
+    public State italics(final Style style) {
       return mapState(style.decoration(TextDecoration.ITALIC));
     }
 
     @Override
-    public State underlined(final @NotNull Style style) {
+    public State underlined(final Style style) {
       return mapState(style.decoration(TextDecoration.UNDERLINED));
     }
 
     @Override
-    public State strikethrough(final @NotNull Style style) {
+    public State strikethrough(final Style style) {
       return mapState(style.decoration(TextDecoration.STRIKETHROUGH));
     }
 
     @Override
-    public State obfuscated(final @NotNull Style style) {
+    public State obfuscated(final Style style) {
       return mapState(style.decoration(TextDecoration.OBFUSCATED));
     }
 
     @Override
-    public @Range(from = -1L, to = 16777215L) int color(final @NotNull Style style) {
+    public @Range(from = -1L, to = 16777215L) int color(final Style style) {
       final TextColor color = style.color();
       return color == null ? -1 : color.value();
     }
 
     @Override
-    public @Nullable String font(final @NotNull Style style) {
+    public @Nullable String font(final Style style) {
       final Key font = style.font();
       return font == null ? null : font.asString();
     }
@@ -128,17 +127,17 @@ final class ANSIComponentSerializerImpl implements ANSIComponentSerializer {
     }
 
     @Override
-    public void pushStyle(final @NotNull Style style) {
+    public void pushStyle(final Style style) {
       this.renderer.pushStyle(style);
     }
 
     @Override
-    public void component(final @NotNull String text) {
+    public void component(final String text) {
       this.renderer.text(text);
     }
 
     @Override
-    public void popStyle(final @NotNull Style style) {
+    public void popStyle(final Style style) {
       this.renderer.popStyle(style);
     }
   }
@@ -152,19 +151,19 @@ final class ANSIComponentSerializerImpl implements ANSIComponentSerializer {
     }
 
     @Override
-    public @NotNull Builder colorLevel(final @NotNull ColorLevel colorLevel) {
+    public Builder colorLevel(final ColorLevel colorLevel) {
       this.colorLevel = colorLevel;
       return this;
     }
 
     @Override
-    public @NotNull Builder flattener(final @NotNull ComponentFlattener componentFlattener) {
+    public Builder flattener(final ComponentFlattener componentFlattener) {
       this.flattener = componentFlattener;
       return this;
     }
 
     @Override
-    public @NotNull ANSIComponentSerializer build() {
+    public ANSIComponentSerializer build() {
       return new ANSIComponentSerializerImpl(this.colorLevel, this.flattener);
     }
   }

--- a/text-serializer-commons/src/main/java/module-info.java
+++ b/text-serializer-commons/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+/**
+ * Constants useful for creating any component serializer following the vanilla tree structure.
+ */
+module net.kyori.adventure.text.serializer.commons {
+  requires transitive static org.jetbrains.annotations;
+
+  exports net.kyori.adventure.text.serializer.commons;
+}

--- a/text-serializer-gson/src/main/java/module-info.java
+++ b/text-serializer-gson/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Gson based serialization and deserialization.
+ */
+@NullMarked
+module net.kyori.adventure.text.serializer.gson {
+  requires transitive net.kyori.adventure.text.serializer.json;
+  requires gson;
+  requires net.kyori.adventure.text.serializer.commons;
+  requires static com.google.auto.service;
+
+  exports net.kyori.adventure.text.serializer.gson;
+}

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ComponentSerializerImpl.java
@@ -58,7 +58,7 @@ import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import net.kyori.adventure.text.object.SpriteObjectContents;
 import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.option.OptionState;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static net.kyori.adventure.text.serializer.commons.ComponentTreeConstants.EXTRA;
 import static net.kyori.adventure.text.serializer.commons.ComponentTreeConstants.KEYBIND;

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializer.java
@@ -34,8 +34,7 @@ import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import net.kyori.adventure.util.PlatformAPI;
 import net.kyori.option.OptionState;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A gson component serializer.
@@ -55,7 +54,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
    * @return a gson component serializer
    * @since 4.0.0
    */
-  static @NotNull GsonComponentSerializer gson() {
+  static GsonComponentSerializer gson() {
     return GsonComponentSerializerImpl.Instances.INSTANCE;
   }
 
@@ -68,7 +67,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
    * @return a gson component serializer
    * @since 4.0.0
    */
-  static @NotNull GsonComponentSerializer colorDownsamplingGson() {
+  static GsonComponentSerializer colorDownsamplingGson() {
     return GsonComponentSerializerImpl.Instances.LEGACY_INSTANCE;
   }
 
@@ -88,7 +87,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
    * @return a gson serializer
    * @since 4.0.0
    */
-  @NotNull Gson serializer();
+  Gson serializer();
 
   /**
    * Gets the underlying gson populator.
@@ -96,7 +95,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
    * @return a gson populator
    * @since 4.0.0
    */
-  @NotNull UnaryOperator<GsonBuilder> populator();
+  UnaryOperator<GsonBuilder> populator();
 
   /**
    * Deserialize a component from input of type {@link JsonElement}.
@@ -105,7 +104,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
    * @return the component
    * @since 4.7.0
    */
-  @NotNull Component deserializeFromTree(final @NotNull JsonElement input);
+  Component deserializeFromTree(final JsonElement input);
 
   /**
    * Deserialize a component to output of type {@link JsonElement}.
@@ -114,7 +113,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
    * @return the json element
    * @since 4.7.0
    */
-  @NotNull JsonElement serializeToTree(final @NotNull Component component);
+  JsonElement serializeToTree(final Component component);
 
   /**
    * A builder for {@link GsonComponentSerializer}.
@@ -123,13 +122,13 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
    */
   interface Builder extends AbstractBuilder<GsonComponentSerializer>, JSONComponentSerializer.Builder {
     @Override
-    @NotNull Builder options(final @NotNull OptionState flags);
+    Builder options(final OptionState flags);
 
     @Override
-    @NotNull Builder editOptions(final @NotNull Consumer<OptionState.Builder> optionEditor);
+    Builder editOptions(final Consumer<OptionState.Builder> optionEditor);
 
     @Override
-    @NotNull Builder legacyHoverEventSerializer(final net.kyori.adventure.text.serializer.json.@Nullable LegacyHoverEventSerializer serializer);
+    Builder legacyHoverEventSerializer(final net.kyori.adventure.text.serializer.json.@Nullable LegacyHoverEventSerializer serializer);
 
     /**
      * Builds the serializer.
@@ -137,7 +136,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
      * @return the built serializer
      */
     @Override
-    @NotNull GsonComponentSerializer build();
+    GsonComponentSerializer build();
   }
 
   /**
@@ -156,7 +155,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull GsonComponentSerializer gson();
+    GsonComponentSerializer gson();
 
     /**
      * Provides a legacy {@link GsonComponentSerializer}.
@@ -166,7 +165,7 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull GsonComponentSerializer gsonLegacy();
+    GsonComponentSerializer gsonLegacy();
 
     /**
      * Completes the building process of {@link Builder}.
@@ -176,6 +175,6 @@ public interface GsonComponentSerializer extends JSONComponentSerializer {
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull Consumer<Builder> builder();
+    Consumer<Builder> builder();
   }
 }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonComponentSerializerImpl.java
@@ -33,8 +33,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.adventure.util.Services;
 import net.kyori.option.OptionState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -75,17 +74,17 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   }
 
   @Override
-  public @NotNull Gson serializer() {
+  public Gson serializer() {
     return this.serializer;
   }
 
   @Override
-  public @NotNull UnaryOperator<GsonBuilder> populator() {
+  public UnaryOperator<GsonBuilder> populator() {
     return this.populator;
   }
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String string) {
+  public Component deserialize(final String string) {
     final Component component = this.serializer().fromJson(string, Component.class);
     if (component == null) throw ComponentSerializerImpl.notSureHowToDeserialize(string);
     return component;
@@ -100,24 +99,24 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
   }
 
   @Override
-  public @NotNull String serialize(final @NotNull Component component) {
+  public String serialize(final Component component) {
     return this.serializer().toJson(component);
   }
 
   @Override
-  public @NotNull Component deserializeFromTree(final @NotNull JsonElement input) {
+  public Component deserializeFromTree(final JsonElement input) {
     final Component component = this.serializer().fromJson(input, Component.class);
     if (component == null) throw ComponentSerializerImpl.notSureHowToDeserialize(input);
     return component;
   }
 
   @Override
-  public @NotNull JsonElement serializeToTree(final @NotNull Component component) {
+  public JsonElement serializeToTree(final Component component) {
     return this.serializer().toJsonTree(component);
   }
 
 //  @Override TODO: common builder interface?
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -136,13 +135,13 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
     }
 
     @Override
-    public @NotNull Builder options(final @NotNull OptionState flags) {
+    public Builder options(final OptionState flags) {
       this.flags = requireNonNull(flags, "flags");
       return this;
     }
 
     @Override
-    public @NotNull Builder editOptions(final @NotNull Consumer<OptionState.Builder> optionEditor) {
+    public Builder editOptions(final Consumer<OptionState.Builder> optionEditor) {
       final OptionState.Builder builder = JSONOptions.schema().stateBuilder()
         .values(this.flags);
       requireNonNull(optionEditor, "flagEditor").accept(builder);
@@ -151,13 +150,13 @@ final class GsonComponentSerializerImpl implements GsonComponentSerializer {
     }
 
     @Override
-    public @NotNull Builder legacyHoverEventSerializer(final net.kyori.adventure.text.serializer.json.@Nullable LegacyHoverEventSerializer serializer) {
+    public Builder legacyHoverEventSerializer(final net.kyori.adventure.text.serializer.json.@Nullable LegacyHoverEventSerializer serializer) {
       this.legacyHoverSerializer = serializer;
       return this;
     }
 
     @Override
-    public @NotNull GsonComponentSerializer build() {
+    public GsonComponentSerializer build() {
       return new GsonComponentSerializerImpl(this.flags, this.legacyHoverSerializer);
     }
   }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonDataComponentValue.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonDataComponentValue.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.serializer.gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import net.kyori.adventure.text.event.DataComponentValue;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -45,7 +44,7 @@ public sealed interface GsonDataComponentValue extends DataComponentValue permit
    * @return a newly created item data holder instance
    * @since 4.17.0
    */
-  static GsonDataComponentValue gsonDataComponentValue(final @NotNull JsonElement data) {
+  static GsonDataComponentValue gsonDataComponentValue(final JsonElement data) {
     if (data instanceof JsonNull) {
       return GsonDataComponentValueImpl.RemovedGsonComponentValueImpl.INSTANCE;
     } else {
@@ -59,5 +58,5 @@ public sealed interface GsonDataComponentValue extends DataComponentValue permit
    * @return a copy of the contained element
    * @since 4.17.0
    */
-  @NotNull JsonElement element();
+  JsonElement element();
 }

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonDataComponentValueImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonDataComponentValueImpl.java
@@ -30,23 +30,22 @@ import java.util.stream.Stream;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 sealed class GsonDataComponentValueImpl implements GsonDataComponentValue {
   private final JsonElement element;
 
-  GsonDataComponentValueImpl(final @NotNull JsonElement element) {
+  GsonDataComponentValueImpl(final JsonElement element) {
     this.element = element;
   }
 
   @Override
-  public @NotNull JsonElement element() {
+  public JsonElement element() {
     return this.element;
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("element", this.element)
     );

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonHacks.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/GsonHacks.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import java.io.IOException;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class GsonHacks {
   private GsonHacks() {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/SerializerFactory.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/SerializerFactory.java
@@ -41,7 +41,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.option.OptionState;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class SerializerFactory implements TypeAdapterFactory {
   static final Class<Key> KEY_TYPE = Key.class;

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowEntitySerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowEntitySerializer.java
@@ -37,7 +37,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEventImpl;
 import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.option.OptionState;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static net.kyori.adventure.text.serializer.commons.ComponentTreeConstants.SHOW_ENTITY_ID;
 import static net.kyori.adventure.text.serializer.commons.ComponentTreeConstants.SHOW_ENTITY_NAME;

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/ShowItemSerializer.java
@@ -40,8 +40,7 @@ import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.adventure.text.event.HoverEventImpl;
 import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.option.OptionState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static net.kyori.adventure.text.serializer.commons.ComponentTreeConstants.SHOW_ITEM_COMPONENTS;
 import static net.kyori.adventure.text.serializer.commons.ComponentTreeConstants.SHOW_ITEM_COUNT;
@@ -144,7 +143,7 @@ final class ShowItemSerializer extends TypeAdapter<HoverEventImpl.ShowItem> {
       out.value(count);
     }
 
-    final @NotNull Map<Key, DataComponentValue> dataComponents = value.dataComponents();
+    final Map<Key, DataComponentValue> dataComponents = value.dataComponents();
     if (!dataComponents.isEmpty() && this.itemDataMode != JSONOptions.ShowItemHoverDataMode.EMIT_LEGACY_NBT) {
       out.name(SHOW_ITEM_COMPONENTS);
       out.beginObject();

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/StyleSerializer.java
@@ -48,7 +48,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.json.JSONOptions;
 import net.kyori.adventure.util.Codec;
 import net.kyori.option.OptionState;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static net.kyori.adventure.text.serializer.commons.ComponentTreeConstants.CLICK_EVENT_ACTION;
 import static net.kyori.adventure.text.serializer.commons.ComponentTreeConstants.CLICK_EVENT_CAMEL;

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorSerializer.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorSerializer.java
@@ -31,8 +31,7 @@ import java.util.Locale;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.NamedTextColorImpl;
 import net.kyori.adventure.text.format.TextColor;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class TextColorSerializer extends TypeAdapter<TextColor> {
   static final TypeAdapter<TextColor> INSTANCE = new TextColorSerializer(false).nullSafe();
@@ -67,7 +66,7 @@ final class TextColorSerializer extends TypeAdapter<TextColor> {
     return this.downsampleColor ? NamedTextColor.nearestTo(color) : color;
   }
 
-  static @Nullable TextColor fromString(final @NotNull String value) {
+  static @Nullable TextColor fromString(final String value) {
     if (value.startsWith(TextColor.HEX_PREFIX)) {
       return TextColor.fromHexString(value);
     } else {

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorWrapper.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/TextColorWrapper.java
@@ -31,7 +31,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /*
  * This is a hack.

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/GsonDataComponentValueConverterProvider.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/GsonDataComponentValueConverterProvider.java
@@ -32,7 +32,6 @@ import net.kyori.adventure.text.event.DataComponentValue;
 import net.kyori.adventure.text.event.DataComponentValueConverterRegistry;
 import net.kyori.adventure.text.serializer.gson.GsonDataComponentValue;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A provider for Gson's implementations of data component value converters.
@@ -47,12 +46,12 @@ public final class GsonDataComponentValueConverterProvider implements DataCompon
   private static final Key ID = Key.key(Adventure.NAMESPACE, "serializer/gson");
 
   @Override
-  public @NotNull Key id() {
+  public Key id() {
     return ID;
   }
 
   @Override
-  public @NotNull Iterable<DataComponentValueConverterRegistry.Conversion<?, ?>> conversions() {
+  public Iterable<DataComponentValueConverterRegistry.Conversion<?, ?>> conversions() {
     return Collections.singletonList(
       DataComponentValueConverterRegistry.Conversion.convert(
         DataComponentValue.Removed.class,

--- a/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/JSONComponentSerializerProviderImpl.java
+++ b/text-serializer-gson/src/main/java/net/kyori/adventure/text/serializer/gson/impl/JSONComponentSerializerProviderImpl.java
@@ -29,7 +29,6 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import net.kyori.adventure.util.Services;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Implementation of the JSON component serializer provider.
@@ -40,12 +39,12 @@ import org.jetbrains.annotations.NotNull;
 @AutoService(JSONComponentSerializer.Provider.class)
 public final class JSONComponentSerializerProviderImpl implements JSONComponentSerializer.Provider, Services.Fallback {
   @Override
-  public @NotNull JSONComponentSerializer instance() {
+  public JSONComponentSerializer instance() {
     return GsonComponentSerializer.gson();
   }
 
   @Override
-  public @NotNull Supplier<JSONComponentSerializer.@NotNull Builder> builder() {
+  public Supplier<JSONComponentSerializer.Builder> builder() {
     return GsonComponentSerializer::builder;
   }
 

--- a/text-serializer-json-legacy-impl/src/main/java/module-info.java
+++ b/text-serializer-json-legacy-impl/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * JSON legacy hover event serialization and deserialization.
+ *
+ * <p>This is a replacement for the old {@code adventure-text-serializer-gson-legacyimpl} module.</p>
+ */
+@NullMarked
+module net.kyori.adventure.text.serializer.json.legacyimpl {
+  requires transitive net.kyori.adventure.text.serializer.json;
+  requires net.kyori.adventure.nbt;
+
+  exports net.kyori.adventure.text.serializer.json.legacyimpl;
+}

--- a/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializer.java
+++ b/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializer.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.serializer.json.legacyimpl;
 
 import net.kyori.adventure.text.event.HoverEventImpl;
 import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A legacy {@link HoverEventImpl} serializer.
@@ -39,7 +38,7 @@ public interface NBTLegacyHoverEventSerializer extends LegacyHoverEventSerialize
    * @return a legacy {@link HoverEventImpl} serializer
    * @since 4.14.0
    */
-  static @NotNull LegacyHoverEventSerializer get() {
+  static LegacyHoverEventSerializer get() {
     return NBTLegacyHoverEventSerializerImpl.INSTANCE;
   }
 }

--- a/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
+++ b/text-serializer-json-legacy-impl/src/main/java/net/kyori/adventure/text/serializer/json/legacyimpl/NBTLegacyHoverEventSerializerImpl.java
@@ -34,8 +34,7 @@ import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.HoverEventImpl;
 import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
 import net.kyori.adventure.util.Codec;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSerializer {
   static final NBTLegacyHoverEventSerializerImpl INSTANCE = new NBTLegacyHoverEventSerializerImpl();
@@ -54,7 +53,7 @@ final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSeriali
   }
 
   @Override
-  public HoverEventImpl.@NotNull ShowItem deserializeShowItem(final @NotNull Component input) throws IOException {
+  public HoverEventImpl.ShowItem deserializeShowItem(final Component input) throws IOException {
     assertTextComponent(input);
     final CompoundBinaryTag contents = SNBT_CODEC.decode(((TextComponent) input).content());
     final CompoundBinaryTag tag = contents.getCompound(ITEM_TAG);
@@ -66,7 +65,7 @@ final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSeriali
   }
 
   @Override
-  public @NotNull Component serializeShowItem(final HoverEventImpl.@NotNull ShowItem input) throws IOException {
+  public Component serializeShowItem(final HoverEventImpl.ShowItem input) throws IOException {
     final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
       .putString(ITEM_TYPE, input.item().asString())
       .putByte(ITEM_COUNT, (byte) input.count());
@@ -78,7 +77,7 @@ final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSeriali
   }
 
   @Override
-  public HoverEventImpl.@NotNull ShowEntity deserializeShowEntity(final @NotNull Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
+  public HoverEventImpl.ShowEntity deserializeShowEntity(final Component input, final Codec.Decoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
     assertTextComponent(input);
     final CompoundBinaryTag contents = SNBT_CODEC.decode(((TextComponent) input).content());
     return HoverEventImpl.ShowEntity.showEntity(
@@ -89,7 +88,7 @@ final class NBTLegacyHoverEventSerializerImpl implements LegacyHoverEventSeriali
   }
 
   @Override
-  public @NotNull Component serializeShowEntity(final HoverEventImpl.@NotNull ShowEntity input, final Codec.Encoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
+  public Component serializeShowEntity(final HoverEventImpl.ShowEntity input, final Codec.Encoder<Component, String, ? extends RuntimeException> componentCodec) throws IOException {
     final CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
       .putString(ENTITY_ID, input.id().toString())
       .putString(ENTITY_TYPE, input.type().asString());

--- a/text-serializer-json/src/main/java/module-info.java
+++ b/text-serializer-json/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A common abstraction providing an API to serializer components with multiple JSON libraries.
+ */
+@NullMarked
+module net.kyori.adventure.text.serializer.json {
+  requires transitive net.kyori.adventure.api;
+  requires transitive net.kyori.option;
+
+  exports net.kyori.adventure.text.serializer.json;
+}

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/DummyJSONComponentSerializer.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/DummyJSONComponentSerializer.java
@@ -26,8 +26,7 @@ package net.kyori.adventure.text.serializer.json;
 import java.util.function.Consumer;
 import net.kyori.adventure.text.Component;
 import net.kyori.option.OptionState;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class DummyJSONComponentSerializer implements JSONComponentSerializer {
   static final JSONComponentSerializer INSTANCE = new DummyJSONComponentSerializer();
@@ -38,34 +37,34 @@ final class DummyJSONComponentSerializer implements JSONComponentSerializer {
     Is your environment configured in a way that causes ServiceLoader to malfunction?""";
 
   @Override
-  public @NotNull Component deserialize(final @NotNull String input) {
+  public Component deserialize(final String input) {
     throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
   }
 
   @Override
-  public @NotNull String serialize(final @NotNull Component component) {
+  public String serialize(final Component component) {
     throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
   }
 
   // A no-op builder that just returns the unsupported instance.
   static final class BuilderImpl implements Builder {
     @Override
-    public @NotNull Builder options(final @NotNull OptionState flags) {
+    public Builder options(final OptionState flags) {
       return this;
     }
 
     @Override
-    public @NotNull Builder editOptions(final @NotNull Consumer<OptionState.Builder> optionEditor) {
+    public Builder editOptions(final Consumer<OptionState.Builder> optionEditor) {
       return this;
     }
 
     @Override
-    public @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer) {
+    public Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer) {
       return this;
     }
 
     @Override
-    public @NotNull JSONComponentSerializer build() {
+    public JSONComponentSerializer build() {
       return INSTANCE;
     }
   }

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONComponentSerializer.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONComponentSerializer.java
@@ -30,8 +30,7 @@ import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.PlatformAPI;
 import net.kyori.option.OptionState;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A JSON component serializer.
@@ -48,7 +47,7 @@ public interface JSONComponentSerializer extends ComponentSerializer<Component, 
    * @return a JSON component serializer
    * @since 4.14.0
    */
-  static @NotNull JSONComponentSerializer json() {
+  static JSONComponentSerializer json() {
     return JSONComponentSerializerAccessor.Instances.INSTANCE;
   }
 
@@ -58,7 +57,7 @@ public interface JSONComponentSerializer extends ComponentSerializer<Component, 
    * @return the new builder
    * @since 4.14.0
    */
-  static JSONComponentSerializer.@NotNull Builder builder() {
+  static JSONComponentSerializer.Builder builder() {
     return JSONComponentSerializerAccessor.Instances.BUILDER_SUPPLIER.get();
   }
 
@@ -78,7 +77,7 @@ public interface JSONComponentSerializer extends ComponentSerializer<Component, 
      * @see JSONOptions
      * @since 4.15.0
      */
-    @NotNull Builder options(final @NotNull OptionState flags);
+    Builder options(final OptionState flags);
 
     /**
      * Edit the active set of serializer options.
@@ -88,7 +87,7 @@ public interface JSONComponentSerializer extends ComponentSerializer<Component, 
      * @see JSONOptions
      * @since  4.15.0
      */
-    @NotNull Builder editOptions(final @NotNull Consumer<OptionState.Builder> optionEditor);
+    Builder editOptions(final Consumer<OptionState.Builder> optionEditor);
 
     /**
      * Sets a serializer that will be used to interpret legacy hover event {@code value} payloads.
@@ -99,7 +98,7 @@ public interface JSONComponentSerializer extends ComponentSerializer<Component, 
      * @return this builder
      * @since 4.14.0
      */
-    @NotNull Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
+    Builder legacyHoverEventSerializer(final @Nullable LegacyHoverEventSerializer serializer);
 
     /**
      * Create a finished serializer instance.
@@ -107,7 +106,7 @@ public interface JSONComponentSerializer extends ComponentSerializer<Component, 
      * @return the new serializer
      * @since 4.14.0
      */
-    @NotNull JSONComponentSerializer build();
+    JSONComponentSerializer build();
   }
 
   /**
@@ -126,7 +125,7 @@ public interface JSONComponentSerializer extends ComponentSerializer<Component, 
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull JSONComponentSerializer instance();
+    JSONComponentSerializer instance();
 
     /**
      * Provide a supplier for builder builders of {@link JSONComponentSerializer} instances.
@@ -136,6 +135,6 @@ public interface JSONComponentSerializer extends ComponentSerializer<Component, 
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull Supplier<@NotNull Builder> builder();
+    Supplier<Builder> builder();
   }
 }

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONOptions.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/JSONOptions.java
@@ -26,7 +26,6 @@ package net.kyori.adventure.text.serializer.json;
 import net.kyori.option.Option;
 import net.kyori.option.OptionSchema;
 import net.kyori.option.OptionState;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Options that can apply to JSON serializers.
@@ -224,7 +223,7 @@ public final class JSONOptions {
    * @return the schema of known json options
    * @since 4.20.0
    */
-  public static @NotNull OptionSchema schema() {
+  public static OptionSchema schema() {
     return SCHEMA;
   }
 
@@ -234,7 +233,7 @@ public final class JSONOptions {
    * @return the versioned flag set
    * @since 4.15.0
    */
-  public static OptionState.@NotNull Versioned byDataVersion() {
+  public static OptionState.Versioned byDataVersion() {
     return BY_DATA_VERSION;
   }
 
@@ -246,7 +245,7 @@ public final class JSONOptions {
    * @return the most widely compatible feature flag set
    * @since 4.15.0
    */
-  public static @NotNull OptionState compatibility() {
+  public static OptionState compatibility() {
     return MOST_COMPATIBLE;
   }
 

--- a/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/LegacyHoverEventSerializer.java
+++ b/text-serializer-json/src/main/java/net/kyori/adventure/text/serializer/json/LegacyHoverEventSerializer.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEventImpl;
 import net.kyori.adventure.util.Codec;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Adapter to convert between modern and legacy hover event formats.
@@ -43,7 +42,7 @@ public interface LegacyHoverEventSerializer {
    * @throws IOException if the input is improperly formatted
    * @since 4.14.0
    */
-  HoverEventImpl.@NotNull ShowItem deserializeShowItem(@NotNull Component input) throws IOException;
+  HoverEventImpl.ShowItem deserializeShowItem(Component input) throws IOException;
 
   /**
    * Convert a modern hover event {@code show_item} value to its legacy format.
@@ -53,7 +52,7 @@ public interface LegacyHoverEventSerializer {
    * @throws IOException if the input is improperly formatted
    * @since 4.14.0
    */
-  @NotNull Component serializeShowItem(HoverEventImpl.@NotNull ShowItem input) throws IOException;
+  Component serializeShowItem(HoverEventImpl.ShowItem input) throws IOException;
 
   /**
    * Convert a legacy hover event {@code show_entity} value to its modern format.
@@ -64,7 +63,7 @@ public interface LegacyHoverEventSerializer {
    * @throws IOException if the input is improperly formatted
    * @since 4.14.0
    */
-  HoverEventImpl.@NotNull ShowEntity deserializeShowEntity(@NotNull Component input, Codec.Decoder<Component, String, ? extends RuntimeException> componentDecoder) throws IOException;
+  HoverEventImpl.ShowEntity deserializeShowEntity(Component input, Codec.Decoder<Component, String, ? extends RuntimeException> componentDecoder) throws IOException;
 
   /**
    * Convert a modern hover event {@code show_entity} value to its legacy format.
@@ -75,5 +74,5 @@ public interface LegacyHoverEventSerializer {
    * @throws IOException if the input is improperly formatted
    * @since 4.14.0
    */
-  @NotNull Component serializeShowEntity(HoverEventImpl.@NotNull ShowEntity input, Codec.Encoder<Component, String, ? extends RuntimeException> componentEncoder) throws IOException;
+  Component serializeShowEntity(HoverEventImpl.ShowEntity input, Codec.Encoder<Component, String, ? extends RuntimeException> componentEncoder) throws IOException;
 }

--- a/text-serializer-legacy/src/main/java/module-info.java
+++ b/text-serializer-legacy/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Legacy text based serialization and deserialization.
+ */
+@NullMarked
+module net.kyori.adventure.text.serializer.legacy {
+  requires transitive net.kyori.adventure.api;
+
+  exports net.kyori.adventure.text.serializer.legacy;
+}

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormat.java
@@ -31,8 +31,6 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.format.TextFormat;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
 /**
@@ -184,7 +182,7 @@ public sealed interface CharacterAndFormat extends Examinable permits CharacterA
    * @return a new character and format instance.
    * @since 4.14.0
    */
-  static @NotNull CharacterAndFormat characterAndFormat(final char character, final @NotNull TextFormat format) {
+  static CharacterAndFormat characterAndFormat(final char character, final TextFormat format) {
     return characterAndFormat(character, format, false);
   }
 
@@ -197,7 +195,7 @@ public sealed interface CharacterAndFormat extends Examinable permits CharacterA
    * @return a new character and format instance.
    * @since 4.17.0
    */
-  static @NotNull CharacterAndFormat characterAndFormat(final char character, final @NotNull TextFormat format, final boolean caseInsensitive) {
+  static CharacterAndFormat characterAndFormat(final char character, final TextFormat format, final boolean caseInsensitive) {
     return new CharacterAndFormatImpl(character, format, caseInsensitive);
   }
 
@@ -208,7 +206,7 @@ public sealed interface CharacterAndFormat extends Examinable permits CharacterA
    * @since 4.14.0
    */
   @Unmodifiable
-  static @NotNull List<CharacterAndFormat> defaults() {
+  static List<CharacterAndFormat> defaults() {
     return CharacterAndFormatImpl.Defaults.DEFAULTS;
   }
 
@@ -226,7 +224,7 @@ public sealed interface CharacterAndFormat extends Examinable permits CharacterA
    * @return the format
    * @since 4.14.0
    */
-  @NotNull TextFormat format();
+  TextFormat format();
 
   /**
    * If the {@link #character()} is case-insensitive.
@@ -237,7 +235,7 @@ public sealed interface CharacterAndFormat extends Examinable permits CharacterA
   boolean caseInsensitive();
 
   @Override
-  default @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  default Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("character", this.character()),
       ExaminableProperty.of("format", this.format()),

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/CharacterAndFormatImpl.java
@@ -26,20 +26,19 @@ package net.kyori.adventure.text.serializer.legacy;
 import java.util.List;
 import net.kyori.adventure.internal.Internals;
 import net.kyori.adventure.text.format.TextFormat;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
 record CharacterAndFormatImpl(char character, TextFormat format, boolean caseInsensitive) implements CharacterAndFormat {
-  CharacterAndFormatImpl(final char character, final @NotNull TextFormat format, final boolean caseInsensitive) {
+  CharacterAndFormatImpl(final char character, final TextFormat format, final boolean caseInsensitive) {
     this.character = character;
     this.format = requireNonNull(format, "format");
     this.caseInsensitive = caseInsensitive;
   }
 
   @Override
-  public @NotNull TextFormat format() {
+  public TextFormat format() {
     return this.format;
   }
 
@@ -65,7 +64,7 @@ record CharacterAndFormatImpl(char character, TextFormat format, boolean caseIns
   }
 
   @Override
-  public @NotNull String toString() {
+  public String toString() {
     return Internals.toString(this);
   }
 

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializer.java
@@ -37,8 +37,7 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.PlatformAPI;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A legacy component serializer.
@@ -59,7 +58,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return a component serializer for legacy serialization and deserialization
    * @since 4.0.0
    */
-  static @NotNull LegacyComponentSerializer legacySection() {
+  static LegacyComponentSerializer legacySection() {
     return LegacyComponentSerializerImpl.Instances.SECTION;
   }
 
@@ -73,7 +72,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return a component serializer for legacy serialization and deserialization
    * @since 4.0.0
    */
-  static @NotNull LegacyComponentSerializer legacyAmpersand() {
+  static LegacyComponentSerializer legacyAmpersand() {
     return LegacyComponentSerializerImpl.Instances.AMPERSAND;
   }
 
@@ -86,7 +85,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return a component serializer for legacy serialization and deserialization
    * @since 4.0.0
    */
-  static @NotNull LegacyComponentSerializer legacy(final char legacyCharacter) {
+  static LegacyComponentSerializer legacy(final char legacyCharacter) {
     if (legacyCharacter == SECTION_CHAR) {
       return legacySection();
     } else if (legacyCharacter == AMPERSAND_CHAR) {
@@ -112,7 +111,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return the builder
    * @since 4.0.0
    */
-  static @NotNull Builder builder() {
+  static Builder builder() {
     return new LegacyComponentSerializerImpl.BuilderImpl();
   }
 
@@ -144,7 +143,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return the component
    */
   @Override
-  @NotNull TextComponent deserialize(final @NotNull String input);
+  TextComponent deserialize(final String input);
 
   /**
    * Serializes a component into a legacy {@link String}.
@@ -153,10 +152,10 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
    * @return the string
    */
   @Override
-  @NotNull String serialize(final @NotNull Component component);
+  String serialize(final Component component);
 
   // TODO: new common builder interface?
-  @NotNull Builder toBuilder();
+  Builder toBuilder();
 
   /**
    * A builder for {@link LegacyComponentSerializer}.
@@ -171,7 +170,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NotNull Builder character(final char legacyCharacter);
+    Builder character(final char legacyCharacter);
 
     /**
      * Sets the legacy hex character used by the serializer.
@@ -180,7 +179,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NotNull Builder hexCharacter(final char legacyHexCharacter);
+    Builder hexCharacter(final char legacyHexCharacter);
 
     /**
      * Sets that the serializer should extract URLs into {@link ClickEventImpl}s
@@ -189,7 +188,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NotNull Builder extractUrls();
+    Builder extractUrls();
 
     /**
      * Sets that the serializer should extract URLs into {@link ClickEventImpl}s
@@ -199,7 +198,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.2.0
      */
-    @NotNull Builder extractUrls(final @NotNull Pattern pattern);
+    Builder extractUrls(final Pattern pattern);
 
     /**
      * Sets that the serializer should extract URLs into {@link ClickEventImpl}s
@@ -209,7 +208,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NotNull Builder extractUrls(final @Nullable Style style);
+    Builder extractUrls(final @Nullable Style style);
 
     /**
      * Sets that the serializer should extract URLs into {@link ClickEventImpl}s
@@ -220,7 +219,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.2.0
      */
-    @NotNull Builder extractUrls(final @NotNull Pattern pattern, final @Nullable Style style);
+    Builder extractUrls(final Pattern pattern, final @Nullable Style style);
 
     /**
      * Sets that the serializer should support hex colors.
@@ -230,7 +229,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NotNull Builder hexColors();
+    Builder hexColors();
 
     /**
      * Sets that the serializer should use the '&amp;x' repeated code format when serializing hex
@@ -249,7 +248,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.0.0
      */
-    @NotNull Builder useUnusualXRepeatedCharacterHexFormat();
+    Builder useUnusualXRepeatedCharacterHexFormat();
 
     /**
      * Use this component flattener to convert components into plain text.
@@ -260,7 +259,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.7.0
      */
-    @NotNull Builder flattener(final @NotNull ComponentFlattener flattener);
+    Builder flattener(final ComponentFlattener flattener);
 
     /**
      * Sets the formats to use.
@@ -269,7 +268,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return this builder
      * @since 4.14.0
      */
-    @NotNull Builder formats(final @NotNull List<CharacterAndFormat> formats);
+    Builder formats(final List<CharacterAndFormat> formats);
 
     /**
      * Builds the serializer.
@@ -277,7 +276,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      * @return the built serializer
      */
     @Override
-    @NotNull LegacyComponentSerializer build();
+    LegacyComponentSerializer build();
   }
 
   /**
@@ -296,7 +295,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull LegacyComponentSerializer legacyAmpersand();
+    LegacyComponentSerializer legacyAmpersand();
 
     /**
      * Provides a {@link LegacyComponentSerializer} using {@link #SECTION_CHAR}.
@@ -306,7 +305,7 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull LegacyComponentSerializer legacySection();
+    LegacyComponentSerializer legacySection();
 
     /**
      * Completes the building process of {@link Builder}.
@@ -316,6 +315,6 @@ public interface LegacyComponentSerializer extends ComponentSerializer<Component
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull Consumer<Builder> legacy();
+    Consumer<Builder> legacy();
   }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyComponentSerializerImpl.java
@@ -47,8 +47,7 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.format.TextFormat;
 import net.kyori.adventure.util.Services;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
@@ -210,7 +209,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   }
 
   @Override
-  public @NotNull TextComponent deserialize(final @NotNull String input) {
+  public TextComponent deserialize(final String input) {
     int next = input.lastIndexOf(this.character, input.length() - 2);
     if (next == -1) {
       return this.extractUrl(Component.text(input));
@@ -273,13 +272,13 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   }
 
   @Override
-  public @NotNull String serialize(final @NotNull Component component) {
+  public String serialize(final Component component) {
     final Cereal state = new Cereal();
     this.flattener.flatten(component, state);
     return state.toString();
   }
 
-  private static boolean applyFormat(final TextComponent.@NotNull Builder builder, final @NotNull TextFormat format) {
+  private static boolean applyFormat(final TextComponent.Builder builder, final TextFormat format) {
     return switch (format) {
       case TextColor textColor -> {
         builder.colorIfAbsent(textColor);
@@ -295,7 +294,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -308,7 +307,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     private int head = -1;
 
     @Override
-    public void pushStyle(final @NotNull Style pushed) {
+    public void pushStyle(final Style pushed) {
       final int idx = ++this.head;
       if (idx >= this.styles.length) {
         this.styles = Arrays.copyOf(this.styles, this.styles.length * 2);
@@ -331,7 +330,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public void component(final @NotNull String text) {
+    public void component(final String text) {
       if (!text.isEmpty()) {
         if (this.head < 0) throw new IllegalStateException("No style has been pushed!");
 
@@ -341,13 +340,13 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public void popStyle(final @NotNull Style style) {
+    public void popStyle(final Style style) {
       if (this.head-- < 0) {
         throw new IllegalStateException("Tried to pop beyond what was pushed!");
       }
     }
 
-    void append(final @NotNull TextFormat format) {
+    void append(final TextFormat format) {
       if (this.lastWritten != format) {
         final String legacyCode = LegacyComponentSerializerImpl.this.toLegacyCode(format);
         if (legacyCode == null) {
@@ -372,7 +371,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         this.decorations = EnumSet.noneOf(TextDecoration.class);
       }
 
-      void set(final @NotNull StyleState that) {
+      void set(final StyleState that) {
         this.color = that.color;
         this.decorations.clear();
         this.decorations.addAll(that.decorations);
@@ -383,7 +382,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
         this.decorations.clear();
       }
 
-      void apply(final @NotNull Style component) {
+      void apply(final Style component) {
         final TextColor color = component.color();
         if (color != null) {
           this.color = color;
@@ -459,7 +458,7 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
       BUILDER.accept(this); // let service provider touch the builder before anybody else touches it
     }
 
-    BuilderImpl(final @NotNull LegacyComponentSerializerImpl serializer) {
+    BuilderImpl(final LegacyComponentSerializerImpl serializer) {
       this();
       this.character = serializer.character;
       this.hexCharacter = serializer.hexCharacter;
@@ -471,34 +470,34 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public @NotNull Builder character(final char legacyCharacter) {
+    public Builder character(final char legacyCharacter) {
       this.character = legacyCharacter;
       return this;
     }
 
     @Override
-    public @NotNull Builder hexCharacter(final char legacyHexCharacter) {
+    public Builder hexCharacter(final char legacyHexCharacter) {
       this.hexCharacter = legacyHexCharacter;
       return this;
     }
 
     @Override
-    public @NotNull Builder extractUrls() {
+    public Builder extractUrls() {
       return this.extractUrls(DEFAULT_URL_PATTERN, null);
     }
 
     @Override
-    public @NotNull Builder extractUrls(final @NotNull Pattern pattern) {
+    public Builder extractUrls(final Pattern pattern) {
       return this.extractUrls(pattern, null);
     }
 
     @Override
-    public @NotNull Builder extractUrls(final @Nullable Style style) {
+    public Builder extractUrls(final @Nullable Style style) {
       return this.extractUrls(DEFAULT_URL_PATTERN, style);
     }
 
     @Override
-    public @NotNull Builder extractUrls(final @NotNull Pattern pattern, final @Nullable Style style) {
+    public Builder extractUrls(final Pattern pattern, final @Nullable Style style) {
       requireNonNull(pattern, "pattern");
       this.urlReplacementConfig = TextReplacementConfig.builder()
         .match(pattern)
@@ -520,31 +519,31 @@ final class LegacyComponentSerializerImpl implements LegacyComponentSerializer {
     }
 
     @Override
-    public @NotNull Builder hexColors() {
+    public Builder hexColors() {
       this.hexColours = true;
       return this;
     }
 
     @Override
-    public @NotNull Builder useUnusualXRepeatedCharacterHexFormat() {
+    public Builder useUnusualXRepeatedCharacterHexFormat() {
       this.useTerriblyStupidHexFormat = true; // :(
       return this;
     }
 
     @Override
-    public @NotNull Builder flattener(final @NotNull ComponentFlattener flattener) {
+    public Builder flattener(final ComponentFlattener flattener) {
       this.flattener = requireNonNull(flattener, "flattener");
       return this;
     }
 
     @Override
-    public @NotNull Builder formats(final @NotNull List<CharacterAndFormat> formats) {
+    public Builder formats(final List<CharacterAndFormat> formats) {
       this.formats = CharacterAndFormatSet.of(formats);
       return this;
     }
 
     @Override
-    public @NotNull LegacyComponentSerializer build() {
+    public LegacyComponentSerializer build() {
       return new LegacyComponentSerializerImpl(this.character, this.hexCharacter, this.urlReplacementConfig, this.hexColours, this.useTerriblyStupidHexFormat, this.flattener, this.formats);
     }
   }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java
@@ -30,8 +30,7 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /*
  * This is a hack.
@@ -117,7 +116,7 @@ public final class LegacyFormat implements Examinable {
   }
 
   @Override
-  public @NotNull Stream<? extends ExaminableProperty> examinableProperties() {
+  public Stream<? extends ExaminableProperty> examinableProperties() {
     return Stream.of(
       ExaminableProperty.of("color", this.color),
       ExaminableProperty.of("decoration", this.decoration),

--- a/text-serializer-plain/src/main/java/module-info.java
+++ b/text-serializer-plain/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Plain text based serialization and deserialization.
+ */
+@NullMarked
+module net.kyori.adventure.text.serializer.plain {
+  requires transitive net.kyori.adventure.api;
+
+  exports net.kyori.adventure.text.serializer.plain;
+}

--- a/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializer.java
+++ b/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializer.java
@@ -33,7 +33,6 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.PlatformAPI;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A plain-text component serializer.
@@ -50,7 +49,7 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
    * @return serializer instance
    * @since 4.8.0
    */
-  static @NotNull PlainTextComponentSerializer plainText() {
+  static PlainTextComponentSerializer plainText() {
     return PlainTextComponentSerializerImpl.Instances.INSTANCE;
   }
 
@@ -60,17 +59,17 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
    * @return a new plain serializer builder
    * @since 4.8.0
    */
-  static PlainTextComponentSerializer.@NotNull Builder builder() {
+  static PlainTextComponentSerializer.Builder builder() {
     return new PlainTextComponentSerializerImpl.BuilderImpl();
   }
 
   @Override
-  default @NotNull TextComponent deserialize(final @NotNull String input) {
+  default TextComponent deserialize(final String input) {
     return Component.text(input);
   }
 
   @Override
-  default @NotNull String serialize(final @NotNull Component component) {
+  default String serialize(final Component component) {
     final StringBuilder sb = new StringBuilder();
     this.serialize(sb, component);
     return sb.toString();
@@ -83,10 +82,10 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
    * @param component the component
    * @since 4.8.0
    */
-  void serialize(final @NotNull StringBuilder sb, final @NotNull Component component);
+  void serialize(final StringBuilder sb, final Component component);
 
   // TODO: common builder interface?
-  @NotNull Builder toBuilder();
+  Builder toBuilder();
 
   /**
    * A builder for the plain-text component serializer.
@@ -103,7 +102,7 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
      * @return this builder
      * @since 4.8.0
      */
-    @NotNull Builder flattener(final @NotNull ComponentFlattener flattener);
+    Builder flattener(final ComponentFlattener flattener);
   }
 
   /**
@@ -122,7 +121,7 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull PlainTextComponentSerializer plainTextSimple();
+    PlainTextComponentSerializer plainTextSimple();
 
     /**
      * Completes the building process of {@link Builder}.
@@ -132,6 +131,6 @@ public interface PlainTextComponentSerializer extends ComponentSerializer<Compon
      */
     @ApiStatus.Internal
     @PlatformAPI
-    @NotNull Consumer<Builder> plainText();
+    Consumer<Builder> plainText();
   }
 }

--- a/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializerImpl.java
+++ b/text-serializer-plain/src/main/java/net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializerImpl.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.util.Services;
-import org.jetbrains.annotations.NotNull;
 
 import static java.util.Objects.requireNonNull;
 
@@ -59,12 +58,12 @@ final class PlainTextComponentSerializerImpl implements PlainTextComponentSerial
   }
 
   @Override
-  public void serialize(final @NotNull StringBuilder sb, final @NotNull Component component) {
+  public void serialize(final StringBuilder sb, final Component component) {
     this.flattener.flatten(requireNonNull(component, "component"), sb::append);
   }
 
   @Override
-  public @NotNull Builder toBuilder() {
+  public Builder toBuilder() {
     return new BuilderImpl(this);
   }
 
@@ -81,13 +80,13 @@ final class PlainTextComponentSerializerImpl implements PlainTextComponentSerial
     }
 
     @Override
-    public PlainTextComponentSerializer.@NotNull Builder flattener(final @NotNull ComponentFlattener flattener) {
+    public PlainTextComponentSerializer.Builder flattener(final ComponentFlattener flattener) {
       this.flattener = requireNonNull(flattener, "flattener");
       return this;
     }
 
     @Override
-    public @NotNull PlainTextComponentSerializer build() {
+    public PlainTextComponentSerializer build() {
       return new PlainTextComponentSerializerImpl(this.flattener);
     }
   }


### PR DESCRIPTION
*(( directly related to #1253 ))*

This PR adds a `module-info.java` file to each module and replaces all nullability annotations with jspecify's annotations.

depends on #1324
supersedes #984
closes #982
closes #1287