### PR TITLE
chore(docs): Remove incorrect annotations from ForwardingAudience.Single methods

### DIFF
--- a/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
+++ b/api/src/main/java/net/kyori/adventure/audience/ForwardingAudience.java
@@ -75,7 +75,7 @@ public interface ForwardingAudience extends Audience {
 
   @Override
   default Audience filterAudience(final Predicate<? super Audience> filter) {
-    @Nullable List<Audience> audiences = null;
+    List<Audience> audiences = null;
     for (final Audience audience : this.audiences()) {
       if (filter.test(audience)) {
         final Audience filtered = audience.filterAudience(filter);
@@ -229,16 +229,8 @@ public interface ForwardingAudience extends Audience {
      * @return the audience
      * @since 4.0.0
      */
-    @ApiStatus.OverrideOnly
     Audience audience();
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return {@link #audience()}
-     * @deprecated this audience only supports forwarding to a single audience
-     */
-    @Deprecated
     @Override
     default Iterable<? extends Audience> audiences() {
       return Collections.singleton(this.audience());


### PR DESCRIPTION
Implementing classes will already know to override audience as it doesn't have a default.

The audiences method also shouldn't be deprecated as it is not unusable and won't be removed.