### PR TITLE
Mark gson as a transitive dependency in text-serializer-gson module descriptor

### DIFF
--- a/text-serializer-gson/src/main/java/module-info.java
+++ b/text-serializer-gson/src/main/java/module-info.java
@@ -3,7 +3,7 @@
  */
 module net.kyori.adventure.text.serializer.gson {
   requires transitive net.kyori.adventure.text.serializer.json;
-  requires com.google.gson;
+  requires transitive com.google.gson;
   requires net.kyori.adventure.text.serializer.commons;
   requires static com.google.auto.service;
 


### PR DESCRIPTION
gson is an exposed dependency in the text-serializer-gson API and is made available to consumers of the maven module, so the module descriptor should reflect that transitivity