### PR TITLE
refactor(minimessage): revert change to Hover tag SNBT resolution

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/HoverTag.java
@@ -129,11 +129,13 @@ final class HoverTag {
         final Key key = Key.key(args.popOr("Show item hover needs at least an item ID").value());
         final int count = args.hasNext() ? args.pop().asInt().orElseThrow(() -> ctx.newException("The count argument was not a valid integer")) : 1;
         if (args.hasNext()) {
-          // if the value starts with a '{' we assume it's SNBT. The previous behavior of legacy parsing has
-          // been removed in Adventure 5.0.0.
+          // Compatibility with legacy versions:
+          // if the value starts with a '{' we assume it's SNBT, and parse it as such to create a legacy holder
+          // otherwise, we'll parse argument pairs as a map of ResourceLocation -> SNBT value
           final String value = args.peek().value();
           if (value.startsWith("{")) {
-            throw ctx.newException("Legacy SNBT serializing is since Adventure 5.0.0 no longer supported.");
+            args.pop();
+            return legacyShowItem(key, count, value);
           }
 
           final Map<Key, DataComponentValue> datas = new HashMap<>();
@@ -150,6 +152,10 @@ final class HoverTag {
       } catch (final InvalidKeyException | NumberFormatException ex) {
         throw ctx.newException("Exception parsing show_item hover", ex, args);
       }
+    }
+
+    private static HoverEvent.ShowItem legacyShowItem(final Key id, final int count, final String value) {
+      return HoverEvent.ShowItem.showItem(id, count, BinaryTagHolder.binaryTagHolder(value));
     }
 
     @Override


### PR DESCRIPTION
This PR reverts to the previous behavior where it allowed SNBT to be passed as an argument for item display. The commit changed that behaviour by throwing an exception instead, marking it as deprecated and removed.

Closes #1397 