### PR TITLE
feature(minimessage): Presets

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -23,14 +23,19 @@
  */
 package net.kyori.adventure.text.minimessage;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import net.kyori.adventure.builder.AbstractBuilder;
 import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.VirtualComponent;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import net.kyori.adventure.text.minimessage.tree.Node;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
+import net.kyori.adventure.util.Index;
 import net.kyori.adventure.util.PlatformAPI;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
@@ -52,6 +57,134 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    */
   static MiniMessage miniMessage() {
     return MiniMessageImpl.Instances.INSTANCE;
+  }
+
+  /**
+   * Gets an instance based on a specific preset.
+   *
+   * @param preset the preset to use
+   * @return an instance
+   * @since 5.0.0
+   */
+  static MiniMessage miniMessage(final Preset preset) {
+    Objects.requireNonNull(preset, "preset");
+    return MiniMessageImpl.Instances.PRESETS.get(preset);
+  }
+
+  /**
+   * A variety of presets for configuring MiniMessage.
+   *
+   * <p>
+   *   These presets can be used to get a default confuguration for MiniMessage by
+   *   using the {@link #miniMessage(Preset)} method.
+   * </p>
+   *
+   * <p>
+   *   Alternatively, you can get a pre-configured builder based on a preset.
+   *   This can be used to make your own custom MiniMessage instance whilst still keeping
+   *   any configuration provided by a preset, such as post-processing.
+   *   An example of how to do this is provided below.
+   * </p>
+   * <pre>
+   * {@code
+   * // Obtain the pre-configured builder.
+   * final MiniMessage.Builder builder = MiniMessage.builder(MiniMessage.Preset.NON_INTERACTABLE);
+   *
+   * // Add your own tags or override other settings if needed.
+   * builder.editTags(tags -> {
+   *   tags
+   *     .resolver(new MyCustomTagResolver())
+   *     .resolver(fetchExternalTags());
+   * });
+   *
+   * // Then build your MiniMessage instance!
+   * final MiniMessage myMiniMessageInstance = builder.build();
+   * }
+   * </pre>
+   *
+   * @see #miniMessage(Preset)
+   * @see #builder(Preset)
+   * @since 5.0.0
+   */
+  enum Preset implements Consumer<Builder> {
+    /**
+     * The default preset, containing all features of MiniMessage.
+     *
+     * @since 5.0.0
+     */
+    DEFAULT {
+      @Override
+      public void accept(final Builder builder) {
+        // no op, we keep default settings
+      }
+    },
+
+    /**
+     * A preset that disables all interactive features, such as hover and click events.
+     *
+     * <p>This preset also removes hover and click events from the returned component
+     * using a custom post-processor.</p>
+     *
+     * @since 5.0.0
+     */
+    NON_INTERACTABLE {
+      @Override
+      public void accept(final Builder builder) {
+        Objects.requireNonNull(builder, "builder");
+        builder.tags(StandardTags.forPreset(this));
+        builder.postProcessor(component ->
+          component
+            .toBuilder()
+            .applyDeep(child -> child.clickEvent(null).hoverEvent(null).insertion(null))
+            .build()
+            .compact()
+        );
+      }
+    },
+
+    /**
+     * A preset that disables all non-text component types and only allows formatting
+     * text components (i.e., color, shadow, decorations, fonts).
+     *
+     * <p>This preset also performs the following modifications to the resulting component
+     * using a custom post-processor:</p>
+     * <ul>
+     *   <li>Removes click events, hover events, and insertions from all text components.</li>
+     *   <li>Filters out any non-text components.</li>
+     * </ul>
+     *
+     * @since 5.0.0
+     */
+    FORMATTED_TEXT {
+      @Override
+      public void accept(final Builder builder) {
+        Objects.requireNonNull(builder, "builder");
+        builder.tags(StandardTags.forPreset(this));
+        builder.postProcessor(component ->
+          Component
+            .textOfChildren(component) // Wrap it in the empty component so we don't care about the root when mapping.
+            .toBuilder()
+            .mapChildrenDeep(child -> {
+              if (child instanceof TextComponent && !(child instanceof VirtualComponent)) {
+                return child.toBuilder().clickEvent(null).hoverEvent(null).insertion(null).build();
+              } else {
+                return Component.empty();
+              }
+            })
+            .build()
+            .compact()
+        );
+      }
+    };
+
+    /**
+     * The name map.
+     *
+     * <p>This can be used to easily make configurable presets.</p>
+     *
+     * @since 5.0.0
+     */
+    public static final Index<String, Preset> NAMES = Index.create(Preset.class, Preset::name);
   }
 
   /**
@@ -300,6 +433,20 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    */
   static Builder builder() {
     return new MiniMessageImpl.BuilderImpl();
+  }
+
+  /**
+   * Creates a new {@link MiniMessage.Builder} pre-configured for a specific preset.
+   *
+   * @param preset the preset
+   * @return the builder
+   * @since 5.0.0
+   */
+  static Builder builder(final Preset preset) {
+    Objects.requireNonNull(preset, "preset");
+    final Builder builder = MiniMessage.builder();
+    preset.accept(builder);
+    return builder;
   }
 
   /**

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -23,9 +23,12 @@
  */
 package net.kyori.adventure.text.minimessage;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.internal.serializer.SerializableResolver;
