### PR TITLE
feat: introduce MiniMessageContext to distinguish MiniMessage when rendering

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/VirtualComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/VirtualComponentRenderer.java
@@ -52,4 +52,15 @@ public interface VirtualComponentRenderer<C> {
   default String fallbackString() {
     return "";
   }
+
+  /**
+   * Checks if a {@link VirtualComponent} should be skipped when being rendered through a {@link net.kyori.adventure.text.renderer.TranslatableComponentRenderer} when used as an argument.
+   *
+   * @param component the component
+   * @return {@code true} to skip rendering, or {@code false} to render
+   * @since 5.2.1
+   */
+  default boolean skipRenderingWhenUsedAsTranslationArgument(final VirtualComponent component) {
+    return false;
+  }
 }

--- a/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
+++ b/api/src/main/java/net/kyori/adventure/text/renderer/TranslatableComponentRenderer.java
@@ -209,7 +209,7 @@ public abstract class TranslatableComponentRenderer<C> extends AbstractComponent
         final List<TranslationArgument> translatedArguments = new ArrayList<>(arguments);
         for (int i = 0; i < translatedArguments.size(); i++) {
           final TranslationArgument arg = translatedArguments.get(i);
-          if (arg.value() instanceof Component && !(arg.value() instanceof VirtualComponent)) {
+          if (arg.value() instanceof Component && !(arg.value() instanceof final VirtualComponent virtual && virtual.renderer().skipRenderingWhenUsedAsTranslationArgument(virtual))) {
             translatedArguments.set(i, TranslationArgument.component(this.render((Component) arg.value(), context)));
           }
         }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslatorArgument.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslatorArgument.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.minimessage.translation;
 
 import java.util.Objects;
 import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.VirtualComponent;
 import net.kyori.adventure.text.VirtualComponentRenderer;
 import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.tag.TagPattern;
@@ -47,5 +48,10 @@ record MiniMessageTranslatorArgument<T>(String name, T data) implements VirtualC
     } else {
       return null;
     }
+  }
+
+  @Override
+  public boolean skipRenderingWhenUsedAsTranslationArgument(final VirtualComponent component) {
+    return true;
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslatorTarget.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/translation/MiniMessageTranslatorTarget.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.minimessage.translation;
 
 import net.kyori.adventure.pointer.Pointered;
 import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.VirtualComponent;
 import net.kyori.adventure.text.VirtualComponentRenderer;
 import org.jetbrains.annotations.UnknownNullability;
 
@@ -33,5 +34,10 @@ record MiniMessageTranslatorTarget(Pointered pointered) implements VirtualCompon
   @Override
   public @UnknownNullability ComponentLike apply(final Void context) {
     return null;
+  }
+
+  @Override
+  public boolean skipRenderingWhenUsedAsTranslationArgument(final VirtualComponent component) {
+    return true;
   }
 }


### PR DESCRIPTION
We currently prevent rendering `VirtualComponent`s through `TranslatableComponentRenderer` when they are used as arguments to a `TranslatableComponent`. Supporting them requires extending the renderer and overriding `renderTranslatable` to restore that behavior, which is not ideal.