### PR TITLE
fix(api): Unbound profileProperties Collection

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContents.java
+++ b/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContents.java
@@ -211,7 +211,7 @@ public sealed interface PlayerHeadObjectContents extends ObjectContents permits 
      * @since 4.25.0
      */
     @Contract(value = "_ -> this")
-    Builder profileProperties(final Collection<ProfileProperty> properties);
+    Builder profileProperties(final Collection<? extends ProfileProperty> properties);
 
     /**
      * Sets the skin (name, id, properties, and texture) from the given source, overriding any existing values.

--- a/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContentsImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContentsImpl.java
@@ -79,7 +79,7 @@ record PlayerHeadObjectContentsImpl(@Nullable String name, @Nullable UUID id, Li
     }
 
     @Override
-    public Builder profileProperties(final Collection<ProfileProperty> properties) {
+    public Builder profileProperties(final Collection<? extends ProfileProperty> properties) {
       for (final ProfileProperty property : requireNonNull(properties, "properties")) {
         this.profileProperty(property);
       }


### PR DESCRIPTION
This should allow subtypes of ProfileProperty, which is commonly used by the implementing platform to return a different type that may contain more information.

This should not be an ABI break.