### PR TITLE
chore: add back dropped toString implementations

### DIFF
--- a/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
+++ b/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java
@@ -100,6 +100,17 @@ sealed abstract class SoundImpl implements Sound permits SoundImpl.Eager, SoundI
     return result;
   }
 
+  @Override
+  public String toString() {
+    return "SoundImpl{" +
+      "name=" + this.name() +
+      ", source=" + this.source +
+      ", volume=" + this.volume +
+      ", pitch=" + this.pitch +
+      ", seed=" + this.seed +
+      '}';
+  }
+
   static final class BuilderImpl implements Builder {
     private static final float DEFAULT_VOLUME = 1f;
     private static final float DEFAULT_PITCH = 1f;

--- a/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java
@@ -200,6 +200,16 @@ final class DecorationMap extends AbstractMap<TextDecoration, TextDecoration.Sta
     return this.bitSet;
   }
 
+  @Override
+  public String toString() {
+    return "DecorationMap{" +
+      Arrays.stream(DECORATIONS)
+        .map(decoration -> decoration.toString() + '=' + this.get(decoration))
+        .reduce((a, b) -> a + ", " + b)
+        .orElse("") +
+      '}';
+  }
+
   final class EntrySet extends AbstractSet<Entry<TextDecoration, TextDecoration.State>> {
     @Override
     public Iterator<Entry<TextDecoration, TextDecoration.State>> iterator() {

--- a/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java
+++ b/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java
@@ -163,6 +163,15 @@ public abstract class AbstractTranslationStore<T> implements TranslationStore<T>
     return this.name.hashCode();
   }
 
+  @Override
+  public String toString() {
+    return "AbstractTranslationStore{" +
+      "name=" + this.name +
+      ", translations=" + this.translations +
+      ", defaultLocale=" + this.defaultLocale +
+      '}';
+  }
+
   private final class Translation {
     private final String key;
     private final Map<Locale, T> translations;
@@ -202,6 +211,14 @@ public abstract class AbstractTranslationStore<T> implements TranslationStore<T>
     @Override
     public int hashCode() {
       return Objects.hash(this.key, this.translations);
+    }
+
+    @Override
+    public String toString() {
+      return "Translation{" +
+        "key='" + this.key + '\'' +
+        ", translations=" + this.translations +
+        '}';
     }
   }
 

--- a/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java
@@ -108,4 +108,11 @@ final class GlobalTranslatorImpl implements GlobalTranslator {
     }
     return null;
   }
+
+  @Override
+  public String toString() {
+    return "GlobalTranslatorImpl{" +
+      "sources=" + this.sources +
+      '}';
+  }
 }

--- a/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java
+++ b/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java
@@ -111,4 +111,13 @@ public final class LegacyFormat {
     result = (31 * result) + Boolean.hashCode(this.reset);
     return result;
   }
+
+  @Override
+  public String toString() {
+    return "LegacyFormat{" +
+      "color=" + this.color +
+      ", decoration=" + this.decoration +
+      ", reset=" + this.reset +
+      '}';
+  }
 }


### PR DESCRIPTION
This PR adds back some toString implementations that were dropped with the removal of the examination api on classes that were not converted to records.

Unless I missed something, everything that was previously implementing `Examinable` should now be either a record or have its own toString (except `StyleImpl`, which is covered by #1373).

(The links take you to the old examinable implementation on main/4)
- [`SoundImpl`](https://github.com/PaperMC/adventure/blob/main/4/api/src/main/java/net/kyori/adventure/sound/SoundImpl.java#L109)
- [`DecorationMap`](https://github.com/PaperMC/adventure/blob/main/4/api/src/main/java/net/kyori/adventure/text/format/DecorationMap.java#L137)
- [`AbstractTranslationStore`](https://github.com/PaperMC/adventure/blob/main/4/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java#L160) (missing `name` and `defaultLocale`)
- [`AbstractTranslationStore.Translation`](https://github.com/PaperMC/adventure/blob/5e2284abb3259be2334911dc024bd4aaede65e6e/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java#L213)
- [`GlobalTranslatorImpl`](https://github.com/PaperMC/adventure/blob/5e2284abb3259be2334911dc024bd4aaede65e6e/api/src/main/java/net/kyori/adventure/translation/GlobalTranslatorImpl.java#L116)
- [`LegacyFormat`](https://github.com/PaperMC/adventure/blob/main/4/text-serializer-legacy/src/main/java/net/kyori/adventure/text/serializer/legacy/LegacyFormat.java#L120)