### PR TITLE
feat(text-logger-slf4j): add structured log context injector hook

### DIFF
--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogContextInjector.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogContextInjector.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public interface ComponentLogContextInjector {
+  @Nullable Scope begin(final @NotNull ComponentLogRecord record);
+
+  interface Scope extends AutoCloseable {
+    @Override
+    void close();
+  }
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogContextInjector.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogContextInjector.java
@@ -27,10 +27,27 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Injects context for component-aware log calls.
+ *
+ * @since 4.27.0
+ */
 @ApiStatus.Internal
 public interface ComponentLogContextInjector {
+  /**
+   * Begin injection of context for a component log record.
+   *
+   * @param record the current log record
+   * @return a scope to close when logging is complete, or {@code null}
+   * @since 4.27.0
+   */
   @Nullable Scope begin(final @NotNull ComponentLogRecord record);
 
+  /**
+   * A context scope that is closed after a log operation completes.
+   *
+   * @since 4.27.0
+   */
   interface Scope extends AutoCloseable {
     @Override
     void close();

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogRecord.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogRecord.java
@@ -30,6 +30,11 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
 
+/**
+ * A single component logger call captured for context injection.
+ *
+ * @since 4.27.0
+ */
 @ApiStatus.Internal
 public final class ComponentLogRecord {
   private final @NotNull Level level;
@@ -39,6 +44,17 @@ public final class ComponentLogRecord {
   private final @Nullable Object[] arguments;
   private final @Nullable Throwable throwable;
 
+  /**
+   * Create a new log record for context injection.
+   *
+   * @param level the log level
+   * @param marker the log marker, if any
+   * @param componentFormatOrMessage the component format or message, if any
+   * @param stringFormatOrMessage the string format or message, if any
+   * @param arguments the log arguments, if any
+   * @param throwable the associated throwable, if any
+   * @since 4.27.0
+   */
   public ComponentLogRecord(
     final @NotNull Level level,
     final @Nullable Marker marker,
@@ -55,26 +71,62 @@ public final class ComponentLogRecord {
     this.throwable = throwable;
   }
 
+  /**
+   * Get the level for this record.
+   *
+   * @return the log level
+   * @since 4.27.0
+   */
   public @NotNull Level level() {
     return this.level;
   }
 
+  /**
+   * Get the marker associated with this record.
+   *
+   * @return the marker, if present
+   * @since 4.27.0
+   */
   public @Nullable Marker marker() {
     return this.marker;
   }
 
+  /**
+   * Get the component format or message associated with this record.
+   *
+   * @return the component format or message, if present
+   * @since 4.27.0
+   */
   public @Nullable Component componentFormatOrMessage() {
     return this.componentFormatOrMessage;
   }
 
+  /**
+   * Get the string format or message associated with this record.
+   *
+   * @return the string format or message, if present
+   * @since 4.27.0
+   */
   public @Nullable String stringFormatOrMessage() {
     return this.stringFormatOrMessage;
   }
 
+  /**
+   * Get the argument array associated with this record.
+   *
+   * @return the argument array, if present
+   * @since 4.27.0
+   */
   public @Nullable Object[] arguments() {
     return this.arguments;
   }
 
+  /**
+   * Get the throwable associated with this record.
+   *
+   * @return the throwable, if present
+   * @since 4.27.0
+   */
   public @Nullable Throwable throwable() {
     return this.throwable;
   }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogRecord.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLogRecord.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.logger.slf4j;
+
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
+
+@ApiStatus.Internal
+public final class ComponentLogRecord {
+  private final @NotNull Level level;
+  private final @Nullable Marker marker;
+  private final @Nullable Component componentFormatOrMessage;
+  private final @Nullable String stringFormatOrMessage;
+  private final @Nullable Object[] arguments;
+  private final @Nullable Throwable throwable;
+
+  public ComponentLogRecord(
+    final @NotNull Level level,
+    final @Nullable Marker marker,
+    final @Nullable Component componentFormatOrMessage,
+    final @Nullable String stringFormatOrMessage,
+    final @Nullable Object[] arguments,
+    final @Nullable Throwable throwable
+  ) {
+    this.level = level;
+    this.marker = marker;
+    this.componentFormatOrMessage = componentFormatOrMessage;
+    this.stringFormatOrMessage = stringFormatOrMessage;
+    this.arguments = arguments;
+    this.throwable = throwable;
+  }
+
+  public @NotNull Level level() {
+    return this.level;
+  }
+
+  public @Nullable Marker marker() {
+    return this.marker;
+  }
+
+  public @Nullable Component componentFormatOrMessage() {
+    return this.componentFormatOrMessage;
+  }
+
+  public @Nullable String stringFormatOrMessage() {
+    return this.stringFormatOrMessage;
+  }
+
+  public @Nullable Object[] arguments() {
+    return this.arguments;
+  }
+
+  public @Nullable Throwable throwable() {
+    return this.throwable;
+  }
+}

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerProvider.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
@@ -73,5 +74,24 @@ public interface ComponentLoggerProvider {
      * @since 4.11.0
      */
     @NotNull ComponentLogger delegating(final @NotNull Logger base, final @NotNull Function<Component, String> serializer);
+
+    /**
+     * Create a component logger based on one which delegates to an underlying plain {@link Logger} implementation.
+     *
+     * <p>This overload allows platforms to inject additional structured log context for each log call.</p>
+     *
+     * @param base the base logger
+     * @param serializer the serializer to translate and format a component in a log message
+     * @param injector an optional structured context injector
+     * @return a new logger
+     * @since 4.27.0
+     */
+    default @NotNull ComponentLogger delegating(
+      final @NotNull Logger base,
+      final @NotNull Function<Component, String> serializer,
+      final @Nullable ComponentLogContextInjector injector
+    ) {
+      return this.delegating(base, serializer);
+    }
   }
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/Handler.java
@@ -32,6 +32,7 @@ import net.kyori.adventure.text.flattener.ComponentFlattener;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.util.Services;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +84,15 @@ final class Handler {
     @Override
     public @NotNull ComponentLogger delegating(final @NotNull Logger base, final @NotNull Function<Component, String> serializer) {
       return new WrappingComponentLoggerImpl(base, serializer);
+    }
+
+    @Override
+    public @NotNull ComponentLogger delegating(
+      final @NotNull Logger base,
+      final @NotNull Function<Component, String> serializer,
+      final @Nullable ComponentLogContextInjector injector
+    ) {
+      return new WrappingComponentLoggerImpl(base, serializer, injector);
     }
   }
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -42,11 +42,21 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   private final Logger logger;
   private final boolean isLocationAware;
   private final Function<Component, String> serializer;
+  private final @Nullable ComponentLogContextInjector injector;
 
   WrappingComponentLoggerImpl(final Logger backing, final Function<Component, String> serializer) {
+    this(backing, serializer, null);
+  }
+
+  WrappingComponentLoggerImpl(
+    final Logger backing,
+    final Function<Component, String> serializer,
+    final @Nullable ComponentLogContextInjector injector
+  ) {
     this.serializer = serializer;
     this.logger = backing;
     this.isLocationAware = backing instanceof LocationAwareLogger;
+    this.injector = injector;
   }
 
   private String serialize(final Component input) {
@@ -82,6 +92,57 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
     }
 
     return writable;
+  }
+
+  private @Nullable ComponentLogContextInjector.Scope beginContext(
+    final @NotNull Level level,
+    final @Nullable Marker marker,
+    final @Nullable Component componentFormatOrMessage,
+    final @Nullable String stringFormatOrMessage,
+    final @Nullable Object[] arguments,
+    final @Nullable Throwable throwable
+  ) {
+    if (this.injector == null) return null;
+
+    try {
+      return this.injector.begin(new ComponentLogRecord(level, marker, componentFormatOrMessage, stringFormatOrMessage, arguments, throwable));
+    } catch (final Throwable ignored) {
+      return null;
+    }
+  }
+
+  private void closeContext(final @Nullable ComponentLogContextInjector.Scope scope) {
+    if (scope == null) return;
+
+    try {
+      scope.close();
+    } catch (final Throwable ignored) {
+    }
+  }
+
+  private void withContext(
+    final @NotNull Level level,
+    final @Nullable Marker marker,
+    final @Nullable Component componentFormatOrMessage,
+    final @Nullable String stringFormatOrMessage,
+    final @Nullable Object[] arguments,
+    final @Nullable Throwable throwable,
+    final @NotNull Runnable action
+  ) {
+    final @Nullable ComponentLogContextInjector.Scope scope = this.beginContext(
+      level,
+      marker,
+      componentFormatOrMessage,
+      stringFormatOrMessage,
+      arguments,
+      throwable
+    );
+
+    try {
+      action.run();
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   // Basic methods, plain delegation
@@ -166,1801 +227,2001 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   public void trace(final @NotNull String format) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        format,
-        null,
-        null
-      );
-    } else {
-      this.logger.trace(format);
-    }
+    this.withContext(Level.TRACE, null, null, format, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          format,
+          null,
+          null
+        );
+      } else {
+        this.logger.trace(format);
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.trace(format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.TRACE, null, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.trace(format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.trace(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.TRACE, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.trace(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        format,
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.trace(format, this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.TRACE, null, null, format, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          format,
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.trace(format, this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.trace(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.TRACE, null, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.trace(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        msg,
-        null,
-        null
-      );
-    } else {
-      this.logger.trace(marker, msg);
-    }
+    this.withContext(Level.TRACE, marker, null, msg, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          msg,
+          null,
+          null
+        );
+      } else {
+        this.logger.trace(marker, msg);
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.trace(marker, format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.TRACE, marker, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.trace(marker, format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.trace(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.TRACE, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.trace(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        format,
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.trace(marker, format, this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.TRACE, marker, null, format, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          format,
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.trace(marker, format, this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.trace(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.TRACE, marker, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.trace(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull String format) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        format,
-        null,
-        null
-      );
-    } else {
-      this.logger.debug(format);
-    }
+    this.withContext(Level.DEBUG, null, null, format, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          format,
+          null,
+          null
+        );
+      } else {
+        this.logger.debug(format);
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.debug(format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.DEBUG, null, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.debug(format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.debug(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.DEBUG, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.debug(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        format,
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.debug(format, this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.DEBUG, null, null, format, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          format,
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.debug(format, this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.debug(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.DEBUG, null, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.debug(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        msg,
-        null,
-        null
-      );
-    } else {
-      this.logger.debug(marker, msg);
-    }
+    this.withContext(Level.DEBUG, marker, null, msg, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          msg,
+          null,
+          null
+        );
+      } else {
+        this.logger.debug(marker, msg);
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.debug(marker, format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.DEBUG, marker, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.debug(marker, format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.debug(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.DEBUG, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.debug(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        format,
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.debug(marker, format, this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.DEBUG, marker, null, format, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          format,
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.debug(marker, format, this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.debug(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.DEBUG, marker, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.debug(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull String format) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        format,
-        null,
-        null
-      );
-    } else {
-      this.logger.info(format);
-    }
+    this.withContext(Level.INFO, null, null, format, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          format,
+          null,
+          null
+        );
+      } else {
+        this.logger.info(format);
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.info(format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.INFO, null, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.info(format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.info(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.INFO, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.info(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        format,
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.info(format, this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.INFO, null, null, format, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          format,
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.info(format, this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.info(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.INFO, null, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.info(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        msg,
-        null,
-        null
-      );
-    } else {
-      this.logger.info(marker, msg);
-    }
+    this.withContext(Level.INFO, marker, null, msg, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          msg,
+          null,
+          null
+        );
+      } else {
+        this.logger.info(marker, msg);
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.info(marker, format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.INFO, marker, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.info(marker, format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.info(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.INFO, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.info(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        format,
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.info(marker, format, this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.INFO, marker, null, format, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          format,
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.info(marker, format, this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.info(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.INFO, marker, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.info(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull String format) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        format,
-        null,
-        null
-      );
-    } else {
-      this.logger.warn(format);
-    }
+    this.withContext(Level.WARN, null, null, format, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          format,
+          null,
+          null
+        );
+      } else {
+        this.logger.warn(format);
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.warn(format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.WARN, null, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.warn(format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.warn(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.WARN, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.warn(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        format,
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.warn(format, this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.WARN, null, null, format, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          format,
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.warn(format, this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.warn(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.WARN, null, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.warn(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        msg,
-        null,
-        null
-      );
-    } else {
-      this.logger.warn(marker, msg);
-    }
+    this.withContext(Level.WARN, marker, null, msg, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          msg,
+          null,
+          null
+        );
+      } else {
+        this.logger.warn(marker, msg);
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.warn(marker, format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.WARN, marker, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.warn(marker, format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.warn(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.WARN, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.warn(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        format,
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.warn(marker, format, this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.WARN, marker, null, format, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          format,
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.warn(marker, format, this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.warn(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.WARN, marker, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.warn(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull String format) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        format,
-        null,
-        null
-      );
-    } else {
-      this.logger.error(format);
-    }
+    this.withContext(Level.ERROR, null, null, format, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          format,
+          null,
+          null
+        );
+      } else {
+        this.logger.error(format);
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.error(format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.ERROR, null, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.error(format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.error(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.ERROR, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.error(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        format,
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.error(format, this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.ERROR, null, null, format, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          format,
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.error(format, this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.error(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.ERROR, null, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.error(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        msg,
-        null,
-        null
-      );
-    } else {
-      this.logger.error(marker, msg);
-    }
+    this.withContext(Level.ERROR, marker, null, msg, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          msg,
+          null,
+          null
+        );
+      } else {
+        this.logger.error(marker, msg);
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.error(marker, format, this.maybeSerialize(arg));
-    }
+    this.withContext(Level.ERROR, marker, null, format, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.error(marker, format, this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        format,
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.error(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.ERROR, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          format,
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.error(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        format,
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.error(marker, format, this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.ERROR, marker, null, format, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          format,
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.error(marker, format, this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        msg,
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.error(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.ERROR, marker, null, msg, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          msg,
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.error(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
-  // Component-primary methods
+  // Component methods
 
   @Override
   public void trace(final @NotNull Component format) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(format),
-        null,
-        null
-      );
-    } else {
-      this.logger.trace(this.serialize(format));
-    }
+    this.withContext(Level.TRACE, null, format, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(format),
+          null,
+          null
+        );
+      } else {
+        this.logger.trace(this.serialize(format));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.trace(this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.TRACE, null, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.trace(this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.trace(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.TRACE, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.trace(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(format),
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.trace(this.serialize(format), this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.TRACE, null, format, null, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(format),
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.trace(this.serialize(format), this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.trace(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.TRACE, null, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.trace(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(msg),
-        null,
-        null
-      );
-    } else {
-      this.logger.trace(marker, this.serialize(msg));
-    }
+    this.withContext(Level.TRACE, marker, msg, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(msg),
+          null,
+          null
+        );
+      } else {
+        this.logger.trace(marker, this.serialize(msg));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.trace(marker, this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.TRACE, marker, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.trace(marker, this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.trace(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.TRACE, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.trace(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(format),
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.trace(marker, this.serialize(format), this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.TRACE, marker, format, null, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(format),
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.trace(marker, this.serialize(format), this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.TRACE_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.trace(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.TRACE, marker, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.TRACE_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.trace(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Component format) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(format),
-        null,
-        null
-      );
-    } else {
-      this.logger.debug(this.serialize(format));
-    }
+    this.withContext(Level.DEBUG, null, format, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(format),
+          null,
+          null
+        );
+      } else {
+        this.logger.debug(this.serialize(format));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.debug(this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.DEBUG, null, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.debug(this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.debug(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.DEBUG, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.debug(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(format),
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.debug(this.serialize(format), this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.DEBUG, null, format, null, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(format),
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.debug(this.serialize(format), this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.debug(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.DEBUG, null, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.debug(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(msg),
-        null,
-        null
-      );
-    } else {
-      this.logger.debug(marker, this.serialize(msg));
-    }
+    this.withContext(Level.DEBUG, marker, msg, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(msg),
+          null,
+          null
+        );
+      } else {
+        this.logger.debug(marker, this.serialize(msg));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.debug(marker, this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.DEBUG, marker, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.debug(marker, this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.debug(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.DEBUG, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.debug(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(format),
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.debug(marker, this.serialize(format), this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.DEBUG, marker, format, null, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(format),
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.debug(marker, this.serialize(format), this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.DEBUG_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.debug(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.DEBUG, marker, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.DEBUG_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.debug(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Component format) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(format),
-        null,
-        null
-      );
-    } else {
-      this.logger.info(this.serialize(format));
-    }
+    this.withContext(Level.INFO, null, format, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(format),
+          null,
+          null
+        );
+      } else {
+        this.logger.info(this.serialize(format));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.info(this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.INFO, null, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.info(this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.info(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.INFO, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.info(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(format),
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.info(this.serialize(format), this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.INFO, null, format, null, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(format),
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.info(this.serialize(format), this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.info(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.INFO, null, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.info(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(msg),
-        null,
-        null
-      );
-    } else {
-      this.logger.info(marker, this.serialize(msg));
-    }
+    this.withContext(Level.INFO, marker, msg, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(msg),
+          null,
+          null
+        );
+      } else {
+        this.logger.info(marker, this.serialize(msg));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.info(marker, this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.INFO, marker, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.info(marker, this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.info(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.INFO, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.info(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(format),
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.info(marker, this.serialize(format), this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.INFO, marker, format, null, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(format),
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.info(marker, this.serialize(format), this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.INFO_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.info(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.INFO, marker, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.INFO_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.info(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Component format) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(format),
-        null,
-        null
-      );
-    } else {
-      this.logger.warn(this.serialize(format));
-    }
+    this.withContext(Level.WARN, null, format, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(format),
+          null,
+          null
+        );
+      } else {
+        this.logger.warn(this.serialize(format));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.warn(this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.WARN, null, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.warn(this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.warn(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.WARN, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.warn(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(format),
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.warn(this.serialize(format), this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.WARN, null, format, null, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(format),
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.warn(this.serialize(format), this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.warn(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.WARN, null, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.warn(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(msg),
-        null,
-        null
-      );
-    } else {
-      this.logger.warn(marker, this.serialize(msg));
-    }
+    this.withContext(Level.WARN, marker, msg, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(msg),
+          null,
+          null
+        );
+      } else {
+        this.logger.warn(marker, this.serialize(msg));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.warn(marker, this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.WARN, marker, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.warn(marker, this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.warn(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.WARN, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.warn(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(format),
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.warn(marker, this.serialize(format), this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.WARN, marker, format, null, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(format),
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.warn(marker, this.serialize(format), this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.WARN_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.warn(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.WARN, marker, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.WARN_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.warn(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Component format) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(format),
-        null,
-        null
-      );
-    } else {
-      this.logger.error(this.serialize(format));
-    }
+    this.withContext(Level.ERROR, null, format, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(format),
+          null,
+          null
+        );
+      } else {
+        this.logger.error(this.serialize(format));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.error(this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.ERROR, null, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.error(this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.error(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.ERROR, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.error(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(format),
-        this.maybeSerialize(arguments),
-        null
-      );
-    } else {
-      this.logger.error(this.serialize(format), this.maybeSerialize(arguments));
-    }
+    this.withContext(Level.ERROR, null, format, null, arguments, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(format),
+          this.maybeSerialize(arguments),
+          null
+        );
+      } else {
+        this.logger.error(this.serialize(format), this.maybeSerialize(arguments));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        null,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.error(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.ERROR, null, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          null,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.error(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(msg),
-        null,
-        null
-      );
-    } else {
-      this.logger.error(marker, this.serialize(msg));
-    }
+    this.withContext(Level.ERROR, marker, msg, null, null, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(msg),
+          null,
+          null
+        );
+      } else {
+        this.logger.error(marker, this.serialize(msg));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg)},
-        null
-      );
-    } else {
-      this.logger.error(marker, this.serialize(format), this.maybeSerialize(arg));
-    }
+    this.withContext(Level.ERROR, marker, format, null, new Object[] {arg}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg)},
+          null
+        );
+      } else {
+        this.logger.error(marker, this.serialize(format), this.maybeSerialize(arg));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(format),
-        new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
-        null
-      );
-    } else {
-      this.logger.error(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
-    }
+    this.withContext(Level.ERROR, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(format),
+          new Object[] {this.maybeSerialize(arg1), this.maybeSerialize(arg2)},
+          null
+        );
+      } else {
+        this.logger.error(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(format),
-        this.maybeSerialize(argArray),
-        null
-      );
-    } else {
-      this.logger.error(marker, this.serialize(format), this.maybeSerialize(argArray));
-    }
+    this.withContext(Level.ERROR, marker, format, null, argArray, null, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(format),
+          this.maybeSerialize(argArray),
+          null
+        );
+      } else {
+        this.logger.error(marker, this.serialize(format), this.maybeSerialize(argArray));
+      }
+    });
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
-    if (this.isLocationAware) {
-      ((LocationAwareLogger) this.logger).log(
-        marker,
-        FQCN,
-        LocationAwareLogger.ERROR_INT,
-        this.serialize(msg),
-        null,
-        UnpackedComponentThrowable.unpack(t, this.serializer)
-      );
-    } else {
-      this.logger.error(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
-    }
+    this.withContext(Level.ERROR, marker, msg, null, null, t, () -> {
+      if (this.isLocationAware) {
+        ((LocationAwareLogger) this.logger).log(
+          marker,
+          FQCN,
+          LocationAwareLogger.ERROR_INT,
+          this.serialize(msg),
+          null,
+          UnpackedComponentThrowable.unpack(t, this.serializer)
+        );
+      } else {
+        this.logger.error(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
+      }
+    });
   }
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -120,31 +120,6 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
     }
   }
 
-  private void withContext(
-    final @NotNull Level level,
-    final @Nullable Marker marker,
-    final @Nullable Component componentFormatOrMessage,
-    final @Nullable String stringFormatOrMessage,
-    final @Nullable Object[] arguments,
-    final @Nullable Throwable throwable,
-    final @NotNull Runnable action
-  ) {
-    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(
-      level,
-      marker,
-      componentFormatOrMessage,
-      stringFormatOrMessage,
-      arguments,
-      throwable
-    );
-
-    try {
-      action.run();
-    } finally {
-      this.closeContext(scope);
-    }
-  }
-
   // Basic methods, plain delegation
 
   @Override
@@ -227,7 +202,8 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   public void trace(final @NotNull String format) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, null, format, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, null, format, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -240,14 +216,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(format);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -260,14 +239,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -280,14 +262,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, null, format, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, null, format, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -300,14 +285,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(format, this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -320,14 +308,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, null, msg, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, null, msg, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -340,14 +331,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, msg);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -360,14 +354,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -380,14 +377,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, null, format, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, null, format, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -400,14 +400,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, format, this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -420,14 +423,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull String format) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, null, format, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, null, format, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -440,14 +446,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(format);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -460,14 +469,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -480,14 +492,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, null, format, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, null, format, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -500,14 +515,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(format, this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -520,14 +538,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, null, msg, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, null, msg, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -540,14 +561,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, msg);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -560,14 +584,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -580,14 +607,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, null, format, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, null, format, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -600,14 +630,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, format, this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -620,14 +653,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull String format) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, null, format, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, null, format, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -640,14 +676,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(format);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -660,14 +699,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -680,14 +722,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, null, format, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, null, format, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -700,14 +745,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(format, this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -720,14 +768,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, null, msg, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, null, msg, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -740,14 +791,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, msg);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -760,14 +814,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -780,14 +837,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, null, format, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, null, format, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -800,14 +860,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, format, this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -820,14 +883,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull String format) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, null, format, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, null, format, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -840,14 +906,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(format);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -860,14 +929,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -880,14 +952,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, null, format, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, null, format, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -900,14 +975,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(format, this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -920,14 +998,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, null, msg, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, null, msg, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -940,14 +1021,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, msg);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -960,14 +1044,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -980,14 +1067,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, null, format, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, null, format, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1000,14 +1090,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, format, this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1020,14 +1113,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull String format) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, null, format, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, null, format, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1040,14 +1136,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(format);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull String format, final @Nullable Object arg) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1060,14 +1159,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1080,14 +1182,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull String format, final @Nullable Object @NotNull... arguments) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, null, format, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, null, format, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1100,14 +1205,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(format, this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1120,14 +1228,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String msg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, null, msg, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, null, msg, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1140,14 +1251,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, msg);
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, null, format, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, null, format, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1160,14 +1274,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, format, this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, null, format, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, null, format, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1180,14 +1297,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, format, this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String format, final @Nullable Object @NotNull... argArray) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, null, format, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, null, format, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1200,14 +1320,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, format, this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull String msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, null, msg, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, null, msg, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1220,7 +1343,9 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, msg, UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   // Component methods
@@ -1229,7 +1354,8 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
   public void trace(final @NotNull Component format) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, format, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, format, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1242,14 +1368,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(this.serialize(format));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1262,14 +1391,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1282,14 +1414,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, format, null, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, format, null, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1302,14 +1437,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(this.serialize(format), this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled()) return;
 
-    this.withContext(Level.TRACE, null, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, null, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1322,14 +1460,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, msg, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, msg, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1342,14 +1483,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, this.serialize(msg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1362,14 +1506,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1382,14 +1529,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, format, null, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, format, null, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1402,14 +1552,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, this.serialize(format), this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void trace(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isTraceEnabled(marker)) return;
 
-    this.withContext(Level.TRACE, marker, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.TRACE, marker, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1422,14 +1575,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.trace(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Component format) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, format, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, format, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1442,14 +1598,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(this.serialize(format));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1462,14 +1621,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1482,14 +1644,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, format, null, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, format, null, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1502,14 +1667,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(this.serialize(format), this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled()) return;
 
-    this.withContext(Level.DEBUG, null, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, null, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1522,14 +1690,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, msg, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, msg, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1542,14 +1713,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, this.serialize(msg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1562,14 +1736,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1582,14 +1759,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, format, null, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, format, null, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1602,14 +1782,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, this.serialize(format), this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void debug(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isDebugEnabled(marker)) return;
 
-    this.withContext(Level.DEBUG, marker, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.DEBUG, marker, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1622,14 +1805,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.debug(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Component format) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, format, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, format, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1642,14 +1828,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(this.serialize(format));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1662,14 +1851,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1682,14 +1874,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, format, null, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, format, null, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1702,14 +1897,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(this.serialize(format), this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled()) return;
 
-    this.withContext(Level.INFO, null, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, null, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1722,14 +1920,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, msg, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, msg, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1742,14 +1943,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, this.serialize(msg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1762,14 +1966,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1782,14 +1989,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, format, null, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, format, null, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1802,14 +2012,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, this.serialize(format), this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void info(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isInfoEnabled(marker)) return;
 
-    this.withContext(Level.INFO, marker, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.INFO, marker, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1822,14 +2035,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.info(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Component format) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, format, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, format, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1842,14 +2058,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(this.serialize(format));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1862,14 +2081,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1882,14 +2104,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, format, null, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, format, null, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1902,14 +2127,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(this.serialize(format), this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled()) return;
 
-    this.withContext(Level.WARN, null, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, null, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -1922,14 +2150,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, msg, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, msg, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1942,14 +2173,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, this.serialize(msg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1962,14 +2196,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -1982,14 +2219,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, format, null, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, format, null, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -2002,14 +2242,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, this.serialize(format), this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void warn(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isWarnEnabled(marker)) return;
 
-    this.withContext(Level.WARN, marker, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.WARN, marker, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -2022,14 +2265,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.warn(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Component format) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, format, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, format, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -2042,14 +2288,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(this.serialize(format));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -2062,14 +2311,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -2082,14 +2334,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Component format, final @Nullable Object @NotNull... arguments) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, format, null, arguments, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, format, null, arguments, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -2102,14 +2357,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(this.serialize(format), this.maybeSerialize(arguments));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled()) return;
 
-    this.withContext(Level.ERROR, null, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, null, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           null,
@@ -2122,14 +2380,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component msg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, msg, null, null, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, msg, null, null, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -2142,14 +2403,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, this.serialize(msg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, format, null, new Object[] {arg}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, format, null, new Object[] {arg}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -2162,14 +2426,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, this.serialize(format), this.maybeSerialize(arg));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object arg1, final @Nullable Object arg2) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, format, null, new Object[] {arg1, arg2}, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, format, null, new Object[] {arg1, arg2}, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -2182,14 +2449,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, this.serialize(format), this.maybeSerialize(arg1), this.maybeSerialize(arg2));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component format, final @Nullable Object @NotNull... argArray) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, format, null, argArray, null, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, format, null, argArray, null);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -2202,14 +2472,17 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, this.serialize(format), this.maybeSerialize(argArray));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 
   @Override
   public void error(final @NotNull Marker marker, final @NotNull Component msg, final @Nullable Throwable t) {
     if (!this.isErrorEnabled(marker)) return;
 
-    this.withContext(Level.ERROR, marker, msg, null, null, t, () -> {
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(Level.ERROR, marker, msg, null, null, t);
+    try {
       if (this.isLocationAware) {
         ((LocationAwareLogger) this.logger).log(
           marker,
@@ -2222,6 +2495,8 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
       } else {
         this.logger.error(marker, this.serialize(msg), UnpackedComponentThrowable.unpack(t, this.serializer));
       }
-    });
+    } finally {
+      this.closeContext(scope);
+    }
   }
 }

--- a/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
+++ b/text-logger-slf4j/src/main/java/net/kyori/adventure/text/logger/slf4j/WrappingComponentLoggerImpl.java
@@ -94,7 +94,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
     return writable;
   }
 
-  private @Nullable ComponentLogContextInjector.Scope beginContext(
+  private ComponentLogContextInjector.@Nullable Scope beginContext(
     final @NotNull Level level,
     final @Nullable Marker marker,
     final @Nullable Component componentFormatOrMessage,
@@ -111,7 +111,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
     }
   }
 
-  private void closeContext(final @Nullable ComponentLogContextInjector.Scope scope) {
+  private void closeContext(final ComponentLogContextInjector.@Nullable Scope scope) {
     if (scope == null) return;
 
     try {
@@ -129,7 +129,7 @@ final class WrappingComponentLoggerImpl implements ComponentLogger {
     final @Nullable Throwable throwable,
     final @NotNull Runnable action
   ) {
-    final @Nullable ComponentLogContextInjector.Scope scope = this.beginContext(
+    final ComponentLogContextInjector.@Nullable Scope scope = this.beginContext(
       level,
       marker,
       componentFormatOrMessage,

--- a/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerTest.java
+++ b/text-logger-slf4j/src/test/java/net/kyori/adventure/text/logger/slf4j/ComponentLoggerTest.java
@@ -28,7 +28,11 @@ import com.github.valfirst.slf4jtest.TestLogger;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.github.valfirst.slf4jtest.TestLoggerFactoryExtension;
 import com.google.common.collect.ImmutableList;
+import java.lang.reflect.Proxy;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.util.ComponentMessageThrowable;
@@ -36,22 +40,31 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(TestLoggerFactoryExtension.class)
 public class ComponentLoggerTest {
   private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(ComponentLoggerTest.class);
+  private static final Function<Component, String> PLAIN_SERIALIZER = Handler.LoggerHelperImpl.INSTANCE.plainSerializer();
 
   private static final Marker MARKED = MarkerFactory.getMarker("MARKED");
 
   ComponentLogger makeLogger() {
     return ComponentLogger.logger();
+  }
+
+  ComponentLogger makeLogger(final @Nullable ComponentLogContextInjector injector) {
+    return new WrappingComponentLoggerImpl(LOGGER, PLAIN_SERIALIZER, injector);
   }
 
   @Test
@@ -156,6 +169,104 @@ public class ComponentLoggerTest {
       LOGGER.getLoggingEvents(),
       ImmutableList.of(LoggingEvent.info("Hello {}", "friend"))
     );
+  }
+
+  @Test
+  void testInjectorReceivesRawComponentRecord() {
+    final Component format = Component.text("Hello ").append(Component.text("{}", NamedTextColor.BLUE));
+    final Component arg = Component.text("friend", NamedTextColor.RED);
+    final AtomicReference<ComponentLogRecord> seen = new AtomicReference<>();
+
+    this.makeLogger(record -> {
+      seen.set(record);
+      return null;
+    }).info(format, arg);
+
+    final ComponentLogRecord captured = seen.get();
+    assertNotNull(captured);
+    assertEquals(org.slf4j.event.Level.INFO, captured.level());
+    assertSame(format, captured.componentFormatOrMessage());
+    assertNull(captured.stringFormatOrMessage());
+    assertNotNull(captured.arguments());
+    assertEquals(1, captured.arguments().length);
+    assertSame(arg, captured.arguments()[0]);
+    assertNull(captured.throwable());
+    assertEquals(LOGGER.getLoggingEvents(), ImmutableList.of(LoggingEvent.info("Hello {}", "friend")));
+  }
+
+  @Test
+  void testInjectorReceivesRawThrowableForStringRecord() {
+    final RichTestException throwable = new RichTestException(Component.text("rich"));
+    final AtomicReference<ComponentLogRecord> seen = new AtomicReference<>();
+
+    this.makeLogger(record -> {
+      seen.set(record);
+      return null;
+    }).warn("warn text", throwable);
+
+    final ComponentLogRecord captured = seen.get();
+    assertNotNull(captured);
+    assertEquals(org.slf4j.event.Level.WARN, captured.level());
+    assertEquals("warn text", captured.stringFormatOrMessage());
+    assertNull(captured.componentFormatOrMessage());
+    assertNull(captured.arguments());
+    assertSame(throwable, captured.throwable());
+  }
+
+  @Test
+  void testInjectorScopeClosedOnSuccessAndExceptionsSwallowed() {
+    final AtomicInteger beginCalls = new AtomicInteger();
+    final AtomicInteger closeCalls = new AtomicInteger();
+
+    this.makeLogger(record -> {
+      beginCalls.incrementAndGet();
+      return () -> {
+        closeCalls.incrementAndGet();
+        throw new IllegalStateException("close fail");
+      };
+    }).info("Hello world");
+
+    assertEquals(1, beginCalls.get());
+    assertEquals(1, closeCalls.get());
+    assertEquals(LOGGER.getLoggingEvents(), ImmutableList.of(LoggingEvent.info("Hello world")));
+  }
+
+  @Test
+  void testInjectorBeginFailureIsSwallowed() {
+    this.makeLogger(record -> {
+      throw new IllegalStateException("begin fail");
+    }).info("still logs");
+
+    assertEquals(LOGGER.getLoggingEvents(), ImmutableList.of(LoggingEvent.info("still logs")));
+  }
+
+  @Test
+  void testInjectorScopeClosedWhenUnderlyingLoggerThrows() {
+    final AtomicInteger closeCalls = new AtomicInteger();
+    final Logger throwingLogger = (Logger) Proxy.newProxyInstance(
+      Logger.class.getClassLoader(),
+      new Class<?>[] {Logger.class},
+      (proxy, method, args) -> {
+        if (method.getName().equals("isInfoEnabled")) {
+          return true;
+        } else if (method.getName().equals("info") && method.getParameterCount() == 1) {
+          throw new IllegalStateException("logger fail");
+        } else if (method.getName().equals("getName")) {
+          return "throwing";
+        }
+
+        if (method.getReturnType() == boolean.class) return false;
+        return null;
+      }
+    );
+    final ComponentLogger logger = new WrappingComponentLoggerImpl(
+      throwingLogger,
+      PLAIN_SERIALIZER,
+      record -> () -> closeCalls.incrementAndGet()
+    );
+
+    assertThrows(IllegalStateException.class, () -> logger.info("hello"));
+    assertEquals(1, closeCalls.get());
   }
 
   @Test


### PR DESCRIPTION
 - add internal ComponentLogContextInjector and ComponentLogRecord types for forwarding raw component log metadata
 - extend ComponentLoggerProvider.LoggerHelper with backward-compatible delegating(..., injector) overload
 - wire Handler.LoggerHelperImpl to construct WrappingComponentLoggerImpl with optional injector
 - wrap all enabled log paths in WrappingComponentLoggerImpl with injector scope begin/close, swallowing injector errors and preserving existing output behavior
 - add tests for raw record capture, throwable forwarding, scope close lifecycle, and injector failure tolerance

This will allow for [Endermux](https://github.com/jpenilla/better-fabric-console/pull/143) to forward rich log messages over the socket.