### PR TITLE
chore(build): Publish aggregate javadoc jar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     with:
       publish_releases: true
       publish_release_javadoc: true
-      runtime_version: 21
+      runtime_version: 25
     secrets:
       DEPLOYMENT_APP_ID: "${{ secrets.DEPLOYMENT_APP_ID }}"
       DEPLOYMENT_APP_SECRET: "${{ secrets.DEPLOYMENT_APP_SECRET }}"

--- a/annotation-processors/src/main/java/module-info.java
+++ b/annotation-processors/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module net.kyori.adventure.annotation.processing {
+  requires static com.google.auto.service;
+  requires java.compiler;
+  requires org.jetbrains.annotations;
+}

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -12,7 +12,6 @@ configurations {
 dependencies {
   api(projects.adventureKey)
   compileOnlyApi(libs.jetbrainsAnnotations)
-  compileOnlyApi(libs.jspecify)
   testImplementation(libs.guava)
   annotationProcessor(projects.adventureAnnotationProcessors)
   testCompileOnly(libs.autoService.annotations)

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
   constraints {
     sequenceOf(
       "api",
-      "annotation-processors",
       "key",
       "nbt",
       "serializer-configurate4",

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
   implementation(libs.build.testLogger)
   compileOnly(libs.build.jmh)
   implementation(libs.build.goomph)
+  implementation(libs.build.javadocAggregate)
 }
 
 dependencies {

--- a/build-logic/src/main/kotlin/adventure.aggregate-javadoc-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.aggregate-javadoc-conventions.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 tasks.named<Javadoc>("javadoc").configure {
-  (options as StandardJavadocDocletOptions).applyCommonJavadocTags()
+  (options as StandardJavadocDocletOptions).applyCommonJavadocOptions()
 }
 
 indra {

--- a/build-logic/src/main/kotlin/adventure.aggregate-javadoc-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.aggregate-javadoc-conventions.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+  id("adventure.base-conventions")
+  id("io.freefair.aggregate-javadoc")
+}
+
+tasks.named<Javadoc>("javadoc").configure {
+  (options as StandardJavadocDocletOptions).applyCommonJavadocTags()
+}
+
+indra {
+  configurePublications {
+    artifact(tasks.javadocJar)
+  }
+}

--- a/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.common-conventions.gradle.kts
@@ -84,11 +84,7 @@ indraCrossdoc {
 tasks {
   javadoc {
     val options = options as? StandardJavadocDocletOptions ?: return@javadoc
-    options.tags(
-      "obsolete:a:Obsolete",
-      "sinceMinecraft:a:Since Minecraft:",
-      "obsoleteSinceMinecraft:a:Obsolete since Minecraft",
-    )
+    options.applyCommonJavadocOptions()
   }
 
   jacocoTestReport {

--- a/build-logic/src/main/kotlin/extensions.kt
+++ b/build-logic/src/main/kotlin/extensions.kt
@@ -21,10 +21,12 @@ fun Project.applyJarMetadata(moduleName: String) {
   }
 }
 
-fun StandardJavadocDocletOptions.applyCommonJavadocTags() {
+fun StandardJavadocDocletOptions.applyCommonJavadocOptions() {
   tags(
     "obsolete:a:Obsolete",
     "sinceMinecraft:a:Since Minecraft:",
     "obsoleteSinceMinecraft:a:Obsolete since Minecraft",
   )
+
+  use(true)
 }

--- a/build-logic/src/main/kotlin/extensions.kt
+++ b/build-logic/src/main/kotlin/extensions.kt
@@ -1,6 +1,7 @@
 import net.kyori.indra.git.IndraGitExtension
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.kotlin.dsl.attributes
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.named
@@ -18,4 +19,12 @@ fun Project.applyJarMetadata(moduleName: String) {
       indraGit?.applyVcsInformationToManifest(manifest)
     }
   }
+}
+
+fun StandardJavadocDocletOptions.applyCommonJavadocTags() {
+  tags(
+    "obsolete:a:Obsolete",
+    "sinceMinecraft:a:Since Minecraft:",
+    "obsoleteSinceMinecraft:a:Obsolete since Minecraft",
+  )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ build-indra-spotless = { module = "net.kyori:indra-licenser-spotless", version.r
 build-goomph = "com.diffplug.gradle:goomph:4.4.1"
 build-jmh = { module = "me.champeau.jmh:jmh-gradle-plugin", version.ref = "jmhPlugin" }
 build-testLogger = "com.adarshr:gradle-test-logger-plugin:4.0.0"
+build-javadocAggregate = "io.freefair.aggregate-javadoc:io.freefair.aggregate-javadoc.gradle.plugin:9.2.0"
 
 # unused, for renovate
 zCheckstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }

--- a/javadoc/build.gradle.kts
+++ b/javadoc/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+  id("adventure.aggregate-javadoc-conventions")
+}
+
+dependencies {
+  listOf(
+    "api",
+    "key",
+    "nbt",
+    "serializer-configurate4",
+    "text-logger-slf4j",
+    "text-minimessage",
+    "text-serializer-commons",
+    "text-serializer-ansi",
+    "text-serializer-gson",
+    "text-serializer-json",
+    "text-serializer-json-legacy-impl",
+    "text-serializer-legacy",
+    "text-serializer-plain"
+  ).forEach {
+    javadoc(project(":adventure-$it"))
+  }
+
+  javadocClasspath(libs.jspecify)
+  javadocClasspath(libs.jetbrainsAnnotations)
+  javadocClasspath(libs.autoService)
+  javadocClasspath(libs.slf4j)
+}
+
+tasks.named<Javadoc>("javadoc").configure {
+  title = "Adventure $version (all modules)"
+}

--- a/key/build.gradle.kts
+++ b/key/build.gradle.kts
@@ -9,8 +9,8 @@ configurations {
 }
 
 dependencies {
+  api(libs.jspecify)
   compileOnlyApi(libs.jetbrainsAnnotations)
-  compileOnlyApi(libs.jspecify)
   testImplementation(libs.guava)
 }
 

--- a/nbt/build.gradle.kts
+++ b/nbt/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
+  api(libs.jspecify)
   compileOnlyApi(libs.jetbrainsAnnotations)
-  compileOnlyApi(libs.jspecify)
 }
 
 applyJarMetadata("net.kyori.adventure.nbt")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ sequenceOf(
   "api",
   "annotation-processors",
   "bom",
+  "javadoc",
   "key",
   "nbt",
   "serializer-configurate4",

--- a/text-serializer-commons/build.gradle.kts
+++ b/text-serializer-commons/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
+  api(libs.jspecify)
   compileOnlyApi(libs.jetbrainsAnnotations)
-  compileOnlyApi(libs.jspecify)
 }
 
 applyJarMetadata("net.kyori.adventure.text.serializer.constant")


### PR DESCRIPTION
Minor additional changes:
- Modify jSpecify dependency to be api, as directed
- Remove annotation processors from BOM
- Create missing module-info.java for annotation processors