### PR TITLE
perf(minimessage): add system property to skip tag validation

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/TagInternals.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/TagInternals.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public final class TagInternals {
   private static final Pattern TAG_NAME_PATTERN = Pattern.compile(TagPattern.TAG_NAME_REGEX);
+  private static final Boolean SKIP_VALIDATION = Boolean.getBoolean("minimessage.perf.skipValidation");
 
   private TagInternals() {
   }
@@ -49,6 +50,7 @@ public final class TagInternals {
    * @since 4.10.0
    */
   public static void assertValidTagName(@TagPattern final String tagName) {
+    if (SKIP_VALIDATION) return;
     if (!TAG_NAME_PATTERN.matcher(Objects.requireNonNull(tagName)).matches()) {
       throw new IllegalArgumentException("Tag name must match pattern " + TAG_NAME_PATTERN.pattern() + ", was " + tagName);
     }
@@ -63,6 +65,7 @@ public final class TagInternals {
    * @since 4.10.1
    */
   public static boolean sanitizeAndCheckValidTagName(@TagPattern final String tagName) {
+    if (SKIP_VALIDATION) return true;
     return TAG_NAME_PATTERN.matcher(Objects.requireNonNull(tagName).toLowerCase(Locale.ROOT)).matches();
   }
 


### PR DESCRIPTION
This PR introduces a system property intended for use by advanced users who are confident that they are using valid minimessage tags.

This has a very small usecase but a pretty major impact.

https://spark.lucko.me/Aqo35xCxyT?hl=8160

As seen in this spark at the linked method call, its allocation rate is about 650kbps which is quite high for what the call does and adds up.