### PR TITLE
Add back BuildableComponent

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/BuildableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/BuildableComponent.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of adventure, licensed under the MIT License.
+ *
+ * Copyright (c) 2017-2025 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text;
+
+import net.kyori.adventure.util.Buildable;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A component which may be built.
+ *
+ * @param <C> the component type
+ * @param <B> the builder type
+ * @since 4.0.0
+ * @deprecated For removal in 6.0, since 4.26 with no replacement. See instead {@link Component#toBuilder()}.
+ */
+@Deprecated(forRemoval = true)
+@ApiStatus.ScheduledForRemoval(inVersion = "6.0.0")
+public sealed interface BuildableComponent<C extends Component, B extends ComponentBuilder<C, ?>> extends Buildable<B>, Component permits KeybindComponent, NBTComponent, ObjectComponent, ScoreComponent, SelectorComponent, TextComponent, TranslatableComponent {
+  /**
+   * Create a builder from this component.
+   *
+   * @return the builder
+   */
+  @Override
+  B toBuilder();
+}

--- a/api/src/main/java/net/kyori/adventure/text/Component.java
+++ b/api/src/main/java/net/kyori/adventure/text/Component.java
@@ -108,7 +108,8 @@ import static java.util.Objects.requireNonNull;
  * @see LinearComponents
  * @since 4.0.0
  */
-public sealed interface Component extends ComponentBuilderApplicable, ComponentLike, HoverEventSource<Component>, StyleGetter, StyleSetter<Component> permits NBTComponent, ScopedComponent {
+@SuppressWarnings("removal")
+public sealed interface Component extends ComponentBuilderApplicable, ComponentLike, HoverEventSource<Component>, StyleGetter, StyleSetter<Component> permits BuildableComponent, ScopedComponent {
   /**
    * A predicate that checks equality of two {@code Component}s using {@link Objects#equals(Object, Object)}.
    *

--- a/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/KeybindComponent.java
@@ -38,7 +38,8 @@ import org.jetbrains.annotations.Contract;
  * @since 4.0.0
  * @sinceMinecraft 1.12
  */
-public sealed interface KeybindComponent extends ScopedComponent<KeybindComponent> permits KeybindComponentImpl {
+@SuppressWarnings("removal")
+public sealed interface KeybindComponent extends ScopedComponent<KeybindComponent>, BuildableComponent<KeybindComponent, KeybindComponent.Builder> permits KeybindComponentImpl {
   /**
    * Gets the keybind.
    *

--- a/api/src/main/java/net/kyori/adventure/text/NBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/NBTComponent.java
@@ -49,7 +49,8 @@ import org.jspecify.annotations.Nullable;
  * @since 4.0.0
  * @sinceMinecraft 1.14
  */
-public sealed interface NBTComponent<C extends NBTComponent<C>> extends Component permits BlockNBTComponent, EntityNBTComponent, StorageNBTComponent {
+@SuppressWarnings("removal")
+public sealed interface NBTComponent<C extends NBTComponent<C>> extends BuildableComponent<C, NBTComponentBuilder<C, ?>> permits BlockNBTComponent, EntityNBTComponent, StorageNBTComponent {
   /**
    * The default value for {@link #interpret()}.
    *

--- a/api/src/main/java/net/kyori/adventure/text/ObjectComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ObjectComponent.java
@@ -33,7 +33,8 @@ import org.jspecify.annotations.Nullable;
  * @since 4.25.0
  * @sinceMinecraft 1.21.9
  */
-public sealed interface ObjectComponent extends ScopedComponent<ObjectComponent>, ObjectContentsLike permits ObjectComponentImpl {
+@SuppressWarnings("removal")
+public sealed interface ObjectComponent extends ScopedComponent<ObjectComponent>, BuildableComponent<ObjectComponent, ObjectComponent.Builder>, ObjectContentsLike permits ObjectComponentImpl {
   /**
    * Gets the contents of this object component.
    *

--- a/api/src/main/java/net/kyori/adventure/text/ScoreComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/ScoreComponent.java
@@ -49,7 +49,8 @@ import org.jspecify.annotations.Nullable;
  *
  * @since 4.0.0
  */
-public sealed interface ScoreComponent extends ScopedComponent<ScoreComponent> permits ScoreComponentImpl {
+@SuppressWarnings("removal")
+public sealed interface ScoreComponent extends ScopedComponent<ScoreComponent>, BuildableComponent<ScoreComponent, ScoreComponent.Builder> permits ScoreComponentImpl {
   /**
    * Gets the score name.
    *

--- a/api/src/main/java/net/kyori/adventure/text/SelectorComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/SelectorComponent.java
@@ -41,7 +41,8 @@ import org.jspecify.annotations.Nullable;
  *
  * @since 4.0.0
  */
-public sealed interface SelectorComponent extends ScopedComponent<SelectorComponent> permits SelectorComponentImpl {
+@SuppressWarnings("removal")
+public sealed interface SelectorComponent extends ScopedComponent<SelectorComponent>, BuildableComponent<SelectorComponent, SelectorComponent.Builder> permits SelectorComponentImpl {
   /**
    * Gets the selector pattern.
    *

--- a/api/src/main/java/net/kyori/adventure/text/TextComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TextComponent.java
@@ -36,7 +36,8 @@ import org.jetbrains.annotations.Contract;
  *
  * @since 4.0.0
  */
-public sealed interface TextComponent extends ScopedComponent<TextComponent> permits TextComponentImpl, VirtualComponent {
+@SuppressWarnings("removal")
+public sealed interface TextComponent extends ScopedComponent<TextComponent>, BuildableComponent<TextComponent, TextComponent.Builder> permits TextComponentImpl, VirtualComponent {
   /**
    * Gets the plain text content.
    *

--- a/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/TranslatableComponent.java
@@ -58,7 +58,8 @@ import org.jspecify.annotations.Nullable;
  * @see TranslationStore
  * @since 4.0.0
  */
-public sealed interface TranslatableComponent extends ScopedComponent<TranslatableComponent> permits TranslatableComponentImpl {
+@SuppressWarnings("removal")
+public sealed interface TranslatableComponent extends ScopedComponent<TranslatableComponent>, BuildableComponent<TranslatableComponent, TranslatableComponent.Builder> permits TranslatableComponentImpl {
   /**
    * Gets the translation key.
    *

--- a/build-logic/src/main/kotlin/adventure.legacy-component-builder-abi-fix.gradle.kts
+++ b/build-logic/src/main/kotlin/adventure.legacy-component-builder-abi-fix.gradle.kts
@@ -12,8 +12,9 @@ import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
 // Remove in 6.x.
-// In 5.x, ComponentBuilder#build erased from Object to Component, causing NoSuchMethodError for 4.x-compiled clients.
-// This adds a build-time classfile bridge for build():Object while keeping the 5.x source API strongly typed.
+// In 5.x, ComponentBuilder#build erased from Object/BuildableComponent to Component,
+// causing NoSuchMethodError for 4.x-compiled clients.
+// This adds build-time classfile bridges for the legacy return types while keeping the 5.x source API strongly typed.
 
 abstract class PatchComponentBuilderAbi : DefaultTask() {
   @get:InputFile
@@ -28,17 +29,43 @@ abstract class PatchComponentBuilderAbi : DefaultTask() {
     val writer = ClassWriter(reader, 0)
 
     var hasComponentBuild = false
+    var hasBuildableComponentBuild = false
     var hasObjectBuild = false
 
     reader.accept(object : ClassVisitor(Opcodes.ASM9, writer) {
       override fun visitMethod(access: Int, name: String, desc: String, sig: String?, ex: Array<out String>?): MethodVisitor {
         if (name == "build" && desc == "()Lnet/kyori/adventure/text/Component;") hasComponentBuild = true
+        if (name == "build" && desc == "()Lnet/kyori/adventure/text/BuildableComponent;") hasBuildableComponentBuild = true
         if (name == "build" && desc == "()Ljava/lang/Object;") hasObjectBuild = true
         return super.visitMethod(access, name, desc, sig, ex)
       }
 
       override fun visitEnd() {
         check(hasComponentBuild) { "Missing ComponentBuilder.build():Component" }
+
+        if (!hasBuildableComponentBuild) {
+          super.visitMethod(
+            Opcodes.ACC_PUBLIC or Opcodes.ACC_BRIDGE or Opcodes.ACC_SYNTHETIC,
+            "build",
+            "()Lnet/kyori/adventure/text/BuildableComponent;",
+            null,
+            null
+          ).apply {
+            visitCode()
+            visitVarInsn(Opcodes.ALOAD, 0)
+            visitMethodInsn(
+              Opcodes.INVOKEINTERFACE,
+              "net/kyori/adventure/text/ComponentBuilder",
+              "build",
+              "()Lnet/kyori/adventure/text/Component;",
+              true
+            )
+            visitTypeInsn(Opcodes.CHECKCAST, "net/kyori/adventure/text/BuildableComponent")
+            visitInsn(Opcodes.ARETURN)
+            visitMaxs(1, 1)
+            visitEnd()
+          }
+        }
 
         if (!hasObjectBuild) {
           super.visitMethod(


### PR DESCRIPTION
## Summary

Restore binary compatibility for 4.x-compiled component builder calls that expect `build(): BuildableComponent`.

Adventure 5 changed `ComponentBuilder#build`’s erased return type from the old `BuildableComponent` hierarchy to `Component`. Code compiled against Adventure 4.x can therefore fail at runtime on Adventure 5.x with:

```text
NoSuchMethodError: TextComponent$Builder.build():BuildableComponent
```

Fixes #1431.

## Changes

- Reintroduce `BuildableComponent` as a deprecated, for-removal compatibility type.
- Make component interfaces assignable to `BuildableComponent` again.
- Extend the existing legacy ABI patch plugin to inject a synthetic bridge:

```text
ComponentBuilder.build():BuildableComponent
```

in addition to the existing `build():Object` bridge.

The public source API remains based on `ComponentBuilder<C extends Component, ...>`, so normal newly compiled 5.x code continues to target the modern ABI:

```text
build():Component
```

To emit bytecode referencing the restored legacy bridge, code must explicitly use the deprecated compatibility type, for example:

```java
BuildableComponent<?, ?> component = Component.text().build();
```

That usage produces deprecation/removal warnings and is not intended for new code.

## Compatibility notes

This supports:

- 4.x-compiled code running on Adventure 5.x

It does not make 5.x-compiled code run on Adventure 4.x, and it does not make `BuildableComponent` a supported long-term API again. The restored type and bridge should be removed in 6.x.

## Verification

- Verified that 4.26.1-compiled bytecode calling:

```text
TextComponent$Builder.build():BuildableComponent
```

runs successfully against the rebuilt 5.x jar.
- Verified that normal newly compiled 5.x code still emits:

```text
TextComponent$Builder.build():Component
```

for `Component.text().build()`.
- Verified that bytecode only references `BuildableComponent` when source explicitly uses the deprecated `BuildableComponent` type.
