### PR TITLE
fix: improve KeyPattern.NAMESPACE_PATTERN regex

### DIFF
--- a/key/src/main/java/net/kyori/adventure/key/KeyPattern.java
+++ b/key/src/main/java/net/kyori/adventure/key/KeyPattern.java
@@ -46,7 +46,7 @@ public @interface KeyPattern {
    *
    * @since 5.0.0
    */
-  @RegExp String NAMESPACE_PATTERN = "^(?!\\.\\.$)[a-z0-9_.-]+$";
+  @RegExp String NAMESPACE_PATTERN = "(?!\\.\\.(?:$|:))[a-z0-9_.-]+";
   /**
    * The pattern for values.
    *


### PR DESCRIPTION
Hi,
this PR aims to fix #1435.
I removed the `^` and `$` at the start and end of the regex respectively as they are already enforced by the usages of the regex itself. The regex is not used in a way that it could only match a part of the pattern.
If I only remove those the regex would match `..` again as valid to prevent that I added a non-capturing group inside the negative lookahead to make it compatible with a full key of the form `namespace:value`.
This non-capturing group does accept the end of the line or a colon as the end the namespace and therefore works either for matching the namespace or a full key.
All tests still pass and the warnings for `@KeyPattern` align with the expected test results as far as I can tell.

Any feedback is welcome :slightly_smiling_face: 