### PR TITLE
chore(configurate-4): replace checkerframework annotations

### DIFF
--- a/serializer-configurate4/src/main/java/module-info.java
+++ b/serializer-configurate4/src/main/java/module-info.java
@@ -6,7 +6,6 @@ module net.kyori.adventure.serializer.configurate4 {
   requires net.kyori.adventure.text.serializer.commons;
   requires io.leangen.geantyref;
   requires org.spongepowered.configurate;
-  requires static org.checkerframework.checker.qual;
 
   exports net.kyori.adventure.serializer.configurate4;
 }

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateDataComponentValueTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ConfigurateDataComponentValueTypeSerializer.java
@@ -24,7 +24,7 @@
 package net.kyori.adventure.serializer.configurate4;
 
 import java.lang.reflect.Type;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ProfilePropertySerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ProfilePropertySerializer.java
@@ -25,7 +25,7 @@ package net.kyori.adventure.serializer.configurate4;
 
 import java.lang.reflect.Type;
 import net.kyori.adventure.text.object.PlayerHeadObjectContents;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ShadowColorSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/ShadowColorSerializer.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.serializer.configurate4;
 import java.lang.reflect.Type;
 import java.util.List;
 import net.kyori.adventure.text.format.ShadowColor;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;

--- a/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TranslationArgumentTypeSerializer.java
+++ b/serializer-configurate4/src/main/java/net/kyori/adventure/serializer/configurate4/TranslationArgumentTypeSerializer.java
@@ -26,7 +26,7 @@ package net.kyori.adventure.serializer.configurate4;
 import java.lang.reflect.Type;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TranslationArgument;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;


### PR DESCRIPTION
This PR gets rid of the checkerframework annotations, which were still present in configurate4 (oops)