### PR TITLE
feature(api): Speedup *Color#asHexString

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/format/ShadowColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/ShadowColor.java
@@ -182,12 +182,7 @@ public interface ShadowColor extends StyleBuilderApplicable, ARGBLike {
    * @since 4.18.0
    */
   default String asHexString() {
-    final int argb = this.value();
-    final int a = (argb >> 24) & 0xFF;
-    final int r = (argb >> 16) & 0xFF;
-    final int g = (argb >> 8) & 0xFF;
-    final int b = argb & 0xFF;
-    return String.format("#%02X%02X%02X%02X", r, g, b, a);
+    return ShadowColorImpl.asHexString(this.value());
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/format/ShadowColorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/ShadowColorImpl.java
@@ -23,8 +23,22 @@
  */
 package net.kyori.adventure.text.format;
 
+import java.util.HexFormat;
+
 // value is argb
 record ShadowColorImpl(int value) implements ShadowColor {
   static final int NONE_VALUE = 0;
   static final ShadowColorImpl NONE = new ShadowColorImpl(NONE_VALUE);
+  static final HexFormat HEX_FORMATTER = HexFormat.of().withUpperCase();
+
+  /**
+   * Convert an ARGB value to a hex string in the format of #RRGGBBAA.
+   *
+   * @param argb the ARGB value
+   * @return the uppercase hex string
+   */
+  static String asHexString(final int argb) {
+    final int rgba = Integer.rotateLeft(argb, Byte.SIZE);
+    return '#' + HEX_FORMATTER.toHexDigits(rgba, 8);
+  }
 }

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColor.java
@@ -24,7 +24,6 @@
 package net.kyori.adventure.text.format;
 
 import java.util.List;
-import java.util.Locale;
 import net.kyori.adventure.util.HSVLike;
 import net.kyori.adventure.util.RGBLike;
 import org.jetbrains.annotations.Range;
@@ -212,14 +211,7 @@ public non-sealed interface TextColor extends Comparable<TextColor>, RGBLike, St
    * @since 4.0.0
    */
   default String asHexString() {
-    final StringBuilder result = new StringBuilder();
-    result.append(HEX_PREFIX);
-    final String hex = Integer.toHexString(this.value());
-    for (int i = 0; i < 6 - hex.length(); i++) {
-      result.append('0');
-    }
-    result.append(hex);
-    return result.toString().toUpperCase(Locale.ROOT);
+    return TextColorImpl.hexString(this.value());
   }
 
   /**

--- a/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextColorImpl.java
@@ -23,11 +23,13 @@
  */
 package net.kyori.adventure.text.format;
 
+import java.util.HexFormat;
 import net.kyori.adventure.util.HSVLike;
 import org.jetbrains.annotations.Debug;
 
 @Debug.Renderer(text = "asHexString()")
 record TextColorImpl(int value) implements TextColor {
+  private static final HexFormat HEX_FORMATTER = HexFormat.of().withUpperCase();
 
   @Override
   public String toString() {
@@ -49,5 +51,15 @@ record TextColorImpl(int value) implements TextColor {
     final float saturationDiff = self.s() - other.s();
     final float valueDiff = self.v() - other.v();
     return hueDistance * hueDistance + saturationDiff * saturationDiff + valueDiff * valueDiff;
+  }
+
+  /**
+   * Parses a value into an RGB hex string using the format #RRGGBB.
+   *
+   * @param value the value in RRGGBB in the range of 0x0 to 0xffffff
+   * @return an uppercase hex string
+   */
+  public static String hexString(final int value) {
+    return HEX_CHARACTER + HEX_FORMATTER.toHexDigits(value, 6);
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/format/NamedTextColorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/NamedTextColorTest.java
@@ -55,6 +55,11 @@ class NamedTextColorTest {
     assertNearest(NamedTextColor.DARK_GRAY, 0x4c4c4c);
   }
 
+  @Test
+  void testAsHexString() {
+    assertEquals("#FF5555", NamedTextColor.RED.asHexString());
+  }
+
   private static void assertNearest(final NamedTextColor expected, final int value) {
     final NamedTextColor nearest = NamedTextColor.nearestTo(TextColor.color(value));
     assertEquals(expected, nearest);

--- a/api/src/test/java/net/kyori/adventure/text/format/ShadowColorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/ShadowColorTest.java
@@ -87,4 +87,10 @@ class ShadowColorTest {
       )
       .testEquals();
   }
+
+  @Test
+  void testAsHexString() {
+    assertEquals("#AABBCCDD", ShadowColor.shadowColor(0xDDAABBCC).asHexString());
+    assertEquals("#FFFFFFFF", ShadowColor.shadowColor(0xFFFFFFFF).asHexString());
+  }
 }

--- a/api/src/test/java/net/kyori/adventure/text/format/TextColorTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/format/TextColorTest.java
@@ -133,4 +133,9 @@ class TextColorTest {
     final TextColor original = TextColor.color(0x77ff11);
     assertEquals(original, TextColor.fromCSSHexString("#7f1"));
   }
+
+  @Test
+  void testAsHexString() {
+    assertEquals("#7F1E2D", TextColor.color(0x7f1e2d).asHexString());
+  }
 }


### PR DESCRIPTION
Ive noticed these methods were showing up in profile reports (Custom GUIs heavily use colors to pass data to custom shaders).

Both of these used slow methods (weird append) & String#format, in JDK 17 HexFormat was introduced, which is way faster for this task.

Another optimization that could be made for NamedTextColor (storing its hex string), but ideally you should store the name instead of the hex string. I havent done this in this PR.

Below are some benchmarks for TextColor similar methods, [benchmark class here.](https://gist.github.com/kermandev/525571fa1216b137cde98b2af2090d7f) (Only tested TextColor based methods & alternatives). I have not tested ShadowColor but its likely way faster just on preliminary benchmarks of a normal String#format.
```
Benchmark                            Mode  Cnt   Score   Error  Units
AdventureBenchmark.adventure         avgt   30  24.434 ± 0.211  ns/op
AdventureBenchmark.hexFormat         avgt   30   5.393 ± 0.047  ns/op
AdventureBenchmark.hexFormat2        avgt   30   5.487 ± 0.185  ns/op
AdventureBenchmark.manualCharArray   avgt   30   5.766 ± 0.133  ns/op
AdventureBenchmark.stringFormat      avgt   30  74.864 ± 0.887  ns/op
AdventureBenchmark.toHexStringTrick  avgt   30  15.277 ± 0.140  ns/op
```

Before (main/5)
```
Benchmark                                                 Mode      Cnt    Score   Error  Units
MiniMessageBenchmark.testManyColorsSerializing          sample  1638279    1.933 ± 0.006  us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.00    sample             1.798          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.50    sample             1.880          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.90    sample             1.940          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.95    sample             1.950          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.99    sample             2.808          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.999   sample             5.144          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.9999  sample            26.177          us/op
MiniMessageBenchmark.testManyColorsSerializing:p1.00    sample           338.944          us/op
```
After
```
Benchmark                                                 Mode      Cnt     Score   Error  Units
MiniMessageBenchmark.testManyColorsSerializing          sample  1652680     1.920 ± 0.013  us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.00    sample              1.798          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.50    sample              1.870          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.90    sample              1.910          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.95    sample              1.930          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.99    sample              2.540          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.999   sample              4.808          us/op
MiniMessageBenchmark.testManyColorsSerializing:p0.9999  sample             17.832          us/op
MiniMessageBenchmark.testManyColorsSerializing:p1.00    sample            295.936          us/op
```