### PR TITLE
Deprecating BossBarViewer

### DIFF
--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBar.java
@@ -388,7 +388,9 @@ public interface BossBar extends Examinable {
    *
    * @return an unmodifiable view of the viewers of this bossbar
    * @since 4.14.0
+   * @deprecated for removal since 4.26.1, {@link BossBarViewer} is deprecated.  Will be replaced with Audience
    */
+  @Deprecated
   @UnmodifiableView
   @NotNull Iterable<? extends BossBarViewer> viewers();
 

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarImpl.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarImpl.java
@@ -265,6 +265,7 @@ final class BossBarImpl extends HackyBossBarPlatformBridge implements BossBar {
     return this;
   }
 
+  @Deprecated
   @Override
   public @NotNull Iterable<? extends BossBarViewer> viewers() {
     if (this.implementation != null) {

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarImplementation.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarImplementation.java
@@ -53,8 +53,10 @@ public interface BossBarImplementation {
    *
    * @return the viewers of this bossbar
    * @since 4.14.0
+   * @deprecated for removal since 4.26.1, {@link BossBarViewer} is deprecated.  Will be replaced with Audience
    */
   @ApiStatus.Internal
+  @Deprecated
   default @NotNull Iterable<? extends BossBarViewer> viewers() {
     return Collections.emptyList();
   }

--- a/api/src/main/java/net/kyori/adventure/bossbar/BossBarViewer.java
+++ b/api/src/main/java/net/kyori/adventure/bossbar/BossBarViewer.java
@@ -23,6 +23,8 @@
  */
 package net.kyori.adventure.bossbar;
 
+import net.kyori.adventure.audience.Audience;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
@@ -30,14 +32,20 @@ import org.jetbrains.annotations.UnmodifiableView;
  * Something that can view a {@link BossBar}.
  *
  * @since 4.14.0
+ * @deprecated for removal since 4.26.1, use separate methods on {@link Audience} for getting the bossbars a player can see
  */
+@ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
+@Deprecated
 public interface BossBarViewer {
   /**
    * Gets an unmodifiable view of all known currently active bossbars.
    *
    * @return an unmodifiable view of all known currently active bossbars
    * @since 4.14.0
+   * @deprecated for removal since 4.26.1, {@link BossBarViewer} is deprecated for removal.  Will be replaced with {@link Audience}
    */
+  @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
+  @Deprecated
   @UnmodifiableView
   @NotNull Iterable<? extends BossBar> activeBossBars();
 }


### PR DESCRIPTION
A secondary PR for #1370 that deprecates functions associated with BossBarViewer in version 4.