### PR TITLE
Fix TextColor not treating hue 1.0 the same as 0.0

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -105,9 +105,7 @@ public non-sealed interface TextColor extends Comparable<TextColor>, RGBLike, St
     final float q = v * (1 - s * f);
     final float t = v * (1 - s * (1 - f));
 
-    if (i == 0) {
-      return color(v, t, p);
-    } else if (i == 1) {
+    if (i == 1) {
       return color(q, v, p);
     } else if (i == 2) {
       return color(p, v, t);
@@ -115,8 +113,10 @@ public non-sealed interface TextColor extends Comparable<TextColor>, RGBLike, St
       return color(p, q, v);
     } else if (i == 4) {
       return color(t, p, v);
-    } else {
+    } else if (i == 5) {
       return color(v, p, q);
+    } else {
+      return color(v, t, p);
     }
   }
 


### PR DESCRIPTION
Passing an HSVLike instance with hue set to 1.0 to TextColor#color returns an incorrect color value with a hue that is off by 60 degrees.

For example: `TextColor.color(HSVLike.hsvLike(1.0f, 1.0f, 0.5f))` should yield \#7F0000, but actually yields \#7F007F.

This pr should address the issue.