@@ -54,8 +57,25 @@ record MiniMessageImpl(
   // We cannot store these fields in MiniMessageImpl directly due to class initialisation issues.
   static final class Instances {
     static final MiniMessage INSTANCE = SERVICE
-      .map(Provider::miniMessage)
+      .map(MiniMessage.Provider::miniMessage)
       .orElseGet(() -> new MiniMessageImpl(TagResolver.standard(), false, true, null, DEFAULT_NO_OP, DEFAULT_COMPACTING_METHOD));
+
+    static final Map<MiniMessage.Preset, MiniMessage> PRESETS = MiniMessage.Preset
+      .NAMES
+      .values()
+      .stream()
+      .collect(
+        Collectors.toMap(
+          Function.identity(),
+          preset -> {
+            if (preset == Preset.DEFAULT) {
+              return INSTANCE;
+            } else {
+              return MiniMessage.builder(preset).build();
+            }
+          }
+        )
+      );
   }
 
   static final UnaryOperator<String> DEFAULT_NO_OP = UnaryOperator.identity();

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -100,6 +100,7 @@ public final class StandardTags {
       RainbowTag.RESOLVER,
       NewlineTag.RESOLVER,
       TransitionTag.RESOLVER,
+      PrideTag.RESOLVER,
       ShadowColorTag.RESOLVER
     )
     .build();

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/StandardTags.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.minimessage.tag.standard;
 
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 import static java.util.Objects.requireNonNull;
@@ -66,6 +67,42 @@ public final class StandardTags {
         SequentialHeadTag.RESOLVER
       )
       .build();
+
+  private static final TagResolver NON_INTERACTABLE = TagResolver.builder()
+    .resolvers(
+      ColorTagResolver.INSTANCE,
+      KeybindTag.RESOLVER,
+      TranslatableTag.RESOLVER,
+      TranslatableFallbackTag.RESOLVER,
+      FontTag.RESOLVER,
+      DecorationTag.RESOLVER,
+      GradientTag.RESOLVER,
+      RainbowTag.RESOLVER,
+      ResetTag.RESOLVER,
+      NewlineTag.RESOLVER,
+      TransitionTag.RESOLVER,
+      SelectorTag.RESOLVER,
+      ScoreTag.RESOLVER,
+      NbtTag.RESOLVER,
+      PrideTag.RESOLVER,
+      ShadowColorTag.RESOLVER,
+      SpriteTag.RESOLVER,
+      SequentialHeadTag.RESOLVER
+    )
+    .build();
+
+  private static final TagResolver FORMATTED_TEXT = TagResolver.builder()
+    .resolvers(
+      ColorTagResolver.INSTANCE,
+      FontTag.RESOLVER,
+      DecorationTag.RESOLVER,
+      GradientTag.RESOLVER,
+      RainbowTag.RESOLVER,
+      NewlineTag.RESOLVER,
+      TransitionTag.RESOLVER,
+      ShadowColorTag.RESOLVER
+    )
+    .build();
 
   /**
    * Get a resolver for a specific text decoration.
@@ -322,5 +359,20 @@ public final class StandardTags {
    */
   public static TagResolver defaults() {
     return ALL;
+  }
+
+  /**
+   * Get a resolver that handles all standard tags for a given preset.
+   *
+   * @param preset the preset
+   * @return the resolver for built-in tags for a preset
+   * @since 5.0.0
+   */
+  public static TagResolver forPreset(final MiniMessage.Preset preset) {
+    return switch (requireNonNull(preset, "preset")) {
+      case DEFAULT -> ALL;
+      case NON_INTERACTABLE -> NON_INTERACTABLE;
+      case FORMATTED_TEXT -> FORMATTED_TEXT;
+    };
   }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessagePresetTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessagePresetTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import org.junit.jupiter.api.Test;
+
+import static net.kyori.adventure.text.Component.empty;
+import static net.kyori.adventure.text.Component.text;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MiniMessagePresetTest extends AbstractTest {
+  @Test
+  void testAllPresetsAreConfigured() {
+    for (final MiniMessage.Preset preset : MiniMessage.Preset.values()) {
+      final MiniMessage miniMessage = MiniMessage.miniMessage(preset);
+      assertNotNull(miniMessage);
+    }
+  }
+
+  @Test
+  void testDefault() {
+    final MiniMessage mm = MiniMessage.miniMessage(MiniMessage.Preset.DEFAULT);
+    this.assertParsedEquals(mm,
+      text().append(text("Hello ", NamedTextColor.RED)
+        .append(text("world", NamedTextColor.BLUE).decorate(TextDecoration.BOLD)))
+        .append(text("!", NamedTextColor.GREEN).clickEvent(ClickEvent.runCommand("/test")))
+        .build(),
+      "<red>Hello <blue><bold>world</bold></blue></red><green><click:run_command:/test>!</click></green>"
+    );
+  }
+
+  @Test
+  void testNonInteractable() {
+    // Click, hover, insertion tags should be ignored and thus remain as literal text.
+    final MiniMessage mm = MiniMessage.miniMessage(MiniMessage.Preset.NON_INTERACTABLE);
+    this.assertParsedEquals(mm,
+      text("<click:run_command:/test>No click</click><hover:show_text:hover>No hover</hover><insert:insert>No insertion</insert>"),
+      "<click:run_command:/test>No click</click><hover:show_text:hover>No hover</hover><insert:insert>No insertion</insert>"
+    );
+
+    // Custom tags producing interactive components should be filtered.
+    final MiniMessage mmCustom = MiniMessage.builder(MiniMessage.Preset.NON_INTERACTABLE)
+      .editTags(t -> t.tag("dangerous", Tag.styling(ClickEvent.runCommand("/kill"))))
+      .build();
+    this.assertParsedEquals(mmCustom,
+      text("test"),
+      "<dangerous>test</dangerous>"
+    );
+  }
+
+  @Test
+  void testFormattedText() {
+    final MiniMessage mm = MiniMessage.miniMessage(MiniMessage.Preset.FORMATTED_TEXT);
+
+    // Basic formatting should work fine.
+    this.assertParsedEquals(mm,
+      text().append(text("Hello ", NamedTextColor.RED)
+        .append(text("world", NamedTextColor.BLUE).decorate(TextDecoration.BOLD)))
+        .build(),
+      "<red>Hello <blue><bold>world</bold></blue></red>"
+    );
+
+    // Click/hover should remain as literal text.
+    this.assertParsedEquals(mm,
+      text("<click:run_command:/test>No click</click>"),
+      "<click:run_command:/test>No click</click>"
+    );
+
+    // Non-text components (like keybind) are also not here and should remain literal.
+    this.assertParsedEquals(mm,
+      text("<keybind:key.jump>"),
+      "<keybind:key.jump>"
+    );
+
+    // Custom tags producing non-text components should be filtered.
+    final MiniMessage mmCustom = MiniMessage.builder(MiniMessage.Preset.FORMATTED_TEXT)
+      .editTags(t -> t.tag("mykey", Tag.inserting(Component.keybind("key.jump"))))
+      .build();
+    this.assertParsedEquals(mmCustom,
+      empty(),
+      "<mykey>"
+    );
+
+    // Custom tags producing interactive text should also be filtered.
+    final MiniMessage mmCustom2 = MiniMessage.builder(MiniMessage.Preset.FORMATTED_TEXT)
+      .editTags(t -> t.tag("dangertext", Tag.inserting(text("danger").clickEvent(ClickEvent.runCommand("/kill")))))
+      .build();
+    this.assertParsedEquals(mmCustom2,
+      text("danger"),
+      "<dangertext>"
+    );
+
+    // Custom tags producing non-text components in children should also be filtered.
+    final MiniMessage mmCustom3 = MiniMessage.builder(MiniMessage.Preset.FORMATTED_TEXT)
+      .editTags(t -> t.tag("nontextchild", Tag.inserting(text("parent").append(Component.keybind("key.jump")))))
+      .build();
+    this.assertParsedEquals(mmCustom3,
+      text("parent"),
+      "<nontextchild>"
+    );
+  }
+}

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -54,7 +54,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MiniMessageTest extends AbstractTest {
-
   @Test
   void testNormalBuilder() {
     final Component expected = text("Test").color(RED);


### PR DESCRIPTION
As evidenced by recent publicity around an """""exploit""""" in Paper servers, MiniMessage could do with an improvement to allow developers to access really simple "safe" presets. This PR introduces such a system via addition of a Preset enum that contains a standardised configuration for builders.