### PR TITLE
Add missing provides directives for provided services to text-serializer-gson module descriptor

### DIFF
--- a/text-serializer-gson/src/main/java/module-info.java
+++ b/text-serializer-gson/src/main/java/module-info.java
@@ -10,4 +10,9 @@ module net.kyori.adventure.text.serializer.gson {
   exports net.kyori.adventure.text.serializer.gson;
 
   uses net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.Provider;
+
+  provides net.kyori.adventure.text.event.DataComponentValueConverterRegistry.Provider
+    with net.kyori.adventure.text.serializer.gson.impl.GsonDataComponentValueConverterProvider;
+  provides net.kyori.adventure.text.serializer.json.JSONComponentSerializer.Provider
+    with net.kyori.adventure.text.serializer.gson.impl.JSONComponentSerializerProviderImpl;
 }


### PR DESCRIPTION
This fixes an issue in modular environments when using the `JSONComponentSerializer` directly (as opposed to `GsonComponentSerializer`) where it fails to find a service provider for `JSONComponentSerializer.Provider` so it falls back to the dummy impl which only throws exceptions.
A similar case applies to the data component value converter, but in that situation all providers are collected so the gson one is skipped and its converters are not registered.